### PR TITLE
Validate Android min SDK against floor and plugin requirements

### DIFF
--- a/src/Commands/PackageCommand.php
+++ b/src/Commands/PackageCommand.php
@@ -4,6 +4,7 @@ namespace Native\Mobile\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
+use Native\Mobile\Plugins\PluginRegistry;
 use Native\Mobile\Traits\ChecksLatestBuildNumber;
 use Native\Mobile\Traits\DisplaysMarketingBanners;
 use Native\Mobile\Traits\PackagesIos;
@@ -145,6 +146,17 @@ class PackageCommand extends Command
             \Laravel\Prompts\note('Android API level 26 (Android 8.0 Oreo) is the minimum version required by NativePHP. Please update your .env or config/nativephp.php.');
 
             return;
+        }
+
+        $plugins = app(PluginRegistry::class)->all();
+        foreach ($plugins as $plugin) {
+            $pluginMinSdk = $plugin->getAndroidMinVersion();
+            if ($pluginMinSdk !== null && $minSdk < $pluginMinSdk) {
+                \Laravel\Prompts\error("Plugin '{$plugin->name}' requires Android API level $pluginMinSdk, but your min SDK is $minSdk.");
+                \Laravel\Prompts\note("Your app may crash on devices running Android API levels $minSdk-".($pluginMinSdk - 1).'. Either raise NATIVEPHP_ANDROID_MIN_SDK to at least '.$pluginMinSdk.' in your .env, or remove the plugin.');
+
+                return;
+            }
         }
 
         $androidPath = base_path('nativephp/android');

--- a/src/Plugins/Plugin.php
+++ b/src/Plugins/Plugin.php
@@ -68,6 +68,13 @@ class Plugin
         return $this->manifest->ios['init_function'] ?? null;
     }
 
+    public function getAndroidMinVersion(): ?int
+    {
+        $value = $this->manifest->android['min_version'] ?? null;
+
+        return $value !== null ? (int) $value : null;
+    }
+
     public function getAndroidInitFunction(): ?string
     {
         return $this->manifest->android['init_function'] ?? null;

--- a/src/Traits/RunsAndroid.php
+++ b/src/Traits/RunsAndroid.php
@@ -81,6 +81,18 @@ trait RunsAndroid
             return;
         }
 
+        $plugins = app(PluginRegistry::class)->all();
+        foreach ($plugins as $plugin) {
+            $pluginMinSdk = $plugin->getAndroidMinVersion();
+            if ($pluginMinSdk !== null && $minSdk < $pluginMinSdk) {
+                $this->logToFile("ERROR: Plugin '{$plugin->name}' requires Android API level $pluginMinSdk, but NATIVEPHP_ANDROID_MIN_SDK is set to $minSdk");
+                error("Plugin '{$plugin->name}' requires Android API level $pluginMinSdk, but your min SDK is $minSdk.");
+                note("Your app may crash on devices running Android API levels $minSdk-".($pluginMinSdk - 1).'. Either raise NATIVEPHP_ANDROID_MIN_SDK to at least '.$pluginMinSdk.' in your .env, or remove the plugin.');
+
+                return;
+            }
+        }
+
         // Start Vite dev server early if watching, so hot file is present during build
         if ($this->option('watch')) {
             $this->startViteDevServer('android');


### PR DESCRIPTION
## Summary
- Bail on `native:run` and `native:package` for Android if `NATIVEPHP_ANDROID_MIN_SDK` is set below 26 (the minimum API level NativePHP supports)
- Check all registered plugins' `android.min_version` against the configured min SDK — if any plugin requires a higher API level, bail with a warning explaining crash risk on older devices
- Add `Plugin::getAndroidMinVersion()` getter for reading the manifest value

## Test plan
- [ ] Set `NATIVEPHP_ANDROID_MIN_SDK=24` and run `native:run android` — should bail with error
- [ ] Install a plugin with `android.min_version: 30`, set min SDK to 28, run `native:run android` — should bail naming the plugin
- [ ] Same checks for `native:package --android`
- [ ] Normal builds with valid min SDK should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)