### PR TITLE
fix(ios): allow apps to override plugin Info.plist permission strings

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -95,6 +95,28 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | iOS Permission Strings (Info.plist Overrides)
+    |--------------------------------------------------------------------------
+    |
+    | Override iOS Info.plist usage descriptions provided by plugins. Anything
+    | you set here is applied AFTER all plugin manifests are merged, so it
+    | always wins — useful when multiple plugins claim the same key (e.g.
+    | mobile-camera and mobile-scanner both set NSCameraUsageDescription) and
+    | you want a single explicit string for App Store review.
+    |
+    | Android has no equivalent: permission rationale is shown by app code at
+    | runtime, not declared in the manifest, so this block is iOS-only.
+    |
+    */
+
+    'permissions' => [
+        // 'NSCameraUsageDescription' => 'Used to take a profile photo.',
+        // 'NSMicrophoneUsageDescription' => 'Used to record audio with your videos.',
+        // 'NSPhotoLibraryUsageDescription' => 'Used to select photos for your post.',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Environment Keys to Clean Up
     |--------------------------------------------------------------------------
     |

--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -299,6 +299,8 @@ class IOSPluginCompiler
             $this->iosProjectPath.'/NativePHP-simulator-Info.plist',
         ];
 
+        $appOverrides = $this->getAppInfoPlistOverrides();
+
         foreach ($plistPaths as $plistPath) {
             if (! $this->files->exists($plistPath)) {
                 continue;
@@ -322,8 +324,21 @@ class IOSPluginCompiler
                 }
             }
 
+            // Apply app-level overrides last so they always win over plugins.
+            if (! empty($appOverrides)) {
+                $plist = $this->injectPlistEntries($plist, $appOverrides);
+            }
+
             $this->files->put($plistPath, $plist);
         }
+    }
+
+    /**
+     * Read app-level Info.plist overrides from config('nativephp.permissions').
+     */
+    protected function getAppInfoPlistOverrides(): array
+    {
+        return config('nativephp.permissions', []);
     }
 
     /**
@@ -350,12 +365,12 @@ class IOSPluginCompiler
         foreach ($entries as $key => $value) {
             // Check if key already exists
             if (str_contains($plist, "<key>{$key}</key>")) {
-                // For array values, merge with existing array
                 if (is_array($value)) {
                     $plist = $this->mergeArrayEntry($plist, $key, $value);
+                } elseif (is_string($value)) {
+                    $plist = $this->updateStringEntry($plist, $key, $this->substituteEnvPlaceholders($value));
                 }
 
-                // Skip non-array values that already exist
                 continue;
             }
 
@@ -387,6 +402,18 @@ class IOSPluginCompiler
         }
 
         return $plist;
+    }
+
+    /**
+     * Update an existing string entry's value in the plist
+     */
+    protected function updateStringEntry(string $plist, string $key, string $value): string
+    {
+        $pattern = '/(<key>'.preg_quote($key, '/').'<\/key>\s*<string>)([^<]*)(<\/string>)/';
+
+        return preg_replace_callback($pattern, function ($matches) use ($value) {
+            return $matches[1].htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8').$matches[3];
+        }, $plist, 1);
     }
 
     /**

--- a/tests/Feature/Plugins/IOSCompilerTest.php
+++ b/tests/Feature/Plugins/IOSCompilerTest.php
@@ -283,9 +283,58 @@ class NestedClass {}');
     /**
      * @test
      *
-     * Should not duplicate Info.plist entries that already exist.
+     * App-level config('nativephp.permissions.ios') wins over plugin manifests,
+     * so an app developer can resolve key collisions between plugins.
      */
