### PR TITLE
Fix cold-launch races in PHP runtime boot and Laravel extraction

### DIFF
--- a/resources/androidstudio/app/src/main/cpp/php_bridge.c
+++ b/resources/androidstudio/app/src/main/cpp/php_bridge.c
@@ -2,6 +2,8 @@
 #include <android/log.h>
 #include <signal.h>
 #include <pthread.h>
+#include <errno.h>
+#include <time.h>
 #include "php_embed.h"
 #include "PHP.h"
 #include <zend_exceptions.h>
@@ -26,6 +28,54 @@ static int php_initialized = 0;    // tracks whether php_embed_init is active
 static pthread_mutex_t g_php_request_mutex = PTHREAD_MUTEX_INITIALIZER;
 static jobject g_callback_obj = NULL;
 static jmethodID g_callback_method = NULL;
+
+// ── Persistent boot gate ─────────────────────────────────────────────────
+// Without this gate, two threads can concurrently call php_embed_init():
+// one from native_persistent_boot (holding g_php_request_mutex), another from
+// native_ephemeral_boot taking the cold path (holding g_ephemeral_mutex, a
+// different lock) because it read php_initialized==0 before persistent set it.
+// Concurrent php_embed_init calls corrupt TSRM/SAPI globals.
+//
+// The gate lets ephemeral block while persistent is mid-boot, then re-check
+// php_initialized and take hot or cold path correctly.
+typedef enum {
+    PERSISTENT_BOOT_NEVER_STARTED = 0,
+    PERSISTENT_BOOT_IN_PROGRESS,
+    PERSISTENT_BOOT_SUCCEEDED,
+    PERSISTENT_BOOT_FAILED,
+} persistent_boot_state_t;
+
+static persistent_boot_state_t g_persistent_boot_state = PERSISTENT_BOOT_NEVER_STARTED;
+static pthread_mutex_t g_persistent_boot_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  g_persistent_boot_cond  = PTHREAD_COND_INITIALIZER;
+
+static void set_persistent_boot_state(persistent_boot_state_t state) {
+    pthread_mutex_lock(&g_persistent_boot_mutex);
+    g_persistent_boot_state = state;
+    pthread_cond_broadcast(&g_persistent_boot_cond);
+    pthread_mutex_unlock(&g_persistent_boot_mutex);
+}
+
+// Wait for persistent boot to leave IN_PROGRESS (settle into a terminal state).
+// Returns 0 once settled; returns -1 on timeout.
+// Callers re-check php_initialized after this to pick hot vs cold path —
+// this helper only prevents the concurrent php_embed_init race.
+static int wait_for_persistent_boot_settled(int timeout_seconds) {
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += timeout_seconds;
+
+    pthread_mutex_lock(&g_persistent_boot_mutex);
+    while (g_persistent_boot_state == PERSISTENT_BOOT_IN_PROGRESS) {
+        int rc = pthread_cond_timedwait(&g_persistent_boot_cond, &g_persistent_boot_mutex, &deadline);
+        if (rc == ETIMEDOUT) {
+            pthread_mutex_unlock(&g_persistent_boot_mutex);
+            return -1;
+        }
+    }
+    pthread_mutex_unlock(&g_persistent_boot_mutex);
+    return 0;
+}
 
 #define BUFFER_CHUNK_SIZE (256 * 1024)  // 256KB increments
 #define MAX_BUFFER_SIZE (16 * 1024 * 1024)  // 16MB max buffer
