### PR TITLE
Compile plugins during native:package builds

### DIFF
--- a/src/Commands/PackageCommand.php
+++ b/src/Commands/PackageCommand.php
@@ -157,6 +157,10 @@ class PackageCommand extends Command
             $this->prepareAndroidBuild();
         }
 
+        if (! $this->compileAndroidPlugins()) {
+            return;
+        }
+
         // Build with signing
         $gradleTask = $this->buildType === 'bundle' ? 'bundleRelease' : 'assembleRelease';
 


### PR DESCRIPTION
## Summary
- `PackageCommand::buildAndroid()` was missing the `compileAndroidPlugins()` call that `RunCommand` uses via `runAndroid()`
- This meant plugin bridge functions (like SecureStorage) were never registered in Bifrost/release builds, causing `nativephp_call()` to return null for all plugin methods
- Fixes: Secure Storage Plugin (and all other plugins) not working in Bifrost builds while working fine with `native:run`

## Test plan
- [ ] Build an app with plugins installed using `native:package android`
- [ ] Verify `PluginBridgeFunctionRegistration.kt` is generated with plugin registrations
- [ ] Verify plugin bridge functions (e.g. SecureStorage) work in the release/bundle build
- [ ] Verify `native:run` still works as before