### PR TITLE
iOS persistent runtime, scheduler, and queue worker

### DIFF
--- a/bootstrap/ios/persistent.php
+++ b/bootstrap/ios/persistent.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Persistent PHP Runtime Bootstrap — iOS
+ *
+ * Executed ONCE when the persistent interpreter boots.
+ * Loads Composer autoloader, boots Laravel, creates the kernel,
+ * and stores references for Runtime::dispatch() to reuse.
+ *
+ * After this script runs, the PHP interpreter stays alive.
+ * Subsequent requests are dispatched via Runtime::dispatch()
+ * through zend_eval_string() — no more init/shutdown per request.
+ */
+
+use Native\Mobile\Runtime;
+
+$_timing = ['start' => microtime(true)];
+
+// Capture OPcache status
+$_opcacheInfo = 'unknown';
+if (function_exists('opcache_get_status')) {
+    $opcacheStatus = @opcache_get_status(false);
+    if ($opcacheStatus) {
+        $_opcacheInfo = 'enabled=' . ($opcacheStatus['opcache_enabled'] ? 'YES' : 'NO');
+        $_opcacheInfo .= ',cached=' . ($opcacheStatus['opcache_statistics']['num_cached_scripts'] ?? 0);
+    } else {
+        $_opcacheInfo = 'disabled';
+    }
+} else {
+    $_opcacheInfo = 'NOT_AVAILABLE';
+}
+
+define('LARAVEL_START', microtime(true));
+
+// 1. Autoload (once)
+require $_SERVER['COMPOSER_AUTOLOADER_PATH'];
+$_timing['autoload'] = microtime(true);
+
+// 2. Bootstrap Laravel application (once)
+$app = require_once $_SERVER['LARAVEL_BOOTSTRAP_PATH'] . '/app.php';
+$_timing['bootstrap'] = microtime(true);
+
+// 3. Boot the persistent runtime — stores kernel + app for reuse
+Runtime::boot($app);
+$_timing['runtime_boot'] = microtime(true);
+
+// Calculate timing
+$autoloadMs = round(($_timing['autoload'] - $_timing['start']) * 1000, 1);
+$bootstrapMs = round(($_timing['bootstrap'] - $_timing['autoload']) * 1000, 1);
+$runtimeBootMs = round(($_timing['runtime_boot'] - $_timing['bootstrap']) * 1000, 1);
+$totalMs = round(($_timing['runtime_boot'] - $_timing['start']) * 1000, 1);
+
+error_log("PerfTiming: persistent.php opcache={$_opcacheInfo} autoload={$autoloadMs}ms bootstrap={$bootstrapMs}ms runtime_boot={$runtimeBootMs}ms TOTAL={$totalMs}ms");
+
+// The interpreter stays alive from here.
+// All subsequent work happens via zend_eval_string() calling Runtime::dispatch().

--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -129,9 +129,10 @@ return [
         'storage/framework/cache',
         'storage/framework/testing',
         'storage/logs/laravel.log',
+        'storage/nativephp/*',
     ],
 
