### PR TITLE
iOS build now respects cleanup_exclude_files config

### DIFF
--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -149,7 +149,7 @@ class BuildIosAppCommand extends Command
         $source = base_path();
 
         $excludedDirs = array_merge(
-            config('nativephp.cleanup_exclude_files', []),
+            config('nativephp.cleanup_exclude_files') ?? [],
             [
                 'vendor/nativephp/mobile/resources',
                 'vendor/nativephp/mobile/vendor',

--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -5,7 +5,6 @@ namespace Native\Mobile\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
-use Illuminate\Support\Str;
 use Native\Mobile\Plugins\Compilers\IOSPluginCompiler;
 use Native\Mobile\Plugins\PluginHookRunner;
 use Native\Mobile\Plugins\PluginRegistry;
@@ -15,13 +14,14 @@ use Native\Mobile\Traits\CleansEnvFile;
 use Native\Mobile\Traits\DisplaysMarketingBanners;
 use Native\Mobile\Traits\InstallsAppIcon;
 use Native\Mobile\Traits\InstallsSplashScreen;
+use Native\Mobile\Traits\PlatformFileOperations;
 use Native\Mobile\Traits\ValidatesAppConfig;
 
 use function Laravel\Prompts\error;
 
 class BuildIosAppCommand extends Command
 {
-    use ChecksLatestBuildNumber, CleansEnvFile, DisplaysMarketingBanners, InstallsAppIcon, InstallsSplashScreen, ValidatesAppConfig;
+    use ChecksLatestBuildNumber, CleansEnvFile, DisplaysMarketingBanners, InstallsAppIcon, InstallsSplashScreen, PlatformFileOperations, ValidatesAppConfig;
 
     private bool $verbose;
 
@@ -144,58 +144,29 @@ class BuildIosAppCommand extends Command
     {
         $destination = $this->appPath;
 
-        // Make sure we clear out any old version
         shell_exec("rm -rf {$destination}/*");
 
-        $source = rtrim(str_replace('\\', '/', base_path()), '/').'/';
+        $source = base_path();
 
-        $visitedRealPaths = [];
-        $files = [];
-
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator(
-                $source,
-                \RecursiveDirectoryIterator::SKIP_DOTS | \FilesystemIterator::FOLLOW_SYMLINKS
-            ),
-            \RecursiveIteratorIterator::LEAVES_ONLY
+        $excludedDirs = array_merge(
+            config('nativephp.cleanup_exclude_files', []),
+            [
+                'vendor/nativephp/mobile/resources',
+                'vendor/nativephp/mobile/vendor',
+                'vendor/',
+                'node_modules/',
+                'nativephp/',
+                'output/',
+                'build/',
+                'dist/',
+                'artifacts/',
+                '.git/',
+                'storage/logs/',
+                'storage/framework/cache/',
+            ]
         );
 
-        foreach ($iterator as $file) {
-            $realPath = $file->getRealPath();
-
-            // Skip if we've already visited this real path (prevents infinite loops from circular symlinks)
-            if ($realPath === false || isset($visitedRealPaths[$realPath])) {
-                continue;
-            }
-
-            $visitedRealPaths[$realPath] = true;
-            $files[] = $file;
-        }
-
-        foreach ($files as $file) {
-            // Where the *link* lives (keeps relative paths correct)
-            $logicalPath = str_replace('\\', '/', $file->getPathname());
-            // Where the link **points** (or the same file if not a link)
-            $realPath = str_replace('\\', '/', $file->getRealPath());
-
-            $relativePath = ltrim(substr($logicalPath, strlen($source)), '/');
-
-            if (Str::startsWith($relativePath, 'vendor/nativephp/mobile/resources') ||
-                Str::startsWith($relativePath, 'vendor/nativephp/mobile/vendor') ||
-                Str::startsWith($relativePath, 'nativephp') ||
-                Str::startsWith($relativePath, 'output/') ||
-                Str::startsWith($relativePath, 'build/') ||
-                Str::startsWith($relativePath, 'dist/') ||
-                Str::startsWith($relativePath, 'artifacts/') ||
-                Str::startsWith($relativePath, '.git/') ||
-                Str::startsWith($relativePath, 'storage/logs/') ||
-                Str::startsWith($relativePath, 'storage/framework/cache/')) {
-                continue;
-            }
-
-            @File::makeDirectory(dirname($destination.$relativePath), recursive: true, force: true);
-            @File::copy($realPath, $destination.$relativePath);
-        }
+        $this->platformOptimizedCopy($source, $destination, $excludedDirs);
     }
 
     private function updateAppVersion(): void
@@ -794,7 +765,6 @@ class BuildIosAppCommand extends Command
 
     private function removeUnnecessaryFiles(): void
     {
-
         $directoriesToRemove = [
             '.git',
             '.github',

--- a/tests/Feature/IosBuildCopyTest.php
+++ b/tests/Feature/IosBuildCopyTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\File;
+use Native\Mobile\Commands\BuildIosAppCommand;
+use ReflectionClass;
+use Tests\TestCase;
+
+class IosBuildCopyTest extends TestCase
+{
+    protected string $testProjectPath;
+
+    protected string $appPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testProjectPath = sys_get_temp_dir().'/nativephp_ios_copy_test_'.uniqid();
+        File::makeDirectory($this->testProjectPath, 0755, true);
+
+        $this->appPath = $this->testProjectPath.'/nativephp/ios/laravel/';
+        File::makeDirectory($this->appPath, 0755, true);
+
+        app()->setBasePath($this->testProjectPath);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->testProjectPath);
+        parent::tearDown();
+    }
+
+    public function test_copy_respects_cleanup_exclude_files_config(): void
+    {
+        config(['nativephp.cleanup_exclude_files' => ['custom-excluded/']]);
+
+        $source = $this->testProjectPath.'/source/';
+        File::makeDirectory($source.'custom-excluded', 0755, true);
+        File::put($source.'custom-excluded/file.txt', 'should not be copied');
+        File::makeDirectory($source.'app/Models', 0755, true);
+        File::put($source.'app/Models/User.php', '<?php class User {}');
+        File::makeDirectory($source.'vendor', 0755, true);
+        File::put($source.'vendor/autoload.php', '<?php');
+
+        app()->setBasePath($source);
+
+        $command = $this->app->make(BuildIosAppCommand::class);
+        $reflection = new ReflectionClass($command);
+
+        $appPathProp = $reflection->getProperty('appPath');
+        $appPathProp->setValue($command, $this->appPath);
+
+        $method = $reflection->getMethod('copyLaravelAppIntoIosApp');
+        $method->invoke($command);
+
+        $this->assertDirectoryDoesNotExist(
+            $this->appPath.'custom-excluded',
+            'User-configured excluded directory should not be copied'
+        );
+
+        $this->assertDirectoryExists(
+            $this->appPath.'app/Models',
+            'Non-excluded directory should be copied'
+        );
+
+        $this->assertDirectoryDoesNotExist(
+            $this->appPath.'vendor',
+            'Default excluded directory should not be copied'
+        );
+    }
+
+    public function test_copy_handles_empty_cleanup_exclude_files_config(): void
+    {
+        config(['nativephp.cleanup_exclude_files' => []]);
+
+        $source = $this->testProjectPath.'/source/';
+        File::makeDirectory($source.'node_modules', 0755, true);
+        File::put($source.'node_modules/package.json', '{}');
+        File::makeDirectory($source.'app', 0755, true);
+        File::put($source.'app/test.php', '<?php');
+
+        app()->setBasePath($source);
+
+        $command = $this->app->make(BuildIosAppCommand::class);
+        $reflection = new ReflectionClass($command);
+
+        $appPathProp = $reflection->getProperty('appPath');
+        $appPathProp->setValue($command, $this->appPath);
+
+        $method = $reflection->getMethod('copyLaravelAppIntoIosApp');
+        $method->invoke($command);
+
+        $this->assertDirectoryDoesNotExist($this->appPath.'node_modules');
+        $this->assertDirectoryExists($this->appPath.'app');
+    }
+
+    public function test_copy_handles_null_cleanup_exclude_files_config(): void
+    {
+        config(['nativephp.cleanup_exclude_files' => null]);
+
+        $source = $this->testProjectPath.'/source/';
+        File::makeDirectory($source.'.git', 0755, true);
+        File::put($source.'.git/config', '[core]');
+        File::makeDirectory($source.'storage', 0755, true);
+        File::put($source.'storage/test.txt', 'test');
+
+        app()->setBasePath($source);
+
+        $command = $this->app->make(BuildIosAppCommand::class);
+        $reflection = new ReflectionClass($command);
+
+        $appPathProp = $reflection->getProperty('appPath');
+        $appPathProp->setValue($command, $this->appPath);
+
+        $method = $reflection->getMethod('copyLaravelAppIntoIosApp');
+        $method->invoke($command);
+
+        $this->assertDirectoryDoesNotExist($this->appPath.'.git');
+        $this->assertDirectoryExists($this->appPath.'storage');
+    }
+
+    public function test_copy_merges_user_config_with_defaults(): void
+    {
+        config(['nativephp.cleanup_exclude_files' => [
+            'custom-dir/',
+            'another-custom/',
+        ]]);
+
+        $source = $this->testProjectPath.'/source/';
+        File::makeDirectory($source.'custom-dir', 0755, true);
+        File::makeDirectory($source.'another-custom', 0755, true);
+        File::makeDirectory($source.'vendor', 0755, true);
+        File::makeDirectory($source.'node_modules', 0755, true);
+        File::makeDirectory($source.'app', 0755, true);
+
+        app()->setBasePath($source);
+
+        $command = $this->app->make(BuildIosAppCommand::class);
+        $reflection = new ReflectionClass($command);
+
+        $appPathProp = $reflection->getProperty('appPath');
+        $appPathProp->setValue($command, $this->appPath);
+
+        $method = $reflection->getMethod('copyLaravelAppIntoIosApp');
+        $method->invoke($command);
+
+        $this->assertDirectoryDoesNotExist($this->appPath.'custom-dir');
+        $this->assertDirectoryDoesNotExist($this->appPath.'another-custom');
+        $this->assertDirectoryDoesNotExist($this->appPath.'vendor');
+        $this->assertDirectoryDoesNotExist($this->appPath.'node_modules');
+        $this->assertDirectoryExists($this->appPath.'app');
+    }
+}


### PR DESCRIPTION
BuildIosAppCommand::copyLaravelAppIntoIosApp() had hardcoded exclusions that ignored the user config in nativephp.cleanup_exclude_files.

Replace with the shared PlatformFileOperations::platformOptimizedCopy() already in use on the android side.