### PR TITLE
Fix iOS Podfile pod injection corrupting START/END markers

### DIFF
--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -989,12 +989,38 @@ SECTION;
             return;
         }
 
-        // Check if marker exists (preferred injection point)
-        if (str_contains($podfile, '# NATIVEPHP_PLUGIN_PODS')) {
-            $podfile = str_replace(
-                '# NATIVEPHP_PLUGIN_PODS',
-                "# NativePHP Plugin Dependencies\n{$newPodLines}",
-                $podfile
+        // Check if marker exists (preferred injection point).
+        //
+        // The shipped iOS Podfile template uses a paired marker block so the same
+        // injection site works on every run:
+        //
+        //   # NATIVEPHP_PLUGIN_PODS_START
+        //   # NATIVEPHP_PLUGIN_PODS_END
+        //
+        // Replace the entire block (preserving the markers) so subsequent runs are
+        // idempotent. A naive str_replace on '# NATIVEPHP_PLUGIN_PODS' would match
+        // both marker lines and corrupt them into 'pod ...'_START / 'pod ...'_END.
+        $blockPattern = '/^[ \t]*# NATIVEPHP_PLUGIN_PODS_START\s*?\R.*?^[ \t]*# NATIVEPHP_PLUGIN_PODS_END[ \t]*$/ms';
+
+        if (preg_match($blockPattern, $podfile)) {
+            $replacement = "  # NATIVEPHP_PLUGIN_PODS_START\n"
+                ."  # NativePHP Plugin Dependencies\n"
+                ."{$newPodLines}\n"
+                ."  # NATIVEPHP_PLUGIN_PODS_END";
+
+            $podfile = preg_replace_callback(
+                $blockPattern,
+                fn () => $replacement,
+                $podfile,
+                1
+            );
+        } elseif (str_contains($podfile, '# NATIVEPHP_PLUGIN_PODS')) {
+            // Legacy single-marker template — replace it once with the comment + pods.
+            $podfile = preg_replace(
+                '/# NATIVEPHP_PLUGIN_PODS\b(?!_)/',
+                "# NativePHP Plugin Dependencies\n".addcslashes($newPodLines, '\\$'),
+                $podfile,
+                1
             );
         } else {
             // Find the NativePHP target block and insert before its 'end'
@@ -1037,7 +1063,8 @@ platform :ios, '15.0'
 use_frameworks!
 
 target 'NativePHP' do
-  # NATIVEPHP_PLUGIN_PODS
+  # NATIVEPHP_PLUGIN_PODS_START
+  # NATIVEPHP_PLUGIN_PODS_END
 end
 
 post_install do |installer|


### PR DESCRIPTION
## Summary

Fixes the 3.3.0 regression where `native:run` (iOS) fails at `pod install` with a Ruby syntax error:

```
pod 'FirebaseMessaging', '~> 12.6.0'_START
...
pod 'FirebaseMessaging', '~> 12.6.0'_END
```

The shipped iOS Podfile template (`resources/xcode/Podfile`) wraps the injection site in a paired marker block inside `def shared_pods`:

```
  # NATIVEPHP_PLUGIN_PODS_START
  # NATIVEPHP_PLUGIN_PODS_END
```

`addPodDependencies()` was checking `str_contains($podfile, '# NATIVEPHP_PLUGIN_PODS')` and then `str_replace('# NATIVEPHP_PLUGIN_PODS', …)`. That shared prefix matches **both** marker lines, so str_replace appends the generated pod lines onto each marker, leaving the literal `_START` / `_END` suffixes hanging off the last pod line — exactly the broken Podfile reported.

## Fix

- Detect the full `START…END` block with an `ms`-mode regex and replace the whole block (preserving the markers) via `preg_replace_callback`. The callback bypasses backreference parsing in the replacement string, so pod names with `$` or `\` cannot mangle the output. Idempotent on re-run.
- Pods stay **inside `def shared_pods`**, so both the `NativePHP` and `NativePHP-simulator` targets pick them up — preserving the template's intent.
- A second branch preserves backwards compatibility with the legacy single `# NATIVEPHP_PLUGIN_PODS` marker (with a `\b(?!_)` guard so it doesn't re-match the new paired markers).
- `createPodfile()` now emits the paired-marker template so freshly created Podfiles take the canonical injection path.

## Test plan

- [ ] Apply this patch on a 3.3.0 app with iOS plugins (e.g. `nativephp/mobile-firebase`) and run `native:install --force` → `npm run build` → `native:run`
- [ ] Confirm `pod install` succeeds and the generated `nativephp/ios/Podfile` has pods between the START/END markers, inside `def shared_pods`
- [ ] Confirm running `native:run` a second time does not duplicate or further mutate the marker block (idempotency)
- [ ] Confirm an app with no iOS plugins still produces a valid Podfile (markers preserved, no pods between them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)