### PR TITLE
Added support for dictionary info_plist values

### DIFF
--- a/tests/Feature/Plugins/IOSCompilerTest.php
+++ b/tests/Feature/Plugins/IOSCompilerTest.php
@@ -581,6 +581,17 @@ class NestedClass {}');
                 'info_plist' => [
                     'NSCameraUsageDescription' => 'Camera description',  // String
                     'UIRequiredDeviceCapabilities' => ['arm64'],  // Array (if supported)
+                    'UIApplicationSceneManifest' => [ // Dictionary with nested types
+                        'UIApplicationSupportsMultipleScenes' => true,
+                        'UISceneConfigurations' => [
+                            'UIWindowSceneSessionRoleExternalDisplayNonInteractive' => [
+                                [
+                                    'UISceneConfigurationName' => 'External Display',
+                                    'UISceneDelegateClassName' => 'NativePHP.SceneDelegate'
+                                ]
+                            ]
+                        ]
+                    ]
                 ],
             ],
         ]);
@@ -596,6 +607,10 @@ class NestedClass {}');
 
         $this->assertStringContainsString('NSCameraUsageDescription', $content);
         $this->assertStringContainsString('Camera description', $content);
+
+        $this->assertStringContainsString('UISceneConfigurationName', $content);
+        $this->assertStringContainsString('External Display', $content);
+        $this->assertStringContainsString('NativePHP.SceneDelegate', $content);
     }
 
     /**


### PR DESCRIPTION
## Summary
The plist merge in the iOS compile only supports strings and arrays. There are features the require dictionary and boolean values in the plist file.

## Solution
The change was to add a method to handle all the types (String, Array, Dictionary, and Bool). 

## Changes

* src/Plugins/Compilers/IOSPluginCompiler.php - Added a method to recursively handle the structure.
* tests/Feature/Plugins/IOSCompilerTest.php - Updated `it_handles_various_plist_value_types` with all the types 