### PR TITLE
Localize iOS permission strings via InfoPlist.strings

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -117,6 +117,36 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | iOS Permission String Localizations
+    |--------------------------------------------------------------------------
+    |
+    | Provide per-locale overrides for the strings declared above. Each key is
+    | a BCP 47 locale code (e.g. 'nl', 'fr', 'zh-Hans') and its value mirrors
+    | the `permissions` array shape. At build time these are written to
+    | {locale}.lproj/InfoPlist.strings inside the iOS bundle, and the locales
+    | are registered with the Xcode project so they ship with the app.
+    |
+    | iOS picks the right string at runtime based on the user's preferred
+    | language, falling back to the value in `permissions` (Info.plist).
+    |
+    | Plugins can ship their own localizations via `ios.info_plist_localizations`
+    | in their nativephp.json — app-level entries win on key collisions.
+    |
+    */
+
+    'permission_localizations' => [
+        // 'nl' => [
+        //     'NSCameraUsageDescription' => 'Gebruikt om een profielfoto te maken.',
+        //     'NSMicrophoneUsageDescription' => 'Gebruikt om audio op te nemen bij je video\'s.',
+        //     'NSPhotoLibraryUsageDescription' => 'Gebruikt om foto\'s voor je bericht te selecteren.',
+        // ],
+        // 'fr' => [
+        //     'NSCameraUsageDescription' => 'Utilisé pour prendre une photo de profil.',
+        // ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Environment Keys to Clean Up
     |--------------------------------------------------------------------------
     |

--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -119,8 +119,18 @@ class IOSPluginCompiler
             return ! empty($p->getIosInfoPlist()) || ! empty($p->getIosDependencies());
         });
 
+        // The app may declare per-locale permission strings without depending on
+        // any plugin shipping iOS data — keep going past the early return below
+        // so writeInfoPlistLocalizations() can run on app config alone.
+        $hasAppLocalizations = ! empty($this->getAppInfoPlistLocalizations());
+
         // If no plugins have any iOS-related data, generate empty registration
