### PR TITLE
Remove accidental pptx entry from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,3 @@ test-keystore.jks
 .github/workflows/test-package-local.yml
 
 /composer.lock
-NativePHP-Mobile-v3.1.pptx


### PR DESCRIPTION
## Summary
- Removes `NativePHP-Mobile-v3.1.pptx` from `.gitignore` — looks like it was committed by mistake with the v3.1 release.

## Test plan
- No functional changes, gitignore only.