-    /*
+   /*
     |--------------------------------------------------------------------------
     | Runtime Configuration
     |--------------------------------------------------------------------------

--- a/resources/xcode/Include/Bridge/PHP.c
+++ b/resources/xcode/Include/Bridge/PHP.c
@@ -1,18 +1,115 @@
 #include "php_embed.h"
 #include "PHP.h"
+#include <pthread.h>
+#include <pthread/qos.h>
+#include <signal.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <zend_exceptions.h>
 
 static phpOutputCallback swiftOutputCallback = NULL;
 
-size_t capture_php_output(const char *str, size_t str_length) {
-    // Forward to Swift callback if available
-    if (swiftOutputCallback) {
-        // We need a null-terminated C-string for Swift
-        char *buffer = malloc(str_length + 1);
-        memcpy(buffer, str, str_length);
-        buffer[str_length] = '\0';
-        swiftOutputCallback(buffer);
-        free(buffer);
+// ── Thread-local output capture ─────────────────────
+// Each PHP thread (persistent, worker) gets its own output buffer via
+// pthread_key_t, preventing cross-thread corruption.
+
+#define BUFFER_CHUNK_SIZE (256 * 1024)
+#define MAX_BUFFER_SIZE   (16 * 1024 * 1024)
+
+typedef struct {
+    char  *output;
+    size_t length;
+    size_t capacity;
+} php_output_buffer_t;
+
+static pthread_key_t  g_output_key;
+static pthread_once_t g_output_key_once = PTHREAD_ONCE_INIT;
+
+static void destroy_output_buffer(void *ptr) {
+    if (!ptr) return;
+    php_output_buffer_t *buf = (php_output_buffer_t *)ptr;
+    free(buf->output);
+    free(buf);
+}
+
+static void create_output_key(void) {
+    pthread_key_create(&g_output_key, destroy_output_buffer);
+}
+
+static php_output_buffer_t *get_thread_output_buffer(void) {
+    pthread_once(&g_output_key_once, create_output_key);
+    php_output_buffer_t *buf = (php_output_buffer_t *)pthread_getspecific(g_output_key);
+    if (!buf) {
+        buf = (php_output_buffer_t *)calloc(1, sizeof(php_output_buffer_t));
+        if (buf) {
+            buf->capacity = BUFFER_CHUNK_SIZE;
+            buf->output = (char *)malloc(buf->capacity);
+            if (buf->output) buf->output[0] = '\0';
+            pthread_setspecific(g_output_key, buf);
+        }
     }
+    return buf;
+}
+
+static void clear_output_buffer(void) {
+    php_output_buffer_t *buf = get_thread_output_buffer();
+    if (!buf) return;
+    free(buf->output);
+    buf->capacity = BUFFER_CHUNK_SIZE;
+    buf->length   = 0;
+    buf->output   = (char *)malloc(buf->capacity);
+    if (buf->output) buf->output[0] = '\0';
+}
+
+static char *get_collected_output(void) {
+    php_output_buffer_t *buf = get_thread_output_buffer();
+    return buf ? buf->output : NULL;
+}
+
+static void append_output(const char *str, size_t len) {
+    php_output_buffer_t *buf = get_thread_output_buffer();
+    if (!buf || !buf->output) {
+        clear_output_buffer();
+        buf = get_thread_output_buffer();
+        if (!buf || !buf->output) return;
+    }
+
+    if (buf->length + len + 1 > buf->capacity) {
+        size_t needed = buf->capacity;
+        while (needed < buf->length + len + 1) {
+            needed += BUFFER_CHUNK_SIZE;
+        }
+        if (needed > MAX_BUFFER_SIZE) return;
+
+        char *new_buf = (char *)realloc(buf->output, needed);
+        if (!new_buf) return;
+        buf->output   = new_buf;
+        buf->capacity = needed;
+    }
+
+    memcpy(buf->output + buf->length, str, len);
+    buf->length += len;
+    buf->output[buf->length] = '\0';
+}
+
+size_t capture_php_output(const char *str, size_t str_length) {
+    if (str_length == 0) return 0;
+
+    // Forward to Swift callback (legacy per-request mode)
+    if (swiftOutputCallback) {
+        char *buffer = malloc(str_length + 1);
+        if (buffer) {
+            memcpy(buffer, str, str_length);
+            buffer[str_length] = '\0';
+            swiftOutputCallback(buffer);
+            free(buffer);
+        }
+    }
+
+    // Accumulate in thread-local buffer
+    append_output(str, str_length);
+
     return str_length;
 }
 
@@ -24,20 +121,932 @@ void override_embed_module_output(phpOutputCallback callback) {
 void initialize_php_with_request(const char *post_data,
                                  const char *method,
                                  const char *uri) {
-
-    // Initialize $_POST
     if (strcmp(method, "POST") == 0) {
         size_t post_data_length = strlen(post_data);
-        
+
         php_stream *mem_stream = php_stream_memory_create(TEMP_STREAM_DEFAULT);
         php_stream_write(mem_stream, post_data, post_data_length);
 
-        // Populate the php://input stream
-        SG(request_info).request_body    = mem_stream;
-        SG(request_info).request_method  = "POST";
-        
-        // TODO: Pass this in from outside
-        SG(request_info).content_type    = "application/x-www-form-urlencoded";
-        SG(request_info).content_length  = post_data_length;
+        SG(request_info).request_body   = mem_stream;
+        SG(request_info).request_method = "POST";
+        SG(request_info).content_type   = "application/x-www-form-urlencoded";
+        SG(request_info).content_length = post_data_length;
     }
+}
+
+// ── Header handler ──────────────────────────────────
+
+static int ios_header_handler(sapi_header_struct *sapi_header,
+                              sapi_header_op_enum op,
+                              sapi_headers_struct *sapi_headers) {
+    if (op == SAPI_HEADER_DELETE_ALL || op == SAPI_HEADER_DELETE) {
+        return 0;
+    }
+    // Accumulate headers into output buffer so Swift can parse them
+    if (sapi_header && sapi_header->header) {
+        // Headers are emitted by the PHP dispatch code itself — no action needed here
+    }
+    return 0;
+}
+
+// ── Dedicated PHP Worker Thread ─────────────────────
+// All PHP work runs on a single dedicated pthread, mirroring Android's
+// phpExecutor. This guarantees TSRM thread-local storage is always valid
+// since php_embed_init() and all subsequent PHP calls share the same thread.
+//
+// Uses dispatch_semaphore_t for synchronization (simpler and more reliable
+// than pthread condvars on Apple platforms).
+
+#include <dispatch/dispatch.h>
+
+// Dispatch parameters
+typedef struct {
+    const char *method;
+    const char *uri;
+    const char *postData;
+    const char *scriptPath;
+    const char *cookieHeader;
+    const char *contentType;
+} dispatch_params_t;
+
+// Work item types
+typedef enum {
+    PHP_WORK_DISPATCH,
+    PHP_WORK_ARTISAN,
+    PHP_WORK_SHUTDOWN
+} php_work_type_t;
+
+// Synchronization: caller posts to work_sem, worker posts to done_sem
+static dispatch_semaphore_t php_work_sem = NULL;
+static dispatch_semaphore_t php_done_sem = NULL;
+
+static php_work_type_t      php_work_type;
+static const char          *php_work_str_arg    = NULL;
+static dispatch_params_t    php_work_dispatch_params;
+static int                  php_work_int_result  = 0;
+static char                *php_work_str_result  = NULL;
+
+static int persistent_initialized = 0;
+
+// Forward declarations
+static void do_dispatch(const dispatch_params_t *params);
+static void do_artisan(const char *command);
+static void do_shutdown(void);
+
+static void setup_persistent_sapi(void) {
+    php_embed_module.ub_write       = capture_php_output;
+    php_embed_module.phpinfo_as_text = 1;
+    php_embed_module.php_ini_ignore  = 0;
+    php_embed_module.ini_entries     = "output_buffering=4096\n"
+                                       "implicit_flush=0\n"
+                                       "display_errors=1\n"
+                                       "error_reporting=E_ALL\n";
+    php_embed_module.header_handler  = ios_header_handler;
+}
+
+// ── Worker thread ───────────────────────────────────
+// Boots PHP, then loops processing work items.
+
+static void *php_worker_main(void *arg) {
+    const char *bootstrapPath = (const char *)arg;
+
+    fprintf(stderr, "PHP-WORKER: thread started tid=%p, booting PHP...\n", (void *)pthread_self());
+    fflush(stderr);
+
+    // ── Boot PHP on this thread ──
+    clear_output_buffer();
+
+    setenv("NATIVEPHP_RUNNING", "true", 1);
+    setenv("NATIVEPHP_PLATFORM", "ios", 1);
+    setenv("APP_URL", "php://127.0.0.1", 1);
+    setenv("ASSET_URL", "php://127.0.0.1/_assets/", 1);
+
+    setup_persistent_sapi();
+
+    if (php_embed_init(0, NULL) != SUCCESS) {
+        fprintf(stderr, "PHP-WORKER: php_embed_init FAILED\n");
+        fflush(stderr);
+        php_work_int_result = -1;
+        dispatch_semaphore_signal(php_done_sem);
+        return NULL;
+    }
+
+    fprintf(stderr, "PHP-WORKER: php_embed_init SUCCESS\n");
+    fflush(stderr);
+
+    sapi_module.header_handler = ios_header_handler;
+
+    zend_first_try {
+        zend_activate_modules();
+        zend_file_handle fileHandle;
+        zend_stream_init_filename(&fileHandle, bootstrapPath);
+        php_execute_script(&fileHandle);
+    } zend_end_try();
+
+    fprintf(stderr, "PHP-WORKER: bootstrap complete\n");
+    fflush(stderr);
+
+    persistent_initialized = 1;
+    php_work_int_result = 0;
+
+    // Signal boot complete
+    dispatch_semaphore_signal(php_done_sem);
+
+    // ── Work loop ──
+    while (1) {
+        dispatch_semaphore_wait(php_work_sem, DISPATCH_TIME_FOREVER);
+
+        switch (php_work_type) {
+            case PHP_WORK_DISPATCH:
+                do_dispatch(&php_work_dispatch_params);
+                break;
+            case PHP_WORK_ARTISAN:
+                do_artisan(php_work_str_arg);
+                break;
+            case PHP_WORK_SHUTDOWN:
+                do_shutdown();
+                break;
+        }
+
+        dispatch_semaphore_signal(php_done_sem);
+    }
+
+    return NULL;
+}
+
+// ── Work handlers (all run on the PHP worker thread) ──
+
+static void do_dispatch(const dispatch_params_t *params) {
+    if (!persistent_initialized) {
+        php_work_str_result = strdup("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\nPersistent runtime not initialized.");
+        return;
+    }
+
+    clear_output_buffer();
+
+    // Set env vars for this request
+    setenv("REQUEST_URI", params->uri, 1);
+    setenv("REQUEST_METHOD", params->method, 1);
+    setenv("SCRIPT_FILENAME", params->scriptPath, 1);
+    setenv("PHP_SELF", "/native.php", 1);
+    setenv("HTTP_HOST", "127.0.0.1", 1);
+    setenv("APP_URL", "php://127.0.0.1", 1);
+    setenv("ASSET_URL", "php://127.0.0.1/_assets/", 1);
+    setenv("NATIVEPHP_RUNNING", "true", 1);
+    setenv("NATIVEPHP_PLATFORM", "ios", 1);
+
+    // Query string
+    const char *query_start = strchr(params->uri, '?');
+    if (query_start && strlen(query_start + 1) > 0) {
+        setenv("QUERY_STRING", query_start + 1, 1);
+    } else {
+        unsetenv("QUERY_STRING");
+    }
+
+    // Cookie header
+    if (params->cookieHeader && strlen(params->cookieHeader) > 0) {
+        setenv("HTTP_COOKIE", params->cookieHeader, 1);
+    } else {
+        unsetenv("HTTP_COOKIE");
+    }
+
+    // Reset SAPI state — safe because we're on the PHP thread with valid TSRM
+    SG(headers_sent) = 0;
+    SG(post_read) = 0;
+    SG(read_post_bytes) = 0;
+    SG(request_info).request_method = params->method;
+    SG(request_info).request_uri = (char *)params->uri;
+    SG(request_info).proto_num = 1001;
+
+    memset(&SG(sapi_headers), 0, sizeof(sapi_headers_struct));
+    SG(sapi_headers).http_response_code = 200;
+    zend_llist_init(&SG(sapi_headers).headers, sizeof(sapi_header_struct), NULL, 0);
+
+    // POST data → php://input
+    if (params->postData && strlen(params->postData) > 0) {
+        php_stream *post_stream = php_stream_memory_create(TEMP_STREAM_DEFAULT);
+        if (post_stream) {
+            php_stream_write(post_stream, params->postData, strlen(params->postData));
+            php_stream_seek(post_stream, 0, SEEK_SET);
+
+            if (SG(request_info).request_body) {
+                php_stream_close(SG(request_info).request_body);
+            }
+            SG(request_info).request_body = post_stream;
+            SG(request_info).content_length = strlen(params->postData);
+
+            if (params->contentType && strstr(params->contentType, "json")) {
+                SG(request_info).content_type = "application/json";
+            } else {
+                SG(request_info).content_type = "application/x-www-form-urlencoded";
+            }
+        }
+    } else {
+        if (SG(request_info).request_body) {
+            php_stream_close(SG(request_info).request_body);
+            SG(request_info).request_body = NULL;
+        }
+        SG(request_info).content_length = 0;
+    }
+
+    // Build dispatch eval code — same pattern as Android
+    static char eval_code[8192];
+    snprintf(eval_code, sizeof(eval_code),
+        "try {\n"
+        "    while (ob_get_level() > 0) { ob_end_clean(); }\n"
+        "\n"
+        "    $_SERVER['REQUEST_METHOD'] = '%s';\n"
+        "    $_SERVER['REQUEST_URI'] = '%s';\n"
+        "    $_SERVER['SCRIPT_FILENAME'] = '%s';\n"
+        "    $_SERVER['PHP_SELF'] = '/native.php';\n"
+        "    $_SERVER['HTTP_HOST'] = '127.0.0.1';\n"
+        "    $_SERVER['SERVER_NAME'] = '127.0.0.1';\n"
+        "    $_SERVER['SERVER_PORT'] = '80';\n"
+        "    $_SERVER['APP_URL'] = 'php://127.0.0.1';\n"
+        "    $_SERVER['NATIVEPHP_RUNNING'] = 'true';\n"
+        "    $_SERVER['NATIVEPHP_PLATFORM'] = 'ios';\n"
+        "\n"
+        "    foreach (getenv() as $__k => $__v) {\n"
+        "        $_SERVER[$__k] = $__v;\n"
+        "    }\n"
+        "\n"
+        "    if (isset($_SERVER['HTTP_CONTENT_TYPE'])) {\n"
+        "        $_SERVER['CONTENT_TYPE'] = $_SERVER['HTTP_CONTENT_TYPE'];\n"
+        "    }\n"
+        "    if (isset($_SERVER['HTTP_CONTENT_LENGTH'])) {\n"
+        "        $_SERVER['CONTENT_LENGTH'] = $_SERVER['HTTP_CONTENT_LENGTH'];\n"
+        "    }\n"
+        "\n"
+        "    $__qpos = strpos($_SERVER['REQUEST_URI'], '?');\n"
+        "    if ($__qpos !== false) {\n"
+        "        $_SERVER['QUERY_STRING'] = substr($_SERVER['REQUEST_URI'], $__qpos + 1);\n"
+        "    } else {\n"
+        "        $_SERVER['QUERY_STRING'] = '';\n"
+        "    }\n"
+        "\n"
+        "    $_GET = [];\n"
+        "    $_POST = [];\n"
+        "    $_COOKIE = [];\n"
+        "    $_FILES = [];\n"
+        "    $_REQUEST = [];\n"
+        "\n"
+        "    if (isset($_SERVER['HTTP_COOKIE']) && $_SERVER['HTTP_COOKIE'] !== '') {\n"
+        "        foreach (explode('; ', $_SERVER['HTTP_COOKIE']) as $__pair) {\n"
+        "            $__parts = explode('=', $__pair, 2);\n"
+        "            if (count($__parts) === 2) {\n"
+        "                $_COOKIE[$__parts[0]] = urldecode($__parts[1]);\n"
+        "            }\n"
+        "        }\n"
+        "    }\n"
+        "\n"
+        "    if ($_SERVER['QUERY_STRING'] !== '') {\n"
+        "        parse_str($_SERVER['QUERY_STRING'], $_GET);\n"
+        "    }\n"
+        "\n"
+        "    $__response = \\Native\\Mobile\\Runtime::dispatch(\n"
+        "        \\Illuminate\\Http\\Request::capture()\n"
+        "    );\n"
+        "    $__code = $__response->getStatusCode();\n"
+        "    $__status = \\Symfony\\Component\\HttpFoundation\\Response::$statusTexts[$__code] ?? 'OK';\n"
+        "    echo \"HTTP/1.1 {$__code} {$__status}\\r\\n\";\n"
+        "    foreach ($__response->headers->all() as $__name => $__values) {\n"
+        "        foreach ($__values as $__value) {\n"
+        "            echo \"{$__name}: {$__value}\\r\\n\";\n"
+        "        }\n"
+        "    }\n"
+        "    echo \"\\r\\n\";\n"
+        "    $__response->sendContent();\n"
+        "} catch (\\Throwable $e) {\n"
+        "    echo \"HTTP/1.1 500 Internal Server Error\\r\\n\";\n"
+        "    echo \"Content-Type: text/plain\\r\\n\\r\\n\";\n"
+        "    echo 'Persistent dispatch error: ' . $e->getMessage() . \"\\n\";\n"
+        "    echo $e->getTraceAsString();\n"
+        "}\n",
+        params->method, params->uri, params->scriptPath);
+
+    zend_first_try {
+        zend_eval_string(eval_code, NULL, "persistent_dispatch");
+    } zend_end_try();
+
+    char *out = get_collected_output();
+    php_work_str_result = out ? strdup(out) : strdup("");
+}
+
+static void do_artisan(const char *command) {
+    if (!persistent_initialized) {
+        php_work_str_result = strdup("Persistent runtime not initialized.");
+        return;
+    }
+
+    clear_output_buffer();
+
+    setenv("APP_RUNNING_IN_CONSOLE", "true", 1);
+
+    char eval_code[4096];
+    snprintf(eval_code, sizeof(eval_code),
+        "try {\n"
+        "    echo \\Native\\Mobile\\Runtime::artisan('%s');\n"
+        "} catch (\\Throwable $e) {\n"
+        "    echo 'Artisan error: ' . $e->getMessage();\n"
+        "}\n",
+        command);
+
+    zend_first_try {
+        zend_eval_string(eval_code, NULL, "persistent_artisan");
+    } zend_end_try();
+
+    char *out = get_collected_output();
+    php_work_str_result = out ? strdup(out) : strdup("");
+
+    unsetenv("APP_RUNNING_IN_CONSOLE");
+}
+
+static void do_shutdown(void) {
+    if (!persistent_initialized) return;
+
+    clear_output_buffer();
+
+    zend_first_try {
+        zend_eval_string(
+            "\\Native\\Mobile\\Runtime::shutdown();",
+            NULL, "persistent_shutdown");
+    } zend_end_try();
+
+    sigset_t mask, oldmask;
+    sigfillset(&mask);
+    pthread_sigmask(SIG_BLOCK, &mask, &oldmask);
+    php_embed_shutdown();
+    pthread_sigmask(SIG_SETMASK, &oldmask, NULL);
+
+    persistent_initialized = 0;
+}
+
+// ── Public API (called from Swift, dispatches to PHP thread) ──
+
+// Helper: submit work and wait for completion
+static void submit_and_wait(php_work_type_t type) {
+    dispatch_semaphore_signal(php_work_sem);
+    dispatch_semaphore_wait(php_done_sem, DISPATCH_TIME_FOREVER);
+}
+
+int persistent_php_boot(const char *bootstrapPath) {
+    fprintf(stderr, "persistent_php_boot: creating worker thread\n");
+    fflush(stderr);
+
+    php_work_sem = dispatch_semaphore_create(0);
+    php_done_sem = dispatch_semaphore_create(0);
+
+    // Create the worker thread — it boots PHP immediately, then enters work loop
+    pthread_t thread;
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    pthread_attr_setstacksize(&attr, 8 * 1024 * 1024);
+    pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INITIATED, 0);
+
+    int rc = pthread_create(&thread, &attr, php_worker_main, (void *)bootstrapPath);
+    pthread_attr_destroy(&attr);
+
+    if (rc != 0) {
+        fprintf(stderr, "persistent_php_boot: pthread_create FAILED: %d\n", rc);
+        fflush(stderr);
+        return -1;
+    }
+
+    fprintf(stderr, "persistent_php_boot: waiting for boot to complete...\n");
+    fflush(stderr);
+
+    // Block until worker finishes booting
+    dispatch_semaphore_wait(php_done_sem, DISPATCH_TIME_FOREVER);
+
+    fprintf(stderr, "persistent_php_boot: done, result=%d\n", php_work_int_result);
+    fflush(stderr);
+
+    return php_work_int_result;
+}
+
+const char *persistent_php_dispatch(const char *method,
+                                    const char *uri,
+                                    const char *postData,
+                                    const char *scriptPath,
+                                    const char *cookieHeader,
+                                    const char *contentType) {
+    if (!persistent_initialized) {
+        return strdup("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\nNot booted.");
+    }
+
+    php_work_type = PHP_WORK_DISPATCH;
+    php_work_dispatch_params = (dispatch_params_t){
+        .method = method,
+        .uri = uri,
+        .postData = postData,
+        .scriptPath = scriptPath,
+        .cookieHeader = cookieHeader,
+        .contentType = contentType
+    };
+    php_work_str_result = NULL;
+
+    submit_and_wait(PHP_WORK_DISPATCH);
+    return php_work_str_result;
+}
+
+const char *persistent_php_artisan(const char *command) {
+    if (!persistent_initialized) {
+        return strdup("Not booted.");
+    }
+
+    php_work_type = PHP_WORK_ARTISAN;
+    php_work_str_arg = command;
+    php_work_str_result = NULL;
+
+    submit_and_wait(PHP_WORK_ARTISAN);
+    return php_work_str_result;
+}
+
+void persistent_php_shutdown(void) {
+    if (!persistent_initialized) return;
+    php_work_type = PHP_WORK_SHUTDOWN;
+    submit_and_wait(PHP_WORK_SHUTDOWN);
+}
+
+int persistent_php_is_booted(void) {
+    return persistent_initialized;
+}
+
+// Legacy stubs — kept for header compatibility
+void persistent_php_save_context(void) {}
+void persistent_php_restore_context(void) {}
+
+// ============================================================================
+// Queue Worker Runtime — separate TSRM context on its own pthread
+// ============================================================================
+// Mirrors Android's PHPQueueWorker: boots a second PHP interpreter context
+// on a dedicated thread. The worker has its own TSRM thread-local storage
+// so it never contends with the persistent runtime's PHP thread.
+
+static int worker_initialized = 0;
+static pthread_mutex_t g_worker_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+// Worker thread synchronization (same semaphore pattern as persistent runtime)
+static dispatch_semaphore_t worker_work_sem = NULL;
+static dispatch_semaphore_t worker_done_sem = NULL;
+
+typedef enum {
+    WORKER_WORK_ARTISAN,
+    WORKER_WORK_SHUTDOWN
+} worker_work_type_t;
+
+static worker_work_type_t   worker_work_type;
+static const char           *worker_work_str_arg   = NULL;
+static int                   worker_work_int_result = 0;
+static char                 *worker_work_str_result = NULL;
+
+// ── Worker TSRM init/shutdown ───────────────────────
+// Allocates a new TSRM context for the worker thread without calling
+// php_embed_init() again (TSRM is already started by the persistent runtime).
+
+static int worker_embed_init(void) {
+    fprintf(stderr, "WORKER: allocating TSRM context\n");
+    fflush(stderr);
+
+    // Allocate thread-local TSRM storage for this thread
+    ts_resource(0);
+
+    // Configure SAPI (uses thread-local ub_write)
+    setup_persistent_sapi();
+
+    // php_module_startup() is guarded internally — won't re-init modules,
+    // but will call sapi_activate() for this thread's context
+    if (php_embed_module.startup(&php_embed_module) == FAILURE) {
+        fprintf(stderr, "WORKER: module startup FAILED\n");
+        fflush(stderr);
+        return FAILURE;
+    }
+
+    // Initialize request for this thread (executor, compiler globals)
+    if (php_request_startup() == FAILURE) {
+        fprintf(stderr, "WORKER: request startup FAILED\n");
+        fflush(stderr);
+        return FAILURE;
+    }
+
+    fprintf(stderr, "WORKER: TSRM context ready\n");
+    fflush(stderr);
+    return SUCCESS;
+}
+
+static void worker_embed_shutdown(void) {
+    fprintf(stderr, "WORKER: cleaning up TSRM context\n");
+    fflush(stderr);
+    php_request_shutdown(NULL);
+    ts_free_thread();
+    fprintf(stderr, "WORKER: TSRM context freed\n");
+    fflush(stderr);
+}
+
+// ── Worker work handlers ────────────────────────────
+
+static void do_worker_artisan(const char *command) {
+    if (!worker_initialized) {
+        worker_work_str_result = strdup("Worker runtime not initialized.");
+        return;
+    }
+
+    clear_output_buffer();
+
+    setenv("APP_RUNNING_IN_CONSOLE", "true", 1);
+    setenv("PHP_SELF", "artisan.php", 1);
+
+    char eval_code[4096];
+    snprintf(eval_code, sizeof(eval_code),
+        "try {\n"
+        "    $_SERVER['PHP_SELF'] = 'artisan.php';\n"
+        "    $_SERVER['APP_RUNNING_IN_CONSOLE'] = 'true';\n"
+        "    echo \\Native\\Mobile\\Runtime::artisan('%s');\n"
+        "} catch (\\Throwable $e) {\n"
+        "    echo 'Worker artisan error: ' . $e->getMessage();\n"
+        "}\n",
+        command);
+
+    zend_first_try {
+        zend_eval_string(eval_code, NULL, "worker_artisan");
+    } zend_end_try();
+
+    setenv("APP_RUNNING_IN_CONSOLE", "false", 1);
+
+    char *out = get_collected_output();
+    worker_work_str_result = out ? strdup(out) : strdup("");
+}
+
+static void do_worker_shutdown(void) {
+    if (!worker_initialized) return;
+
+    clear_output_buffer();
+
+    zend_first_try {
+        zend_eval_string(
+            "\\Native\\Mobile\\Runtime::shutdown();",
+            NULL, "worker_shutdown");
+    } zend_end_try();
+
+    worker_embed_shutdown();
+    worker_initialized = 0;
+}
+
+// ── Worker thread main ──────────────────────────────
+
+static void *worker_thread_main(void *arg) {
+    const char *bootstrapPath = (const char *)arg;
+
+    fprintf(stderr, "WORKER: thread started tid=%p\n", (void *)pthread_self());
+    fflush(stderr);
+
+    clear_output_buffer();
+
+    setenv("APP_RUNNING_IN_CONSOLE", "true", 1);
+    setenv("PHP_SELF", "artisan.php", 1);
+
+    if (worker_embed_init() != SUCCESS) {
+        fprintf(stderr, "WORKER: embed init FAILED\n");
+        fflush(stderr);
+        worker_work_int_result = -1;
+        dispatch_semaphore_signal(worker_done_sem);
+        return NULL;
+    }
+
+    // Execute bootstrap script to boot Laravel on worker thread
+    zend_first_try {
+        zend_activate_modules();
+        zend_file_handle fileHandle;
+        zend_stream_init_filename(&fileHandle, bootstrapPath);
+        php_execute_script(&fileHandle);
+    } zend_end_try();
+
+    char *boot_output = get_collected_output();
+    if (boot_output && strstr(boot_output, "FATAL") != NULL) {
+        fprintf(stderr, "WORKER: bootstrap errors: %.200s\n", boot_output);
+        fflush(stderr);
+    }
+
+    worker_initialized = 1;
+    worker_work_int_result = 0;
+
+    fprintf(stderr, "WORKER: boot complete, entering work loop\n");
+    fflush(stderr);
+
+    // Signal boot complete
+    dispatch_semaphore_signal(worker_done_sem);
+
+    // ── Work loop ──
+    while (1) {
+        dispatch_semaphore_wait(worker_work_sem, DISPATCH_TIME_FOREVER);
+
+        switch (worker_work_type) {
+            case WORKER_WORK_ARTISAN:
+                do_worker_artisan(worker_work_str_arg);
+                break;
+            case WORKER_WORK_SHUTDOWN:
+                do_worker_shutdown();
+                dispatch_semaphore_signal(worker_done_sem);
+                return NULL;  // Exit thread after shutdown
+        }
+
+        dispatch_semaphore_signal(worker_done_sem);
+    }
+
+    return NULL;
+}
+
+// ── Worker public API (called from Swift) ───────────
+
+int worker_php_boot(const char *bootstrapPath) {
+    fprintf(stderr, "worker_php_boot: creating worker thread\n");
+    fflush(stderr);
+
+    worker_work_sem = dispatch_semaphore_create(0);
+    worker_done_sem = dispatch_semaphore_create(0);
+
+    pthread_t thread;
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    pthread_attr_setstacksize(&attr, 8 * 1024 * 1024);
+    pthread_attr_set_qos_class_np(&attr, QOS_CLASS_UTILITY, 0);
+
+    int rc = pthread_create(&thread, &attr, worker_thread_main, (void *)bootstrapPath);
+    pthread_attr_destroy(&attr);
+
+    if (rc != 0) {
+        fprintf(stderr, "worker_php_boot: pthread_create FAILED: %d\n", rc);
+        fflush(stderr);
+        return -1;
+    }
+
+    // Block until worker finishes booting
+    dispatch_semaphore_wait(worker_done_sem, DISPATCH_TIME_FOREVER);
+
+    fprintf(stderr, "worker_php_boot: done, result=%d\n", worker_work_int_result);
+    fflush(stderr);
+
+    return worker_work_int_result;
+}
+
+const char *worker_php_artisan(const char *command) {
+    if (!worker_initialized) {
+        return strdup("Worker not booted.");
+    }
+
+    worker_work_type = WORKER_WORK_ARTISAN;
+    worker_work_str_arg = command;
+    worker_work_str_result = NULL;
+
+    dispatch_semaphore_signal(worker_work_sem);
+    dispatch_semaphore_wait(worker_done_sem, DISPATCH_TIME_FOREVER);
+
+    return worker_work_str_result;
+}
+
+void worker_php_shutdown(void) {
+    if (!worker_initialized) return;
+
+    worker_work_type = WORKER_WORK_SHUTDOWN;
+    dispatch_semaphore_signal(worker_work_sem);
+    dispatch_semaphore_wait(worker_done_sem, DISPATCH_TIME_FOREVER);
+}
+
+int worker_php_is_booted(void) {
+    return worker_initialized;
+}
+
+// ============================================================================
+// Scheduler Runtime — ephemeral TSRM context on its own pthread
+// ============================================================================
+// Mirrors the worker runtime but designed for ephemeral use: each invocation
+// boots, runs a single artisan command, and shuts down. Used by BGTaskScheduler
+// on iOS (equivalent to Android's WorkManager PHPSchedulerWorker).
+
+static int scheduler_initialized = 0;
+static pthread_mutex_t g_scheduler_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+// Scheduler thread synchronization
+static dispatch_semaphore_t scheduler_work_sem = NULL;
+static dispatch_semaphore_t scheduler_done_sem = NULL;
+
+typedef enum {
+    SCHEDULER_WORK_ARTISAN,
+    SCHEDULER_WORK_SHUTDOWN
+} scheduler_work_type_t;
+
+static scheduler_work_type_t  scheduler_work_type;
+static const char            *scheduler_work_str_arg   = NULL;
+static int                    scheduler_work_int_result = 0;
+static char                  *scheduler_work_str_result = NULL;
+
+// ── Scheduler TSRM init/shutdown ────────────────────
+
+static int scheduler_embed_init(void) {
+    fprintf(stderr, "SCHEDULER: allocating TSRM context\n");
+    fflush(stderr);
+
+    ts_resource(0);
+    setup_persistent_sapi();
+
+    if (php_embed_module.startup(&php_embed_module) == FAILURE) {
+        fprintf(stderr, "SCHEDULER: module startup FAILED\n");
+        fflush(stderr);
+        return FAILURE;
+    }
+
+    if (php_request_startup() == FAILURE) {
+        fprintf(stderr, "SCHEDULER: request startup FAILED\n");
+        fflush(stderr);
+        return FAILURE;
+    }
+
+    fprintf(stderr, "SCHEDULER: TSRM context ready\n");
+    fflush(stderr);
+    return SUCCESS;
+}
+
+static void scheduler_embed_shutdown(void) {
+    fprintf(stderr, "SCHEDULER: cleaning up TSRM context\n");
+    fflush(stderr);
+    php_request_shutdown(NULL);
+    ts_free_thread();
+    fprintf(stderr, "SCHEDULER: TSRM context freed\n");
+    fflush(stderr);
+}
+
+// ── Scheduler work handlers ─────────────────────────
+
+static void do_scheduler_artisan(const char *command) {
+    if (!scheduler_initialized) {
+        scheduler_work_str_result = strdup("Scheduler runtime not initialized.");
+        return;
+    }
+
+    clear_output_buffer();
+
+    setenv("APP_RUNNING_IN_CONSOLE", "true", 1);
+    setenv("PHP_SELF", "artisan.php", 1);
+
+    char eval_code[4096];
+    snprintf(eval_code, sizeof(eval_code),
+        "try {\n"
+        "    $_SERVER['PHP_SELF'] = 'artisan.php';\n"
+        "    $_SERVER['APP_RUNNING_IN_CONSOLE'] = 'true';\n"
+        "    echo \\Native\\Mobile\\Runtime::artisan('%s');\n"
+        "} catch (\\Throwable $e) {\n"
+        "    echo 'Scheduler artisan error: ' . $e->getMessage();\n"
+        "}\n",
+        command);
+
+    zend_first_try {
+        zend_eval_string(eval_code, NULL, "scheduler_artisan");
+    } zend_end_try();
+
+    setenv("APP_RUNNING_IN_CONSOLE", "false", 1);
+
+    char *out = get_collected_output();
+    scheduler_work_str_result = out ? strdup(out) : strdup("");
+}
+
+static void do_scheduler_shutdown(void) {
+    if (!scheduler_initialized) return;
+
+    clear_output_buffer();
+
+    zend_first_try {
+        zend_eval_string(
+            "\\Native\\Mobile\\Runtime::shutdown();",
+            NULL, "scheduler_shutdown");
+    } zend_end_try();
+
+    scheduler_embed_shutdown();
+    scheduler_initialized = 0;
+}
+
+// ── Scheduler thread main ───────────────────────────
+
+static void *scheduler_thread_main(void *arg) {
+    const char *bootstrapPath = (const char *)arg;
+
+    fprintf(stderr, "SCHEDULER: thread started tid=%p\n", (void *)pthread_self());
+    fflush(stderr);
+
+    clear_output_buffer();
+
+    setenv("APP_RUNNING_IN_CONSOLE", "true", 1);
+    setenv("PHP_SELF", "artisan.php", 1);
+
+    if (scheduler_embed_init() != SUCCESS) {
+        fprintf(stderr, "SCHEDULER: embed init FAILED\n");
+        fflush(stderr);
+        scheduler_work_int_result = -1;
+        dispatch_semaphore_signal(scheduler_done_sem);
+        return NULL;
+    }
+
+    // Execute bootstrap script to boot Laravel on scheduler thread
+    zend_first_try {
+        zend_activate_modules();
+        zend_file_handle fileHandle;
+        zend_stream_init_filename(&fileHandle, bootstrapPath);
+        php_execute_script(&fileHandle);
+    } zend_end_try();
+
+    char *boot_output = get_collected_output();
+    if (boot_output && strstr(boot_output, "FATAL") != NULL) {
+        fprintf(stderr, "SCHEDULER: bootstrap errors: %.200s\n", boot_output);
+        fflush(stderr);
+    }
+
+    scheduler_initialized = 1;
+    scheduler_work_int_result = 0;
+
+    fprintf(stderr, "SCHEDULER: boot complete, entering work loop\n");
+    fflush(stderr);
+
+    // Signal boot complete
+    dispatch_semaphore_signal(scheduler_done_sem);
+
+    // ── Work loop ──
+    while (1) {
+        dispatch_semaphore_wait(scheduler_work_sem, DISPATCH_TIME_FOREVER);
+
+        switch (scheduler_work_type) {
+            case SCHEDULER_WORK_ARTISAN:
+                do_scheduler_artisan(scheduler_work_str_arg);
+                break;
+            case SCHEDULER_WORK_SHUTDOWN:
+                do_scheduler_shutdown();
+                dispatch_semaphore_signal(scheduler_done_sem);
+                return NULL;  // Exit thread after shutdown
+        }
+
+        dispatch_semaphore_signal(scheduler_done_sem);
+    }
+
+    return NULL;
+}
+
+// ── Scheduler public API (called from Swift) ────────
+
+int scheduler_php_boot(const char *bootstrapPath) {
+    fprintf(stderr, "scheduler_php_boot: creating scheduler thread\n");
+    fflush(stderr);
+
+    scheduler_work_sem = dispatch_semaphore_create(0);
+    scheduler_done_sem = dispatch_semaphore_create(0);
+
+    pthread_t thread;
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    pthread_attr_setstacksize(&attr, 8 * 1024 * 1024);
+    pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INITIATED, 0);
+
+    int rc = pthread_create(&thread, &attr, scheduler_thread_main, (void *)bootstrapPath);
+    pthread_attr_destroy(&attr);
+
+    if (rc != 0) {
+        fprintf(stderr, "scheduler_php_boot: pthread_create FAILED: %d\n", rc);
+        fflush(stderr);
+        return -1;
+    }
+
+    // Block until scheduler finishes booting
+    dispatch_semaphore_wait(scheduler_done_sem, DISPATCH_TIME_FOREVER);
+
+    fprintf(stderr, "scheduler_php_boot: done, result=%d\n", scheduler_work_int_result);
+    fflush(stderr);
+
+    return scheduler_work_int_result;
+}
+
+const char *scheduler_php_artisan(const char *command) {
+    if (!scheduler_initialized) {
+        return strdup("Scheduler not booted.");
+    }
+
+    scheduler_work_type = SCHEDULER_WORK_ARTISAN;
+    scheduler_work_str_arg = command;
+    scheduler_work_str_result = NULL;
+
+    dispatch_semaphore_signal(scheduler_work_sem);
+    dispatch_semaphore_wait(scheduler_done_sem, DISPATCH_TIME_FOREVER);
+
+    return scheduler_work_str_result;
+}
+
+void scheduler_php_shutdown(void) {
+    if (!scheduler_initialized) return;
+
+    scheduler_work_type = SCHEDULER_WORK_SHUTDOWN;
+    dispatch_semaphore_signal(scheduler_work_sem);
+    dispatch_semaphore_wait(scheduler_done_sem, DISPATCH_TIME_FOREVER);
+}
+
+int scheduler_php_is_booted(void) {
+    return scheduler_initialized;
 }

--- a/resources/xcode/Include/Bridge/PHP.h
+++ b/resources/xcode/Include/Bridge/PHP.h
@@ -9,4 +9,30 @@ void initialize_php_with_request(const char *post_data,
                                  const char *method,
                                  const char *uri);
 
+// Persistent PHP Runtime
+int  persistent_php_boot(const char *bootstrapPath);
+const char *persistent_php_dispatch(const char *method,
+                                    const char *uri,
+                                    const char *postData,
+                                    const char *scriptPath,
+                                    const char *cookieHeader,
+                                    const char *contentType);
+const char *persistent_php_artisan(const char *command);
+void persistent_php_shutdown(void);
+int  persistent_php_is_booted(void);
+void persistent_php_save_context(void);
+void persistent_php_restore_context(void);
+
+// Queue Worker Runtime (separate TSRM context)
+int  worker_php_boot(const char *bootstrapPath);
+const char *worker_php_artisan(const char *command);
+void worker_php_shutdown(void);
+int  worker_php_is_booted(void);
+
+// Scheduler Runtime (ephemeral TSRM context — boot/run/shutdown per invocation)
+int  scheduler_php_boot(const char *bootstrapPath);
+const char *scheduler_php_artisan(const char *command);
+void scheduler_php_shutdown(void);
+int  scheduler_php_is_booted(void);
+
 #endif

--- a/resources/xcode/NativePHP/Bridge/PHPQueueWorker.swift
+++ b/resources/xcode/NativePHP/Bridge/PHPQueueWorker.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+// C functions from PHP.c — worker runtime (separate TSRM context)
+@_silgen_name("worker_php_boot")
+private func _worker_php_boot(_ bootstrapPath: UnsafePointer<CChar>?) -> Int32
+
+@_silgen_name("worker_php_artisan")
+private func _worker_php_artisan(_ command: UnsafePointer<CChar>?) -> UnsafePointer<CChar>?
+
+@_silgen_name("worker_php_shutdown")
+private func _worker_php_shutdown()
+
+@_silgen_name("worker_php_is_booted")
+private func _worker_php_is_booted() -> Int32
+
+/// Background queue worker that processes Laravel queue jobs.
+///
+/// Uses a dedicated PHP TSRM context (worker runtime) so queue processing
+/// never contends with the persistent runtime used for UI requests.
+/// Mirrors Android's PHPQueueWorker.
+final class PHPQueueWorker {
+    static let shared = PHPQueueWorker()
+
+    private let sleepIntervalMs: UInt64 = 1_000
+    private let sleepIdleMs: UInt64 = 3_000
+
+    private var workerThread: Thread?
+    private var running = false
+
+    private init() {}
+
+    /// Start the background queue worker.
+    /// Boots a dedicated worker PHP runtime on a new thread, then loops
+    /// processing jobs via `queue:work --once`.
+    func start() {
+        guard !running else {
+            NSLog("PHPQueueWorker: already running")
+            return
+        }
+
+        running = true
+
+        let thread = Thread {
+            self.workerLoop()
+        }
+        thread.name = "php-queue-worker"
+        thread.qualityOfService = .utility
+        workerThread = thread
+        thread.start()
+
+        NSLog("PHPQueueWorker: thread launched")
+    }
+
+    /// Stop the worker thread and shut down the worker runtime.
+    func stop() {
+        guard running else { return }
+
+        NSLog("PHPQueueWorker: stopping")
+        running = false
+        // Thread will exit on next loop iteration
+        workerThread = nil
+    }
+
+    var isRunning: Bool { running }
+
+    // MARK: - Worker Loop
+
+    private func workerLoop() {
+        NSLog("PHPQueueWorker: starting (dedicated TSRM context)")
+
+        let appPath = AppUpdateManager.shared.getAppPath()
+        let bootstrapPath = appPath + "/vendor/nativephp/mobile/bootstrap/ios/persistent.php"
+
+        // Boot worker runtime — this allocates a new TSRM context and
+        // runs the Laravel bootstrap on this thread
+        let result = _worker_php_boot(bootstrapPath)
+        if result != 0 {
+            NSLog("PHPQueueWorker: boot FAILED (%d), aborting", result)
+            running = false
+            return
+        }
+
+        NSLog("PHPQueueWorker: boot complete, processing jobs")
+
+        while running {
+            let output = artisan(command: "queue:work --once --quiet")
+
+            // Shorter sleep if we just processed a job, longer if idle
+            let sleepMs: UInt64
+            if output.localizedCaseInsensitiveContains("Processed") {
+                sleepMs = sleepIntervalMs
+            } else {
+                sleepMs = sleepIdleMs
+            }
+
+            Thread.sleep(forTimeInterval: Double(sleepMs) / 1000.0)
+        }
+
+        _worker_php_shutdown()
+        NSLog("PHPQueueWorker: stopped")
+    }
+
+    private func artisan(command: String) -> String {
+        guard let resultPtr = _worker_php_artisan(command) else {
+            return ""
+        }
+        let result = String(cString: resultPtr)
+        free(UnsafeMutableRawPointer(mutating: resultPtr))
+        return result
+    }
+}

--- a/resources/xcode/NativePHP/Bridge/PHPScheduler.swift
+++ b/resources/xcode/NativePHP/Bridge/PHPScheduler.swift
@@ -1,0 +1,247 @@
+import Foundation
+import BackgroundTasks
+
+// C functions from PHP.c — scheduler runtime (ephemeral TSRM context)
+@_silgen_name("scheduler_php_boot")
+private func _scheduler_php_boot(_ bootstrapPath: UnsafePointer<CChar>?) -> Int32
+
+@_silgen_name("scheduler_php_artisan")
+private func _scheduler_php_artisan(_ command: UnsafePointer<CChar>?) -> UnsafePointer<CChar>?
+
+@_silgen_name("scheduler_php_shutdown")
+private func _scheduler_php_shutdown()
+
+@_silgen_name("scheduler_php_is_booted")
+private func _scheduler_php_is_booted() -> Int32
+
+/// Scheduler that runs periodic `schedule:run` via BGTaskScheduler.
+///
+/// Each invocation is ephemeral: boots a dedicated scheduler TSRM context,
+/// runs the artisan command, and shuts down. Mirrors Android's
+/// PHPSchedulerWorker + WorkManager approach.
+///
+/// Uses `BGProcessingTask` which can run for minutes and works even when
+/// the app has been terminated by the system (cold boot).
+final class PHPScheduler {
+    static let shared = PHPScheduler()
+
+    /// BGTaskScheduler identifiers — must match Info.plist BGTaskSchedulerPermittedIdentifiers
+    static let processingIdentifier = "com.nativephp.scheduler.run"
+    static let refreshIdentifier = "com.nativephp.scheduler.refresh"
+
+    /// Minimum interval between runs (iOS minimum is ~15 minutes)
+    private let minimumInterval: TimeInterval = 15 * 60
+
+    /// Merged constraints from all background tasks (read from manifest)
+    private var mergedConstraints: [String: Any] = [:]
+
+    private init() {}
+
+    // MARK: - Registration
+
+    /// Register the background task handler with BGTaskScheduler.
+    /// Must be called before app finishes launching (in init or application:didFinishLaunching).
+    func registerBackgroundTasks() {
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: PHPScheduler.processingIdentifier,
+            using: nil
+        ) { task in
+            guard let processingTask = task as? BGProcessingTask else { return }
+            self.handleScheduleRun(task: processingTask)
+        }
+        NSLog("PHPScheduler: registered BGProcessingTask handler")
+
+        BGTaskScheduler.shared.register(
+            forTaskWithIdentifier: PHPScheduler.refreshIdentifier,
+            using: nil
+        ) { task in
+            guard let refreshTask = task as? BGAppRefreshTask else { return }
+            self.handleScheduleRun(task: refreshTask)
+        }
+        NSLog("PHPScheduler: registered BGAppRefreshTask handler")
+    }
+
+    // MARK: - Scheduling
+
+    /// Schedule the next background processing task.
+    /// Call after persistent boot and on entering background.
+    func scheduleNextRun() {
+        // Always refresh constraints from disk before scheduling
+        loadConstraintsFromManifest()
+
+        let request = BGProcessingTaskRequest(identifier: PHPScheduler.processingIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: minimumInterval)
+
+        // Apply merged constraints from manifest
+        if let network = mergedConstraints["network"] as? String, network == "connected" || network == "unmetered" {
+            request.requiresNetworkConnectivity = true
+        } else {
+            request.requiresNetworkConnectivity = false
+        }
+
+        if let charging = mergedConstraints["charging"] as? Bool, charging {
+            request.requiresExternalPower = true
+        } else {
+            request.requiresExternalPower = false
+        }
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            NSLog("PHPScheduler: scheduled next processing run in ~%.0f minutes (network=%@, power=%@)",
+                  minimumInterval / 60,
+                  request.requiresNetworkConnectivity ? "yes" : "no",
+                  request.requiresExternalPower ? "yes" : "no")
+        } catch {
+            NSLog("PHPScheduler: failed to schedule processing task: %@", error.localizedDescription)
+        }
+    }
+
+    /// Schedule the next background app refresh task.
+    /// BGAppRefreshTask runs more frequently (~15-30 min) but for shorter durations.
+    func scheduleNextRefresh() {
+        let request = BGAppRefreshTaskRequest(identifier: PHPScheduler.refreshIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: minimumInterval)
+
+        do {
+            try BGTaskScheduler.shared.submit(request)
+            NSLog("PHPScheduler: scheduled next refresh in ~%.0f minutes", minimumInterval / 60)
+        } catch {
+            NSLog("PHPScheduler: failed to schedule refresh task: %@", error.localizedDescription)
+        }
+    }
+
+    // MARK: - Execution
+
+    /// Handle a background task invocation (works with both BGProcessingTask and BGAppRefreshTask).
+    /// Ephemeral lifecycle: boot → artisan schedule:run → shutdown.
+    private func handleScheduleRun(task: BGTask) {
+        let taskType = task is BGProcessingTask ? "processing" : "refresh"
+        NSLog("PHPScheduler: handleScheduleRun started (type: %@)", taskType)
+
+        // Schedule the next runs before we start (in case we get killed)
+        scheduleNextRun()
+        scheduleNextRefresh()
+
+        // Set up expiration handler
+        task.expirationHandler = {
+            NSLog("PHPScheduler: %@ task expiring, shutting down scheduler runtime", taskType)
+            if _scheduler_php_is_booted() != 0 {
+                _scheduler_php_shutdown()
+            }
+        }
+
+        // Run on a background thread (BGTask callback is on an arbitrary queue)
+        let appPath = AppUpdateManager.shared.getAppPath()
+        let bootstrapPath = appPath + "/vendor/nativephp/mobile/bootstrap/ios/persistent.php"
+
+        NSLog("PHPScheduler: booting scheduler runtime")
+
+        let bootResult = _scheduler_php_boot(bootstrapPath)
+        if bootResult != 0 {
+            NSLog("PHPScheduler: boot FAILED (%d)", bootResult)
+            task.setTaskCompleted(success: false)
+            return
+        }
+
+        // Run each scheduled command in-process instead of `schedule:run`,
+        // which tries to fork a `php` subprocess that doesn't exist on iOS.
+        let commands = loadCommandsFromManifest()
+        if commands.isEmpty {
+            NSLog("PHPScheduler: no commands found in manifest")
+        }
+        for command in commands {
+            NSLog("PHPScheduler: running in-process: %@", command)
+            let output = artisan(command: command)
+            NSLog("PHPScheduler: %@ output: %@", command, output.isEmpty ? "(empty)" : String(output.prefix(500)))
+        }
+
+        NSLog("PHPScheduler: shutting down scheduler runtime")
+        _scheduler_php_shutdown()
+
+        NSLog("PHPScheduler: completed successfully")
+        task.setTaskCompleted(success: true)
+    }
+
+    // MARK: - Constraints
+
+    /// Read background_tasks.json and return the list of artisan command names.
+    private func loadCommandsFromManifest() -> [String] {
+        let appPath = AppUpdateManager.shared.getAppPath()
+        let manifestPath = appPath + "/storage/app/background_tasks.json"
+
+        guard FileManager.default.fileExists(atPath: manifestPath),
+              let data = FileManager.default.contents(atPath: manifestPath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tasks = json["tasks"] as? [[String: Any]] else {
+            NSLog("PHPScheduler: no manifest at app storage path, trying Application Support")
+            return loadCommandsFromAppSupportManifest()
+        }
+
+        return tasks.compactMap { $0["command"] as? String }
+    }
+
+    private func loadCommandsFromAppSupportManifest() -> [String] {
+        let storageDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let manifestPath = storageDir.appendingPathComponent("storage/app/background_tasks.json").path
+
+        guard FileManager.default.fileExists(atPath: manifestPath),
+              let data = FileManager.default.contents(atPath: manifestPath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tasks = json["tasks"] as? [[String: Any]] else {
+            return []
+        }
+
+        return tasks.compactMap { $0["command"] as? String }
+    }
+
+    /// Read background_tasks.json from app storage and merge all task constraints.
+    /// Union strategy: if any task needs network, the merged result needs network.
+    private func loadConstraintsFromManifest() {
+        let storageDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let manifestPath = storageDir.appendingPathComponent("storage/app/background_tasks.json").path
+
+        guard FileManager.default.fileExists(atPath: manifestPath),
+              let data = FileManager.default.contents(atPath: manifestPath),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tasks = json["tasks"] as? [[String: Any]] else {
+            NSLog("PHPScheduler: no background_tasks.json found, using default constraints")
+            mergedConstraints = [:]
+            return
+        }
+
+        var merged: [String: Any] = [:]
+
+        for task in tasks {
+            guard let constraints = task["constraints"] as? [String: Any] else { continue }
+
+            // Network: prefer "unmetered" over "connected" (stricter wins)
+            if let network = constraints["network"] as? String {
+                let current = merged["network"] as? String
+                if current == nil || (current == "connected" && network == "unmetered") {
+                    merged["network"] = network
+                }
+            }
+
+            // Boolean constraints: union (any true → true)
+            for key in ["charging", "battery_not_low", "storage_not_low", "device_idle"] {
+                if let val = constraints[key] as? Bool, val {
+                    merged[key] = true
+                }
+            }
+        }
+
+        mergedConstraints = merged
+        NSLog("PHPScheduler: loaded constraints from manifest: %@", String(describing: merged))
+    }
+
+    // MARK: - Artisan Helper
+
+    private func artisan(command: String) -> String {
+        guard let resultPtr = _scheduler_php_artisan(command) else {
+            return ""
+        }
+        let result = String(cString: resultPtr)
+        free(UnsafeMutableRawPointer(mutating: resultPtr))
+        return result
+    }
+}

--- a/resources/xcode/NativePHP/Bridge/PersistentPHPRuntime.swift
+++ b/resources/xcode/NativePHP/Bridge/PersistentPHPRuntime.swift
@@ -1,0 +1,205 @@
+import Foundation
+
+// C functions declared in PHP.h / PHP.c — linked directly, bypassing the Bridge module
+// which has issues with umbrella parsing of php_embed.h transitive includes.
+@_silgen_name("persistent_php_boot")
+private func _persistent_php_boot(_ bootstrapPath: UnsafePointer<CChar>?) -> Int32
+
+@_silgen_name("persistent_php_dispatch")
+private func _persistent_php_dispatch(
+    _ method: UnsafePointer<CChar>?,
+    _ uri: UnsafePointer<CChar>?,
+    _ postData: UnsafePointer<CChar>?,
+    _ scriptPath: UnsafePointer<CChar>?,
+    _ cookieHeader: UnsafePointer<CChar>?,
+    _ contentType: UnsafePointer<CChar>?
+) -> UnsafePointer<CChar>?
+
+@_silgen_name("persistent_php_artisan")
+private func _persistent_php_artisan(_ command: UnsafePointer<CChar>?) -> UnsafePointer<CChar>?
+
+@_silgen_name("persistent_php_shutdown")
+private func _persistent_php_shutdown()
+
+@_silgen_name("persistent_php_is_booted")
+private func _persistent_php_is_booted() -> Int32
+
+/// Persistent PHP Runtime for iOS.
+/// Boots the PHP interpreter once and dispatches requests via zend_eval_string().
+/// Equivalent to Android's PHPBridge persistent mode.
+///
+/// The C layer manages a dedicated pthread for all PHP work, guaranteeing
+/// TSRM thread-local storage is always valid. Swift callers can call from
+/// any thread — the C functions block until the PHP worker thread completes.
+final class PersistentPHPRuntime {
+    static let shared = PersistentPHPRuntime()
+
+    private(set) var isBooted = false
+
+    /// Serial queue for dispatch calls from WebView (prevents concurrent requests)
+    private let dispatchQueue = DispatchQueue(label: "com.nativephp.persistent-php", qos: .userInitiated)
+
+    private init() {}
+
+    /// Execute a block on the dispatch queue asynchronously.
+    /// The block will call dispatch() which internally routes to the C worker thread.
+    func executeOnPHPThreadAsync(_ block: @escaping () -> Void) {
+        dispatchQueue.async(execute: block)
+    }
+
+    /// Boot the persistent runtime. Call once during app initialization.
+    /// This boots PHP, loads Composer, and boots the Laravel kernel.
+    /// Blocks until boot is complete (work runs on dedicated C pthread).
+    func boot() -> Bool {
+        let appPath = AppUpdateManager.shared.getAppPath()
+
+        // Set environment variables before PHP boots (env vars are process-wide)
+        let storageDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let tempDir = FileManager.default.temporaryDirectory.path
+        let databaseDir = storageDir.appendingPathComponent("database").path
+
+        setenv("LARAVEL_STORAGE_PATH", storageDir.appendingPathComponent("storage").path, 1)
+        setenv("VIEW_COMPILED_PATH", storageDir.appendingPathComponent("storage/framework/views").path, 1)
+        setenv("DB_DATABASE", "\(databaseDir)/database.sqlite", 1)
+        setenv("NATIVEPHP_TEMPDIR", tempDir, 1)
+        setenv("NATIVEPHP_PLATFORM", "ios", 1)
+        setenv("REMOTE_ADDR", "0.0.0.0", 1)
+
+        // Composer autoloader and bootstrap paths (used by persistent.php)
+        setenv("COMPOSER_AUTOLOADER_PATH", appPath + "/vendor/autoload.php", 1)
+        setenv("LARAVEL_BOOTSTRAP_PATH", appPath + "/bootstrap", 1)
+
+        // PHP INI
+        let caPath = Bundle.main.path(forResource: "cacert", ofType: "pem") ?? ""
+        setenv("PHPRC", createPhpIni(caPath: caPath), 1)
+
+        // APP_KEY from Keychain
+        if let appKey = getAppKey() {
+            setenv("APP_KEY", appKey, 1)
+        }
+
+        let bootstrapPath = appPath + "/vendor/nativephp/mobile/bootstrap/ios/persistent.php"
+
+        print("PersistentPHPRuntime: booting with \(bootstrapPath)")
+
+        // This blocks until the C worker thread completes boot
+        let result = _persistent_php_boot(bootstrapPath)
+
+        if result == 0 {
+            isBooted = true
+            print("PersistentPHPRuntime: boot succeeded")
+        } else {
+            print("PersistentPHPRuntime: boot FAILED (\(result))")
+        }
+
+        return isBooted
+    }
+
+    /// Dispatch a web request through the persistent runtime.
+    /// Returns the raw HTTP response (headers + body).
+    /// Blocks until the C worker thread completes the request.
+    func dispatch(request: RequestData) -> String {
+        guard isBooted else {
+            return "HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\nPersistent runtime not booted."
+        }
+
+        var uri = request.uri
+        if let query = request.query, !query.isEmpty {
+            uri += "?" + query
+        }
+
+        let appPath = AppUpdateManager.shared.getAppPath()
+        let scriptPath = appPath + "/vendor/nativephp/mobile/bootstrap/ios/native.php"
+
+        // Set HTTP headers as env vars (like Android does)
+        var envKeys: [String] = []
+        for (header, value) in request.headers {
+            let formattedKey = "HTTP_" + header
+                .replacingOccurrences(of: "-", with: "_")
+                .uppercased()
+            setenv(formattedKey, value, 1)
+            envKeys.append(formattedKey)
+        }
+
+        let cookieHeader = request.headers["Cookie"] ?? ""
+        let contentType = request.headers["Content-Type"] ?? request.headers["content-type"] ?? ""
+
+        // This blocks until the C worker thread completes dispatch
+        let resultPtr = _persistent_php_dispatch(
+            request.method,
+            uri,
+            request.data,
+            scriptPath,
+            cookieHeader,
+            contentType
+        )
+
+        // Clean up HTTP header env vars
+        for key in envKeys {
+            unsetenv(key)
+        }
+
+        guard let resultPtr else {
+            return "HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\nNull response from persistent dispatch."
+        }
+
+        let result = String(cString: resultPtr)
+        free(UnsafeMutableRawPointer(mutating: resultPtr))
+        return result
+    }
+
+    /// Run an artisan command through the persistent runtime.
+    /// Blocks until the C worker thread completes the command.
+    func artisan(command: String) -> String {
+        guard isBooted else { return "Persistent runtime not booted." }
+
+        guard let resultPtr = _persistent_php_artisan(command) else {
+            return ""
+        }
+
+        let result = String(cString: resultPtr)
+        free(UnsafeMutableRawPointer(mutating: resultPtr))
+        return result
+    }
+
+    /// Shutdown the persistent runtime.
+    func shutdown() {
+        _persistent_php_shutdown()
+        isBooted = false
+    }
+
+    // MARK: - Helpers
+
+    private func createPhpIni(caPath: String) -> String {
+        let supportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let iniPath = supportDir.appendingPathComponent("php.ini")
+
+        let phpIni = """
+        curl.cainfo="\(caPath)"
+        openssl.cafile="\(caPath)"
+        """
+
+        try? FileManager.default.createDirectory(at: supportDir, withIntermediateDirectories: true)
+        try? phpIni.write(to: iniPath, atomically: true, encoding: .utf8)
+
+        return iniPath.path(percentEncoded: false)
+    }
+
+    private func getAppKey() -> String? {
+        let service = Bundle.main.bundleIdentifier ?? "com.nativephp.app"
+        let account = "APP_KEY"
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecAttrService as String: service,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecSuccess, let data = result as? Data {
+            return String(data: data, encoding: .utf8)
+        }
+        return nil
+    }
+}

--- a/resources/xcode/NativePHP/NativePHPApp.swift
+++ b/resources/xcode/NativePHP/NativePHPApp.swift
@@ -20,10 +20,15 @@ struct NativePHPApp: App {
 
     static var shared: NativePHPApp?
 
+    @Environment(\.scenePhase) private var scenePhase
+
     init() {
         Self.shared = self
 
         DebugLogger.shared.log("📱 NativePHPApp.init() starting (minimal)")
+
+        // Register BGTaskScheduler handlers before app finishes launching
+        PHPScheduler.shared.registerBackgroundTasks()
 
         // Only register bridge functions in init - this is fast and doesn't block
         // All heavy initialization is deferred to after the splash view is visible
@@ -36,19 +41,45 @@ struct NativePHPApp: App {
     /// Performs heavy initialization work after the splash view is visible.
     /// This runs on a background thread to avoid blocking the main thread.
     private func performDeferredInitialization() {
-        DebugLogger.shared.log("📱 Deferred initialization starting")
+        NSLog("[NativePHP] Deferred initialization starting")
 
-        // 1. Initialize PHP environment
-        DebugLogger.shared.log("📱 Deferred init: preparing PHP environment")
+        // 1. Initialize PHP environment (env vars, php.ini, database)
+        NSLog("[NativePHP] preparePhpEnvironment START")
         _ = preparePhpEnvironment()
+        NSLog("[NativePHP] preparePhpEnvironment DONE")
 
         // 2. Ensure app is extracted from bundle if needed
-        DebugLogger.shared.log("📱 Deferred init: checking for app")
+        NSLog("[NativePHP] ensureAppExists START")
         AppUpdateManager.shared.ensureAppExists()
+        NSLog("[NativePHP] ensureAppExists DONE")
 
-        // 3. Create storage symlink
-        DebugLogger.shared.log("📱 Deferred init: creating storage symlink")
-        createStorageLink()
+        // 3. Boot persistent PHP runtime (one-time Laravel boot)
+        NSLog("[NativePHP] PersistentPHPRuntime.boot() START")
+        let booted = PersistentPHPRuntime.shared.boot()
+        NSLog("[NativePHP] PersistentPHPRuntime.boot() DONE, booted=\(booted)")
+
+        if booted {
+            NSLog("[NativePHP] artisan migrate START")
+            _ = PersistentPHPRuntime.shared.artisan(command: "migrate --force")
+            NSLog("[NativePHP] artisan migrate DONE")
+
+            NSLog("[NativePHP] artisan storage:link START")
+            _ = PersistentPHPRuntime.shared.artisan(command: "storage:link")
+            NSLog("[NativePHP] artisan storage:link DONE")
+
+            // Start background queue worker (separate TSRM context)
+            NSLog("[NativePHP] PHPQueueWorker.start()")
+            PHPQueueWorker.shared.start()
+
+            // Schedule background task runners
+            NSLog("[NativePHP] PHPScheduler.scheduleNextRun()")
+            PHPScheduler.shared.scheduleNextRun()
+            NSLog("[NativePHP] PHPScheduler.scheduleNextRefresh()")
+            PHPScheduler.shared.scheduleNextRefresh()
+        } else {
+            NSLog("[NativePHP] persistent boot failed, falling back to classic mode")
+            createStorageLink()
+        }
 
         // 4. Execute plugin initialization callbacks (on main thread)
         DispatchQueue.main.async {
@@ -61,10 +92,10 @@ struct NativePHPApp: App {
         #endif
 
         // 6. Check for OTA updates (after everything is set up)
-        DebugLogger.shared.log("📱 Deferred init: checking for OTA update")
+        NSLog("[NativePHP] checkForUpdates START")
         AppUpdateManager.shared.checkForUpdates()
 
-        DebugLogger.shared.log("📱 Deferred initialization completed")
+        NSLog("[NativePHP] Deferred initialization completed")
 
         // Notify that PHP is ready and allow WebView to be rendered
         // WebView will call markInitialized() when first page loads to dismiss splash

--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -4,15 +4,8 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
     let domain = "127.0.0.1"
 
     private let maxRedirects = 10
-    private let phpSerialQueue: DispatchQueue
     private var activeTasks: [ObjectIdentifier: WKURLSchemeTask] = [:]
     private let taskLock = NSLock()
-
-    override init() {
-        let appName = Bundle.main.infoDictionary?["CFBundleName"] as? String ?? "DefaultAppName"
-        let queueLabel = "com.NativePHP.\(appName).phpSerialQueue"
-        self.phpSerialQueue = DispatchQueue(label: queueLabel)
-    }
 
     // This method is called when the web view starts loading a request with your custom scheme
     func webView(_ webView: WKWebView, start schemeTask: WKURLSchemeTask) {
@@ -595,14 +588,25 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
 
     private func getResponse(request: RequestData,
                               completion: @escaping (Result<Data, Error>) -> Void) {
-        phpSerialQueue.async {
-            print()
-            print("\(request.method) \(request.uri)")
-            print()
-            print(request.headers.map { "\($0.key)=\($0.value)" }.joined(separator: "\n"))
+        // Execute on dedicated PHP thread (same thread as php_embed_init for ZTS compatibility)
+        PersistentPHPRuntime.shared.executeOnPHPThreadAsync {
+            let mode = PersistentPHPRuntime.shared.isBooted ? "PERSISTENT" : "CLASSIC"
+            let start = CFAbsoluteTimeGetCurrent()
+            NSLog("[NativePHP] [\(mode)] --> \(request.method) \(request.uri)")
 
-            // Pass the request to Laravel and get Laravel's response
-            let response = NativePHPApp.laravel(request: request) ?? "No response from Laravel"
+            let response: String
+            if PersistentPHPRuntime.shared.isBooted {
+                // Persistent mode — dispatch through booted Laravel kernel
+                response = PersistentPHPRuntime.shared.dispatch(request: request)
+            } else {
+                // Fallback to legacy per-request mode
+                response = NativePHPApp.laravel(request: request) ?? "No response from Laravel"
+            }
+
+            let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
+            // Extract status code from first line (e.g. "HTTP/1.1 200 OK")
+            let statusLine = response.prefix(while: { $0 != "\r" && $0 != "\n" })
+            NSLog("[NativePHP] [\(mode)] <-- \(statusLine) (\(String(format: "%.1f", elapsed))ms)")
 
             // Extract cookie headers
             let components = response.components(separatedBy: "\r\n\r\n")
@@ -610,12 +614,16 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
 
             let headersList = headers.components(separatedBy: "\n").filter { !$0.isEmpty }
 
-            let setCookieHeaders = headersList.filter { $0.hasPrefix("Set-Cookie:") }
+            let setCookieHeaders = headersList.filter { $0.hasPrefix("Set-Cookie:") || $0.hasPrefix("set-cookie:") }
 
             DispatchQueue.main.async {
                 for header in setCookieHeaders {
-                    // Remove "Set-Cookie: " prefix
-                    let cookieString = header.replacingOccurrences(of: "Set-Cookie: ", with: "")
+                    // Remove "Set-Cookie: " prefix (case-insensitive)
+                    var cookieString = header
+                    if let range = cookieString.range(of: "Set-Cookie: ", options: .caseInsensitive) {
+                        cookieString = String(cookieString[range.upperBound...])
+                    }
+                    cookieString = cookieString
                         .trimmingCharacters(in: .whitespacesAndNewlines)
                         .replacingOccurrences(of: ";\\s+", with: ";", options: .regularExpression)
 

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -180,9 +180,12 @@ class Runtime
             }
         }
 
+        error_log("[Runtime::artisan] calling: {$commandName}");
         Artisan::call($commandName, array_slice($params, 1), $output);
+        $result = $output->fetch();
+        error_log("[Runtime::artisan] output length: " . strlen($result));
 
-        return $output->fetch();
+        return $result;
     }
 
     /**

--- a/src/Traits/OpensIosProject.php
+++ b/src/Traits/OpensIosProject.php
@@ -8,10 +8,10 @@ trait OpensIosProject
 {
     public function openIosProject(): void
     {
-        $projectPath = base_path('nativephp/ios/NativePHP.xcodeproj');
+        $projectPath = base_path('nativephp/ios/NativePHP.xcworkspace');
 
         if (! is_dir($projectPath)) {
-            $this->error('Xcode project not found at '.$projectPath);
+            $this->error('Xcode workspace not found at '.$projectPath);
 
             return;
         }


### PR DESCRIPTION
## Summary
- Adds a persistent PHP runtime for iOS that keeps the Laravel kernel alive across requests
- Integrates BGTaskScheduler for background task execution with constraint support (network, charging, etc.)
- Scheduler reads `background_tasks.json` manifest and runs commands in-process via `Runtime::artisan()` — bypasses Laravel's process-forking `schedule:run` which can't work on iOS (no `php` binary)
- Adds a queue worker that polls via the persistent runtime

## Test plan
- [x] Verified `sync:data` command executes in-process and writes to disk on physical device
- [ ] Verify BGTask fires correctly after backgrounding the app
- [ ] Confirm no impact on Android builds
- [ ] Test queue worker processes jobs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)