-        if ($pluginsWithCode->isEmpty() && $pluginsWithFunctions->isEmpty() && $pluginsWithIosData->isEmpty()) {
+        if (
+            $pluginsWithCode->isEmpty()
+            && $pluginsWithFunctions->isEmpty()
+            && $pluginsWithIosData->isEmpty()
+            && ! $hasAppLocalizations
+        ) {
             $this->generateEmptyRegistration();
 
             return;
@@ -137,6 +147,9 @@ class IOSPluginCompiler
 
         // Merge Info.plist entries (for any plugins with iOS permissions)
         $this->mergeInfoPlistEntries($allPlugins);
+
+        // Write per-locale InfoPlist.strings for any localized permission entries
+        $this->writeInfoPlistLocalizations($allPlugins);
 
         // Merge background modes into Info.plist
         $this->mergeBackgroundModes($allPlugins);
@@ -339,6 +352,166 @@ class IOSPluginCompiler
     protected function getAppInfoPlistOverrides(): array
     {
         return config('nativephp.permissions', []);
+    }
+
+    /**
+     * Read app-level per-locale Info.plist overrides from
+     * config('nativephp.permission_localizations').
+     *
+     * Shape: ['nl' => ['NSCameraUsageDescription' => 'Dutch text'], 'fr' => [...]]
+     *
+     * @return array<string, array<string, string>>
+     */
+    protected function getAppInfoPlistLocalizations(): array
+    {
+        return config('nativephp.permission_localizations', []);
+    }
+
+    /**
+     * Write {locale}.lproj/InfoPlist.strings files for each locale that has
+     * per-locale permission strings, and register the locales with the Xcode
+     * project so they ship with the app bundle.
+     *
+     * Plugin manifests contribute via `ios.info_plist_localizations`; the app
+     * config wins on key collisions, mirroring how flat entries are merged.
+     */
+    protected function writeInfoPlistLocalizations(Collection $plugins): void
+    {
+        // [locale => [key => value]]
+        $merged = [];
+
+        foreach ($plugins as $plugin) {
+            foreach ($plugin->getIosInfoPlistLocalizations() as $locale => $entries) {
+                if (! is_array($entries)) {
+                    continue;
+                }
+                $locale = $this->normalizeLocale($locale);
+                $merged[$locale] = array_merge($merged[$locale] ?? [], $entries);
+            }
+        }
+
+        foreach ($this->getAppInfoPlistLocalizations() as $locale => $entries) {
+            if (! is_array($entries)) {
+                continue;
+            }
+            $locale = $this->normalizeLocale($locale);
+            $merged[$locale] = array_merge($merged[$locale] ?? [], $entries);
+        }
+
+        if (empty($merged)) {
+            return;
+        }
+
+        // Write one .lproj folder per locale inside the synced NativePHP group;
+        // Xcode 16's PBXFileSystemSynchronizedRootGroup picks them up automatically.
+        $resourcesRoot = $this->iosProjectPath.'/NativePHP';
+
+        foreach ($merged as $locale => $entries) {
+            $lprojPath = $resourcesRoot.'/'.$locale.'.lproj';
+            $this->files->ensureDirectoryExists($lprojPath);
+
+            $this->files->put(
+                $lprojPath.'/InfoPlist.strings',
+                $this->renderInfoPlistStrings($entries)
+            );
+        }
+
+        $this->registerKnownRegions(array_keys($merged));
+    }
+
+    /**
+     * Render a strings file body. iOS expects UTF-8 with one `"key" = "value";`
+     * entry per line; backslashes, quotes, and newlines must be escaped.
+     */
+    protected function renderInfoPlistStrings(array $entries): string
+    {
+        ksort($entries);
+
+        $lines = [];
+        foreach ($entries as $key => $value) {
+            if (! is_string($value)) {
+                continue;
+            }
+            $value = $this->substituteEnvPlaceholders($value);
+            $lines[] = sprintf(
+                '"%s" = "%s";',
+                $this->escapeStringsLiteral((string) $key),
+                $this->escapeStringsLiteral($value)
+            );
+        }
+
+        return implode("\n", $lines)."\n";
+    }
+
+    /**
+     * Escape a value for inclusion in a .strings file literal.
+     */
+    protected function escapeStringsLiteral(string $value): string
+    {
+        return strtr($value, [
+            '\\' => '\\\\',
+            '"' => '\\"',
+            "\n" => '\\n',
+            "\r" => '\\r',
+            "\t" => '\\t',
+        ]);
+    }
+
+    /**
+     * Apple uses BCP 47 / POSIX style locale identifiers in .lproj names
+     * (e.g. `en`, `nl`, `zh-Hans`, `pt-BR`). Normalize PHP/Laravel-style
+     * `nl_NL` to `nl-NL` so it lands in the right bundle folder.
+     */
+    protected function normalizeLocale(string $locale): string
+    {
+        return str_replace('_', '-', trim($locale));
+    }
+
+    /**
+     * Add any new locales to the PBXProject's `knownRegions` list so Xcode
+     * includes the .lproj folders during the resource copy phase. The
+     * `developmentRegion` is left untouched; Info.plist remains the source
+     * of truth for the default language.
+     */
+    protected function registerKnownRegions(array $locales): void
+    {
+        $projectPath = $this->iosProjectPath.'/NativePHP.xcodeproj/project.pbxproj';
+
+        if (! $this->files->exists($projectPath)) {
+            return;
+        }
+
+        $pbxproj = $this->files->get($projectPath);
+
+        $pattern = '/(knownRegions\s*=\s*\()([^)]*)(\s*\))/s';
+
+        if (! preg_match($pattern, $pbxproj)) {
+            return;
+        }
+
+        $updated = preg_replace_callback($pattern, function ($matches) use ($locales) {
+            $existing = $matches[2];
+            $additions = '';
+
+            foreach ($locales as $locale) {
+                // Match on delimiters so `en` doesn't match `en-GB`.
+                if (preg_match('/(^|,|\s)'.preg_quote($locale, '/').'(\s*,|\s*$)/', $existing)) {
+                    continue;
+                }
+
+                $additions .= "\n\t\t\t\t".$locale.',';
+            }
+
+            if ($additions === '') {
+                return $matches[0];
+            }
+
+            return $matches[1].rtrim($matches[2], "\n\t ").$additions."\n\t\t\t".ltrim($matches[3]);
+        }, $pbxproj, 1);
+
+        if ($updated !== null && $updated !== $pbxproj) {
+            $this->files->put($projectPath, $updated);
+        }
     }
 
     /**

--- a/src/Plugins/Plugin.php
+++ b/src/Plugins/Plugin.php
@@ -38,6 +38,19 @@ class Plugin
         return $this->manifest->ios['info_plist'] ?? [];
     }
 
+    /**
+     * Per-locale overrides for Info.plist string entries.
+     *
+     * Shape: ['nl' => ['NSCameraUsageDescription' => 'Dutch text'], 'fr' => [...]]
+     * Locale keys become {locale}.lproj/InfoPlist.strings at build time.
+     *
+     * @return array<string, array<string, string>>
+     */
+    public function getIosInfoPlistLocalizations(): array
+    {
+        return $this->manifest->ios['info_plist_localizations'] ?? [];
+    }
+
     public function getAndroidDependencies(): array
     {
         return $this->manifest->android['dependencies'] ?? [];

--- a/tests/Feature/Plugins/IOSCompilerTest.php
+++ b/tests/Feature/Plugins/IOSCompilerTest.php
@@ -88,6 +88,11 @@ let package = Package(
 
     protected function tearDown(): void
     {
+        // Reset any config touched by individual tests so we don't leak state
+        // into later tests in the same process.
+        config()->set('nativephp.permissions', []);
+        config()->set('nativephp.permission_localizations', []);
+
         $this->files->deleteDirectory($this->testBasePath);
         Mockery::close();
         parent::tearDown();
@@ -641,6 +646,207 @@ class NestedClass {}');
 
         $this->assertStringContainsString('iOSOnly.Func', $content);
         $this->assertStringContainsString('iOSOnlyFunctions.Func', $content);
+    }
+
+    /**
+     * @test
+     *
+     * App-level permission_localizations are written to {locale}.lproj/InfoPlist.strings
+     * inside the synced NativePHP group so iOS picks them up at runtime.
+     */
+    public function it_writes_app_level_info_plist_localizations(): void
+    {
+        config()->set('nativephp.permission_localizations', [
+            'nl' => [
+                'NSCameraUsageDescription' => 'Camera-toegang nodig.',
+                'NSMicrophoneUsageDescription' => 'Microfoon-toegang nodig.',
+            ],
+            'fr' => [
+                'NSCameraUsageDescription' => 'Accès caméra requis.',
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$this->createTestPlugin()]));
+
+        $this->compiler->compile();
+
+        $nlPath = $this->testBasePath.'/ios/NativePHP/nl.lproj/InfoPlist.strings';
+        $frPath = $this->testBasePath.'/ios/NativePHP/fr.lproj/InfoPlist.strings';
+
+        $this->assertFileExists($nlPath);
+        $this->assertFileExists($frPath);
+
+        $nl = $this->files->get($nlPath);
+        $this->assertStringContainsString('"NSCameraUsageDescription" = "Camera-toegang nodig.";', $nl);
+        $this->assertStringContainsString('"NSMicrophoneUsageDescription" = "Microfoon-toegang nodig.";', $nl);
+
+        $fr = $this->files->get($frPath);
+        $this->assertStringContainsString('"NSCameraUsageDescription" = "Accès caméra requis.";', $fr);
+
+        config()->set('nativephp.permission_localizations', []);
+    }
+
+    /**
+     * @test
+     *
+     * Plugins can ship their own per-locale permission strings via
+     * `ios.info_plist_localizations`; the app-level config wins on collisions.
+     */
+    public function it_merges_plugin_localizations_with_app_overrides(): void
+    {
+        config()->set('nativephp.permission_localizations', [
+            'nl' => [
+                'NSCameraUsageDescription' => 'App-level NL string.',
+            ],
+        ]);
+
+        $plugin = $this->createTestPlugin([
+            'ios' => [
+                'info_plist' => [],
+                'info_plist_localizations' => [
+                    'nl' => [
+                        'NSCameraUsageDescription' => 'Plugin NL string.',
+                        'NSMicrophoneUsageDescription' => 'Plugin NL microfoon.',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $nl = $this->files->get($this->testBasePath.'/ios/NativePHP/nl.lproj/InfoPlist.strings');
+
+        // App override wins for the camera key, plugin string is gone.
+        $this->assertStringContainsString('"NSCameraUsageDescription" = "App-level NL string.";', $nl);
+        $this->assertStringNotContainsString('Plugin NL string.', $nl);
+
+        // Plugin-only keys still come through.
+        $this->assertStringContainsString('"NSMicrophoneUsageDescription" = "Plugin NL microfoon.";', $nl);
+
+        config()->set('nativephp.permission_localizations', []);
+    }
+
+    /**
+     * @test
+     *
+     * When permission_localizations is empty, no .lproj folders should be created
+     * — this is the default-config case and we don't want spurious files.
+     */
+    public function it_does_not_write_localizations_when_config_is_empty(): void
+    {
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$this->createTestPlugin()]));
+
+        $this->compiler->compile();
+
+        $this->assertFileDoesNotExist($this->testBasePath.'/ios/NativePHP/en.lproj/InfoPlist.strings');
+        $this->assertFileDoesNotExist($this->testBasePath.'/ios/NativePHP/nl.lproj/InfoPlist.strings');
+    }
+
+    /**
+     * @test
+     *
+     * Quotes, backslashes, and newlines in localized strings must be escaped
+     * so the resulting .strings file remains valid.
+     */
+    public function it_escapes_special_characters_in_localized_strings(): void
+    {
+        config()->set('nativephp.permission_localizations', [
+            'nl' => [
+                'NSCameraUsageDescription' => "Camera \"toegang\" \\nodig\nop regel 2",
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$this->createTestPlugin()]));
+
+        $this->compiler->compile();
+
+        $nl = $this->files->get($this->testBasePath.'/ios/NativePHP/nl.lproj/InfoPlist.strings');
+
+        $this->assertStringContainsString(
+            '"NSCameraUsageDescription" = "Camera \\"toegang\\" \\\\nodig\\nop regel 2";',
+            $nl
+        );
+
+        config()->set('nativephp.permission_localizations', []);
+    }
+
+    /**
+     * @test
+     *
+     * Locales used in permission_localizations must be added to the pbxproj's
+     * `knownRegions` list so Xcode bundles the .lproj folders as resources.
+     */
+    public function it_registers_new_locales_in_pbxproj_known_regions(): void
+    {
+        // Minimal pbxproj fragment with the same knownRegions block shape
+        // the real project uses.
+        $pbxprojPath = $this->testBasePath.'/ios/NativePHP.xcodeproj/project.pbxproj';
+        $this->files->ensureDirectoryExists(dirname($pbxprojPath));
+        $this->files->put($pbxprojPath, "// !\$*UTF8\$*!\n{\n\tobjects = {\n\t\t95BD5DBB /* Project object */ = {\n\t\t\tisa = PBXProject;\n\t\t\tdevelopmentRegion = en;\n\t\t\tknownRegions = (\n\t\t\t\ten,\n\t\t\t\tBase,\n\t\t\t);\n\t\t};\n\t};\n}\n");
+
+        config()->set('nativephp.permission_localizations', [
+            'nl' => ['NSCameraUsageDescription' => 'NL'],
+            'fr' => ['NSCameraUsageDescription' => 'FR'],
+            'en' => ['NSCameraUsageDescription' => 'EN (already known)'],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$this->createTestPlugin()]));
+
+        $this->compiler->compile();
+
+        $pbxproj = $this->files->get($pbxprojPath);
+
+        // New locales are inserted before the closing paren.
+        $this->assertMatchesRegularExpression('/knownRegions\s*=\s*\(\s*en,\s*Base,\s*nl,\s*fr,\s*\)/s', $pbxproj);
+
+        // Existing `en` not duplicated.
+        $this->assertEquals(1, substr_count($pbxproj, "\ten,"));
+
+        config()->set('nativephp.permission_localizations', []);
+    }
+
+    /**
+     * @test
+     *
+     * Re-running compile should be idempotent for localizations — no duplicate
+     * lines in the .strings file, no duplicate entries in knownRegions.
+     */
+    public function it_is_idempotent_for_localizations_on_recompile(): void
+    {
+        $pbxprojPath = $this->testBasePath.'/ios/NativePHP.xcodeproj/project.pbxproj';
+        $this->files->ensureDirectoryExists(dirname($pbxprojPath));
+        $this->files->put($pbxprojPath, "// !\$*UTF8\$*!\n{\n\tknownRegions = (\n\t\ten,\n\t\tBase,\n\t);\n}\n");
+
+        config()->set('nativephp.permission_localizations', [
+            'nl' => ['NSCameraUsageDescription' => 'NL'],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$this->createTestPlugin()]));
+
+        $this->compiler->compile();
+        $this->compiler->compile();
+
+        $nl = $this->files->get($this->testBasePath.'/ios/NativePHP/nl.lproj/InfoPlist.strings');
+        $this->assertEquals(1, substr_count($nl, 'NSCameraUsageDescription'));
+
+        $pbxproj = $this->files->get($pbxprojPath);
+        $this->assertEquals(1, substr_count($pbxproj, "\tnl,"));
+
+        config()->set('nativephp.permission_localizations', []);
     }
 
     /**


### PR DESCRIPTION
## Summary

iOS shows permission usage descriptions in the system language, but the existing `nativephp.permissions` config only feeds **one** set of strings into `Info.plist` — so prompts appear in whichever language the developer wrote, regardless of the user's device locale.

This PR adds per-locale overrides:

- New app config key **`nativephp.permission_localizations`**
- New plugin manifest key **`ios.info_plist_localizations`**

At compile time, `IOSPluginCompiler` writes one `{locale}.lproj/InfoPlist.strings` file per locale inside the synced `NativePHP` group. Xcode 16's `PBXFileSystemSynchronizedRootGroup` picks the files up automatically; only `knownRegions` in the pbxproj needs a small update so the locales ship with the bundle. `Info.plist` remains the source of truth for the fallback language.

App-level entries win over plugins on key collisions, matching the existing merge rules for flat `permissions`.

### Config example

```php
'permissions' => [
    'NSCameraUsageDescription' => 'To upload a profile photo, we need camera access.',
],

'permission_localizations' => [
    'nl' => [
        'NSCameraUsageDescription' => 'Voor het uploaden van een profielfoto hebben we cameratoegang nodig.',
    ],
    'fr' => [
        'NSCameraUsageDescription' => 'Pour téléverser une photo de profil, nous avons besoin de l\\'accès à la caméra.',
    ],
],
```

### Plugin manifest example

```json
{
  "ios": {
    "info_plist": {
      "NSCameraUsageDescription": "Used to take a profile photo."
    },
    "info_plist_localizations": {
      "nl": {
        "NSCameraUsageDescription": "Gebruikt om een profielfoto te maken."
      }
    }
  }
}
```

## Test plan

- [x] All existing tests still pass (`vendor/bin/pest`)
- [x] New tests in `tests/Feature/Plugins/IOSCompilerTest.php`:
  - [x] App-level `permission_localizations` produce the right `.lproj/InfoPlist.strings` files
  - [x] Plugin localizations merge with app overrides (app wins)
  - [x] Empty config writes no files
  - [x] Quotes / backslashes / newlines are escaped in `.strings` literals
  - [x] New locales are added to `knownRegions` in `project.pbxproj`
  - [x] Re-running `compile()` is idempotent (no dupes in strings file or knownRegions)
- [x] Manually verified in a real app build (iOS device on Dutch shows Dutch prompts; switched to English shows the Info.plist fallback)