### PR TITLE
Fix hot reload and HMR for persistent PHP runtime

### DIFF
--- a/resources/androidstudio/app/src/main/cpp/php_bridge.c
+++ b/resources/androidstudio/app/src/main/cpp/php_bridge.c
@@ -300,6 +300,7 @@ char* run_php_script_once(const char* scriptPath, const char* method, const char
 // The mutex serializes all access — only one PHP execution at a time.
 
 static int persistent_initialized = 0;
+static char *persistent_bootstrap_path = NULL;
 
 /**
  * Boot the persistent PHP interpreter once.
@@ -350,6 +351,11 @@ JNIEXPORT jint JNICALL native_persistent_boot(JNIEnv *env, jobject thiz, jstring
     }
 
     persistent_initialized = 1;
+
+    // Store bootstrap path for reboot capability
+    if (persistent_bootstrap_path) free(persistent_bootstrap_path);
+    persistent_bootstrap_path = strdup(bootstrapPath);
+
     LOGI("persistent_boot: PHP interpreter is now persistent and Laravel is booted");
 
     (*env)->ReleaseStringUTFChars(env, jBootstrapPath, bootstrapPath);
@@ -589,6 +595,76 @@ JNIEXPORT jstring JNICALL native_persistent_artisan(JNIEnv *env, jobject thiz, j
 }
 
 /**
+ * Reboot the persistent runtime WITHOUT restarting the PHP interpreter.
+ * Flushes the Laravel app, clears opcache, and re-executes the bootstrap script.
+ * The PHP process stays alive — only the Laravel application is rebuilt.
+ */
+JNIEXPORT jint JNICALL native_persistent_reboot(JNIEnv *env, jobject thiz) {
+    pthread_mutex_lock(&g_php_request_mutex);
+
+    if (!persistent_initialized || !persistent_bootstrap_path) {
+        LOGE("persistent_reboot: runtime not initialized or no bootstrap path");
+        pthread_mutex_unlock(&g_php_request_mutex);
+        return -1;
+    }
+
+    LOGI("persistent_reboot: rebooting Laravel (PHP interpreter stays alive)...");
+
+    // 1. Shut down the Laravel application (flush container, null out kernel)
+    zend_first_try {
+        zend_eval_string("\\Native\\Mobile\\Runtime::shutdown();", NULL, "persistent_reboot_shutdown");
+    } zend_end_try();
+    LOGI("persistent_reboot: Runtime::shutdown() complete");
+
+    // 2. Clear opcache so PHP re-reads files from disk
+    zend_first_try {
+        zend_eval_string(
+            "if (function_exists('opcache_reset')) { opcache_reset(); }",
+            NULL, "persistent_reboot_opcache"
+        );
+    } zend_end_try();
+    LOGI("persistent_reboot: opcache cleared");
+
+    // 3. Clear compiled views and cached config
+    zend_first_try {
+        zend_eval_string(
+            "$__storage = getenv('LARAVEL_STORAGE_PATH');"
+            "if ($__storage) {"
+            "    $__viewsDir = $__storage . '/framework/views';"
+            "    if (is_dir($__viewsDir)) {"
+            "        foreach (glob($__viewsDir . '/*.php') as $__f) { @unlink($__f); }"
+            "    }"
+            "    @unlink($__storage . '/framework/cache/config.php');"
+            "    @unlink($__storage . '/framework/cache/routes-v7.php');"
+            "}",
+            NULL, "persistent_reboot_clear_cache"
+        );
+    } zend_end_try();
+    LOGI("persistent_reboot: compiled views and cache cleared");
+
+    // 4. Rebuild the Laravel application from scratch
+    //    Autoloader is already loaded, classes are in memory — just create fresh app + kernel
+    clear_collected_output();
+    zend_first_try {
+        zend_eval_string(
+            "$app = require $_SERVER['LARAVEL_BOOTSTRAP_PATH'] . '/app.php';"
+            "\\Native\\Mobile\\Runtime::boot($app);"
+            "error_log('persistent_reboot: Laravel re-bootstrapped');",
+            NULL, "persistent_reboot_bootstrap"
+        );
+    } zend_end_try();
+
+    char *boot_output = get_collected_output();
+    if (boot_output && strlen(boot_output) > 0) {
+        LOGI("persistent_reboot: bootstrap output: %.500s", boot_output);
+    }
+
+    LOGI("persistent_reboot: Laravel rebooted successfully");
+    pthread_mutex_unlock(&g_php_request_mutex);
+    return 0;
+}
+
+/**
  * Shut down the persistent PHP interpreter.
  * Called on app destroy or before hot-reload reboot.
  */
@@ -611,6 +687,11 @@ JNIEXPORT void JNICALL native_persistent_shutdown(JNIEnv *env, jobject thiz) {
     safe_php_embed_shutdown();
     php_initialized = 0;
     persistent_initialized = 0;
+
+    if (persistent_bootstrap_path) {
+        free(persistent_bootstrap_path);
+        persistent_bootstrap_path = NULL;
+    }
 
     LOGI("persistent_shutdown: done");
     pthread_mutex_unlock(&g_php_request_mutex);
@@ -1073,6 +1154,7 @@ static JNINativeMethod gMethods[] = {
         {"nativePersistentDispatch","(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",(void *) native_persistent_dispatch},
         {"nativePersistentArtisan","(Ljava/lang/String;)Ljava/lang/String;",(void *) native_persistent_artisan},
         {"nativePersistentShutdown","()V",(void *) native_persistent_shutdown},
+        {"nativePersistentReboot","()I",(void *) native_persistent_reboot},
 
         // Worker (background queue) methods
         {"nativeWorkerBoot","(Ljava/lang/String;)I",(void *) native_worker_boot},

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
@@ -57,6 +57,7 @@ class PHPBridge(private val context: Context) {
     ): String
     external fun nativePersistentArtisan(command: String): String
     external fun nativePersistentShutdown()
+    external fun nativePersistentReboot(): Int
 
     // Worker (background queue) JNI methods — runs on a separate thread with its own TSRM context
     external fun nativeWorkerBoot(bootstrapPath: String): Int
@@ -144,6 +145,31 @@ class PHPBridge(private val context: Context) {
     }
 
     fun isPersistentMode(): Boolean = persistentMode && persistentBooted
+
+    /**
+     * Reboot the persistent runtime without restarting the PHP interpreter.
+     * Flushes the Laravel app, clears opcache and compiled views, then re-bootstraps.
+     * Used by hot reload to pick up file changes while keeping persistent mode speed.
+     */
+    fun rebootPersistentRuntime(): Boolean {
+        if (!persistentBooted) {
+            Log.w(TAG, "Cannot reboot — persistent runtime not booted")
+            return false
+        }
+        val future = phpExecutor.submit<Boolean> {
+            val start = System.currentTimeMillis()
+            val result = nativePersistentReboot()
+            val elapsed = System.currentTimeMillis() - start
+            if (result == 0) {
+                Log.i(TAG, "Persistent runtime rebooted in ${elapsed}ms")
+                true
+            } else {
+                Log.e(TAG, "Persistent runtime reboot failed (code=$result) after ${elapsed}ms")
+                false
+            }
+        }
+        return future.get()
+    }
 
     /**
      * Boot the worker PHP runtime on a dedicated TSRM context.

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
@@ -477,10 +477,17 @@ class MainActivity : FragmentActivity(), WebViewProvider {
             val reloadFile = File("${appStorageDir.absolutePath}/laravel/storage/framework/reload_signal.json")
             var lastModified: Long = 0
 
+            Log.d("HotReload", "Watcher started, persistent=${phpBridge.isPersistentMode()}")
+
             while (!shouldStopWatcher && !Thread.currentThread().isInterrupted) {
                 try {
                     if (reloadFile.exists() && reloadFile.lastModified() > lastModified) {
                         lastModified = reloadFile.lastModified()
+
+                        // Reboot the persistent runtime so it picks up file changes
+                        if (phpBridge.isPersistentMode()) {
+                            phpBridge.rebootPersistentRuntime()
+                        }
 
                         runOnUiThread {
                             webView.stopLoading()

--- a/resources/xcode/Include/Bridge/PHP.c
+++ b/resources/xcode/Include/Bridge/PHP.c
@@ -173,7 +173,8 @@ typedef struct {
 typedef enum {
     PHP_WORK_DISPATCH,
     PHP_WORK_ARTISAN,
-    PHP_WORK_SHUTDOWN
+    PHP_WORK_SHUTDOWN,
+    PHP_WORK_REBOOT
 } php_work_type_t;
 
 // Synchronization: caller posts to work_sem, worker posts to done_sem
@@ -189,11 +190,13 @@ static char                *php_work_str_result  = NULL;
 static int persistent_initialized = 0;
 static int worker_thread_alive = 0;
 static char *persistent_boot_error = NULL;
+static char *persistent_bootstrap_path = NULL;
 
 // Forward declarations
 static void do_dispatch(const dispatch_params_t *params);
 static void do_artisan(const char *command);
 static void do_shutdown(void);
+static void do_reboot(void);
 
 static void setup_persistent_sapi(void) {
     php_embed_module.ub_write       = capture_php_output;
@@ -276,6 +279,9 @@ static void *php_worker_main(void *arg) {
         persistent_initialized = 1;
         php_work_int_result = 0;
         free(bootstrap_output);
+        // Store bootstrap path for reboot
+        if (persistent_bootstrap_path) free(persistent_bootstrap_path);
+        persistent_bootstrap_path = strdup(bootstrapPath);
         // Clear any previous boot error
         if (persistent_boot_error) { free(persistent_boot_error); persistent_boot_error = NULL; }
         fprintf(stderr, "PHP-WORKER: bootstrap complete, Runtime::isBooted() confirmed\n");
@@ -317,6 +323,9 @@ static void *php_worker_main(void *arg) {
                 break;
             case PHP_WORK_SHUTDOWN:
                 do_shutdown();
+                break;
+            case PHP_WORK_REBOOT:
+                do_reboot();
                 break;
         }
 
@@ -532,6 +541,70 @@ static void do_shutdown(void) {
 
     persistent_initialized = 0;
     worker_thread_alive = 0;
+
+    if (persistent_bootstrap_path) {
+        free(persistent_bootstrap_path);
+        persistent_bootstrap_path = NULL;
+    }
+}
+
+/// Reboot the persistent runtime WITHOUT restarting the PHP interpreter.
+/// Flushes the Laravel app, clears opcache and compiled views, then re-bootstraps.
+static void do_reboot(void) {
+    if (!persistent_initialized || !persistent_bootstrap_path) {
+        fprintf(stderr, "persistent_reboot: not initialized or no bootstrap path\n");
+        fflush(stderr);
+        php_work_int_result = -1;
+        return;
+    }
+
+    fprintf(stderr, "persistent_reboot: rebooting Laravel (PHP interpreter stays alive)...\n");
+    fflush(stderr);
+
+    // 1. Shut down the Laravel application
+    clear_output_buffer();
+    zend_first_try {
+        zend_eval_string("\\Native\\Mobile\\Runtime::shutdown();", NULL, "persistent_reboot_shutdown");
+    } zend_end_try();
+
+    // 2. Clear opcache
+    zend_first_try {
+        zend_eval_string(
+            "if (function_exists('opcache_reset')) { opcache_reset(); }",
+            NULL, "persistent_reboot_opcache"
+        );
+    } zend_end_try();
+
+    // 3. Clear compiled views and cached config
+    zend_first_try {
+        zend_eval_string(
+            "$__storage = getenv('LARAVEL_STORAGE_PATH');"
+            "if ($__storage) {"
+            "    $__viewsDir = $__storage . '/framework/views';"
+            "    if (is_dir($__viewsDir)) {"
+            "        foreach (glob($__viewsDir . '/*.php') as $__f) { @unlink($__f); }"
+            "    }"
+            "    @unlink($__storage . '/framework/cache/config.php');"
+            "    @unlink($__storage . '/framework/cache/routes-v7.php');"
+            "}",
+            NULL, "persistent_reboot_clear_cache"
+        );
+    } zend_end_try();
+
+    // 4. Rebuild the Laravel application
+    clear_output_buffer();
+    zend_first_try {
+        zend_eval_string(
+            "$app = require $_SERVER['LARAVEL_BOOTSTRAP_PATH'] . '/app.php';"
+            "\\Native\\Mobile\\Runtime::boot($app);"
+            "error_log('persistent_reboot: Laravel re-bootstrapped');",
+            NULL, "persistent_reboot_bootstrap"
+        );
+    } zend_end_try();
+
+    fprintf(stderr, "persistent_reboot: Laravel rebooted successfully\n");
+    fflush(stderr);
+    php_work_int_result = 0;
 }
 
 // ── Public API (called from Swift, dispatches to PHP thread) ──
@@ -634,6 +707,13 @@ void persistent_php_shutdown(void) {
     if (!persistent_initialized) return;
     php_work_type = PHP_WORK_SHUTDOWN;
     submit_and_wait(PHP_WORK_SHUTDOWN);
+}
+
+int persistent_php_reboot(void) {
+    if (!persistent_initialized) return -1;
+    php_work_type = PHP_WORK_REBOOT;
+    submit_and_wait(PHP_WORK_REBOOT);
+    return php_work_int_result;
 }
 
 int persistent_php_is_booted(void) {

--- a/resources/xcode/Include/Bridge/PHP.h
+++ b/resources/xcode/Include/Bridge/PHP.h
@@ -20,6 +20,7 @@ const char *persistent_php_dispatch(const char *method,
                                     const char *contentType);
 const char *persistent_php_artisan(const char *command);
 void persistent_php_shutdown(void);
+int  persistent_php_reboot(void);
 int  persistent_php_is_booted(void);
 void persistent_php_save_context(void);
 void persistent_php_restore_context(void);

--- a/resources/xcode/NativePHP/Bridge/PersistentPHPRuntime.swift
+++ b/resources/xcode/NativePHP/Bridge/PersistentPHPRuntime.swift
@@ -21,6 +21,9 @@ private func _persistent_php_artisan(_ command: UnsafePointer<CChar>?) -> Unsafe
 @_silgen_name("persistent_php_shutdown")
 private func _persistent_php_shutdown()
 
+@_silgen_name("persistent_php_reboot")
+private func _persistent_php_reboot() -> Int32
+
 @_silgen_name("persistent_php_is_booted")
 private func _persistent_php_is_booted() -> Int32
 
@@ -99,10 +102,18 @@ final class PersistentPHPRuntime {
         return isBooted
     }
 
-    /// Re-boot the persistent runtime (shutdown then boot).
+    /// Reboot the persistent runtime without restarting the PHP interpreter.
+    /// Flushes the Laravel app, clears opcache and compiled views, then re-bootstraps.
     func reboot() -> Bool {
-        shutdown()
-        return boot()
+        guard isBooted else { return false }
+        let result = _persistent_php_reboot()
+        if result == 0 {
+            print("PersistentPHPRuntime: reboot succeeded")
+            return true
+        } else {
+            print("PersistentPHPRuntime: reboot FAILED (\(result))")
+            return false
+        }
     }
 
 

--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -335,8 +335,7 @@ struct WebView: UIViewRepresentable {
         }
 
         @objc func reloadWebView() {
-            _ = NativePHPApp.shared?.artisan(additionalArgs: ["view:clear"])
-
+            // Views are already cleared during persistent runtime reboot — just reload
             self.webView?.reload()
         }
 

--- a/resources/xcode/NativePHP/HotReloadServer.swift
+++ b/resources/xcode/NativePHP/HotReloadServer.swift
@@ -34,15 +34,28 @@ class HotReloadServer {
     
     private func handleConnection(_ connection: NWConnection) {
         connection.start(queue: queue)
-        
-        // Any connection triggers a reload
-        DispatchQueue.main.async {
-            NotificationCenter.default.post(name: .reloadWebViewNotification, object: nil)
+
+        print("🔥 Hot reload connection received")
+
+        // Reboot the persistent runtime on a background thread (blocks until done)
+        DispatchQueue.global(qos: .userInitiated).async {
+            if PersistentPHPRuntime.shared.isBooted {
+                print("🔄 Rebooting persistent runtime...")
+                let success = PersistentPHPRuntime.shared.reboot()
+                print("🔄 Persistent runtime reboot: \(success ? "success" : "failed")")
+            } else {
+                print("🔄 Persistent runtime not booted, skipping reboot")
+            }
+
+            // Then trigger WebView reload on main thread
+            DispatchQueue.main.async {
+                NotificationCenter.default.post(name: .reloadWebViewNotification, object: nil)
+                print("🔄 WebView reload notification posted")
+            }
         }
-        
+
         // Immediately close the connection
         connection.cancel()
-        print("🔄 Hot reload triggered")
     }
 }
 

--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -152,7 +152,7 @@ class Runtime
         $output = new BufferedOutput;
 
         // Parse command and arguments
-        $parts = str_getcsv($command, ' ');
+        $parts = str_getcsv($command, ' ', '"', '\\');
         $commandName = array_shift($parts);
 
         $params = ['command' => $commandName];

--- a/src/Traits/WatchesIos.php
+++ b/src/Traits/WatchesIos.php
@@ -49,12 +49,6 @@ trait WatchesIos
         $viteHotFile = $this->getHotFilePath('ios');
         $viteRunning = file_exists($viteHotFile);
 
-        if ($viteRunning) {
-            $this->info('Vite hot reloading detected - skipping full page reloads');
-        } else {
-            $this->info('No Vite hot reloading detected - will trigger full page reloads');
-        }
-
         // Get the derived data path / data container path
         $derivedDataPath = Process::run("xcrun simctl get_app_container {$target} {$appId} data")
             ->output();
@@ -65,6 +59,17 @@ trait WatchesIos
             $this->error('Could not find app container path. Make sure the app is installed and running.');
 
             return;
+        }
+
+        $destinationPath = $derivedDataPath.'/Documents/app/';
+
+        // Sync the hot file to the simulator if Vite is running
+        if ($viteRunning) {
+            $this->info('Vite dev server detected - syncing hot file to simulator');
+            $hotFileDestination = $destinationPath.'public/ios-hot';
+            @mkdir(dirname($hotFileDestination), 0755, true);
+            copy($viteHotFile, $hotFileDestination);
+            $this->triggerIosReload();
         }
 
         $this->line('Watching iOS paths: '.implode(', ', $this->getIosWatchPaths()));
@@ -108,10 +113,12 @@ trait WatchesIos
             $this->line("<fg=green>Synced to iOS:</fg=green> {$relativePath}");
         }
 
-        // Trigger reload only if Vite hot reloading is not active
-        if (! file_exists($viteHotFile)) {
-            $this->triggerIosReload();
+        // Skip reload for files that Vite handles via HMR
+        if (file_exists($viteHotFile) && $this->isViteHandledIosFile($relativePath)) {
+            return;
         }
+
+        $this->triggerIosReload();
     }
 
     private function triggerIosReload(): void
@@ -203,6 +210,22 @@ trait WatchesIos
 
             return $path;
         }, $paths);
+    }
+
+    private function isViteHandledIosFile(string $relativePath): bool
+    {
+        $vitePatterns = [
+            '/^resources\/js\/.*\.(vue|js|ts|jsx|tsx)$/i',
+            '/^resources\/css\/.*\.(css|scss|sass|less)$/i',
+        ];
+
+        foreach ($vitePatterns as $pattern) {
+            if (preg_match($pattern, $relativePath)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function getIosExcludePatterns(): array


### PR DESCRIPTION
Hot reload and HMR were broken because the persistent PHP runtime keeps Laravel booted in memory across requests. File changes synced to the device were ignored since the runtime served stale bytecode.

Adds a `reboot` mechanism (Android + iOS) that flushes the Laravel container, clears opcache/compiled views/cached config, and re-bootstraps the application — all without restarting the PHP interpreter. This preserves persistent mode speed while picking up file changes during development.

Also fixes the iOS file watcher to:
- Only skip reload for Vite-handled files (JS/CSS), not all files
- Sync the hot file to the simulator on watch start so Vite HMR works
- Remove the legacy `view:clear` artisan call from WebView reload that crashed by spawning a second PHP interpreter

Closes #58 