### PR TITLE
Fix #67: native:run ios fails to locate destination specifier ( simula...

### DIFF
--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -1004,7 +1004,7 @@ class BuildIosAppCommand extends Command
             // Add verbose output to help debug build failures
             '-verbose',
             ...($this->target ? [
-                '-destination', 'id='.$this->target.($simulated ? '' : ',platform=iOS'),
+                '-destination', ($simulated ? 'platform=iOS Simulator,id=' : 'platform=iOS,id=').$this->target,
                 'build',
             ] : [
                 '-archivePath', $this->basePath.'/build/NativePHP.xcarchive',


### PR DESCRIPTION
Closes #67

## Summary

The fix is clean. Here's a summary of what was changed and why:

**Root cause:** In `BuildIosAppCommand.php:1007`, the xcodebuild `-destination` for simulator builds was `id=UDID` — without a `platform` specifier. On newer iOS runtimes (iOS 26.x), xcodebuild can't resolve a destination by UDID alone when the runtime has an empty build number (the `DVTDeviceOperation: Encountered a build number "" that is incompatible with DVTBuildVersion` warning). Without the platform hint, xcodebuild has nowhere to look and reports no matching destination.

**Fix:** Changed the simulator destination from `id=UDID` to `platform=iOS Simulator,id=UDID`. This explicitly tells xcodebuild to search the simulator namespace, allowing it to locate the device even when the runtime metadata is incomplete. The real-device path was also updated to the consistent `platform=iOS,id=UDID` form (functionally equivalent, just consistent ordering).
