### PR TITLE
Simplify unzip to stream directly to disk and update plugin accessors

### DIFF
--- a/src/Commands/PluginMakeHookCommand.php
+++ b/src/Commands/PluginMakeHookCommand.php
@@ -179,8 +179,8 @@ class PluginMakeHookCommand extends Command
         $options = [];
         foreach ($plugins as $plugin) {
             $path = $plugin->path;
-            $name = $plugin->manifest->name;
-            $namespace = $plugin->manifest->namespace;
+            $name = $plugin->name;
+            $namespace = $plugin->getNamespace();
 
             // Make path relative for display
             $relativePath = str_replace(base_path().'/', '', $path);


### PR DESCRIPTION
Replace coroutine-based parallel unzip with direct-to-disk streaming to reduce memory overhead. Update PluginMakeHookCommand to use new plugin accessor methods instead of accessing manifest properties directly.