### PR TITLE
fix(ios): pass log message as NSLog argument, not format string

### DIFF
--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -592,7 +592,7 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
         PersistentPHPRuntime.shared.executeOnPHPThreadAsync {
             let mode = PersistentPHPRuntime.shared.isBooted ? "PERSISTENT" : "CLASSIC"
             let start = CFAbsoluteTimeGetCurrent()
-            NSLog("[NativePHP] [\(mode)] --> \(request.method) \(request.uri)")
+            NSLog("%@", "[NativePHP] [\(mode)] --> \(request.method) \(request.uri)")
 
             let response: String
             if PersistentPHPRuntime.shared.isBooted {
@@ -606,7 +606,7 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
             let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
             // Extract status code from first line (e.g. "HTTP/1.1 200 OK")
             let statusLine = response.prefix(while: { $0 != "\r" && $0 != "\n" })
-            NSLog("[NativePHP] [\(mode)] <-- \(statusLine) (\(String(format: "%.1f", elapsed))ms)")
+            NSLog("%@", "[NativePHP] [\(mode)] <-- \(statusLine) (\(String(format: "%.1f", elapsed))ms)")
 
             // Extract cookie headers
             let components = response.components(separatedBy: "\r\n\r\n")


### PR DESCRIPTION
## Problem

`PHPSchemeHandler.getResponse(request:completion:)` interpolates the request URI directly into `NSLog`'s first argument:

```swift
NSLog("[NativePHP] [\(mode)] --> \(request.method) \(request.uri)")
```

`NSLog`'s first argument is a `printf`-style **format string**. Swift string interpolation embeds the URI into that format string verbatim, so any `%` in the URI is parsed as a format specifier. When the URI contains `%XX` percent-encoded sequences (the normal case for any path with reserved characters or `rawurlencode`d data), `NSLog` reads `va_args` that don't exist and dereferences garbage memory.

**Result: `EXC_BAD_ACCESS (SIGSEGV)` on the `com.nativephp.persistent-php` queue.** Reproducible whenever a request's URI contains `%`. Stack trace top frames:

```
__CFStringAppendFormatCore
_CFStringCreateWithFormatAndArgumentsReturningMetadata
_os_log_with_args_impl
_NSLogv
specialized withVaList<A>(_:_:)
closure #1 in PHPSchemeHandler.getResponse(request:completion:)  PHPSchemeHandler.swift:595
```

## Fix

Use `NSLog`'s two-argument form so the message is an *argument* to `%@`, not part of the format string. Two-line change to lines 595 and 609:

```diff
-NSLog("[NativePHP] [\(mode)] --> \(request.method) \(request.uri)")
+NSLog("%@", "[NativePHP] [\(mode)] --> \(request.method) \(request.uri)")
```

```diff
-NSLog("[NativePHP] [\(mode)] <-- \(statusLine) (\(String(format: "%.1f", elapsed))ms)")
+NSLog("%@", "[NativePHP] [\(mode)] <-- \(statusLine) (\(String(format: "%.1f", elapsed))ms)")
```

Identical log output, no crash. Same pattern any printf-style API expects: format string is a constant; data goes through arguments.

## Test plan

- [x] Reproduced crash on simulator with a URI containing `%XX` sequences (real-world rawurlencode'd token)
- [x] After fix: same URI, no crash, identical log output
- [x] URIs without `%` (the only ones that didn't crash before) still log correctly
