### PR TITLE
Track full PHP version in nativephp.lock

### DIFF
--- a/src/Commands/DebugCommand.php
+++ b/src/Commands/DebugCommand.php
@@ -56,13 +56,13 @@ class DebugCommand extends Command
 
     protected function getEmbeddedPhpVersion(): string
     {
-        $jsonPath = base_path('nativephp.json');
+        $lockPath = base_path('nativephp.lock');
 
-        if (! file_exists($jsonPath)) {
+        if (! file_exists($lockPath)) {
             return 'Not installed';
         }
 
-        $nativephp = json_decode(file_get_contents($jsonPath), true) ?? [];
+        $nativephp = json_decode(file_get_contents($lockPath), true) ?? [];
 
         return $nativephp['php']['version'] ?? 'Not installed';
     }

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -2,6 +2,8 @@
 
 namespace Native\Mobile\Commands;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
 use Illuminate\Console\Command;
 use Native\Mobile\Traits\DisplaysMarketingBanners;
 use Native\Mobile\Traits\InstallsAndroid;
@@ -20,6 +22,10 @@ class InstallCommand extends Command
     use DisplaysMarketingBanners, InstallsAndroid, InstallsIos, PlatformFileOperations;
 
     protected bool $forcing = true;
+
+    protected string $phpVersion;
+
+    protected ?array $versionsManifest = null;
 
     protected $signature = 'native:install
         {platform? : The platform to install (android/a, ios/i, or both)}
@@ -124,12 +130,26 @@ class InstallCommand extends Command
 
         $this->callSilently('vendor:publish', ['--tag' => 'nativephp-mobile-config']);
 
+        $this->migrateLegacyNativephpJson();
+
+        $shouldInstallPhp = ! ($this->option('skip-php') && ! $this->forcing);
+
+        if ($shouldInstallPhp) {
+            $this->phpVersion = $this->detectPhpVersion();
+            $this->fetchVersionsManifest();
+        }
+
         if ($installAndroid) {
             $this->setupAndroid();
         }
 
         if ($installIos) {
             $this->setupIos();
+        }
+
+        if ($shouldInstallPhp && $this->versionsManifest) {
+            $includeIcu = (bool) $this->option('with-icu');
+            $this->writeNativephpLock($this->phpVersion, $includeIcu);
         }
 
         file_put_contents($path.DIRECTORY_SEPARATOR.'.gitignore', '*'.PHP_EOL);
@@ -248,5 +268,100 @@ class InstallCommand extends Command
         }
 
         file_put_contents($envPath, $envContents);
+    }
+
+    protected function getBinaryBranch(): string
+    {
+        return env('NATIVEPHP_BIN_BRANCH', 'main');
+    }
+
+    protected function fetchVersionsManifest(): void
+    {
+        $branch = $this->getBinaryBranch();
+        $versionsUrl = "https://bin.nativephp.com/{$branch}/versions.json";
+
+        try {
+            $this->versionsManifest = json_decode(
+                (new Client)->get($versionsUrl)->getBody()->getContents(),
+                true
+            );
+        } catch (RequestException $e) {
+            error("Failed to fetch versions manifest from: {$versionsUrl}");
+        }
+    }
+
+    protected function detectPhpVersion(): string
+    {
+        $supported = ['8.5', '8.4', '8.3'];
+
+        // Check nativephp.lock first (committed by the user or written by a previous install)
+        $lockPath = base_path('nativephp.lock');
+        if (file_exists($lockPath)) {
+            $lock = json_decode(file_get_contents($lockPath), true) ?? [];
+            $lockVersion = $lock['php']['version'] ?? null;
+
+            if (is_string($lockVersion)) {
+                $minor = implode('.', array_slice(explode('.', $lockVersion), 0, 2));
+                if (in_array($minor, $supported, true)) {
+                    return $minor;
+                }
+            }
+        }
+
+        // Fall back to composer.json's PHP constraint
+        $composerPath = base_path('composer.json');
+        if (file_exists($composerPath)) {
+            $composer = json_decode(file_get_contents($composerPath), true);
+            $constraint = $composer['require']['php'] ?? '';
+
+            foreach ($supported as $version) {
+                if (preg_match('/(?:\^|>=|~)?'.preg_quote($version, '/').'/', $constraint)) {
+                    return $version;
+                }
+            }
+        }
+
+        // Fall back to the running PHP version
+        $minor = PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;
+
+        if (in_array($minor, $supported, true)) {
+            return $minor;
+        }
+
+        foreach ($supported as $version) {
+            if (version_compare($minor, $version, '>=')) {
+                return $version;
+            }
+        }
+
+        return '8.3';
+    }
+
+    protected function writeNativephpLock(string $minor, bool $icu): void
+    {
+        $lockPath = base_path('nativephp.lock');
+        $fullVersion = $this->versionsManifest['versions'][$minor]['php_version'] ?? $minor;
+
+        $data = file_exists($lockPath)
+            ? json_decode(file_get_contents($lockPath), true) ?? []
+            : [];
+
+        $data['php'] = [
+            'version' => $fullVersion,
+            'icu' => $icu,
+        ];
+
+        file_put_contents($lockPath, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
+    }
+
+    protected function migrateLegacyNativephpJson(): void
+    {
+        $legacyPath = base_path('nativephp.json');
+
+        if (! file_exists($legacyPath)) {
+            return;
+        }
+
+        @unlink($legacyPath);
     }
 }

