### PR TITLE
fix: require nativephp/mobile ^3.0 in the PluginCreateCommand

### DIFF
--- a/src/Commands/PluginCreateCommand.php
+++ b/src/Commands/PluginCreateCommand.php
@@ -242,7 +242,7 @@ class PluginCreateCommand extends Command
             ],
             'require' => [
                 'php' => '^8.2',
-                'nativephp/mobile' => '^2.0',
+                'nativephp/mobile' => '^3.0',
             ],
             'autoload' => [
                 'psr-4' => [


### PR DESCRIPTION
- Updated the generated composer.json requirement for nativephp/mobile from ^2.0 to ^3.0. Plugin installs fail without this change.