### PR TITLE
fix(ios): preserve URL percent-encoding through to PHP

### DIFF
--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -517,57 +517,11 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
 
                 var request = requestData
                 if let location = headers["location"] {
-                    let trimmedLocation = location.trimmingCharacters(in: .whitespaces)
+                    // Location headers come directly from PHP's HTTP response — they are
+                    // raw strings that never pass through WebKit's URL normalization, so
+                    // they do NOT need re-encoding (unlike initial requests in extractRequestData).
+                    request.uri = location.trimmingCharacters(in: .whitespaces)
                     request.method = "GET"
-
-                    // Re-encode the path in the Location URL to match extractRequestData behavior.
-                    // WKWebView decodes percent-encoded characters in custom scheme URLs, so
-                    // redirect Location headers also need re-encoding for PHP/Laravel parity.
-                    let unreserved = CharacterSet(charactersIn:
-                        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
-
-                    let locationPath: String
-                    let locationPrefix: String
-                    let locationSuffix: String
-
-                    if let hostRange = trimmedLocation.range(of: "://\(self.domain)") {
-                        locationPrefix = String(trimmedLocation[...trimmedLocation.index(before: hostRange.upperBound)])
-                        let afterHost = String(trimmedLocation[hostRange.upperBound...])
-                        if let queryIndex = afterHost.firstIndex(of: "?") {
-                            locationPath = String(afterHost[..<queryIndex])
-                            locationSuffix = String(afterHost[queryIndex...])
-                        } else if let fragmentIndex = afterHost.firstIndex(of: "#") {
-                            locationPath = String(afterHost[..<fragmentIndex])
-                            locationSuffix = String(afterHost[fragmentIndex...])
-                        } else {
-                            locationPath = afterHost
-                            locationSuffix = ""
-                        }
-                    } else if trimmedLocation.hasPrefix("/") {
-                        locationPrefix = ""
-                        if let queryIndex = trimmedLocation.firstIndex(of: "?") {
-                            locationPath = String(trimmedLocation[..<queryIndex])
-                            locationSuffix = String(trimmedLocation[queryIndex...])
-                        } else {
-                            locationPath = trimmedLocation
-                            locationSuffix = ""
-                        }
-                    } else {
-                        locationPath = trimmedLocation
-                        locationPrefix = ""
-                        locationSuffix = ""
-                    }
-
-                    let segments = locationPath.split(separator: "/", omittingEmptySubsequences: false)
-                    let reencodedPath = segments.map { segment in
-                        return segment.addingPercentEncoding(withAllowedCharacters: unreserved) ?? String(segment)
-                    }.joined(separator: "/")
-
-                    if !locationPrefix.isEmpty {
-                        request.uri = locationPrefix + reencodedPath + locationSuffix
-                    } else {
-                        request.uri = reencodedPath + locationSuffix
-                    }
 
                     // Fix root URL redirects: ensure php://127.0.0.1 has trailing slash
                     if request.uri == "php://127.0.0.1" {

--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -295,8 +295,16 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
             }
         }
 
-        // Define the URI
-        let uri = request.url?.path ?? "/"
+        // Define the URI — use percentEncodedPath to preserve percent-encoded
+        // characters (e.g. %3A, %2B, %25) so PHP receives the same encoding
+        // a real browser would send. URL.path silently decodes these sequences.
+        let uri: String
+        if let url = request.url,
+           let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+            uri = components.percentEncodedPath
+        } else {
+            uri = request.url?.path ?? "/"
+        }
 
         // Create a RequestData object
         let requestData = RequestData(

--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -295,16 +295,35 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
             }
         }
 
