### PR TITLE
Remove unused react/http and react/socket dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,6 @@
         "illuminate/support": "^10.0|^11.0|^12.0",
         "laravel/prompts": "^0.1.1|^0.2|^0.3",
         "react/datagram": "^1.10",
-        "react/http": "^1.9",
-        "react/socket": "^1.15",
         "spatie/laravel-package-tools": "^1.14.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
- Removes `react/http` and `react/socket` from composer.json — neither is imported anywhere in the codebase
- Also drops transitive deps `react/stream` and `fig/http-message-util`
- Only `react/event-loop` and `react/datagram` are actually used (by `FileWatcher` and `MdnsAdvertiser`)

## Test plan
- [x] `composer install` succeeds
- [x] Existing tests pass