### PR TITLE
Fix plugin pod dependencies missing on subsequent iOS builds

### DIFF
--- a/resources/xcode/Podfile
+++ b/resources/xcode/Podfile
@@ -5,7 +5,8 @@ project 'NativePHP.xcodeproj'
 def shared_pods
   use_frameworks! :linkage => :static
 
-  # NATIVEPHP_PLUGIN_PODS
+  # NATIVEPHP_PLUGIN_PODS_START
+  # NATIVEPHP_PLUGIN_PODS_END
 end
 
 target 'NativePHP' do

--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -924,9 +924,9 @@ SECTION;
         $newPods = collect($podsToAdd)
             ->filter(function ($pod) use ($podfile) {
                 $name = $pod['name'];
-                // Check if pod exists outside of our plugin dependencies section
+                // Check if pod exists outside of our managed marker section
                 $podfileWithoutSection = preg_replace(
-                    '/# NativePHP Plugin Dependencies\n(?:[ \t]*pod\s+\'[^\']+\'(?:,\s*\'[^\']+\')?\n?)*/s',
+                    '/# NATIVEPHP_PLUGIN_PODS_START\n.*?# NATIVEPHP_PLUGIN_PODS_END/s',
                     '',
                     $podfile
                 );
@@ -934,7 +934,7 @@ SECTION;
                 return ! preg_match("/pod\s+['\"]".preg_quote($name, '/')."['\"]/", $podfileWithoutSection);
             });
 
-        // Build the new plugin pods section
+        // Build the new plugin pods lines
         $newPodLines = $newPods
             ->map(function ($pod) {
                 $name = $pod['name'];
@@ -948,53 +948,22 @@ SECTION;
             })
             ->implode("\n");
 
-        // Remove existing plugin dependencies section (if any)
-        $podfile = preg_replace(
-            '/[ \t]*# NativePHP Plugin Dependencies\n(?:[ \t]*pod\s+\'[^\']+\'(?:,\s*\'[^\']+\')?\n?)*/s',
-            '',
-            $podfile
-        );
+        $pluginContent = $newPods->isNotEmpty() ? "\n{$newPodLines}\n  " : "\n  ";
 
-        // If no new pods to add, just save cleaned podfile
-        if ($newPods->isEmpty()) {
-            $this->files->put($podfilePath, $podfile);
-
-            return;
-        }
-
-        // Check if marker exists (preferred injection point)
-        if (str_contains($podfile, '# NATIVEPHP_PLUGIN_PODS')) {
-            $podfile = str_replace(
-                '# NATIVEPHP_PLUGIN_PODS',
-                "# NativePHP Plugin Dependencies\n{$newPodLines}",
+        // Replace everything between the start/end markers, preserving the markers
+        if (preg_match('/# NATIVEPHP_PLUGIN_PODS_START.*?# NATIVEPHP_PLUGIN_PODS_END/s', $podfile)) {
+            $podfile = preg_replace(
+                '/# NATIVEPHP_PLUGIN_PODS_START.*?# NATIVEPHP_PLUGIN_PODS_END/s',
+                "# NATIVEPHP_PLUGIN_PODS_START{$pluginContent}# NATIVEPHP_PLUGIN_PODS_END",
                 $podfile
             );
-        } else {
-            // Find the NativePHP target block and insert before its 'end'
-            // Use a more precise pattern that only matches within the target block
-            $lines = explode("\n", $podfile);
-            $result = [];
-            $inNativePHPTarget = false;
-            $inserted = false;
-
-            foreach ($lines as $line) {
-                // Detect start of NativePHP target (not simulator)
-                if (preg_match('/^target\s+[\'"]NativePHP[\'"]\s+do/', $line)) {
-                    $inNativePHPTarget = true;
-                }
-
-                // If we're in the target and hit 'end', insert pods before it
-                if ($inNativePHPTarget && ! $inserted && preg_match('/^end\s*$/', $line)) {
-                    $result[] = '  # NativePHP Plugin Dependencies';
-                    $result[] = $newPodLines;
-                    $inserted = true;
-                    $inNativePHPTarget = false;
-                }
-
-                $result[] = $line;
-            }
-
-            $podfile = implode("\n", $result);
+        } elseif (str_contains($podfile, '# NATIVEPHP_PLUGIN_PODS')) {
+            // Migrate old single marker to new start/end markers
+            $podfile = str_replace(
+                '# NATIVEPHP_PLUGIN_PODS',
+                "# NATIVEPHP_PLUGIN_PODS_START{$pluginContent}# NATIVEPHP_PLUGIN_PODS_END",
+                $podfile
+            );
         }
 
         $this->files->put($podfilePath, $podfile);
@@ -1010,7 +979,8 @@ platform :ios, '15.0'
 use_frameworks!
 
 target 'NativePHP' do
-  # NATIVEPHP_PLUGIN_PODS
+  # NATIVEPHP_PLUGIN_PODS_START
+  # NATIVEPHP_PLUGIN_PODS_END
 end
 
 post_install do |installer|


### PR DESCRIPTION
## Summary

- **Plugin pods (e.g. Firebase) were silently dropped from the simulator target on every build after the first `native:run`**, causing missing dependency crashes
- Root cause: the single `# NATIVEPHP_PLUGIN_PODS` marker inside `shared_pods` was consumed on first injection, so subsequent builds fell through to a fallback that injected pods into `target 'NativePHP'` only — the simulator target never got them
- Replaced with a `START`/`END` marker pair that preserves the injection point inside `shared_pods` across unlimited runs
- Existing projects with the old single marker are automatically migrated on next build

## What was happening

```
First run:  marker found in shared_pods → pods injected there → both targets get pods ✅
Second run: marker gone → fallback injects into target 'NativePHP' → simulator missing pods ❌
```

## What it does now

```
Every run: START/END markers always present in shared_pods → content between them replaced → both targets always get pods ✅
```

## Test plan

- [x] Fresh `native:install` + `native:run` with a pod-dependent plugin (e.g. Firebase) — verify pods land in `shared_pods`
- [x] Run `native:run` again — verify pods still in `shared_pods`, not moved to `target 'NativePHP'`
- [x] Run on simulator — verify no missing dependency errors
- [x] Test with a project that has the old single `# NATIVEPHP_PLUGIN_PODS` marker — verify automatic migration to new markers