### PR TITLE
Fix Vite asset loading on Android emulator with Herd HTTPS

### DIFF
--- a/resources/js/vite-plugin.js
+++ b/resources/js/vite-plugin.js
@@ -94,6 +94,11 @@ export function nativephpMobile() {
 
         config.server = {
             host: localIP,
+            https: false,
+            hmr: {
+                host: localIP,
+                protocol: 'ws',
+            },
             cors: {
                 origin: ['php://127.0.0.1'],
             },
@@ -143,6 +148,11 @@ export const mergeConfig = axios.mergeConfig;
 
         config.server = {
             host: localIP,
+            https: false,
+            hmr: {
+                host: localIP,
+                protocol: 'ws',
+            },
             cors: {
                 origin: ['http://127.0.0.1'],
             },
@@ -158,7 +168,17 @@ export const mergeConfig = axios.mergeConfig;
     const mainPlugin = {
         name: 'nativephp',
         enforce: 'pre',
-        config() {
+        config(userConfig) {
+            // laravel-vite-plugin runs with enforce: 'post' and reads
+            // userConfig.server.host / userConfig.server.https / userConfig.server.hmr
+            // to decide whether to apply its Herd/Valet TLS auto-detection.
+            // Mutate userConfig here so its fallbacks see our values and skip
+            // substituting Herd's hostname + self-signed cert — which the
+            // Android emulator can't validate and which breaks asset loading.
+            if (config.server) {
+                userConfig.server = userConfig.server || {};
+                Object.assign(userConfig.server, config.server);
+            }
             return config;
         },
         closeBundle() {

--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -611,20 +611,20 @@ class AndroidPluginCompiler
 
         // Build nested content (intent-filters and meta-data)
         $nestedContent = '';
-        
+
         // Support both snake_case and kebab-case for intent filters
         $intentFilters = $service['intent_filters'] ?? $service['intent-filters'] ?? [];
-        if (!empty($intentFilters)) {
+        if (! empty($intentFilters)) {
             $nestedContent .= $this->buildIntentFilters($intentFilters);
         }
-        
+
         // Add meta-data support at service level
         $metaData = $service['meta_data'] ?? $service['meta-data'] ?? [];
-        if (!empty($metaData)) {
+        if (! empty($metaData)) {
             $nestedContent .= $this->buildComponentMetaData($metaData);
         }
 
-        if (!empty($nestedContent)) {
+        if (! empty($nestedContent)) {
             return "<service\n            {$attrString}>\n{$nestedContent}        </service>";
         }
 
@@ -637,12 +637,12 @@ class AndroidPluginCompiler
     protected function buildComponentMetaData(array $metaDataEntries): string
     {
         $xml = '';
-        
+
         foreach ($metaDataEntries as $metaData) {
             $name = $metaData['name'];
             $value = $metaData['value'] ?? null;
             $resource = $metaData['resource'] ?? null;
-            
+
             if ($resource !== null) {
                 $xml .= "            <meta-data android:name=\"{$name}\" android:resource=\"{$resource}\" />\n";
             } elseif ($value !== null) {
@@ -652,7 +652,7 @@ class AndroidPluginCompiler
                 $xml .= "            <meta-data android:name=\"{$name}\" android:value=\"{$value}\" />\n";
             }
         }
-        
+
         return $xml;
     }
 


### PR DESCRIPTION
## Summary

Closes #109.

When Laravel Herd is installed, it automatically promotes the Vite dev server to HTTPS using a self-signed certificate. The Android emulator can't validate that cert, so every CSS/JS request to the dev server is rejected and the app renders unstyled.

`nativephpMobile()` already returned a server config pinned to the LAN IP, but `laravel-vite-plugin` runs with `enforce: 'post'` and its Herd/Valet TLS auto-detection only steps aside when `userConfig.server.host` / `.https` / `.hmr` are already set. Returning a partial config from our hook isn't enough — laravel-vite-plugin still overwrites our values with Herd's hostname + cert.

## Changes

`resources/js/vite-plugin.js`:

- Add `https: false` and `hmr: { host: localIP, protocol: 'ws' }` to the server block on both the iOS and Android branches.
- Change the plugin's `config()` hook to take `userConfig` and `Object.assign` our server config onto `userConfig.server` before returning. Because `nativephpMobile` is `enforce: 'pre'`, this lands before laravel-vite-plugin's config hook reads `userConfig.server`, so its fallback checks see our values and skip the Herd substitution.

Result: `public/android-hot` (and `public/ios-hot`) are written as `http://<LAN-IP>:5173` and the emulator can load assets without certificate trust gymnastics. Production builds are unaffected (assets are bundled into the APK/AAB).

Considered shipping a debug `network_security_config.xml` with `<certificates src="user"/>` instead, but that still requires every developer to manually export Herd's CA, set a lock-screen PIN on the emulator, push and install the cert via Settings, and repeat for every fresh AVD — strictly worse UX than disabling HTTPS for the dev server.

## Test plan

- [x] On a machine with Laravel Herd installed, run `php artisan native:run -W android` against a fresh emulator.
- [x] Confirm `cat public/android-hot` shows `http://<LAN-IP>:5173` (not `https://*.test:5173`).
- [x] Confirm the app loads with CSS/JS applied and HMR works on save.
- [x] Run `php artisan native:run -W ios` and confirm iOS still loads assets and HMR.
- [ ] Run a production build (`php artisan native:build`) and confirm assets are bundled correctly and the hot files are cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)