### PR TITLE
Add GitHub star prompt to install command

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -12,6 +12,7 @@ use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\note;
 use function Laravel\Prompts\outro;
+use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
 
@@ -134,6 +135,16 @@ class InstallCommand extends Command
         }
 
         outro('NativePHP for Mobile installed successfully!');
+
+        if (confirm('Would you mind starring us on GitHub? It really helps!', default: false)) {
+            $url = 'https://github.com/NativePHP/mobile-air';
+
+            match (PHP_OS_FAMILY) {
+                'Darwin' => exec("open {$url}"),
+                'Windows' => exec("start {$url}"),
+                default => exec("xdg-open {$url}"),
+            };
+        }
 
         $this->showProBanner();
     }


### PR DESCRIPTION
## Summary
- Adds a `confirm()` prompt after successful installation asking users if they'd like to star the repo on GitHub
- Opens `https://github.com/NativePHP/mobile-air` in the default browser if they say yes
- Defaults to "no" so it's non-intrusive
- Uses platform-appropriate browser open commands (open/start/xdg-open)

## Test plan
- [ ] Run `php artisan native:install` and verify the star prompt appears after "installed successfully"
- [ ] Confirm selecting "yes" opens the GitHub repo in the browser
- [ ] Confirm selecting "no" skips and continues to the pro banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)