-    public function it_does_not_duplicate_existing_plist_entries(): void
+    public function it_applies_app_permission_overrides_after_plugins(): void
+    {
+        config()->set('nativephp.permissions', [
+            'NSCameraUsageDescription' => 'App-level camera string.',
+        ]);
+
+        // Two plugins both claim the same key — last wins among plugins,
+        // but app override should beat both.
+        $pluginA = $this->createTestPlugin([
+            'name' => 'plugin-a',
+            'ios' => [
+                'info_plist' => [
+                    'NSCameraUsageDescription' => 'Plugin A camera string.',
+                ],
+            ],
+        ]);
+        $pluginB = $this->createTestPlugin([
+            'name' => 'plugin-b',
+            'ios' => [
+                'info_plist' => [
+                    'NSCameraUsageDescription' => 'Plugin B camera string.',
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$pluginA, $pluginB]));
+
+        $this->compiler->compile();
+
+        $plistPath = $this->testBasePath.'/ios/NativePHP/Info.plist';
+        $content = $this->files->get($plistPath);
+
+        $this->assertStringContainsString('App-level camera string.', $content);
+        $this->assertStringNotContainsString('Plugin A camera string.', $content);
+        $this->assertStringNotContainsString('Plugin B camera string.', $content);
+        $this->assertEquals(1, substr_count($content, 'NSCameraUsageDescription'));
+
+        config()->set('nativephp.permissions', []);
+    }
+
+    /**
+     * @test
+     *
+     * Should update existing Info.plist entries without duplicating the key,
+     * so plugin manifests remain the source of truth across rebuilds.
+     */
+    public function it_updates_existing_plist_entries_without_duplicating(): void
     {
         // Add a permission to the plist first
         $plistPath = $this->testBasePath.'/ios/NativePHP/Info.plist';
@@ -301,7 +350,7 @@ class NestedClass {}');
         $plugin = $this->createTestPlugin([
             'ios' => [
                 'info_plist' => [
-                    'NSCameraUsageDescription' => 'New camera description',  // Should not duplicate
+                    'NSCameraUsageDescription' => 'New camera description',
                 ],
             ],
         ]);
@@ -314,9 +363,10 @@ class NestedClass {}');
 
         $content = $this->files->get($plistPath);
 
-        // Key should only appear once
-        $count = substr_count($content, 'NSCameraUsageDescription');
-        $this->assertEquals(1, $count);
+        // Key should appear exactly once, with the manifest value applied
+        $this->assertEquals(1, substr_count($content, 'NSCameraUsageDescription'));
+        $this->assertStringContainsString('<string>New camera description</string>', $content);
+        $this->assertStringNotContainsString('Existing camera description', $content);
     }
 
     /**


### PR DESCRIPTION
## Summary

- iOS plugin compiler used to silently skip Info.plist keys already present, so plugin manifest changes never reached the rendered plist on rebuild — no way to address App Store rejection emails asking for more explicit permission language without hand-editing `nativephp/ios/NativePHP/Info.plist`.
- It also meant when multiple plugins claim the same key (e.g. `mobile-camera` and `mobile-scanner` both set `NSCameraUsageDescription`), plugin order silently picked the winner with no app-level recourse.

## What changed

- `IOSPluginCompiler::injectPlistEntries` now **updates** existing string/array values instead of skipping them. Plugin manifests stay the source of truth across rebuilds.
- New `permissions` block in `config/nativephp.php`. Anything set there is applied as the final layer after all plugins, giving the app developer the last word:
  ```php
  'permissions' => [
      'NSCameraUsageDescription' => 'Used to take a profile photo.',
      'NSMicrophoneUsageDescription' => 'Used to record audio with your videos.',
  ],
  ```
- Replaced the test that locked in the skip behavior; added coverage for the app-level override path.

Android isn't included — its permission rationale is shown by app code at runtime, not declared in the manifest, so there's no equivalent to override.

## Test plan

- [x] `vendor/bin/phpunit --filter "IOSCompilerTest|AndroidCompilerTest|PluginManifest|PluginRegistry|PluginDiscovery"` — 90 tests pass
- [x] Manual: in an app with conflicting plugins (`mobile-camera` + `mobile-scanner`), set `NSCameraUsageDescription` in `config/nativephp.php` `permissions` block, rebuild iOS, verify `nativephp/ios/NativePHP/Info.plist` and `NativePHP-simulator-Info.plist` both pick up the override.
- [x] Manual: with no app-level override, verify the plugin's manifest value still lands (now updates on rebuild instead of going stale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)