### PR TITLE
Fix str_getcsv deprecation warning on PHP 8.4

### DIFF
--- a/src/Runtime.php
+++ b/src/Runtime.php
@@ -152,7 +152,7 @@ class Runtime
         $output = new BufferedOutput;
 
         // Parse command and arguments
-        $parts = str_getcsv($command, ' ');
+        $parts = str_getcsv($command, ' ', '"', '\\');
         $commandName = array_shift($parts);
 
         $params = ['command' => $commandName];


### PR DESCRIPTION
Explicitly pass all parameters to str_getcsv() to prevent the $escape parameter deprecation notice from spamming logs.