### PR TITLE
Allow plugin:register to discover and register multiple plugins

### DIFF
--- a/src/Commands/PluginListCommand.php
+++ b/src/Commands/PluginListCommand.php
@@ -68,7 +68,7 @@ class PluginListCommand extends Command
                 }
                 $this->newLine();
                 $this->components->info('After publishing the provider, register plugins with:');
-                $this->line('  php artisan native:plugin:register vendor/plugin-name');
+                $this->line('  php artisan native:plugin:register');
             }
 
             return;
@@ -109,21 +109,19 @@ class PluginListCommand extends Command
         }
 
         // Show unregistered plugins
-        if ($unregistered->isNotEmpty() && ($showAll || $this->registry->hasPluginsProvider())) {
+        if ($unregistered->isNotEmpty()) {
             $this->newLine();
             $this->components->warn('Unregistered Plugins (not included in builds):');
 
             foreach ($unregistered as $plugin) {
-                $provider = $plugin->getServiceProvider();
-                $this->line("  - {$plugin->name} (v{$plugin->version})");
-                if ($provider) {
-                    $this->line("    Provider: {$provider}");
-                }
+                $description = $plugin->description ? " - {$plugin->description}" : '';
+                $functions = count($plugin->getBridgeFunctions());
+                $this->line("  - {$plugin->name} (v{$plugin->version}){$description} [{$functions} bridge function(s)]");
             }
 
             $this->newLine();
-            $this->components->info('To register a plugin, run:');
-            $this->line('  php artisan native:plugin:register vendor/plugin-name');
+            $this->components->info('To register plugins, run:');
+            $this->line('  php artisan native:plugin:register');
         }
     }
 


### PR DESCRIPTION
## Summary
- `native:plugin:register` without arguments now discovers unregistered `nativephp-plugin` composer packages and presents a multiselect prompt to register multiple at once
- `native:plugin:list` now always shows unregistered plugins (previously gated behind `--all` flag or provider check), with description and bridge function count
- Hint text updated to point to `php artisan native:plugin:register` (no package name needed)

## Test plan
- [ ] Run `native:plugin:register` without arguments — should show multiselect of unregistered plugins
- [ ] Run `native:plugin:register vendor/plugin-name` — existing single-plugin flow still works
- [ ] Run `native:plugin:list` — unregistered plugins appear automatically with description and function count
- [ ] Run `native:plugin:list --json` — JSON output still includes unregistered array
- [ ] Verify selecting multiple plugins in the multiselect registers all of them into NativeServiceProvider