### PR TITLE
Include build number in Laravel bundle staleness check

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
@@ -28,22 +28,10 @@ class LaravelEnvironment(private val context: Context) {
     // Data class to hold bundle metadata read from ZIP
     private data class BundleMetadata(
         val version: String?,
+        val versionCode: String?,
         val bifrostAppId: String?,
         val runtimeMode: String?
     )
-
-    // Data class for version information with utility methods
-    private data class VersionInfo(val raw: String, val clean: String) {
-        val isDebug: Boolean get() = clean.equals(VERSION_DEBUG, ignoreCase = true)
-
-        companion object {
-            fun from(version: String?): VersionInfo? {
-                if (version == null) return null
-                val clean = version.trim().trim('"').trim('\'')
-                return VersionInfo(version, clean)
-            }
-        }
-    }
 
     companion object {
         // Process-wide lock around Laravel bundle extraction. MainActivity and
@@ -88,8 +76,23 @@ class LaravelEnvironment(private val context: Context) {
         private const val VERSION_DEFAULT = "0.0.0"
 
         // Environment variable regex patterns
-        private const val REGEX_APP_VERSION = "NATIVEPHP_APP_VERSION=(.+)"
+        private const val REGEX_APP_VERSION = "(?m)^NATIVEPHP_APP_VERSION=(.+)$"
+        private const val REGEX_APP_VERSION_CODE = "(?m)^NATIVEPHP_APP_VERSION_CODE=(.+)$"
         private const val REGEX_BIFROST_ID = "BIFROST_APP_ID=(.+)"
+
+        /**
+         * Build the composite identity ("version+b+versionCode" or "DEBUG") used to
+         * decide whether the embedded Laravel bundle needs to be re-extracted.
+         */
+        private fun buildVersionId(version: String?, versionCode: String?): String? {
+            if (version == null) return null
+            val cleanVersion = version.trim().trim('"').trim('\'')
+            if (cleanVersion.equals(VERSION_DEBUG, ignoreCase = true)) {
+                return VERSION_DEBUG
+            }
+            val cleanCode = versionCode?.trim()?.trim('"')?.trim('\'') ?: "0"
+            return "${cleanVersion}b${cleanCode}"
+        }
 
         init {
             System.loadLibrary("php_wrapper")
@@ -217,48 +220,46 @@ class LaravelEnvironment(private val context: Context) {
             return false
         }
 
-        // Get embedded version using VersionInfo wrapper
-        val embeddedVersionRaw = getVersionFromBundledEnv() ?: readVersionFromZip(BUNDLE_ZIP)
-        val embeddedVersion = VersionInfo.from(embeddedVersionRaw)
+        // Build composite "version+b+versionCode" identity from bundle metadata.
+        // This is what we compare against the extracted .env so a build-number-only
+        // bump still triggers re-extraction.
+        val bundleMeta = readBundleMetadata()
+        val embeddedId = buildVersionId(bundleMeta.version, bundleMeta.versionCode)
 
-        if (embeddedVersion == null) {
+        if (embeddedId == null) {
             Log.e(TAG, "❌ Couldn't read version from laravel_bundle.zip")
             return false
         }
 
-        Log.d(TAG, "🔍 DEBUG: embeddedVersion from bundle = '${embeddedVersion.raw}'")
+        Log.d(TAG, "🔍 DEBUG: embeddedId from bundle = '$embeddedId'")
 
-        // Check current version from .env if exists
-        val currentVersionRaw = if (laravelDir.exists()) {
+        // Build composite from extracted .env if it exists
+        val currentId = if (laravelDir.exists()) {
             val envFile = File(laravelDir, ENV_FILE)
             if (envFile.exists()) {
-                getVersionFromEnvFile(envFile)
+                buildVersionId(getVersionFromEnvFile(envFile), getVersionCodeFromEnvFile(envFile))
             } else {
                 null
             }
         } else {
             null
         }
-        val currentVersion = VersionInfo.from(currentVersionRaw)
 
-        Log.d(TAG, "🔍 DEBUG: currentVersion = '${currentVersion?.clean ?: "none"}'")
-        Log.d(TAG, "🔍 DEBUG: embeddedVersion.clean = '${embeddedVersion.clean}'")
-        Log.d(TAG, "🔍 DEBUG: isDebugOverride = ${embeddedVersion.isDebug}")
+        Log.d(TAG, "🔍 DEBUG: currentId = '${currentId ?: "none"}'")
 
-        // If DEBUG mode, ALWAYS extract. Otherwise, only extract if versions don't match
-        val isUpToDate = currentVersion?.clean == embeddedVersion.clean
-        val shouldExtract = embeddedVersion.isDebug || !isUpToDate
+        // If DEBUG mode, ALWAYS extract. Otherwise, only extract if composites don't match.
+        val isDebug = embeddedId.equals(VERSION_DEBUG, ignoreCase = true)
+        val isUpToDate = currentId == embeddedId
+        val shouldExtract = isDebug || !isUpToDate
 
-        Log.d(TAG, "🔍 DEBUG: isUpToDate = $isUpToDate")
-        Log.d(TAG, "🔍 DEBUG: shouldExtract = $shouldExtract")
+        Log.d(TAG, "🔍 DEBUG: isUpToDate = $isUpToDate, isDebug = $isDebug, shouldExtract = $shouldExtract")
 
         if (!shouldExtract) {
-            Log.d(TAG, "✅ Laravel already up to date (version ${embeddedVersion.clean})")
+            Log.d(TAG, "✅ Laravel already up to date (id $embeddedId)")
             return false
         }
 
-        Log.d(TAG, "📦 Extracting Laravel bundle (new version: ${embeddedVersion.raw})")
-        Log.d(TAG, "📦 Current: ${currentVersion?.raw ?: "none"}, Embedded: ${embeddedVersion.raw}")
+        Log.d(TAG, "📦 Extracting Laravel bundle — current: ${currentId ?: "none"}, embedded: $embeddedId")
 
         // Delete entire laravel directory - persisted_data is separate and safe
         if (laravelDir.exists()) {
@@ -290,13 +291,13 @@ class LaravelEnvironment(private val context: Context) {
                 otaMarkerFile.delete()
             }
 
-            // Update .version file to match the environment value
-            val versionFromEnv = getVersionFromEnvFile(File(laravelDir, ENV_FILE))
-            if (versionFromEnv != null) {
-                val versionFile = File(laravelDir, VERSION_FILE)
-                val cleanVersion = versionFromEnv.trim('"').trim('\'')
-                versionFile.writeText(cleanVersion)
-                Log.d(TAG, "✅ Updated .version file to: $cleanVersion")
+            // Update .version file with the composite identity so it stays in sync
+            // with the bundled .version (and survives a re-read for the staleness check).
+            val envFile = File(laravelDir, ENV_FILE)
+            val installedId = buildVersionId(getVersionFromEnvFile(envFile), getVersionCodeFromEnvFile(envFile))
+            if (installedId != null) {
+                File(laravelDir, VERSION_FILE).writeText(installedId)
+                Log.d(TAG, "✅ Updated .version file to: $installedId")
             }
 
             Log.d(TAG, "✅ Extraction complete to ${laravelDir.absolutePath}")
@@ -318,11 +319,6 @@ class LaravelEnvironment(private val context: Context) {
         return true
     }
 
-    private fun isDebugVersion(version: String?): Boolean {
-        // Use VersionInfo for consistent version handling
-        return VersionInfo.from(version)?.isDebug ?: false
-    }
-
     /**
      * Read bundle metadata from bundle_meta.json (fast path) or ZIP scan (fallback).
      * Results are cached to avoid redundant reads.
@@ -336,10 +332,14 @@ class LaravelEnvironment(private val context: Context) {
             val json = context.assets.open(BUNDLE_META).bufferedReader().use { it.readText() }
             val obj = JSONObject(json)
             val version = if (obj.has("version")) obj.getString("version") else null
+            val versionCode = when {
+                !obj.has("version_code") || obj.isNull("version_code") -> null
+                else -> obj.get("version_code").toString()
+            }
             val bifrostAppId = if (obj.has("bifrost_app_id") && !obj.isNull("bifrost_app_id")) obj.getString("bifrost_app_id") else null
             val runtimeMode = if (obj.has("runtime_mode") && !obj.isNull("runtime_mode")) obj.getString("runtime_mode") else null
-            Log.d(TAG, "⚡ Read bundle_meta.json: version=$version, bifrost=$bifrostAppId, runtime_mode=$runtimeMode")
-            val metadata = BundleMetadata(version, bifrostAppId, runtimeMode)
+            Log.d(TAG, "⚡ Read bundle_meta.json: version=$version, version_code=$versionCode, bifrost=$bifrostAppId, runtime_mode=$runtimeMode")
+            val metadata = BundleMetadata(version, versionCode, bifrostAppId, runtimeMode)
             bundleMetadataCache = metadata
             return metadata
         } catch (e: Exception) {
@@ -348,7 +348,9 @@ class LaravelEnvironment(private val context: Context) {
 
         // Slow fallback: scan ZIP for .env and .version
         var version: String? = null
+        var versionCode: String? = null
         var bifrostAppId: String? = null
+        var versionIdFromVersionFile: String? = null
 
         try {
             val zis = ZipInputStream(context.assets.open(BUNDLE_ZIP) as java.io.InputStream)
@@ -358,34 +360,50 @@ class LaravelEnvironment(private val context: Context) {
                 when (entry?.name) {
                     ENV_FILE -> {
                         val envContent = zis.bufferedReader().readText()
-                        val versionMatch = Regex(REGEX_APP_VERSION).find(envContent)
-                        version = versionMatch?.groupValues?.get(1)?.trim()
-                        val bifrostIdMatch = Regex(REGEX_BIFROST_ID).find(envContent)
-                        bifrostAppId = bifrostIdMatch?.groupValues?.get(1)?.trim()
+                        version = Regex(REGEX_APP_VERSION).find(envContent)?.groupValues?.get(1)?.trim()
+                        versionCode = Regex(REGEX_APP_VERSION_CODE).find(envContent)?.groupValues?.get(1)?.trim()
+                        bifrostAppId = Regex(REGEX_BIFROST_ID).find(envContent)?.groupValues?.get(1)?.trim()
                     }
                     VERSION_FILE -> {
-                        if (version == null) {
-                            version = zis.bufferedReader().readText().trim()
-                        }
+                        // .version contains the composite id (e.g. "1.0.0b42") used as a fallback
+                        // when .env can't be parsed.
+                        versionIdFromVersionFile = zis.bufferedReader().readText().trim()
                     }
                 }
-                if (version != null && bifrostAppId != null) break
             }
             zis.close()
         } catch (e: Exception) {
             Log.e(TAG, "Failed to read bundle metadata", e)
         }
 
-        val metadata = BundleMetadata(version, bifrostAppId, null)
+        // If .env didn't yield a version but .version did, decompose the composite back
+        // into version + versionCode so the metadata shape stays consistent.
+        if (version == null && versionIdFromVersionFile != null) {
+            val (parsedVersion, parsedCode) = parseVersionId(versionIdFromVersionFile)
+            version = parsedVersion
+            versionCode = parsedCode
+        }
+
+        val metadata = BundleMetadata(version, versionCode, bifrostAppId, null)
         bundleMetadataCache = metadata
         return metadata
     }
 
-    private fun readVersionFromZip(zipFileName: String): String? {
-        // Use cached metadata instead of reading ZIP again
-        return readBundleMetadata().version
+    /**
+     * Decompose a composite version id ("1.0.0b42" or "DEBUG") back into its parts.
+     * Used when .version is the only metadata source available.
+     */
+    private fun parseVersionId(id: String): Pair<String?, String?> {
+        if (id.equals(VERSION_DEBUG, ignoreCase = true)) {
+            return Pair(VERSION_DEBUG, null)
+        }
+        val sepIndex = id.lastIndexOf('b')
+        if (sepIndex <= 0 || sepIndex == id.length - 1) {
+            return Pair(id, null)
+        }
+        return Pair(id.substring(0, sepIndex), id.substring(sepIndex + 1))
     }
-    
+
     private fun checkAndApplyOTAUpdate(): Boolean {
         // Check if BIFROST_APP_ID exists in environment or app metadata
         val bifrostAppId = getBifrostAppId()
@@ -442,14 +460,23 @@ class LaravelEnvironment(private val context: Context) {
     private fun getVersionFromEnvFile(envFile: File): String? {
         return try {
             val envContent = envFile.readText()
-            val versionMatch = Regex(REGEX_APP_VERSION).find(envContent)
-            versionMatch?.groupValues?.get(1)?.trim()
+            Regex(REGEX_APP_VERSION).find(envContent)?.groupValues?.get(1)?.trim()
         } catch (e: Exception) {
             Log.e(TAG, "Failed to read version from .env file", e)
             null
         }
     }
-    
+
+    private fun getVersionCodeFromEnvFile(envFile: File): String? {
+        return try {
+            val envContent = envFile.readText()
+            Regex(REGEX_APP_VERSION_CODE).find(envContent)?.groupValues?.get(1)?.trim()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to read version code from .env file", e)
+            null
+        }
+    }
+
     private fun getVersionFromBundledEnv(): String? {
         // Use cached metadata instead of reading ZIP again
         return readBundleMetadata().version

--- a/resources/xcode/NativePHP/AppUpdateManager.swift
+++ b/resources/xcode/NativePHP/AppUpdateManager.swift
@@ -260,13 +260,9 @@ class AppUpdateManager {
         }
     }
 
+    /// Returns just the version name (e.g. "1.0.0"). Used for OTA URLs / display.
+    /// For the staleness comparison against the bundle, use `getInstalledVersionId()`.
     func getAppVersion() -> String? {
-        // Try to get version from installed.version file first (fastest)
-        if let installedVersion = getInstalledVersion() {
-            return installedVersion
-        }
-
-        // If app directory doesn't exist, assume DEBUG version
         if !FileManager.default.fileExists(atPath: appPath) {
             print("❌ App directory doesn't exist - assuming DEBUG")
             return "DEBUG"
@@ -284,56 +280,98 @@ class AppUpdateManager {
         return "DEBUG"
     }
 
+    /// Returns the composite "version+build" identity for the installed app
+    /// (e.g. "1.0.0b42", or "DEBUG"). Falls back to building it from the
+    /// extracted .env if installed.version is missing.
+    private func getInstalledVersionId() -> String? {
+        if let id = getInstalledVersion() {
+            return id
+        }
+        return getInstalledVersionIdFromEnv()
+    }
+
+    private func getInstalledVersionIdFromEnv() -> String? {
+        let envFile = appPath + "/.env"
+        guard FileManager.default.fileExists(atPath: envFile) else {
+            return nil
+        }
+        guard let version = getVersionFromEnvFile(envFile) else {
+            return nil
+        }
+        return buildVersionId(version: version, versionCode: getVersionCodeFromEnvFile(envFile))
+    }
+
+    private func buildVersionId(version: String, versionCode: String?) -> String {
+        if version == "DEBUG" {
+            return "DEBUG"
+        }
+        return "\(version)b\(versionCode ?? "0")"
+    }
+
     private func getVersionFromEnvFile(_ envFilePath: String) -> String? {
+        return getEnvValue(envFilePath, key: "NATIVEPHP_APP_VERSION")
+    }
+
+    private func getVersionCodeFromEnvFile(_ envFilePath: String) -> String? {
+        return getEnvValue(envFilePath, key: "NATIVEPHP_APP_VERSION_CODE")
+    }
+
+    private func getEnvValue(_ envFilePath: String, key: String) -> String? {
         do {
             let envContent = try String(contentsOfFile: envFilePath, encoding: .utf8)
-            // Look for NATIVEPHP_APP_VERSION=value
-            let regex = try NSRegularExpression(pattern: "NATIVEPHP_APP_VERSION=(.+)")
+            return extractEnvValue(envContent, key: key)
+        } catch {
+            print("❌ Error reading .env file: \(error)")
+            return nil
+        }
+    }
+
+    private func extractEnvValue(_ envContent: String, key: String) -> String? {
+        do {
+            let pattern = "^\(NSRegularExpression.escapedPattern(for: key))=(.+)$"
+            let regex = try NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
             let range = NSRange(location: 0, length: envContent.utf16.count)
 
             if let match = regex.firstMatch(in: envContent, range: range) {
-                let versionRange = Range(match.range(at: 1), in: envContent)!
-                let version = String(envContent[versionRange]).trimmingCharacters(in: .whitespacesAndNewlines)
-                // Remove surrounding quotes if present
-                let cleanVersion = version.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-                return cleanVersion
+                let valueRange = Range(match.range(at: 1), in: envContent)!
+                let value = String(envContent[valueRange]).trimmingCharacters(in: .whitespacesAndNewlines)
+                return value.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
             }
         } catch {
-            print("❌ Error reading .env file: \(error)")
+            print("❌ Error matching \(key) in .env: \(error)")
         }
-
         return nil
     }
 
     private func shouldUpdateFromBundle() -> Bool {
-        guard let bundledVersion = getBundledAppVersionFast() else {
+        guard let bundledId = getBundledAppVersionFast() else {
             print("⚠️ Could not read version from bundled.version file, falling back to ZIP extraction")
-            guard let bundledVersion = getBundledAppVersion() else {
+            guard let bundledId = getBundledAppVersion() else {
                 print("⚠️ Could not read version from bundled app.zip")
                 return false
             }
-            return shouldUpdateWithVersion(bundledVersion)
+            return shouldUpdateWithVersion(bundledId)
         }
 
-        return shouldUpdateWithVersion(bundledVersion)
+        return shouldUpdateWithVersion(bundledId)
     }
 
-    private func shouldUpdateWithVersion(_ bundledVersion: String) -> Bool {
+    private func shouldUpdateWithVersion(_ bundledId: String) -> Bool {
         // Special case: If bundled version is DEBUG, always update from bundle (for development)
-        if bundledVersion == "DEBUG" {
+        if bundledId == "DEBUG" {
             print("🚧 DEBUG version detected, updating from bundle")
             return true
         }
 
-        let currentVersion = getInstalledVersion() ?? getAppVersion()
+        let currentId = getInstalledVersionId()
 
-        // If versions differ, update from bundle
-        if currentVersion != bundledVersion {
-            print("📦 Bundle version (\(bundledVersion)) differs from current (\(currentVersion ?? "none")), updating from bundle")
+        // If composite identities differ, update from bundle
+        if currentId != bundledId {
+            print("📦 Bundle id (\(bundledId)) differs from current (\(currentId ?? "none")), updating from bundle")
             return true
         }
 
-        print("✅ App already up to date with bundle version (\(bundledVersion))")
+        print("✅ App already up to date with bundle id (\(bundledId))")
         return false
     }
 
@@ -355,7 +393,7 @@ class AppUpdateManager {
             return nil
         }
 
-        // Try to read .env file first
+        // Try to build composite from .env first (preferred - has both version + version_code)
         if let envEntry = archive[".env"] {
             var envContent = Data()
             do {
@@ -363,9 +401,10 @@ class AppUpdateManager {
                     envContent.append(data)
                 }
                 if let envString = String(data: envContent, encoding: .utf8) {
-                    if let version = extractVersionFromEnv(envString) {
-                        print("✅ Read version from .env without full extraction")
-                        return version
+                    if let version = extractEnvValue(envString, key: "NATIVEPHP_APP_VERSION") {
+                        let versionCode = extractEnvValue(envString, key: "NATIVEPHP_APP_VERSION_CODE")
+                        print("✅ Read version id from .env without full extraction")
+                        return buildVersionId(version: version, versionCode: versionCode)
                     }
                 }
             } catch {
@@ -373,7 +412,7 @@ class AppUpdateManager {
             }
         }
 
-        // Fallback: try .version file
+        // Fallback: try .version file (already a composite when written by PreparesBuild)
         if let versionEntry = archive[".version"] {
             var versionContent = Data()
             do {
@@ -381,7 +420,7 @@ class AppUpdateManager {
                     versionContent.append(data)
                 }
                 if let versionString = String(data: versionContent, encoding: .utf8) {
-                    print("✅ Read version from .version without full extraction")
+                    print("✅ Read version id from .version without full extraction")
                     return versionString.trimmingCharacters(in: .whitespacesAndNewlines)
                 }
             } catch {
@@ -390,20 +429,6 @@ class AppUpdateManager {
         }
 
         print("❌ No .env or .version found in ZIP")
-        return nil
-    }
-
-    private func extractVersionFromEnv(_ envContent: String) -> String? {
-        let lines = envContent.components(separatedBy: .newlines)
-        for line in lines {
-            if line.hasPrefix("NATIVEPHP_APP_VERSION=") {
-                let version = String(line.dropFirst("NATIVEPHP_APP_VERSION=".count))
-                let trimmedVersion = version.trimmingCharacters(in: .whitespacesAndNewlines)
-                // Remove surrounding quotes if present
-                let cleanVersion = trimmedVersion.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-                return cleanVersion
-            }
-        }
         return nil
     }
 
@@ -659,16 +684,18 @@ class AppUpdateManager {
     private func createInstalledVersionFile() {
         let installedVersionPath = documentsPath + "/app/installed.version"
 
-        // Get the version from the extracted app's .env file
-        if let version = getAppVersion() {
-            do {
-                try version.write(toFile: installedVersionPath, atomically: true, encoding: .utf8)
-                print("📝 Created installed.version file: \(version)")
-            } catch {
-                print("❌ Failed to create installed.version file: \(error)")
-            }
-        } else {
-            print("⚠️ Could not determine app version for installed.version file")
+        // Build composite identity from the extracted .env so the on-disk
+        // identity matches the bundle (same format: "version+b+versionCode" or "DEBUG").
+        guard let id = getInstalledVersionIdFromEnv() else {
+            print("⚠️ Could not determine app version id for installed.version file")
+            return
+        }
+
+        do {
+            try id.write(toFile: installedVersionPath, atomically: true, encoding: .utf8)
+            print("📝 Created installed.version file: \(id)")
+        } catch {
+            print("❌ Failed to create installed.version file: \(error)")
         }
     }
 

--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -916,11 +916,12 @@ class BuildIosAppCommand extends Command
 
     private function createBundledVersionFile(string $zipPath): void
     {
-        // Get version from Laravel config
         $appVersion = config('nativephp.version', 'DEBUG');
+        $versionCode = config('nativephp.version_code', 1);
+        $bundleVersionId = $appVersion === 'DEBUG' ? 'DEBUG' : "{$appVersion}b{$versionCode}";
 
         $versionFilePath = dirname($zipPath).'/bundled.version';
-        file_put_contents($versionFilePath, $appVersion);
+        file_put_contents($versionFilePath, $bundleVersionId);
 
         // Write bundle_meta.json for fast boot-time metadata reads (matches Android PreparesBuild)
         $bifrostAppId = null;
@@ -934,6 +935,7 @@ class BuildIosAppCommand extends Command
 
         $bundleMeta = json_encode([
             'version' => $appVersion,
+            'version_code' => $versionCode,
             'bifrost_app_id' => $bifrostAppId,
             'runtime_mode' => config('nativephp.runtime.mode', 'persistent'),
         ], JSON_PRETTY_PRINT);

--- a/src/Traits/PreparesBuild.php
+++ b/src/Traits/PreparesBuild.php
@@ -270,8 +270,10 @@ trait PreparesBuild
             });
 
             $version = config('nativephp.version', now()->format('Ymd-His'));
-            $this->logToFile("  Writing version file: $version");
-            file_put_contents($tempDir.DIRECTORY_SEPARATOR.'.version', $version.PHP_EOL);
+            $versionCode = config('nativephp.version_code', 1);
+            $bundleVersionId = $version === 'DEBUG' ? 'DEBUG' : "{$version}b{$versionCode}";
+            $this->logToFile("  Writing version file: $bundleVersionId");
+            file_put_contents($tempDir.DIRECTORY_SEPARATOR.'.version', $bundleVersionId.PHP_EOL);
 
             if (file_exists($source.DIRECTORY_SEPARATOR.'.env')) {
                 $this->logToFile('  Copying and cleaning .env file...');
@@ -306,12 +308,13 @@ trait PreparesBuild
             }
             $bundleMeta = json_encode([
                 'version' => $version,
+                'version_code' => $versionCode,
                 'bifrost_app_id' => $bifrostAppId,
                 'runtime_mode' => config('nativephp.runtime.mode', 'persistent'),
             ], JSON_PRETTY_PRINT);
             file_put_contents($assetsDir.DIRECTORY_SEPARATOR.'bundle_meta.json', $bundleMeta);
             $runtimeMode = config('nativephp.runtime.mode', 'persistent');
-            $this->logToFile("  Written bundle_meta.json: version=$version, bifrost=".($bifrostAppId ?? 'null').", runtime_mode=$runtimeMode");
+            $this->logToFile("  Written bundle_meta.json: version=$version, version_code=$versionCode, bifrost=".($bifrostAppId ?? 'null').", runtime_mode=$runtimeMode");
 
             $sizeMB = round(filesize($destinationZip) / 1024 / 1024, 2);
             $this->logToFile("  Bundle size: {$sizeMB} MB");


### PR DESCRIPTION
## Summary

The native side previously compared only the version *name* (`NATIVEPHP_APP_VERSION`) when deciding whether to re-extract the embedded Laravel bundle, so bumping just the build number — common during dev/TestFlight cycles — left the device running stale code while the binary's bundle had changed.

Both platforms now compare a composite `version+b+versionCode` identity (e.g. `1.0.0b42`), or just `DEBUG`. The DEBUG short-circuit and the OTA flows are preserved.

## What changed

**Build side (PHP)**
- `src/Traits/PreparesBuild.php` — writes `.version` as the composite, adds `version_code` to `bundle_meta.json`
- `src/Commands/BuildIosAppCommand.php` — same treatment for `bundled.version` and the iOS `bundle_meta.json`

**iOS (`AppUpdateManager.swift`)**
- New `buildVersionId()` / `getInstalledVersionId()` / `getInstalledVersionIdFromEnv()` / `getVersionCodeFromEnvFile()`
- `shouldUpdateWithVersion()` compares the composite, so a build-number-only bump triggers re-extraction
- `createInstalledVersionFile()` writes the composite to `installed.version`
- `getAppVersion()` (used for OTA URLs) no longer prefers `installed.version` so the OTA backend still receives the plain version name
- Slow ZIP fallback reads both env vars and builds the composite

**Android (`LaravelEnvironment.kt`)**
- `BundleMetadata` gained a `versionCode` field; `bundle_meta.json` reader picks it up
- Added `buildVersionId()`, `parseVersionId()`, `getVersionCodeFromEnvFile()`, `REGEX_APP_VERSION_CODE`; tightened `REGEX_APP_VERSION` to be line-anchored
- `extractLaravelBundleUnlocked()` compares composites (bundled vs extracted `.env`)
- Post-extraction `.version` is rewritten with the composite so it remains a valid fallback identity
- OTA path keeps using just the version name (unchanged behavior)
- Removed dead code: `VersionInfo`, `isDebugVersion()` (in `LaravelEnvironment`), `readVersionFromZip()`

## Compatibility

Existing installs whose `installed.version` / extracted `.version` contains just `1.0.0` will mismatch the new composite `1.0.0b<n>` once and re-extract — the desired behavior.

## Test plan

- [x] `composer test` (224 passed)
- [x] Build an iOS app with the same version name but bumped build number → confirm bundle re-extracts on next launch
- [x] Build an Android app with the same versionName but bumped versionCode → confirm bundle re-extracts on next launch
- [x] DEBUG mode still always re-extracts on both platforms
- [ ] OTA URL still receives the plain version name (e.g. `?installed=1.0.0`, not `?installed=1.0.0b42`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)