### PR TITLE
Move endroid/qr-code to require and exclude from app bundles

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "laravel/prompts": "^0.1.1|^0.2|^0.3",
         "react/datagram": "^1.10",
-        "spatie/laravel-package-tools": "^1.14.0"
+        "spatie/laravel-package-tools": "^1.14.0",
+        "endroid/qr-code": "^6.1.3"
     },
     "require-dev": {
         "larastan/larastan": "^2.0",
@@ -44,7 +45,6 @@
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "endroid/qr-code": "^5.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {

--- a/resources/jump/router.php
+++ b/resources/jump/router.php
@@ -144,11 +144,11 @@ if ($path === '/jump/qr' || $path === '/jump') {
         ]);
 
         // Generate QR code
-        $result = Builder::create()
-            ->data($qrData)
-            ->size(300)
-            ->margin(10)
-            ->build();
+        $result = (new Builder(
+            data: $qrData,
+            size: 300,
+            margin: 10,
+        ))->build();
 
         $qrCodeDataUri = $result->getDataUri();
 

--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -209,6 +209,7 @@ class BuildIosAppCommand extends Command
 
             if (Str::startsWith($relativePath, 'vendor/nativephp/mobile/resources') ||
                 Str::startsWith($relativePath, 'vendor/nativephp/mobile/vendor') ||
+                Str::startsWith($relativePath, 'vendor/endroid') ||
                 Str::startsWith($relativePath, 'nativephp') ||
                 Str::startsWith($relativePath, 'output/') ||
                 Str::startsWith($relativePath, 'build/') ||

--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -341,6 +341,7 @@ class JumpCommand extends Command
             'nativephp/ios',
             'nativephp/android',
             'vendor/nativephp/mobile/resources',
+            'vendor/endroid',
             'output',
             'tests',
             '.github',

--- a/src/Traits/PreparesBuild.php
+++ b/src/Traits/PreparesBuild.php
@@ -413,6 +413,7 @@ trait PreparesBuild
             if ($shouldExclude ||
                 Str::startsWith($relativePath, 'vendor/nativephp/mobile/resources') ||
                 Str::startsWith($relativePath, 'vendor/nativephp/mobile/vendor') ||
+                Str::startsWith($relativePath, 'vendor/endroid') ||
                 Str::startsWith($relativePath, '.idea') ||
                 Str::startsWith($relativePath, 'output') ||
                 Str::startsWith($relativePath, 'storage/framework/views/') ||


### PR DESCRIPTION
## Summary
- Moves `endroid/qr-code` from `require-dev` to `require` (needed at runtime by Jump dev server for QR code generation)
- Upgrades to v6 (`^6.1.3`) and updates `Builder` API usage in `router.php`
- Excludes `vendor/endroid` from all app bundle build paths to prevent ~15MB bloat:
  - `JumpCommand.php` — Jump ZIP bundle
  - `PreparesBuild.php` — Android `native:run`/`native:package`
  - `BuildIosAppCommand.php` — iOS `native:run`/`native:package`

## Test plan
- [x] Run `native:jump` and verify QR code renders in browser
- [x] Run `native:run android` and confirm bundle size is reduced
- [x] Run `native:run ios` and confirm bundle size is reduced
- [x] Verify `vendor/endroid` is not present in built app bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)