### PR TITLE
Restore PHPBridge.kt API dropped in Jump merge (#111)

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
@@ -13,6 +13,7 @@ import com.nativephp.mobile.security.LaravelCookieStore
 class PHPBridge(private val context: Context) {
     private var lastPostData: String? = null
     private val requestDataMap = ConcurrentHashMap<String, String>()
+    private val postDataByKey = ConcurrentHashMap<String, String>()
     private val phpExecutor = java.util.concurrent.Executors.newSingleThreadExecutor()
 
     private val nativePhpScript: String
@@ -62,6 +63,11 @@ class PHPBridge(private val context: Context) {
     external fun nativeWorkerBoot(bootstrapPath: String): Int
     external fun nativeWorkerArtisan(command: String): String
     external fun nativeWorkerShutdown()
+
+    // Ephemeral runtime JNI methods — generic background TSRM context for plugin use
+    external fun nativeEphemeralBoot(bootstrapPath: String): Int
+    external fun nativeEphemeralArtisan(command: String): String
+    external fun nativeEphemeralShutdown()
 
     @Volatile
     private var runtimeInitialized = false
@@ -282,6 +288,35 @@ class PHPBridge(private val context: Context) {
         if (keysToRemove.isNotEmpty()) {
             Log.d(TAG, "Cleaned up ${keysToRemove.size} old request entries")
         }
+    }
+
+    fun storePostData(key: String, data: String) {
+        postDataByKey[key] = data
+        Log.d(TAG, "Stored POST data for key=$key (length=${data.length})")
+    }
+
+    fun consumePostData(key: String): String? {
+        // Try immediate lookup
+        var data = postDataByKey.remove(key)
+
+        // If not found, the JS bridge may not have fired yet — wait briefly
+        if (data == null) {
+            for (i in 1..10) {
+                Thread.sleep(5)
+                data = postDataByKey.remove(key)
+                if (data != null) {
+                    Log.d(TAG, "POST data for key=$key arrived after ${i * 5}ms wait")
+                    break
+                }
+            }
+        }
+
+        if (data != null) {
+            Log.d(TAG, "Consumed POST data for key=$key (length=${data.length})")
+        } else {
+            Log.w(TAG, "No POST data for key=$key after 50ms — request may have no body")
+        }
+        return data
     }
 
     fun getLastPostData(): String? {


### PR DESCRIPTION
## Summary

Fixes the 3.3.0 regression where Android builds fail to compile in apps using the firebase plugin (or any plugin that drives the ephemeral PHP runtime):

```
PushNotificationService.kt: Unresolved reference 'nativeEphemeralBoot'
PushNotificationService.kt: Unresolved reference 'nativeEphemeralArtisan'
PushNotificationService.kt: Unresolved reference 'nativeEphemeralShutdown'
WebViewManager.kt:          Unresolved reference 'consumePostData'
```

Five public members existed in `PHPBridge.kt` as of `866a6dd` (the Apr 4 Android POST-body fix) and are still required by current code:

- `external fun nativeEphemeralBoot/Artisan/Shutdown` — registered as JNI methods in `php_bridge.c:1354-1356` and called from plugin code such as `nativephp/mobile-firebase`'s `PushNotificationService`.
- `storePostData(key, data)` / `consumePostData(key)` — used by the bundled `WebViewManager.kt` (lines 268, 272, 275, 531, 544, 547) to correlate POST bodies stashed by the injected JS XHR/fetch hook with the intercepted request on the native side.

The Jump merge (#111, commit `026a1b7`) accidentally dropped these declarations from `PHPBridge.kt` while leaving the JNI registrations and all callers in place. Restored verbatim from the canonical jump-playground copy that Jump itself runs against, including the **50 ms wait loop on `consumePostData`** that #84 added to handle the race where the WebView fires the network request before the injected JS hook has finished stashing the body — important for concurrent Livewire `\$wire` bursts to the same endpoint.

## Test plan

- [ ] Build Android against an app with `nativephp/mobile-firebase` (or any plugin invoking the ephemeral runtime) — confirm compile succeeds
- [ ] Submit a Livewire form post in the running app — confirm POST body reaches Laravel populated (no spurious "field is required" errors)
- [ ] Run a few concurrent `\$wire` calls to the same endpoint — confirm none drop the body (50 ms wait loop covers JS-stash race)
- [ ] Confirm Jump's live preview still works against an app on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)