### PR TITLE
Default app version to DEBUG

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'version' => env('NATIVEPHP_APP_VERSION', '1.0.0'),
+    'version' => env('NATIVEPHP_APP_VERSION', 'DEBUG'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -611,20 +611,20 @@ class AndroidPluginCompiler
 
         // Build nested content (intent-filters and meta-data)
         $nestedContent = '';
-        
+
         // Support both snake_case and kebab-case for intent filters
         $intentFilters = $service['intent_filters'] ?? $service['intent-filters'] ?? [];
-        if (!empty($intentFilters)) {
+        if (! empty($intentFilters)) {
             $nestedContent .= $this->buildIntentFilters($intentFilters);
         }
-        
+
         // Add meta-data support at service level
         $metaData = $service['meta_data'] ?? $service['meta-data'] ?? [];
-        if (!empty($metaData)) {
+        if (! empty($metaData)) {
             $nestedContent .= $this->buildComponentMetaData($metaData);
         }
 
-        if (!empty($nestedContent)) {
+        if (! empty($nestedContent)) {
             return "<service\n            {$attrString}>\n{$nestedContent}        </service>";
         }
 
@@ -637,12 +637,12 @@ class AndroidPluginCompiler
     protected function buildComponentMetaData(array $metaDataEntries): string
     {
         $xml = '';
-        
+
         foreach ($metaDataEntries as $metaData) {
             $name = $metaData['name'];
             $value = $metaData['value'] ?? null;
             $resource = $metaData['resource'] ?? null;
-            
+
             if ($resource !== null) {
                 $xml .= "            <meta-data android:name=\"{$name}\" android:resource=\"{$resource}\" />\n";
             } elseif ($value !== null) {
@@ -652,7 +652,7 @@ class AndroidPluginCompiler
                 $xml .= "            <meta-data android:name=\"{$name}\" android:value=\"{$value}\" />\n";
             }
         }
-        
+
         return $xml;
     }
 


### PR DESCRIPTION
## Summary
- Change the default value of `version` in `config/nativephp.php` from `'1.0.0'` to `'DEBUG'`.

## Why
Surfacing `DEBUG` as the default makes it obvious when an app has been built without setting an explicit `NATIVEPHP_APP_VERSION`, avoiding a silent `1.0.0` masquerading as a real release.

## Test plan
- [x] Verify a fresh install picks up `DEBUG` as the displayed app version when `NATIVEPHP_APP_VERSION` is unset
- [x] Verify setting `NATIVEPHP_APP_VERSION` in `.env` still overrides the default