### PR TITLE
Feature: Enable setting active color for tab bar

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/NativeBottomNav.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/NativeBottomNav.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import android.graphics.Color as AndroidColor
 import android.util.Log
 
 private const val TAG = "NativeBottomNav"
@@ -23,6 +24,9 @@ fun NativeBottomNavigation(
     }
 
     val items = bottomNavData?.children?.mapNotNull { it.data } ?: emptyList()
+
+    // Parse custom active color from config
+    val activeColor = bottomNavData?.activeColor?.let { parseHexColor(it) }
 
     Log.d(TAG, "🎨 Rendering bottom nav with ${items.size} items")
 
@@ -71,6 +75,14 @@ fun NativeBottomNavigation(
                     }
                 },
                 selected = item.active == true,
+                colors = if (activeColor != null) {
+                    NavigationBarItemDefaults.colors(
+                        selectedIconColor = activeColor,
+                        selectedTextColor = activeColor
+                    )
+                } else {
+                    NavigationBarItemDefaults.colors()
+                },
                 onClick = {
                     Log.d(TAG, "🖱️ Nav item clicked: ${item.label} -> ${item.url}")
                     // Optimistically update active state to prevent flash
@@ -97,5 +109,25 @@ private fun parseBadgeColor(colorString: String?): Color {
         "pink" -> Color(0xFFEC4899)
         "orange" -> Color(0xFFF97316)
         else -> Color(0xFFEF4444)  // Default to red
+    }
+}
+
+/**
+ * Parse hex color string to Compose Color
+ * Supports both 6-digit (#RRGGBB) and 8-digit (#RRGGBBAA or #AARRGGBB) hex formats
+ * Returns null if parsing fails
+ */
+private fun parseHexColor(hexString: String): Color? {
+    return try {
+        val sanitized = hexString.trimStart('#')
+        val colorInt = when (sanitized.length) {
+            6 -> AndroidColor.parseColor("#$sanitized")
+            8 -> AndroidColor.parseColor("#$sanitized")
+            else -> return null
+        }
+        Color(colorInt)
+    } catch (e: Exception) {
+        Log.w(TAG, "Failed to parse hex color: $hexString")
+        null
     }
 }

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/NativeUIModels.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/NativeUIModels.kt
@@ -24,6 +24,8 @@ data class BottomNavData(
     val dark: Boolean? = null,
     @SerializedName("label_visibility")
     val labelVisibility: String? = "labeled",
+    @SerializedName("active_color")
+    val activeColor: String? = null,
     val children: List<BottomNavItemComponent>? = null
 )
 

--- a/resources/xcode/NativePHP/NativeUI/NativeBottomNav.swift
+++ b/resources/xcode/NativePHP/NativeUI/NativeBottomNav.swift
@@ -4,6 +4,7 @@ import UIKit
 struct NativeUITabBar: UIViewRepresentable {
     let items: [BottomNavItemComponent]
     let labelVisibility: String?
+    let activeColor: String?
     @Binding var selectedTab: String
     let onTabSelected: (String) -> Void
 
@@ -24,6 +25,11 @@ struct NativeUITabBar: UIViewRepresentable {
         tabBar.standardAppearance = appearance
         if #available(iOS 15.0, *) {
             tabBar.scrollEdgeAppearance = appearance
+        }
+
+        // Apply custom active color (tint color for selected items)
+        if let activeColorHex = activeColor, let color = UIColor(hex: activeColorHex) {
+            tabBar.tintColor = color
         }
 
         // Don't add extra margins from safe area - we handle positioning via SwiftUI
@@ -86,6 +92,11 @@ struct NativeUITabBar: UIViewRepresentable {
     }
 
     func updateUIView(_ tabBar: UITabBar, context: Context) {
+        // Apply custom active color (ensure it persists across updates)
+        if let activeColorHex = activeColor, let color = UIColor(hex: activeColorHex) {
+            tabBar.tintColor = color
+        }
+
         // Check if items have changed (count or content)
         let currentItemCount = tabBar.items?.count ?? 0
         let itemsChanged = currentItemCount != items.count
@@ -266,6 +277,7 @@ struct NativeBottomNavigation: View {
                 NativeUITabBar(
                     items: items,
                     labelVisibility: bottomNavData.labelVisibility,
+                    activeColor: bottomNavData.activeColor,
                     selectedTab: $selectedTab,
                     onTabSelected: { tabId in
                         loadTabURL(tabId: tabId)
@@ -286,6 +298,7 @@ struct NativeBottomNavigation: View {
                 NativeUITabBar(
                     items: items,
                     labelVisibility: bottomNavData.labelVisibility,
+                    activeColor: bottomNavData.activeColor,
                     selectedTab: $selectedTab,
                     onTabSelected: { tabId in
                         loadTabURL(tabId: tabId)

--- a/resources/xcode/NativePHP/NativeUI/NativeUIModels.swift
+++ b/resources/xcode/NativePHP/NativeUI/NativeUIModels.swift
@@ -47,11 +47,13 @@ enum ComponentData: Codable {
 struct BottomNavData: Codable, Equatable {
     let dark: Bool?
     let labelVisibility: String?
+    let activeColor: String?
     let children: [BottomNavItemComponent]?
 
     enum CodingKeys: String, CodingKey {
         case dark
         case labelVisibility = "label_visibility"
+        case activeColor = "active_color"
         case children
     }
 }

--- a/src/Edge/Components/Navigation/BottomNav.php
+++ b/src/Edge/Components/Navigation/BottomNav.php
@@ -12,7 +12,8 @@ class BottomNav extends EdgeComponent
 
     public function __construct(
         public ?bool $dark = null,
-        public string $labelVisibility = 'labeled'
+        public string $labelVisibility = 'labeled',
+        public ?string $activeColor = null,
     ) {}
 
     protected function toNativeProps(): array
@@ -20,6 +21,7 @@ class BottomNav extends EdgeComponent
         return [
             'dark' => $this->dark,
             'label_visibility' => $this->labelVisibility,
+            'active_color' => $this->activeColor,
             'id' => 'bottom_nav',
         ];
     }


### PR DESCRIPTION
This PR creates the capability of setting a custom color for the active tab bar item by adding an `active-color` attribute to the `<native:bottom-nav>` component.

Usage
```html
<native:bottom-nav label-visibility="labeled" active-color="#FF00F0">
  <native:bottom-nav-item
    id="home"
    icon="home"
    label="Home"
    url="/home"
    :active="true"
  />
  <native:bottom-nav-item
    id="profile"
    icon="person"
    label="Profile"
    url="/profile"
    badge="3"
  />
</native:bottom-nav>
```

Through my manual testing this has been confirmed to work on Android and iOS.

If merging is planned I can also update documentation to reflect the new option as well.