### PR TITLE
fix(ios): avoid format-string crash in PHPSchemeHandler logs

### DIFF
--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -592,7 +592,7 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
         PersistentPHPRuntime.shared.executeOnPHPThreadAsync {
             let mode = PersistentPHPRuntime.shared.isBooted ? "PERSISTENT" : "CLASSIC"
             let start = CFAbsoluteTimeGetCurrent()
-            NSLog("[NativePHP] [\(mode)] --> \(request.method) \(request.uri)")
+            print("[NativePHP] [\(mode)] --> \(request.method) \(request.uri)")
 
             let response: String
             if PersistentPHPRuntime.shared.isBooted {
@@ -606,7 +606,7 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
             let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
             // Extract status code from first line (e.g. "HTTP/1.1 200 OK")
             let statusLine = response.prefix(while: { $0 != "\r" && $0 != "\n" })
-            NSLog("[NativePHP] [\(mode)] <-- \(statusLine) (\(String(format: "%.1f", elapsed))ms)")
+            print("[NativePHP] [\(mode)] <-- \(statusLine) (\(String(format: "%.1f", elapsed))ms)")
 
             // Extract cookie headers
             let components = response.components(separatedBy: "\r\n\r\n")


### PR DESCRIPTION
## What does this PR do?
- Replaces two `NSLog` calls in `PHPSchemeHandler.getResponse()` with `print` for request/response tracing.
- Prevents native iOS crashes caused when response/request strings include `%` sequences that `NSLog` interprets as format specifiers.
- Keeps logging visibility while avoiding format-string parsing on the persistent PHP queue.

## Risks & Mitigation
- Low risk: change is limited to debug logging statements and does not alter request dispatch or response/cookie behavior.
- Mitigation: only two lines are changed in one file, with no control-flow or data-path changes.
- If needed, behavior can be reverted safely without affecting runtime protocol handling.

## How was this tested?
- Reproduced crash locally from app actions that route through `PHPSchemeHandler`.
- Applied this exact change in the app runtime copy and confirmed simulator + physical device no longer crashed on the same actions.
- Verified the same patch is now committed on this fork branch for upstream review.

Made with [Cursor](https://cursor.com)