### PR TITLE
Fix native:jump hang on Windows and harden port detection

### DIFF
--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -39,9 +39,6 @@ class JumpCommand extends Command
 
         intro('NativePHP Jump Server');
 
-        // Kill existing servers
-        $this->killExistingServers();
-
         // Configuration
         $host = $this->option('host');
         $httpPort = $this->option('http-port') ?? config('nativephp.server.http_port', 3000);
@@ -301,19 +298,35 @@ class JumpCommand extends Command
         $logFile = $logDir.'/jump-bridge.log';
         @file_put_contents($logFile, '=== '.date('Y-m-d H:i:s')." bridge server starting (ws={$wsPort} tcp={$bridgePort} vite_proxy={$viteProxyPort}) ===\n", FILE_APPEND);
 
-        // Run in background (not Workerman daemon mode — it breaks the event loop)
-        $cmd = sprintf(
-            '%s %s %s %d %d %d start >> %s 2>&1 &',
-            escapeshellarg($phpBinary),
-            escapeshellarg($serverPath),
-            escapeshellarg(base_path()),
-            $wsPort,
-            $bridgePort,
-            $viteProxyPort,
-            escapeshellarg($logFile)
-        );
-
-        exec($cmd);
+        // Run in background (not Workerman daemon mode — it breaks the event loop).
+        // Windows: `&` is a command separator (not "background"), so exec() would
+        // block here forever waiting on the long-lived server. Use `start /B` to
+        // detach properly.
+        if (PHP_OS_FAMILY === 'Windows') {
+            $cmd = sprintf(
+                'start "" /B %s %s %s %d %d %d start >> %s 2>&1',
+                escapeshellarg($phpBinary),
+                escapeshellarg($serverPath),
+                escapeshellarg(base_path()),
+                $wsPort,
+                $bridgePort,
+                $viteProxyPort,
+                escapeshellarg($logFile)
+            );
+            pclose(popen($cmd, 'r'));
+        } else {
+            $cmd = sprintf(
+                '%s %s %s %d %d %d start >> %s 2>&1 &',
+                escapeshellarg($phpBinary),
+                escapeshellarg($serverPath),
+                escapeshellarg(base_path()),
+                $wsPort,
+                $bridgePort,
+                $viteProxyPort,
+                escapeshellarg($logFile)
+            );
+            exec($cmd);
+        }
 
         // Give it a moment to start
         usleep(500000);
@@ -639,70 +652,25 @@ APPLESCRIPT;
         }
     }
 
-    private function killExistingServers()
-    {
-        $currentPid = getmypid();
-
-        if (PHP_OS_FAMILY === 'Windows') {
-            // Kill PHP servers running the jump router
-            $output = shell_exec('wmic process where "commandline like \'%router.php%\'" get processid 2>NUL');
-            if (! $output) {
-                $output = shell_exec('powershell -Command "Get-WmiObject Win32_Process | Where-Object { $_.CommandLine -like \'*router.php*\' } | Select-Object -ExpandProperty ProcessId" 2>NUL');
-            }
-
-            if ($output) {
-                $pids = array_filter(preg_split('/\s+/', trim($output)), function ($pid) use ($currentPid) {
-                    return is_numeric($pid) && $pid != $currentPid && ! empty($pid);
-                });
-
-                if (count($pids) > 0) {
-                    $this->components->task('Cleaning up '.count($pids).' existing server(s)', function () use ($pids) {
-                        foreach ($pids as $pid) {
-                            exec("taskkill /F /PID {$pid} 2>NUL");
-                        }
-                        usleep(500000);
-
-                        return true;
-                    });
-                }
-            }
-        } else {
-            // Unix: Kill WebSocket bridge servers and Workerman workers
-            exec("pkill -9 -f 'websocket-server.php' 2>/dev/null");
-            exec("pkill -9 -f 'WorkerMan:' 2>/dev/null");
-            usleep(300000);
-
-            // Unix: Kill PHP servers running the jump router
-            $output = shell_exec("pgrep -f 'router.php' 2>/dev/null");
-
-            if ($output) {
-                $pids = array_filter(explode("\n", trim($output)));
-                $pids = array_filter($pids, function ($pid) use ($currentPid) {
-                    return $pid != $currentPid && ! empty($pid);
-                });
-
-                if (count($pids) > 0) {
-                    $this->components->task('Cleaning up '.count($pids).' existing server(s)', function () use ($pids) {
-                        foreach ($pids as $pid) {
-                            exec("kill -9 {$pid} 2>/dev/null");
-                        }
-                        usleep(500000);
-
-                        return true;
-                    });
-                }
-            }
-        }
-    }
-
     private function isPortInUse($port)
     {
+        // Connect-test: does anything accept on this port right now?
         $connection = @fsockopen('127.0.0.1', $port, $errno, $errstr, 1);
         if ($connection) {
             fclose($connection);
 
             return true;
         }
+
+        // Bind-test: catches ports held by a process that isn't accepting
+        // (stuck/half-dead Windows servers, TIME_WAIT, bound-but-not-listening).
+        // fsockopen alone missed these, which is why a previous run's artisan
+        // serve on 8000 could fool us into picking 8000 again.
+        $socket = @stream_socket_server("tcp://127.0.0.1:{$port}", $errno, $errstr);
+        if ($socket === false) {
+            return true;
+        }
+        fclose($socket);
 
         return false;
     }


### PR DESCRIPTION
## Summary

Fixes a report from a Windows user that `php artisan native:jump` got stuck after printing the Laravel server line, never rendering the QR code.

Three related fixes in `src/Commands/JumpCommand.php`:

- **Drop the `killExistingServers` cleanup step.** With reliable dynamic port selection in place, we don't need to hunt and kill prior processes — and the cleanup never reliably caught stray `artisan serve` instances anyway. Also removes the noisy "Cleaning up N existing server(s)" line.

- **Harden `isPortInUse()` with a bind-test alongside the existing connect-test.** `fsockopen` only detects ports that are *accepting* connections; it misses ports held but not listening (stuck/half-dead Windows servers, `TIME_WAIT`, bound-but-not-listening). That's why a stale previous `artisan serve` on 8000 could fool the old check into selecting 8000 again. We now also try `stream_socket_server` and treat a bind failure as in-use.

- **Fix the actual Windows hang in `startBridgeServer()`.** The bridge spawn used a trailing `&` to background the websocket server, which is Unix shell syntax. On Windows, `&` is a command separator — not a background operator — so `exec()` blocked forever on the long-lived bridge server, which is why the QR code never appeared. Windows now uses `start "" /B ... >> log 2>&1` via `popen`/`pclose` for a proper detached spawn; Unix path is unchanged.

## Test plan

- [ ] On macOS/Linux: `php artisan native:jump` still starts, picks ports, shows QR, and the bridge log fills as the phone connects.
- [ ] On Windows: `php artisan native:jump` reaches the QR display without hanging, even when a prior `artisan serve` is still running on 8000.
- [ ] Re-run `php artisan native:jump` repeatedly without manually killing prior servers — each run picks fresh ports and starts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)