### PR TITLE
Fix plugin directory structure inconsistency in PluginCreateCommand

### DIFF
--- a/src/Commands/PluginValidateCommand.php
+++ b/src/Commands/PluginValidateCommand.php
@@ -201,8 +201,10 @@ class PluginValidateCommand extends Command
         ];
 
         $optionalDirs = [
-            'resources/android/src' => 'Android Kotlin sources',
-            'resources/ios/Sources' => 'iOS Swift sources',
+            'resources/android/src' => 'Android Kotlin sources (nested)',
+            'resources/android' => 'Android Kotlin sources (flat)',
+            'resources/ios/Sources' => 'iOS Swift sources (nested)',
+            'resources/ios' => 'iOS Swift sources (flat)',
         ];
 
         foreach ($requiredDirs as $dir => $description) {
@@ -276,8 +278,20 @@ class PluginValidateCommand extends Command
         }
 
         // Search recursively for the Kotlin file
-        $androidSrc = $basePath.'/resources/android/src';
-        if (! is_dir($androidSrc)) {
+        $searchPaths = [
+            $basePath.'/resources/android/src',
+            $basePath.'/resources/android'
+        ];
+
+        $androidSrc = null;
+        foreach ($searchPaths as $path) {
+            if (is_dir($path)) {
+                $androidSrc = $path;
+                break;
+            }
+        }
+
+        if (! $androidSrc) {
             return null;
         }
 
@@ -300,9 +314,13 @@ class PluginValidateCommand extends Command
         $parts = explode('.', $className);
         $class = $parts[0];
 
-        $swiftPath = $basePath.'/resources/ios/Sources/'.$class.'.swift';
+        $nestedPath = $basePath.'/resources/ios/Sources/'.$class.'.swift';
+        if ($this->files->exists($nestedPath)) {
+            return $nestedPath;
+        }
 
-        return $this->files->exists($swiftPath) ? $swiftPath : null;
+        $flatPath = $basePath.'/resources/ios/'.$class.'.swift';
+        return $this->files->exists($flatPath) ? $flatPath : null;
     }
 
     protected function validateHooks(string $path): void

--- a/src/Commands/PluginValidateCommand.php
+++ b/src/Commands/PluginValidateCommand.php
@@ -280,7 +280,7 @@ class PluginValidateCommand extends Command
         // Search recursively for the Kotlin file
         $searchPaths = [
             $basePath.'/resources/android/src',
-            $basePath.'/resources/android'
+            $basePath.'/resources/android',
         ];
 
         $androidSrc = null;


### PR DESCRIPTION
*Updated PR based on [simonhamp](https://github.com/simonhamp) feedback to adapt the validator instead of the creator.*

### Problem Description
Freshly created plugins generate a flat directory structure (`resources/android/` and `resources/ios/`), but `PluginValidateCommand` strictly expects a nested structure (`/src/` and `/Sources/`), resulting in false positive warnings like `No native code directories found`.

### Solution
Instead of forcing the creation command to use nested folders, this PR updates `PluginValidateCommand` to support both architectures. 

**What changed in `PluginValidateCommand.php`:**
1. The validator now checks for the nested structure first.
2. If not found, it gracefully falls back to checking the flat structure.
3. It only emits warnings if the implementation is missing in *both* locations.
This aligns the validator with the core `Plugin` class which already supports both approaches seamlessly.

### Testing
- [x] Tested locally by generating a fresh plugin with flat structure.
- [x] Ran `native:plugin:validate` (passed with a clean `OK` and 0 warnings).

### Visual Proof (Before & After)

**Before (Current Main):**
```text
$ php artisan native:plugin:validate packages/wilsonatb/plugin-test-bug
  plugin-test-bug (android: 21, ios: 15.0) ...................................................................... WARN  
  ⚠ No native code directories found (resources/android or resources/ios)
  ⚠ Android implementation not found for TestBug.Execute
  ⚠ iOS implementation not found for TestBug.Execute
```

**After (This PR):**
```text
$ php artisan native:plugin:validate packages/wilsonatb/plugin-test-fallback
  plugin-test-fallback (android: 21, ios: 15.0) ........................................................................ OK 
```