### PR TITLE
Make Android theme colors configurable

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -225,9 +225,9 @@ return [
         |
         */
         'theme' => [
-            'color_primary' => env('NATIVEPHP_ANDROID_COLOR_PRIMARY') ?: '#04ABA6',
-            'color_primary_night' => env('NATIVEPHP_ANDROID_COLOR_PRIMARY_NIGHT') ?: '#FFFFFF',
-            'color_on_primary' => env('NATIVEPHP_ANDROID_COLOR_ON_PRIMARY') ?: '#FFFFFF',
+            'color_primary' => env('NATIVEPHP_ANDROID_COLOR_PRIMARY', '#04ABA6'),
+            'color_primary_night' => env('NATIVEPHP_ANDROID_COLOR_PRIMARY_NIGHT', '#FFFFFF'),
+            'color_on_primary' => env('NATIVEPHP_ANDROID_COLOR_ON_PRIMARY', '#FFFFFF'),
         ],
 
         /*

--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -206,6 +206,32 @@ return [
 
         /*
         |--------------------------------------------------------------------------
+        | Android Theme Colors
+        |--------------------------------------------------------------------------
+        |
+        | Colors applied to the generated Android theme (Theme.AndroidPHP). These
+        | drive the colorPrimary / colorOnPrimary values used by native dialogs
+        | such as the date and time pickers (OK / Cancel buttons).
+        |
+        | The night value is written to values-night/themes.xml so Android can
+        | switch automatically when the device is in dark mode.
+        |
+        | Values must be hex strings: #RRGGBB or #AARRGGBB. Wrap them in quotes
+        | inside your .env file (e.g. NATIVEPHP_ANDROID_COLOR_PRIMARY="#04ABA6")
+        | because '#' starts a comment in .env.
+        |
+        | Both values/themes.xml and values-night/themes.xml are written from
+        | these values during `php artisan native:install`.
+        |
+        */
+        'theme' => [
+            'color_primary' => env('NATIVEPHP_ANDROID_COLOR_PRIMARY') ?: '#04ABA6',
+            'color_primary_night' => env('NATIVEPHP_ANDROID_COLOR_PRIMARY_NIGHT') ?: '#FFFFFF',
+            'color_on_primary' => env('NATIVEPHP_ANDROID_COLOR_ON_PRIMARY') ?: '#FFFFFF',
+        ],
+
+        /*
+        |--------------------------------------------------------------------------
         | Android Build Configuration
         |--------------------------------------------------------------------------
         |

--- a/resources/androidstudio/app/src/main/res/values-night/themes.xml
+++ b/resources/androidstudio/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+  <resources>
+      <style name="Theme.AndroidPHP" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+          <item name="colorPrimary">@android:color/white</item>
+          <item name="colorPrimaryVariant">@android:color/white</item>
+          <item name="colorOnPrimary">@android:color/black</item>
+          <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+          <item name="android:statusBarColor">@android:color/transparent</item>
+          <item name="android:navigationBarColor">@android:color/transparent</item>
+          <item name="android:enforceStatusBarContrast">false</item>
+          <item name="android:enforceNavigationBarContrast">false</item>
+      </style>
+  </resources>

--- a/resources/androidstudio/app/src/main/res/values/themes.xml
+++ b/resources/androidstudio/app/src/main/res/values/themes.xml
@@ -3,7 +3,7 @@
     <style name="Theme.AndroidPHP" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
         <item name="colorPrimary">@color/black</item>
         <item name="colorPrimaryVariant">@color/black</item>
-        <item name="colorOnPrimary">@color/black</item>
+        <item name="colorOnPrimary">@color/white</item>
         <item name="android:windowDrawsSystemBarBackgrounds">true</item>
         <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>

--- a/src/Traits/InstallsAndroid.php
+++ b/src/Traits/InstallsAndroid.php
@@ -30,6 +30,7 @@ trait InstallsAndroid
     public function setupAndroid(): void
     {
         $this->createAndroidStudioProject();
+        $this->writeAndroidTheme();
 
         // Skip PHP installation if --skip-php is passed, unless --force/--fresh is also passed
         $shouldSkipPhp = $this->option('skip-php') && ! $this->forcing;
@@ -54,6 +55,60 @@ trait InstallsAndroid
         $source = base_path('vendor/nativephp/mobile/resources/androidstudio');
 
         $this->components->task('Creating Android project', fn () => $this->platformOptimizedCopy($source, $androidPath));
+    }
+
+    private function writeAndroidTheme(): void
+    {
+        $androidRoot = base_path('nativephp/android');
+        $valuesPath = "{$androidRoot}/app/src/main/res/values/themes.xml";
+        $valuesNightPath = "{$androidRoot}/app/src/main/res/values-night/themes.xml";
+
+        $primary = $this->normalizeThemeColor(config('nativephp.android.theme.color_primary') ?: '#000000');
+        $primaryNight = $this->normalizeThemeColor(config('nativephp.android.theme.color_primary_night') ?: '#FFFFFF');
+        $onPrimary = $this->normalizeThemeColor(config('nativephp.android.theme.color_on_primary') ?: '#FFFFFF');
+
+        File::ensureDirectoryExists(dirname($valuesNightPath));
+
+        $this->components->task('Applying Android theme', function () use ($valuesPath, $valuesNightPath, $primary, $primaryNight, $onPrimary) {
+            File::put($valuesPath, $this->renderThemeXml($primary, $onPrimary));
+            File::put($valuesNightPath, $this->renderThemeXml($primaryNight, $onPrimary));
+
+            return true;
+        });
+    }
+
+    private function normalizeThemeColor(string $value): string
+    {
+        if (! preg_match('/^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/', $value)) {
+            warning("Invalid hex color '{$value}' in nativephp.android.theme — falling back to #000000.");
+            $value = '#000000';
+        }
+
+        $hex = strtoupper(ltrim($value, '#'));
+
+        return '#'.(strlen($hex) === 6 ? 'FF'.$hex : $hex);
+    }
+
+    private function renderThemeXml(string $primary, string $onPrimary): string
+    {
+        return <<<XML
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+                <style name="Theme.AndroidPHP" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+                    <item name="colorPrimary">{$primary}</item>
+                    <item name="colorPrimaryVariant">{$primary}</item>
+                    <item name="colorOnPrimary">{$onPrimary}</item>
+                    <item name="colorAccent">{$primary}</item>
+                    <item name="android:colorAccent">{$primary}</item>
+                    <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+                    <item name="android:statusBarColor">@android:color/transparent</item>
+                    <item name="android:navigationBarColor">@android:color/transparent</item>
+                    <item name="android:enforceStatusBarContrast">false</item>
+                    <item name="android:enforceNavigationBarContrast">false</item>
+                </style>
+            </resources>
+
+            XML;
     }
 
     private function installPHPAndroid(): void


### PR DESCRIPTION
This update allows users to choose their own colors for the Android theme. This makes it possible for date and time pickers to be displayed in the app's branding and resolves the issue where buttons were not visible in dark mode.

Fixes #42 