--- a/src/Traits/InstallsAndroid.php
+++ b/src/Traits/InstallsAndroid.php
@@ -15,11 +15,6 @@ trait InstallsAndroid
 {
     use PlatformFileOperations;
 
-    private function getBinaryBranch(): string
-    {
-        return env('NATIVEPHP_BIN_BRANCH', 'main');
-    }
-
     protected ?bool $includeIcu = null;
 
     public function promptAndroidOptions(): void
@@ -61,52 +56,14 @@ trait InstallsAndroid
         $this->components->task('Creating Android project', fn () => $this->platformOptimizedCopy($source, $androidPath));
     }
 
-    private function detectPhpVersion(): string
-    {
-        $composerPath = base_path('composer.json');
-
-        if (! file_exists($composerPath)) {
-            return '8.3';
-        }
-
-        $composer = json_decode(file_get_contents($composerPath), true);
-        $constraint = $composer['require']['php'] ?? '';
-
-        // Check from highest to lowest — first match wins
-        if (preg_match('/(?:\^|>=|~)?8\.5/', $constraint)) {
-            return '8.5';
-        }
-
-        if (preg_match('/(?:\^|>=|~)?8\.4/', $constraint)) {
-            return '8.4';
-        }
-
-        return '8.3';
-    }
-
     private function installPHPAndroid(): void
     {
         $includeIcu = $this->includeIcu ?? false;
-        $phpVersion = $this->detectPhpVersion();
+        $phpVersion = $this->phpVersion;
+        $versions = $this->versionsManifest;
 
-        $branch = $this->getBinaryBranch();
-        $versionsUrl = "https://bin.nativephp.com/{$branch}/versions.json";
-
-        $client = new Client;
-
-        try {
-            $versions = json_decode(
-                $client->get($versionsUrl)->getBody()->getContents(),
-                true
-            );
-        } catch (RequestException $e) {
-            error("Failed to fetch versions manifest from: {$versionsUrl}");
-
-            return;
-        }
-
-        if (! isset($versions['versions'][$phpVersion])) {
-            error("PHP {$phpVersion} binaries not available in {$branch} branch");
+        if (! $versions || ! isset($versions['versions'][$phpVersion])) {
+            error("PHP {$phpVersion} binaries not available");
 
             return;
         }
@@ -139,7 +96,8 @@ trait InstallsAndroid
         $zipFile = $cacheDir.DIRECTORY_SEPARATOR.$zipFilename;
         $extractPath = storage_path('android-temp');
 
-        $this->components->twoColumnDetail('PHP version', $phpVersion.'.x');
+        $fullVersion = $versions['versions'][$phpVersion]['php_version'] ?? $phpVersion;
+        $this->components->twoColumnDetail('PHP version', $fullVersion);
         $this->components->twoColumnDetail('ICU support', $includeIcu ? 'Enabled' : 'Disabled');
 
         if (file_exists($zipFile)) {
@@ -240,14 +198,6 @@ trait InstallsAndroid
         File::ensureDirectoryExists($destination);
 
         $this->components->task('Installing Android libraries', fn () => $this->platformOptimizedCopy($extractPath, $destination));
-
-        // Store ICU preference for run command
-        $icuFlagFile = base_path('nativephp/android/.icu-enabled');
-        if ($includeIcu) {
-            File::put($icuFlagFile, '1');
-        } elseif (File::exists($icuFlagFile)) {
-            File::delete($icuFlagFile);
-        }
 
         try {
             $this->removeDirectory($extractPath);

--- a/src/Traits/InstallsIos.php
+++ b/src/Traits/InstallsIos.php
@@ -14,11 +14,6 @@ use function Laravel\Prompts\warning;
 
 trait InstallsIos
 {
-    private function getIosBinaryBranch(): string
-    {
-        return env('NATIVEPHP_BIN_BRANCH', 'main');
-    }
-
     public string $iosPath;
 
     protected ?bool $includeIcuIos = null;
@@ -63,26 +58,11 @@ trait InstallsIos
     private function installPHPIos(): void
     {
         $includeIcu = $this->includeIcuIos ?? false;
-        $phpVersion = $this->detectPhpVersion();
+        $phpVersion = $this->phpVersion;
+        $versions = $this->versionsManifest;
 
-        $branch = $this->getIosBinaryBranch();
-        $versionsUrl = "https://bin.nativephp.com/{$branch}/versions.json";
-
-        $client = new Client;
-
-        try {
-            $versions = json_decode(
-                $client->get($versionsUrl)->getBody()->getContents(),
-                true
-            );
-        } catch (RequestException $e) {
-            error("Failed to fetch versions manifest from: {$versionsUrl}");
-
-            return;
-        }
-
-        if (! isset($versions['versions'][$phpVersion])) {
-            error("PHP {$phpVersion} binaries not available in {$branch} branch");
+        if (! $versions || ! isset($versions['versions'][$phpVersion])) {
+            error("PHP {$phpVersion} binaries not available");
 
             return;
         }
@@ -108,7 +88,8 @@ trait InstallsIos
             return;
         }
 
-        $this->components->twoColumnDetail('PHP version', $phpVersion.'.x');
+        $fullVersion = $versions['versions'][$phpVersion]['php_version'] ?? $phpVersion;
+        $this->components->twoColumnDetail('PHP version', $fullVersion);
         $this->components->twoColumnDetail('ICU support', $includeIcu ? 'Enabled' : 'Disabled');
 
         $cacheDir = base_path('nativephp/binaries');
@@ -193,14 +174,6 @@ trait InstallsIos
         $bridgeDst = $this->iosPath.'/Include/Bridge';
         if (is_dir($bridgeSrc)) {
             File::copyDirectory($bridgeSrc, $bridgeDst);
-        }
-
-        // Store ICU preference for run command
-        $icuFlagFile = base_path('nativephp/ios/.icu-enabled');
-        if ($includeIcu) {
-            File::put($icuFlagFile, '1');
-        } elseif (File::exists($icuFlagFile)) {
-            File::delete($icuFlagFile);
         }
 
         try {

--- a/src/Traits/RunsAndroid.php
+++ b/src/Traits/RunsAndroid.php
@@ -382,13 +382,13 @@ XML;
 
     private function updateIcuConfiguration(): void
     {
-        $jsonPath = base_path('nativephp.json');
+        $lockPath = base_path('nativephp.lock');
 
-        if (! file_exists($jsonPath)) {
+        if (! file_exists($lockPath)) {
             return;
         }
 
-        $nativephp = json_decode(file_get_contents($jsonPath), true) ?? [];
+        $nativephp = json_decode(file_get_contents($lockPath), true) ?? [];
 
         if (empty($nativephp['php']['icu'])) {
             return;

--- a/tests/Feature/AndroidBuildIntegrationTest.php
+++ b/tests/Feature/AndroidBuildIntegrationTest.php
@@ -131,8 +131,8 @@ class AndroidBuildIntegrationTest extends TestCase
 
         File::copyDirectory($source, $dest);
 
-        // Enable ICU via nativephp.json
-        File::put($this->testProjectPath.'/nativephp.json', json_encode(['php' => ['version' => '8.4.7', 'icu' => true]]));
+        // Enable ICU via nativephp.lock
+        File::put($this->testProjectPath.'/nativephp.lock', json_encode(['php' => ['version' => '8.4.7', 'icu' => true]]));
     }
 
     protected function mockRunCommand(): void

--- a/tests/Unit/ConfigurationUpdatesTest.php
+++ b/tests/Unit/ConfigurationUpdatesTest.php
@@ -69,8 +69,8 @@ class ConfigurationUpdatesTest extends TestCase
         // Create google-services.json
         File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
 
-        // Enable ICU via nativephp.json
-        File::put($this->testProjectPath.'/nativephp.json', json_encode(['php' => ['version' => '8.4.7', 'icu' => true]]));
+        // Enable ICU via nativephp.lock
+        File::put($this->testProjectPath.'/nativephp.lock', json_encode(['php' => ['version' => '8.4.7', 'icu' => true]]));
 
         // Execute configuration update
         $this->testUpdateAndroidConfiguration();
@@ -564,13 +564,13 @@ Java_com_nativephp_mobile_bridge_PHPBridge',
 
     protected function updateIcuConfiguration(): void
     {
-        $jsonPath = $this->testProjectPath.'/nativephp.json';
+        $lockPath = $this->testProjectPath.'/nativephp.lock';
 
-        if (! file_exists($jsonPath)) {
+        if (! file_exists($lockPath)) {
             return;
         }
 
-        $nativephp = json_decode(file_get_contents($jsonPath), true) ?? [];
+        $nativephp = json_decode(file_get_contents($lockPath), true) ?? [];
 
         if (empty($nativephp['php']['icu'])) {
             return;

--- a/tests/Unit/EdgeCasesAndErrorHandlingTest.php
+++ b/tests/Unit/EdgeCasesAndErrorHandlingTest.php
@@ -140,15 +140,15 @@ class EdgeCasesAndErrorHandlingTest extends TestCase
         }
     }
 
-    public function test_handles_icu_disabled_in_json()
+    public function test_handles_icu_disabled_in_lock()
     {
-        // Create PHPBridge.kt with ICU disabled in nativephp.json
+        // Create PHPBridge.kt with ICU disabled in nativephp.lock
         $bridgePath = $this->testProjectPath.'/nativephp/android/app/src/main/java/com/test/app/bridge/PHPBridge.kt';
         File::makeDirectory(dirname($bridgePath), 0755, true);
         File::put($bridgePath, 'class PHPBridge { init { System.loadLibrary("php") } }');
 
         config(['nativephp.app_id' => 'com.test.app']);
-        File::put($this->testProjectPath.'/nativephp.json', json_encode(['php' => ['version' => '8.4.7', 'icu' => false]]));
+        File::put($this->testProjectPath.'/nativephp.lock', json_encode(['php' => ['version' => '8.4.7', 'icu' => false]]));
 
         // Update ICU configuration with ICU disabled
         $this->updateIcuConfiguration();

--- a/tests/Unit/Traits/InstallsAndroidTest.php
+++ b/tests/Unit/Traits/InstallsAndroidTest.php
@@ -98,7 +98,7 @@ class InstallsAndroidTest extends TestCase
         $this->assertFileExists($androidPath.'/new.txt');
     }
 
-    public function test_install_php_android_with_icu_json()
+    public function test_install_php_android_with_icu_lock()
     {
         $this->mockConfirm('➕ Include ICU-enabled PHP binary? (~30MB extra)', true);
 
@@ -106,15 +106,15 @@ class InstallsAndroidTest extends TestCase
         $destination = $this->testProjectPath.'/nativephp/android/app/src/main';
         File::makeDirectory($destination, 0755, true);
 
-        // ICU preference is now stored in nativephp.json by InstallCommand
-        $jsonPath = $this->testProjectPath.'/nativephp.json';
-        File::put($jsonPath, json_encode(['php' => ['version' => '8.4.7', 'icu' => true]]));
+        // ICU preference is now stored in nativephp.lock by InstallCommand
+        $lockPath = $this->testProjectPath.'/nativephp.lock';
+        File::put($lockPath, json_encode(['php' => ['version' => '8.4.7', 'icu' => true]]));
 
-        $data = json_decode(File::get($jsonPath), true);
+        $data = json_decode(File::get($lockPath), true);
         $this->assertTrue($data['php']['icu']);
     }
 
-    public function test_install_php_android_without_icu_json()
+    public function test_install_php_android_without_icu_lock()
     {
         $this->mockConfirm('➕ Include ICU-enabled PHP binary? (~30MB extra)', false);
 
@@ -122,11 +122,11 @@ class InstallsAndroidTest extends TestCase
         $destination = $this->testProjectPath.'/nativephp/android/app/src/main';
         File::makeDirectory($destination, 0755, true);
 
-        // ICU preference is now stored in nativephp.json by InstallCommand
-        $jsonPath = $this->testProjectPath.'/nativephp.json';
-        File::put($jsonPath, json_encode(['php' => ['version' => '8.4.7', 'icu' => false]]));
+        // ICU preference is now stored in nativephp.lock by InstallCommand
+        $lockPath = $this->testProjectPath.'/nativephp.lock';
+        File::put($lockPath, json_encode(['php' => ['version' => '8.4.7', 'icu' => false]]));
 
-        $data = json_decode(File::get($jsonPath), true);
+        $data = json_decode(File::get($lockPath), true);
         $this->assertFalse($data['php']['icu']);
     }
 


### PR DESCRIPTION
## Summary

- Restores the install-time writer dropped in the Jump PR (#111) that recorded the embedded PHP version and ICU preference, but renames the file from `nativephp.json` to `nativephp.lock` and stores the **full** PHP version (e.g. `8.4.20`) instead of the major.minor (`8.4`) the previous writer used.
- Pulls the full version from the `versions.json` manifest's `php_version` field.
- Migrates away from the `nativephp/{android,ios}/.icu-enabled` flag files — that state lives in `nativephp.lock` now.
- Deletes any pre-existing root `nativephp.json` on install (treated as a build artifact, not a manifest — plugin `nativephp.json` files are unaffected).
- Consolidates manifest fetching and version detection into `InstallCommand` so it happens once per install instead of once per platform.

## Why

The previous writer stored only `8.4`, which is enough to look up a binary in the manifest but loses the actual patch version that's been embedded — making CI and debug output less useful. Renaming to `nativephp.lock` reflects what the file actually is (a build-state lock file, not a manifest), and is consistent with `composer.lock` / `package-lock.json` conventions. Moving ICU into the lock file removes the awkward dual-source state where ICU lived in a flag file under the gitignored `nativephp/` directory while version data lived elsewhere.

## Test plan

- [x] `composer test` — 225 passed (4 risky / 3 skipped, all pre-existing)
- [x] `php -l` clean on all touched files
- [x] Manually run `php artisan native:install` on a fresh project — verify `nativephp.lock` is written with the full PHP version
- [x] Run `native:install` on a project with a stale `nativephp.json` at the root — verify it gets removed
- [x] Run `native:install --with-icu` then `native:run android` — verify ICU loads via the lock file
- [x] Run `php artisan native:debug` — verify embedded PHP version reads from the lock file

🤖 Generated with [Claude Code](https://claude.com/claude-code)