### PR TITLE
Fix iOS top bar breaking edge-to-edge webview layout

### DIFF
--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -12,14 +12,19 @@ struct ContentView: View {
     @StateObject private var uiState = NativeUIState.shared
 
     var body: some View {
-        NativeSideNavigation(onNavigate: handleNavigation) {
-            WebViewLayoutContainer(onTabSelected: handleNavigation)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .safeAreaInset(edge: .top, spacing: 0) {
-                    if uiState.hasTopBar() {
-                        NativeTopBar(onNavigate: handleNavigation)
-                    }
+        ZStack {
+            NativeSideNavigation(onNavigate: handleNavigation) {
+                WebViewLayoutContainer(onTabSelected: handleNavigation)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+
+            // Top bar overlay — sits on top of webview so web content extends edge-to-edge behind it
+            if uiState.hasTopBar() {
+                VStack(spacing: 0) {
+                    NativeTopBar(onNavigate: handleNavigation)
+                    Spacer()
                 }
+            }
         }
     }
 
@@ -130,7 +135,7 @@ struct WebViewLayoutContainer: View {
                     // Single WebView instance - fills available space
                     WebView(shared: SharedWebView.shared, horizontalSizeClass: horizontalSizeClass)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .ignoresSafeArea(.all, edges: uiState.hasTopBar() ? .horizontal : .all)
+                        .ignoresSafeArea()
 
                     // Bottom navigation at bottom
                     NativeBottomNavigation(onTabSelected: onTabSelected)
@@ -140,7 +145,7 @@ struct WebViewLayoutContainer: View {
             // No bottom nav - WebView fills entire screen
             WebView(shared: SharedWebView.shared, horizontalSizeClass: horizontalSizeClass)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .ignoresSafeArea(.all, edges: uiState.hasTopBar() ? [.horizontal, .bottom] : .all)
+                .ignoresSafeArea()
         }
     }
 }
@@ -246,6 +251,9 @@ struct WebView: UIViewRepresentable {
 
             let insets = windowScene?.windows.first?.safeAreaInsets ?? webView.window?.safeAreaInsets ?? .zero
 
+            // When top bar overlays the webview, add its height to the top inset
+            let topInset = insets.top + (NativeUIState.shared.hasTopBar() ? NativeUIState.topBarHeight : 0)
+
             // Also get color scheme for CSS variable
             let isDarkMode = windowScene?.windows.first?.traitCollection.userInterfaceStyle == .dark
             let colorScheme = isDarkMode ? "dark" : "light"
@@ -254,7 +262,7 @@ struct WebView: UIViewRepresentable {
             (function() {
                 // Set CSS variables directly on documentElement for immediate availability
                 if (document.documentElement) {
-                    document.documentElement.style.setProperty('--inset-top', '\(insets.top)px');
+                    document.documentElement.style.setProperty('--inset-top', '\(topInset)px');
                     document.documentElement.style.setProperty('--inset-right', '\(insets.right)px');
                     document.documentElement.style.setProperty('--inset-bottom', '\(insets.bottom)px');
                     document.documentElement.style.setProperty('--inset-left', '\(insets.left)px');
@@ -615,7 +623,7 @@ struct WebView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
-        // No manual insets needed - safeAreaInset handles topbar automatically
+        // Top bar overlays via ZStack; --inset-top includes its height when present
         // Bottom nav uses its own safeAreaInset in WebViewLayoutContainer
     }
 }

--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -12,17 +12,17 @@ struct ContentView: View {
     @StateObject private var uiState = NativeUIState.shared
 
     var body: some View {
-        ZStack {
-            NativeSideNavigation(onNavigate: handleNavigation) {
+        NativeSideNavigation(onNavigate: handleNavigation) {
+            ZStack(alignment: .top) {
                 WebViewLayoutContainer(onTabSelected: handleNavigation)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-            }
 
-            // Top bar overlay — sits on top of webview so web content extends edge-to-edge behind it
-            if uiState.hasTopBar() {
-                VStack(spacing: 0) {
-                    NativeTopBar(onNavigate: handleNavigation)
-                    Spacer()
+                // Top bar overlay — inside side nav so it doesn't cover the drawer
+                if uiState.hasTopBar() {
+                    VStack(spacing: 0) {
+                        NativeTopBar(onNavigate: handleNavigation)
+                        Spacer()
+                    }
                 }
             }
         }

--- a/resources/xcode/NativePHP/NativeUI/NativeUIState.swift
+++ b/resources/xcode/NativePHP/NativeUI/NativeUIState.swift
@@ -10,6 +10,9 @@ class NativeUIState: ObservableObject {
     @Published var sideNavData: SideNavData?
     @Published var topBarData: TopBarData?
 
+    // Standard UINavigationBar height + padding below
+    static let topBarHeight: CGFloat = 52
+
     // Cache to prevent unnecessary updates
     private var lastJsonString: String?
 


### PR DESCRIPTION
## Summary
- Changed top bar from `safeAreaInset(edge: .top)` to a ZStack overlay so the webview stays edge-to-edge behind the status bar and top bar
- Updated `--inset-top` CSS injection to include nav bar height (52pt) when top bar is present, so `.nativephp-safe-area` padding still works
- Removed top-bar-dependent `ignoresSafeArea` conditions — webview now always ignores all safe areas

## Test plan
- [ ] Verify red/colored backgrounds extend edge-to-edge behind status bar with top bar present
- [ ] Verify content text has padding below the top bar (not flush against it)
- [ ] Verify layout still works correctly without a top bar
- [ ] Verify bottom nav layouts (iOS 26+ and iOS 18) are unaffected
- [ ] Test with side nav — menu button should still open sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)