-        // Define the URI — use percentEncodedPath to preserve percent-encoded
-        // characters (e.g. %3A, %2B, %25) so PHP receives the same encoding
-        // a real browser would send. URL.path silently decodes these sequences.
-        let uri: String
-        if let url = request.url,
-           let components = URLComponents(url: url, resolvingAgainstBaseURL: false) {
-            uri = components.percentEncodedPath
+        // WKWebView normalizes URLs for custom scheme handlers by decoding
+        // percent-encoded characters before passing them to the handler.
+        // For example, %253A in HTML becomes %3A in request.url.absoluteString.
+        // To match browser behavior (where URLs are sent as-is), we re-encode
+        // each path segment so PHP receives the same encoding it would from
+        // a real browser. rawurldecode() in PHP then produces the correct result.
+        let unreserved = CharacterSet(charactersIn:
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+        let rawPath: String
+        if let absoluteString = request.url?.absoluteString,
+           let hostRange = absoluteString.range(of: "://\(domain)") {
+            let afterHost = String(absoluteString[hostRange.upperBound...])
+            if let queryIndex = afterHost.firstIndex(of: "?") {
+                rawPath = String(afterHost[..<queryIndex])
+            } else if let fragmentIndex = afterHost.firstIndex(of: "#") {
+                rawPath = String(afterHost[..<fragmentIndex])
+            } else {
+                rawPath = afterHost
+            }
         } else {
-            uri = request.url?.path ?? "/"
+            rawPath = request.url?.path ?? "/"
         }
+
+        // Re-encode each path segment to undo WebKit's normalization
+        let segments = rawPath.split(separator: "/", omittingEmptySubsequences: false)
+        let uri = segments.map { segment in
+            return segment.addingPercentEncoding(withAllowedCharacters: unreserved) ?? String(segment)
+        }.joined(separator: "/")
 
         // Create a RequestData object
         let requestData = RequestData(
@@ -498,8 +517,57 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
 
                 var request = requestData
                 if let location = headers["location"] {
-                    request.uri = location.trimmingCharacters(in: .whitespaces)
+                    let trimmedLocation = location.trimmingCharacters(in: .whitespaces)
                     request.method = "GET"
+
+                    // Re-encode the path in the Location URL to match extractRequestData behavior.
+                    // WKWebView decodes percent-encoded characters in custom scheme URLs, so
+                    // redirect Location headers also need re-encoding for PHP/Laravel parity.
+                    let unreserved = CharacterSet(charactersIn:
+                        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+                    let locationPath: String
+                    let locationPrefix: String
+                    let locationSuffix: String
+
+                    if let hostRange = trimmedLocation.range(of: "://\(self.domain)") {
+                        locationPrefix = String(trimmedLocation[...trimmedLocation.index(before: hostRange.upperBound)])
+                        let afterHost = String(trimmedLocation[hostRange.upperBound...])
+                        if let queryIndex = afterHost.firstIndex(of: "?") {
+                            locationPath = String(afterHost[..<queryIndex])
+                            locationSuffix = String(afterHost[queryIndex...])
+                        } else if let fragmentIndex = afterHost.firstIndex(of: "#") {
+                            locationPath = String(afterHost[..<fragmentIndex])
+                            locationSuffix = String(afterHost[fragmentIndex...])
+                        } else {
+                            locationPath = afterHost
+                            locationSuffix = ""
+                        }
+                    } else if trimmedLocation.hasPrefix("/") {
+                        locationPrefix = ""
+                        if let queryIndex = trimmedLocation.firstIndex(of: "?") {
+                            locationPath = String(trimmedLocation[..<queryIndex])
+                            locationSuffix = String(trimmedLocation[queryIndex...])
+                        } else {
+                            locationPath = trimmedLocation
+                            locationSuffix = ""
+                        }
+                    } else {
+                        locationPath = trimmedLocation
+                        locationPrefix = ""
+                        locationSuffix = ""
+                    }
+
+                    let segments = locationPath.split(separator: "/", omittingEmptySubsequences: false)
+                    let reencodedPath = segments.map { segment in
+                        return segment.addingPercentEncoding(withAllowedCharacters: unreserved) ?? String(segment)
+                    }.joined(separator: "/")
+
+                    if !locationPrefix.isEmpty {
+                        request.uri = locationPrefix + reencodedPath + locationSuffix
+                    } else {
+                        request.uri = reencodedPath + locationSuffix
+                    }
 
                     // Fix root URL redirects: ensure php://127.0.0.1 has trailing slash
                     if request.uri == "php://127.0.0.1" {

--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -274,11 +274,18 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
             return
         }
 
-        // Extract GET parameters
+        // Extract URI + query with percent-encoding preserved. PHP consumes them
+        // verbatim as $_SERVER['REQUEST_URI'] / $_SERVER['QUERY_STRING'], so they
+        // must match what a real HTTP server would set — same shape Android
+        // produces via Uri.encodedPath. Using .path / .query would decode once
+        // and corrupt paths containing reserved chars ('/', '+', '$', '*') or
+        // literal '%' from the data.
+        var uri = "/"
         var query: String?
         if let url = request.url {
             let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
-            query = urlComponents?.query
+            uri = urlComponents?.percentEncodedPath ?? "/"
+            query = urlComponents?.percentEncodedQuery
         }
 
         // Extract HTTP method
@@ -294,20 +301,6 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
                 data = body
             }
         }
-
-        // WKWebView normalizes URLs for custom scheme handlers by decoding
-        // percent-encoded characters before passing them to the handler.
-        // For example, %253A in HTML becomes %3A in request.url.absoluteString.
-        // To match browser behavior (where URLs are sent as-is), we re-encode
-        // the path so PHP receives the same encoding it would from a real browser.
-        // rawurldecode() in PHP then produces the correct result.
-        let components = URLComponents(string: request.url!.absoluteString)
-        let rawPath = components?.percentEncodedPath ?? "/"
-
-        // Re-encode to restore any encoding levels stripped by WebKit's normalization.
-        // .urlPathAllowed does NOT include %, so percent-encoded sequences like %3A
-        // are properly re-encoded to %253A, preserving the encoding depth PHP expects.
-        let uri = rawPath.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? rawPath
 
         // Create a RequestData object
         let requestData = RequestData(

--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -301,13 +301,8 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
         // To match browser behavior (where URLs are sent as-is), we re-encode
         // the path so PHP receives the same encoding it would from a real browser.
         // rawurldecode() in PHP then produces the correct result.
-        let rawPath: String
-        if let url = request.url,
-           let components = URLComponents(string: url.absoluteString) {
-            rawPath = components.percentEncodedPath.isEmpty ? "/" : components.percentEncodedPath
-        } else {
-            rawPath = request.url?.path ?? "/"
-        }
+        let components = URLComponents(string: request.url!.absoluteString)
+        let rawPath = components?.percentEncodedPath ?? "/"
 
         // Re-encode to restore any encoding levels stripped by WebKit's normalization.
         // .urlPathAllowed does NOT include %, so percent-encoded sequences like %3A

--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -501,9 +501,6 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
 
                 var request = requestData
                 if let location = headers["location"] {
-                    // Location headers come directly from PHP's HTTP response — they are
-                    // raw strings that never pass through WebKit's URL normalization, so
-                    // they do NOT need re-encoding (unlike initial requests in extractRequestData).
                     request.uri = location.trimmingCharacters(in: .whitespaces)
                     request.method = "GET"
 

--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -299,37 +299,26 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
         // percent-encoded characters before passing them to the handler.
         // For example, %253A in HTML becomes %3A in request.url.absoluteString.
         // To match browser behavior (where URLs are sent as-is), we re-encode
-        // each path segment so PHP receives the same encoding it would from
-        // a real browser. rawurldecode() in PHP then produces the correct result.
-        let unreserved = CharacterSet(charactersIn:
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
-
+        // the path so PHP receives the same encoding it would from a real browser.
+        // rawurldecode() in PHP then produces the correct result.
         let rawPath: String
-        if let absoluteString = request.url?.absoluteString,
-           let hostRange = absoluteString.range(of: "://\(domain)") {
-            let afterHost = String(absoluteString[hostRange.upperBound...])
-            if let queryIndex = afterHost.firstIndex(of: "?") {
-                rawPath = String(afterHost[..<queryIndex])
-            } else if let fragmentIndex = afterHost.firstIndex(of: "#") {
-                rawPath = String(afterHost[..<fragmentIndex])
-            } else {
-                rawPath = afterHost
-            }
+        if let url = request.url,
+           let components = URLComponents(string: url.absoluteString) {
+            rawPath = components.percentEncodedPath.isEmpty ? "/" : components.percentEncodedPath
         } else {
             rawPath = request.url?.path ?? "/"
         }
 
-        // Re-encode each path segment to undo WebKit's normalization
-        let segments = rawPath.split(separator: "/", omittingEmptySubsequences: false)
-        let uri = segments.map { segment in
-            return segment.addingPercentEncoding(withAllowedCharacters: unreserved) ?? String(segment)
-        }.joined(separator: "/")
+        // Re-encode to restore any encoding levels stripped by WebKit's normalization.
+        // .urlPathAllowed does NOT include %, so percent-encoded sequences like %3A
+        // are properly re-encoded to %253A, preserving the encoding depth PHP expects.
+        let uri = rawPath.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? rawPath
 
         // Create a RequestData object
         let requestData = RequestData(
             method: method,
             uri: uri,
-            data: data ?? nil,
+            data: data,
             query: query ?? "",
             headers: headers
         )


### PR DESCRIPTION
## Problem

Laravel's URL generator (`route()`, `redirect()`, etc.) percent-encodes path and query values. PHP expects to consume the URI with that encoding intact — the shape `$_SERVER['REQUEST_URI']` and `$_SERVER['QUERY_STRING']` would have behind a real HTTP server.

**Android** preserves the encoding via `Uri.encodedPath` (added in #24).

**iOS** does not. The current handler uses `URL.path`, which percent-decodes once before handing the URI to PHP:

```swift
let uri = request.url?.path ?? "/"
```

When Laravel generates a URL like `/game-board/abc%2Fdef`, PHP on iOS sees `/game-board/abc/def`. Reserved characters (`/`, `+`, `$`, `*`) and literal `%` from route parameters arrive as bare characters, breaking route matching — Symfony rejects URIs Laravel itself generated as malformed (HTTP 400).

The encoding Laravel produces and the encoding iOS NativePHP delivers do not match.

## Fix

Use `URLComponents.percentEncodedPath` and `.percentEncodedQuery` — the iOS-equivalent of Android's `Uri.encodedPath`. PHP receives the URI in the same shape on both platforms, matching what Laravel and Symfony expect.

This PR also depends on https://github.com/NativePHP/mobile-air/pull/108 being merged, as 108 actually fails first before it reaches this point.

## Test plan

- [x] Routes with reserved chars in path (`/`, `+`, `$`, `*`)
- [x] Routes with literal `%` in route parameter data
- [x] Long URLs (~3500 char real-world tokens)
- [x] Static asset routes
- [x] Routes without special characters
