### PR TITLE
Bail native:run on host PHP / nativephp.lock mismatch

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -308,20 +308,7 @@ class InstallCommand extends Command
             }
         }
 
-        // Fall back to composer.json's PHP constraint
-        $composerPath = base_path('composer.json');
-        if (file_exists($composerPath)) {
-            $composer = json_decode(file_get_contents($composerPath), true);
-            $constraint = $composer['require']['php'] ?? '';
-
-            foreach ($supported as $version) {
-                if (preg_match('/(?:\^|>=|~)?'.preg_quote($version, '/').'/', $constraint)) {
-                    return $version;
-                }
-            }
-        }
-
-        // Fall back to the running PHP version
+        // Fall back to the host PHP — Composer resolves against it.
         $minor = PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;
 
         if (in_array($minor, $supported, true)) {

--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -11,6 +11,7 @@ use Native\Mobile\Traits\PlatformFileOperations;
 use Native\Mobile\Traits\RunsAndroid;
 use Native\Mobile\Traits\RunsIos;
 
+use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\note;
@@ -36,6 +37,10 @@ class RunCommand extends Command
     public function handle(): int
     {
         $this->ensureValidAppId();
+
+        if (! $this->ensureHostPhpMatchesLock()) {
+            return self::FAILURE;
+        }
 
         // Check watchman is installed when --watch flag is used
         if ($this->option('watch') && ! $this->checkWatchmanDependencies()) {
@@ -149,6 +154,59 @@ class RunCommand extends Command
 
         note('Register them in your NativeServiceProvider or run: php artisan native:plugin:register');
         $this->newLine();
+    }
+
+    protected function ensureHostPhpMatchesLock(): bool
+    {
+        $lockPath = base_path('nativephp.lock');
+
+        if (! file_exists($lockPath)) {
+            return true;
+        }
+
+        $lock = json_decode(file_get_contents($lockPath), true) ?? [];
+        $lockedVersion = $lock['php']['version'] ?? null;
+
+        if (! is_string($lockedVersion) || $lockedVersion === '') {
+            return true;
+        }
+
+        $lockedMinor = implode('.', array_slice(explode('.', $lockedVersion), 0, 2));
+        $hostMinor = PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION;
+
+        if ($lockedMinor === $hostMinor) {
+            return true;
+        }
+
+        error("Host PHP {$hostMinor} does not match nativephp.lock ({$lockedVersion}).");
+        note('Composer resolves your app dependencies against the host PHP, but the bundled runtime is pinned to PHP '.$lockedMinor.'. Building now will likely fail or produce a bundle that crashes on device.');
+
+        $supported = ['8.5', '8.4', '8.3'];
+
+        if (! in_array($hostMinor, $supported, true)) {
+            note("Your host PHP {$hostMinor} is not supported by NativePHP. Switch your host to PHP {$lockedMinor}.x and retry.");
+
+            return false;
+        }
+
+        if (! confirm("Re-run `native:install --force` to bundle PHP {$hostMinor} instead?", default: true)) {
+            note("Switch your host to PHP {$lockedMinor}.x and retry, or re-install when ready.");
+
+            return false;
+        }
+
+        $lock['php']['version'] = $hostMinor;
+        file_put_contents($lockPath, json_encode($lock, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
+
+        $exitCode = $this->call('native:install', ['--force' => true]);
+
+        if ($exitCode !== 0) {
+            error('native:install --force failed. Resolve the install error and retry.');
+
+            return false;
+        }
+
+        return true;
     }
 
     protected function ensureValidAppId(): void


### PR DESCRIPTION
## Summary

- `native:run` now compares the host PHP major.minor against the `php.version` recorded in `nativephp.lock`. If they differ, the build is halted before Composer runs against the wrong PHP and produces a broken bundle.
- On mismatch the user is offered a confirm prompt to re-pin the lock to the host minor and invoke `php artisan native:install --force`, which clears the cached PHP binaries so the right runtime is downloaded.
- If the host PHP isn't a supported NativePHP version (currently `8.3` / `8.4` / `8.5`), the run bails with guidance to switch host PHP — re-installing wouldn't help.

## Why

Composer resolves an app's dependencies against the host PHP, but the on-device runtime is whatever was bundled at the last `native:install`. A mismatch (e.g. host 8.5 / lock 8.4) silently produces a bundle that either fails to install or crashes at runtime. Previously `native:run` only logged the host version to the build log and never compared it.

## Behavior

| Situation | Result |
|---|---|
| No `nativephp.lock` or no `php.version` in it | Skip check, proceed |
| Host minor == lock minor | Proceed silently |
| Host minor != lock minor, host unsupported | Error + note, bail |
| Host minor != lock minor, host supported | Confirm prompt; on **yes** rewrite lock's `php.version` to host minor and call `native:install --force`, then continue the build; on **no** bail |

## Test plan

- [x] Run `native:run` with matching host/lock — proceeds without prompt.
- [x] Run `native:run` with mismatched supported host PHP — prompt appears; accepting kicks off `native:install --force` and writes the host minor into `nativephp.lock`.
- [ ] Run `native:run` with mismatched host on an unsupported PHP version — bails with guidance, no prompt.
- [x] Run `native:run` with no `nativephp.lock` present — proceeds unchanged.