### PR TITLE
Bypass WebView fetch for native event dispatch

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebViewManager.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebViewManager.kt
@@ -22,7 +22,7 @@ import com.nativephp.mobile.security.LaravelSecurity
 class WebViewManager(
     private val context: Context,
     private val webView: WebView,
-    private val phpBridge: PHPBridge
+    internal val phpBridge: PHPBridge
 ) {
     private val TAG = "PHPMonitor"
     private var fullscreenView: View? = null

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/utils/NativeActionCoordinator.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/utils/NativeActionCoordinator.kt
@@ -5,6 +5,8 @@ import android.webkit.WebView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import com.nativephp.mobile.network.PHPRequest
+import com.nativephp.mobile.network.WebViewManager
 import org.json.JSONObject
 
 interface WebViewProvider {
@@ -28,7 +30,7 @@ class NativeActionCoordinator : Fragment() {
     }
 
     fun launchAlert(title: String, message: String, buttons: Array<String>, id: String?, eventClass: String?) {
-        Log.d("NativeActionCoordinator", "🚨 launchAlert called with title: '$title', message: '$message', buttons: ${buttons.contentToString()}, id: '$id', eventClass: '$eventClass'")
+        Log.d("NativeActionCoordinator", "launchAlert called with title: '$title', message: '$message', buttons: ${buttons.contentToString()}, id: '$id', eventClass: '$eventClass'")
 
         val context = requireContext()
 
@@ -68,32 +70,39 @@ class NativeActionCoordinator : Fragment() {
                     if (window.Livewire && typeof window.Livewire.dispatch === 'function') {
                         window.Livewire.dispatch("native:$eventForJs", payload);
                     }
-
-                    fetch('/_native/api/events', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                            'X-Requested-With': 'XMLHttpRequest'
-                        },
-                        body: JSON.stringify({
-                            event: "$eventForJs",
-                            payload: payload
-                        })
-                    }).then(response => response.json())
-                      .then(data => {
-                          if (data.message && data.message.includes("Unknown named parameter")) {
-                              console.log("API Event Dispatch: Parameter issue detected");
-                          } else {
-                              console.log("API Event Dispatch Success");
-                          }
-                      })
-                      .catch(error => console.error("API Event Dispatch Error:", error.message));
                 })();
             """.trimIndent()
 
-            Log.d("NativeActionCoordinator", "📢 Dispatching JS event: $event")
+            Log.d("NativeActionCoordinator", "Dispatching JS event: $event")
 
             (activity as? WebViewProvider)?.getWebView()?.evaluateJavascript(js, null)
+
+            Thread {
+                try {
+                    val phpBridge = WebViewManager.shared?.phpBridge
+                    if (phpBridge != null) {
+                        val requestBody = JSONObject().apply {
+                            put("event", event)
+                            put("payload", JSONObject(payloadJson))
+                        }.toString()
+                        val request = PHPRequest(
+                            url = "/_native/api/events",
+                            method = "POST",
+                            body = requestBody,
+                            headers = mapOf(
+                                "Content-Type" to "application/json",
+                                "X-Requested-With" to "XMLHttpRequest"
+                            )
+                        )
+                        phpBridge.handleLaravelRequest(request)
+                        Log.d("NativeActionCoordinator", "Direct PHP dispatch success for: $event")
+                    } else {
+                        Log.w("NativeActionCoordinator", "PHPBridge not available, skipping direct dispatch for: $event")
+                    }
+                } catch (e: Exception) {
+                    Log.e("NativeActionCoordinator", "Direct PHP dispatch failed for: $event - ${e.message}")
+                }
+            }.start()
         }
 
 

--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -259,7 +259,6 @@ struct WebView: UIViewRepresentable {
                 return literal
             }()
 
-            // 1. Inject JS event into the current web page
             if let jsonData = try? JSONSerialization.data(withJSONObject: payload, options: []),
                let jsonString = String(data: jsonData, encoding: .utf8) {
 
@@ -275,20 +274,6 @@ struct WebView: UIViewRepresentable {
                         }
                     );
                     document.dispatchEvent(event);
-
-                    fetch('/_native/api/events', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                            'X-Requested-With': 'XMLHttpRequest'
-                        },
-                        body: JSON.stringify({
-                            event: \(event),
-                            payload: \(jsonString),
-                        })
-                    }).then(response => response.json())
-                      .then(data => console.log("API Event Dispatch Success:", JSON.stringify(data, null, 2)))
-                      .catch(error => console.error("API Event Dispatch Error:", error));
                 })();
                 """
 
@@ -300,16 +285,21 @@ struct WebView: UIViewRepresentable {
                     }
                 }
 
-                // FUTURE: Send a request to Laravel backend directly
-//                let request = RequestData(
-//                    method: "POST",
-//                    uri: "php://127.0.0.1/_native/api/events",
-//                    data: jsonString,
-//                    headers: [
-//                        "Content-Type": "application/json"
-//                    ])
-//
-//                _ = NativePHPApp.laravel(request: request)
+                let requestBody = """
+                {"event":\(event),"payload":\(jsonString)}
+                """
+
+                let request = RequestData(
+                    method: "POST",
+                    uri: "php://127.0.0.1/_native/api/events",
+                    data: requestBody,
+                    query: "",
+                    headers: [
+                        "Content-Type": "application/json",
+                        "X-Requested-With": "XMLHttpRequest"
+                    ])
+
+                _ = NativePHPApp.laravel(request: request)
 
             }
         }


### PR DESCRIPTION
This PR replaces the `fetch()` call with a direct platform bridge call on both Android and iOS, so native events bypass the WebView transport entirely.

## Changes

**Android** (`NativeActionCoordinator.kt`, `WebViewManager.kt`):
- Removed `fetch()` from injected JS
- Added direct `phpBridge.handleLaravelRequest()` call on a background thread
- Changed `phpBridge` visibility from `private` to `internal` in `WebViewManager`

**iOS** (`ContentView.swift`):
- Removed `fetch()` from injected JS in `notifyLaravel()`
- Added direct `NativePHPApp.laravel(request:)` call with proper `RequestData`