@@ -331,9 +381,14 @@ JNIEXPORT jint JNICALL native_persistent_boot(JNIEnv *env, jobject thiz, jstring
     setenv("APP_URL", "http://127.0.0.1", 1);
     setenv("ASSET_URL", "http://127.0.0.1/_assets/", 1);
 
+    // Open the boot gate so any concurrent ephemeral_embed_init call blocks
+    // instead of racing into a second php_embed_init().
+    set_persistent_boot_state(PERSISTENT_BOOT_IN_PROGRESS);
+
     setup_embed_module();
     if (php_embed_init(0, NULL) != SUCCESS) {
         LOGE("persistent_boot: php_embed_init() FAILED");
+        set_persistent_boot_state(PERSISTENT_BOOT_FAILED);
         (*env)->ReleaseStringUTFChars(env, jBootstrapPath, bootstrapPath);
         pthread_mutex_unlock(&g_php_request_mutex);
         return -1;
@@ -356,6 +411,7 @@ JNIEXPORT jint JNICALL native_persistent_boot(JNIEnv *env, jobject thiz, jstring
     }
 
     persistent_initialized = 1;
+    set_persistent_boot_state(PERSISTENT_BOOT_SUCCEEDED);
     LOGI("persistent_boot: PHP interpreter is now persistent and Laravel is booted");
 
     (*env)->ReleaseStringUTFChars(env, jBootstrapPath, bootstrapPath);
@@ -630,6 +686,9 @@ JNIEXPORT void JNICALL native_persistent_shutdown(JNIEnv *env, jobject thiz) {
     safe_php_embed_shutdown();
     php_initialized = 0;
     persistent_initialized = 0;
+    // Reset the gate so a future ephemeral_embed_init cold path is safe and
+    // a subsequent persistent_boot can transition IN_PROGRESS cleanly.
+    set_persistent_boot_state(PERSISTENT_BOOT_NEVER_STARTED);
 
     LOGI("persistent_shutdown: done");
     pthread_mutex_unlock(&g_php_request_mutex);
@@ -959,6 +1018,14 @@ static void worker_embed_shutdown(void) {
  * Called once from the worker thread when it starts.
  */
 JNIEXPORT jint JNICALL native_worker_boot(JNIEnv *env, jobject thiz, jstring jBootstrapPath) {
+    // Worker's ts_resource(0) assumes tsrm_startup() already ran (inside
+    // persistent's php_embed_init). Wait for persistent to settle so we
+    // don't race past a half-initialized TSRM.
+    if (wait_for_persistent_boot_settled(10) != 0) {
+        LOGE("worker_boot: timed out waiting for persistent boot to settle");
+        return -1;
+    }
+
     pthread_mutex_lock(&g_worker_mutex);
 
     if (worker_initialized) {
@@ -1085,6 +1152,15 @@ JNIEXPORT void JNICALL native_worker_shutdown(JNIEnv *env, jobject thiz) {
 // cold start after app killed).
 
 static int ephemeral_embed_init(void) {
+    // If persistent is mid-boot (started but not yet finished php_embed_init),
+    // wait. Otherwise php_initialized would read 0 and we'd take the cold path
+    // — calling php_embed_init() concurrently with the persistent thread, which
+    // corrupts TSRM/SAPI globals.
+    if (wait_for_persistent_boot_settled(10) != 0) {
+        LOGE("ephemeral_embed_init: timed out waiting for persistent boot to settle");
+        return FAILURE;
+    }
+
     if (php_initialized) {
         // Hot path: persistent runtime is alive, allocate a TSRM thread context
         LOGI("ephemeral_embed_init: hot path — using existing TSRM");

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
@@ -13,8 +13,20 @@ import java.net.HttpURLConnection
 import java.net.URL
 import org.json.JSONObject
 import java.security.MessageDigest
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 class LaravelEnvironment(private val context: Context) {
+    companion object {
+        // Process-wide lock around Laravel bundle extraction. MainActivity and
+        // PHPSchedulerWorker each construct their own LaravelEnvironment, so an
+        // instance-level lock wouldn't serialize them. Without this, an updated
+        // APK + queued WorkManager job can run an ephemeral PHP task against a
+        // mid-delete / mid-extract vendor/ tree and fail with
+        // `Class "Native\Mobile\Runtime" not found`.
+        private val extractionLock = ReentrantLock()
+    }
+
     private val appStorageDir = context.getDir("storage", Context.MODE_PRIVATE)
     private val phpBridge = PHPBridge(context)
 
@@ -174,8 +186,15 @@ class LaravelEnvironment(private val context: Context) {
 
     /**
      * Extract Laravel bundle if needed. Returns true if extraction was performed.
+     * Serialized process-wide via extractionLock so MainActivity's init thread and
+     * a WorkManager worker can't clobber each other mid-extract. Safe to call from
+     * either path; the isUpToDate check inside short-circuits repeat callers.
      */
-    private fun extractLaravelBundle(): Boolean {
+    private fun extractLaravelBundle(): Boolean = extractionLock.withLock {
+        extractLaravelBundleUnlocked()
+    }
+
+    private fun extractLaravelBundleUnlocked(): Boolean {
         val laravelDir = File(appStorageDir, DIR_LARAVEL)
         val otaMarkerFile = File(laravelDir, OTA_MARKER)
 
@@ -898,7 +917,17 @@ openssl.cafile="${context.filesDir.absolutePath}/$CACERT_FILE"
     fun initializeForBackground() {
         try {
             setupDirectories()
+            // Run extraction too. If MainActivity already extracted, the isUpToDate
+            // check returns false (no work). If MainActivity is mid-extract, the
+            // lock inside extractLaravelBundle() blocks us here until it finishes.
+            // If we arrived first (WorkManager cold start after an app update), we
+            // do the extraction ourselves before the ephemeral runtime touches vendor/.
+            val didExtract = extractLaravelBundle()
             setupEnvironment()
+            if (didExtract) {
+                Log.d(TAG, "📦 Running post-extraction artisan commands (background path)...")
+                runBaseArtisanCommands()
+            }
             Log.d(TAG, "Background environment initialized")
         } catch (e: Exception) {
             Log.e(TAG, "Error initializing background environment", e)

--- a/resources/xcode/Include/Bridge/PHP.c
+++ b/resources/xcode/Include/Bridge/PHP.c
@@ -6,6 +6,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <errno.h>
+#include <time.h>
 #include <zend_exceptions.h>
 
 static phpOutputCallback swiftOutputCallback = NULL;
@@ -190,6 +192,53 @@ static int persistent_initialized = 0;
 static int worker_thread_alive = 0;
 static char *persistent_boot_error = NULL;
 
+// ── Persistent boot gate ─────────────────────────────────────────────────
+// Serializes startup: worker/ephemeral runtimes wait until php_embed_init
+// has finished in php_worker_main before they call ts_resource and
+// php_module_startup. Without this gate, a cold-launch race (e.g. iOS BGTask
+// handler firing while the main thread is mid-boot) can enter SAPI init
+// before sapi_startup() has completed, crashing in sapi_initialize_empty_request
+// (NULL write to sapi_globals).
+typedef enum {
+    PERSISTENT_BOOT_NEVER_STARTED = 0,
+    PERSISTENT_BOOT_IN_PROGRESS,
+    PERSISTENT_BOOT_SUCCEEDED,
+    PERSISTENT_BOOT_FAILED,
+} persistent_boot_state_t;
+
+static persistent_boot_state_t g_persistent_boot_state = PERSISTENT_BOOT_NEVER_STARTED;
+static pthread_mutex_t g_persistent_boot_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  g_persistent_boot_cond  = PTHREAD_COND_INITIALIZER;
+
+static void set_persistent_boot_state(persistent_boot_state_t state) {
+    pthread_mutex_lock(&g_persistent_boot_mutex);
+    g_persistent_boot_state = state;
+    pthread_cond_broadcast(&g_persistent_boot_cond);
+    pthread_mutex_unlock(&g_persistent_boot_mutex);
+}
+
+// Wait for persistent boot to leave IN_PROGRESS.
+// Returns 0 on SUCCEEDED, -1 on timeout, -2 on FAILED or NEVER_STARTED.
+// iOS ephemeral/worker runtimes require a successful persistent boot to
+// piggyback on; NEVER_STARTED is a caller-ordering error here.
+static int wait_for_persistent_boot(int timeout_seconds) {
+    struct timespec deadline;
+    clock_gettime(CLOCK_REALTIME, &deadline);
+    deadline.tv_sec += timeout_seconds;
+
+    pthread_mutex_lock(&g_persistent_boot_mutex);
+    while (g_persistent_boot_state == PERSISTENT_BOOT_IN_PROGRESS) {
+        int rc = pthread_cond_timedwait(&g_persistent_boot_cond, &g_persistent_boot_mutex, &deadline);
+        if (rc == ETIMEDOUT) {
+            pthread_mutex_unlock(&g_persistent_boot_mutex);
+            return -1;
+        }
+    }
+    int result = (g_persistent_boot_state == PERSISTENT_BOOT_SUCCEEDED) ? 0 : -2;
+    pthread_mutex_unlock(&g_persistent_boot_mutex);
+    return result;
+}
+
 // Forward declarations
 static void do_dispatch(const dispatch_params_t *params);
 static void do_artisan(const char *command);
@@ -230,6 +279,7 @@ static void *php_worker_main(void *arg) {
         fflush(stderr);
         php_work_int_result = -1;
         worker_thread_alive = 0;
+        set_persistent_boot_state(PERSISTENT_BOOT_FAILED);
         dispatch_semaphore_signal(php_done_sem);
         return NULL;
     }
@@ -297,9 +347,13 @@ static void *php_worker_main(void *arg) {
         pthread_sigmask(SIG_SETMASK, &oldmask, NULL);
 
         worker_thread_alive = 0;
+        set_persistent_boot_state(PERSISTENT_BOOT_FAILED);
         dispatch_semaphore_signal(php_done_sem);
         return NULL;  // Exit thread — do NOT enter work loop
     }
+
+    // Release any threads waiting to piggyback on the persistent runtime
+    set_persistent_boot_state(PERSISTENT_BOOT_SUCCEEDED);
 
     // Signal boot complete
     dispatch_semaphore_signal(php_done_sem);
@@ -532,6 +586,9 @@ static void do_shutdown(void) {
 
     persistent_initialized = 0;
     worker_thread_alive = 0;
+    // After shutdown the per-thread TSRM/SAPI state is gone; reset the gate
+    // so a later ephemeral/worker caller can't wrongly take the hot path.
+    set_persistent_boot_state(PERSISTENT_BOOT_NEVER_STARTED);
 }
 
 // ── Public API (called from Swift, dispatches to PHP thread) ──
@@ -560,6 +617,10 @@ int persistent_php_boot(const char *bootstrapPath) {
 
     php_work_sem = dispatch_semaphore_create(0);
     php_done_sem = dispatch_semaphore_create(0);
+
+    // Flip the gate BEFORE pthread_create so any ephemeral/worker caller that
+    // arrives before php_worker_main runs will wait, not race-past.
+    set_persistent_boot_state(PERSISTENT_BOOT_IN_PROGRESS);
 
     // Create the worker thread — it boots PHP immediately, then enters work loop
     pthread_t thread;
@@ -831,6 +892,15 @@ static void *worker_thread_main(void *arg) {
 // ── Worker public API (called from Swift) ───────────
 
 int worker_php_boot(const char *bootstrapPath) {
+    // Worker piggybacks on persistent's tsrm_startup/sapi_startup — wait for
+    // that to finish before we call ts_resource() on a new thread.
+    int gate = wait_for_persistent_boot(10);
+    if (gate != 0) {
+        fprintf(stderr, "worker_php_boot: persistent runtime not ready (gate=%d), aborting\n", gate);
+        fflush(stderr);
+        return -4;
+    }
+
     fprintf(stderr, "worker_php_boot: creating worker thread\n");
     fflush(stderr);
 
@@ -1065,6 +1135,16 @@ static void *ephemeral_thread_main(void *arg) {
 // ── Ephemeral public API (called from Swift plugins) ────────
 
 int ephemeral_php_boot(const char *bootstrapPath) {
+    // Ephemeral piggybacks on persistent's tsrm_startup/sapi_startup — wait
+    // for that to finish before we call ts_resource() on a new thread.
+    // Fixes a cold-launch BGTask crash where SAPI init ran before sapi_startup.
+    int gate = wait_for_persistent_boot(10);
+    if (gate != 0) {
+        fprintf(stderr, "ephemeral_php_boot: persistent runtime not ready (gate=%d), aborting\n", gate);
+        fflush(stderr);
+        return -4;
+    }
+
     fprintf(stderr, "ephemeral_php_boot: creating ephemeral thread\n");
     fflush(stderr);
 


### PR DESCRIPTION
## Summary

Two related cold-launch races surfaced by background-tasks testing on both iOS and Android. Both are fixed here with targeted gates at the C and Kotlin layers; no changes to happy-path behavior.

### 1. PHP runtime boot race (C layer, iOS + Android)

The ephemeral and worker runtimes piggyback on the global ``tsrm_startup``/``sapi_startup`` done inside the persistent runtime's ``php_embed_init``. They skip straight to ``ts_resource(0)`` and module startup, assuming persistent has already finished its init. If something triggers ephemeral/worker boot before persistent completes:

* **iOS**: a BGTaskScheduler handler fires on a background thread while the main-thread persistent runtime is mid-``php_embed_init``. ``ts_resource`` returns valid TSRM storage but ``sapi_globals`` is still unallocated; ``sapi_initialize_empty_request`` writes to NULL and we crash (``EXC_BAD_ACCESS``). This is the crash reported by users running the background-tasks plugin on physical devices.
* **Android**: WorkManager starts an ephemeral task while ``native_persistent_boot`` is mid-``php_embed_init``. They hold different mutexes, so the ephemeral reads ``php_initialized == 0`` and takes the cold path, calling a second ``php_embed_init`` concurrently with the persistent thread and corrupting TSRM/SAPI globals.

Fix: add a ``pthread_cond_t``-backed boot-state gate (``NEVER_STARTED`` / ``IN_PROGRESS`` / ``SUCCEEDED`` / ``FAILED``) that ``persistent_boot`` transitions through. Worker/ephemeral callers wait out ``IN_PROGRESS`` before proceeding. iOS returns an error if persistent didn't succeed (it requires persistent to piggyback on); Android preserves its cold-path fallback after the wait settles, so WorkManager-started-from-killed still works. 10s timeout on both.

Shutdown resets state to ``NEVER_STARTED`` so a subsequent boot cycle transitions cleanly.

### 2. Laravel extraction race (Kotlin layer, Android-only)

After an APK update, WorkManager can resurrect scheduled jobs from the previous install and fire ``PHPSchedulerWorker`` before ``MainActivity``'s init thread finishes deleting and re-extracting the Laravel bundle. The worker boots an ephemeral PHP (correctly, via the cold path — so the C gate above correctly does not block it) but invokes ``\Native\Mobile\Runtime::artisan()`` against a mid-delete ``vendor/`` tree, producing ``Class "Native\Mobile\Runtime" not found``.

The C gate doesn't cover this because ``persistent_boot_state`` is still ``NEVER_STARTED`` when the worker arrives — the gate correctly allows the cold path. The gap is at the Kotlin layer: extraction and ephemeral dispatch run on different threads with no shared serialization.

Fix: add a process-wide ``ReentrantLock`` around ``extractLaravelBundle()`` and have ``initializeForBackground()`` run extraction too (the existing ``isUpToDate`` check makes it idempotent):

* Whichever entry grabs the lock first extracts; the other blocks and short-circuits on version match.
* WorkManager cold start after an APK update is safe — the worker does the extraction itself if ``MainActivity`` isn't handling it.
* Warm launches pay one uncontended lock acquisition plus a version-file read.

## Testing

Verified both fixes end-to-end on an emulator against the bundled kitchen-sink app:

* **Before, Android:** post-update install shows ``PHPSchedulerWorker: Executing scheduled command: sync:data`` at t=+1s followed by ``Ephemeral artisan error: Class "Native\Mobile\Runtime" not found`` while ``bash rm`` is still running.
* **After, Android:** same scenario, post-update install. ``LaravelInit`` extracts 13:30:52 → 13:30:56; persistent boots at 13:30:57; worker boots at 13:30:58; ``PHPSchedulerWorker`` fires at 13:30:59, takes the hot path cleanly (``ephemeral_embed_init: hot path — using existing TSRM``), runs ``sync:data`` and ``sync:data-two`` which each fire a ``LocalNotification.Show`` successfully.
* **iOS:** clean launch. Both gates transition correctly in order — ``PHP-WORKER: php_embed_init SUCCESS`` (C state → ``SUCCEEDED``) → ``PHPScheduler: runtime marked ready`` (Swift latch opens) → worker thread spawns without waiting. Companion ``PHPScheduler`` gate in ``mobile-background-tasks`` 0.0.3 fast-paths this when the group is already empty.

## Test plan

- [x] Android: update-install during queued WorkManager task, verify no ``Class "Native\Mobile\Runtime" not found``.
- [x] iOS: cold-launch with BGTasks registered, verify no ``sapi_initialize_empty_request`` crash in logs.
- [x] Warm-launch regression check: persistent boot time unchanged (~135ms Android, ~136ms iOS).
- [x] Soak test on a physical iOS device overnight to confirm the reported "crashes multiple times a day" symptom is resolved.
- [x] Run existing unit/integration tests.

## Related

Companion fix in ``NativePHP/mobile-background-tasks`` (commit d7c2514) adds a Swift-side ``PHPScheduler.runtimeReadyGroup`` latch so ``handleTask`` doesn't even spawn ephemeral work until persistent boot completes. That layer is defensive / fast-path; this PR closes the window at the C runtime layer so any future plugin doing background PHP work is also safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)