### PR TITLE
Add meta-data support inside Android receiver components

### DIFF
--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -673,12 +673,22 @@ class AndroidPluginCompiler
 
         $attrString = implode("\n            ", $attrs);
 
+        $nestedContent = '';
+
         // Support both snake_case and kebab-case
         $intentFilters = $receiver['intent_filters'] ?? $receiver['intent-filters'] ?? [];
         if (! empty($intentFilters)) {
-            $filters = $this->buildIntentFilters($intentFilters);
+            $nestedContent .= $this->buildIntentFilters($intentFilters);
+        }
 
-            return "<receiver\n            {$attrString}>\n{$filters}        </receiver>";
+        // Add meta-data support at receiver level (e.g. for AppWidgetProvider)
+        $metaData = $receiver['meta_data'] ?? $receiver['meta-data'] ?? [];
+        if (! empty($metaData)) {
+            $nestedContent .= $this->buildComponentMetaData($metaData);
+        }
+
+        if (! empty($nestedContent)) {
+            return "<receiver\n            {$attrString}>\n{$nestedContent}        </receiver>";
         }
 
         return "<receiver\n            {$attrString} />";

--- a/tests/Feature/Plugins/AndroidCompilerTest.php
+++ b/tests/Feature/Plugins/AndroidCompilerTest.php
@@ -955,6 +955,154 @@ object TestFunctions {
     }
 
     /**
+     * @test
+     *
+     * Should add meta-data entries inside a receiver component using resource attribute (e.g. AppWidgetProvider).
+     */
+    public function it_adds_meta_data_with_resource_inside_receiver(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'permissions' => [],
+                'dependencies' => [],
+                'receivers' => [
+                    [
+                        'name' => 'com.example.MyWidgetProvider',
+                        'exported' => true,
+                        'meta-data' => [
+                            ['name' => 'android.appwidget.provider', 'resource' => '@xml/my_widget_info'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $manifestPath = $this->testBasePath.'/android/app/src/main/AndroidManifest.xml';
+        $content = $this->files->get($manifestPath);
+
+        $this->assertStringContainsString('<receiver', $content);
+        $this->assertStringContainsString('<meta-data android:name="android.appwidget.provider" android:resource="@xml/my_widget_info" />', $content);
+        $this->assertStringContainsString('</receiver>', $content);
+    }
+
+    /**
+     * @test
+     *
+     * Should add meta-data entries inside a receiver component using value attribute.
+     */
+    public function it_adds_meta_data_with_value_inside_receiver(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'permissions' => [],
+                'dependencies' => [],
+                'receivers' => [
+                    [
+                        'name' => 'com.example.MyReceiver',
+                        'exported' => false,
+                        'meta_data' => [
+                            ['name' => 'com.example.API_KEY', 'value' => 'abc123'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $manifestPath = $this->testBasePath.'/android/app/src/main/AndroidManifest.xml';
+        $content = $this->files->get($manifestPath);
+
+        $this->assertStringContainsString('<meta-data android:name="com.example.API_KEY" android:value="abc123" />', $content);
+        $this->assertStringContainsString('</receiver>', $content);
+    }
+
+    /**
+     * @test
+     *
+     * Should support both intent-filters and meta-data nested inside a receiver (AppWidgetProvider use-case).
+     */
+    public function it_supports_both_intent_filters_and_meta_data_in_receiver(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'permissions' => [],
+                'dependencies' => [],
+                'receivers' => [
+                    [
+                        'name' => 'com.example.MyWidgetProvider',
+                        'exported' => true,
+                        'intent-filters' => [
+                            ['action' => 'android.appwidget.action.APPWIDGET_UPDATE'],
+                        ],
+                        'meta-data' => [
+                            ['name' => 'android.appwidget.provider', 'resource' => '@xml/my_widget_info'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $manifestPath = $this->testBasePath.'/android/app/src/main/AndroidManifest.xml';
+        $content = $this->files->get($manifestPath);
+
+        $this->assertStringContainsString('<intent-filter>', $content);
+        $this->assertStringContainsString('<action android:name="android.appwidget.action.APPWIDGET_UPDATE" />', $content);
+        $this->assertStringContainsString('<meta-data android:name="android.appwidget.provider" android:resource="@xml/my_widget_info" />', $content);
+        $this->assertStringContainsString('</receiver>', $content);
+    }
+
+    /**
+     * @test
+     *
+     * Receiver without meta-data or intent-filters should remain self-closing.
+     */
+    public function it_keeps_receiver_self_closing_without_nested_content(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'permissions' => [],
+                'dependencies' => [],
+                'receivers' => [
+                    [
+                        'name' => 'com.example.SimpleReceiver',
+                        'exported' => false,
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $manifestPath = $this->testBasePath.'/android/app/src/main/AndroidManifest.xml';
+        $content = $this->files->get($manifestPath);
+
+        $this->assertStringContainsString('com.example.SimpleReceiver', $content);
+        $this->assertMatchesRegularExpression('/<receiver[^>]*\/>/', $content);
+        $this->assertStringNotContainsString('</receiver>', $content);
+    }
+
+    /**
      * Helper method to create a test Plugin instance.
      */
     private function createTestPlugin(array $manifestData = [], ?string $path = null): Plugin


### PR DESCRIPTION
## Problem

The `buildReceiverEntry()` method did not support `meta-data` elements inside receiver components, unlike `buildServiceEntry()` which already calls `buildComponentMetaData()`.

This made it impossible to register an Android `AppWidgetProvider` via a plugin's `nativephp.json`, because Android requires a `<meta-data android:name="android.appwidget.provider" android:resource="@xml/..."/>` element **inside** the `<receiver>` block to recognize it as a widget provider and display it in the widget picker.

Without this, the receiver is registered (intent-filter is present) but Android silently ignores it as a widget provider — the widget never appears in the picker.

## Solution

Apply the same pattern already used in `buildServiceEntry()`: read `meta_data`/`meta-data` from the receiver config and pass it to the existing `buildComponentMetaData()` method (which already handles both `value` and `resource` attributes).

## Usage example

`nativephp.json` in a plugin:

```json
{
    "android": {
        "receivers": [
            {
                "name": "com.example.myplugin.MyWidgetProvider",
                "exported": true,
                "intent-filters": [
                    { "action": "android.appwidget.action.APPWIDGET_UPDATE" }
                ],
                "meta-data": [
                    {
                        "name": "android.appwidget.provider",
                        "resource": "@xml/my_widget_info"
                    }
                ]
            }
        ]
    }
}
```

Produces:

```xml
<receiver
    android:name="com.example.myplugin.MyWidgetProvider"
    android:exported="true">
    <intent-filter>
        <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
    </intent-filter>
    <meta-data android:name="android.appwidget.provider" android:resource="@xml/my_widget_info" />
</receiver>
```

## Test plan

- [x] `it_adds_meta_data_with_resource_inside_receiver` — resource attribute (AppWidgetProvider use-case)
- [x] `it_adds_meta_data_with_value_inside_receiver` — value attribute
- [x] `it_supports_both_intent_filters_and_meta_data_in_receiver` — combined intent-filter + meta-data
- [x] `it_keeps_receiver_self_closing_without_nested_content` — no regression on receivers without nested content

🤖 Generated with [Claude Code](https://claude.com/claude-code)