### PR TITLE
Fix native:jump hang after IP select on Windows

### DIFF
--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -31,6 +31,8 @@ class JumpCommand extends Command
 
     private array $laravelPipes = [];
 
+    private $bridgeProcess = null;
+
     private bool $verbose = false;
 
     public function handle()
@@ -299,21 +301,37 @@ class JumpCommand extends Command
         @file_put_contents($logFile, '=== '.date('Y-m-d H:i:s')." bridge server starting (ws={$wsPort} tcp={$bridgePort} vite_proxy={$viteProxyPort}) ===\n", FILE_APPEND);
 
         // Run in background (not Workerman daemon mode — it breaks the event loop).
-        // Windows: `&` is a command separator (not "background"), so exec() would
-        // block here forever waiting on the long-lived server. Use `start /B` to
-        // detach properly.
         if (PHP_OS_FAMILY === 'Windows') {
+            // `&` is a command separator on Windows (not "background"), and the
+            // previous `pclose(popen("start /B ..."))` approach hangs: cmd.exe's
+            // stdout pipe (created by popen) gets inherited by the grandchild
+            // PHP via CreateProcess(bInheritHandles=TRUE) and the pipe never
+            // sees EOF, so pclose blocks until the long-lived bridge exits.
+            //
+            // Use proc_open with explicit file handles (no inheritable pipes)
+            // and bypass_shell so no cmd.exe sits in the middle. Intentionally
+            // do NOT proc_close the resource — that would wait on the
+            // long-running child. The OS process is independent and the PHP
+            // resource is cleaned up at script shutdown.
             $cmd = sprintf(
-                'start "" /B %s %s %s %d %d %d start >> %s 2>&1',
+                '%s %s %s %d %d %d start',
                 escapeshellarg($phpBinary),
                 escapeshellarg($serverPath),
                 escapeshellarg(base_path()),
                 $wsPort,
                 $bridgePort,
-                $viteProxyPort,
-                escapeshellarg($logFile)
+                $viteProxyPort
             );
-            pclose(popen($cmd, 'r'));
+            $desc = [
+                0 => ['file', 'NUL', 'r'],
+                1 => ['file', $logFile, 'a'],
+                2 => ['file', $logFile, 'a'],
+            ];
+            // Keep the resource on the instance so its destructor doesn't fire
+            // mid-command (proc_close blocks waiting for the long-lived child).
+            // On Ctrl+C the PHP process is hard-terminated by Windows and the
+            // bridge stays running, matching Mac/Linux behaviour.
+            $this->bridgeProcess = @proc_open($cmd, $desc, $pipes, base_path(), null, ['bypass_shell' => true]);
         } else {
             $cmd = sprintf(
                 '%s %s %s %d %d %d start >> %s 2>&1 &',


### PR DESCRIPTION
## Summary

Windows users running `php artisan native:jump` saw the TUI freeze immediately after picking an IP from the "Multiple network interfaces detected" prompt — the QR code never rendered.

The previous fix (#126) switched bridge-server spawning to `pclose(popen("start \"\" /B ... >> log 2>&1", "r"))`. That still hangs on some setups: `popen` inherits the cmd.exe stdout pipe, `start /B` propagates that handle into the long-lived bridge grandchild via `CreateProcess(bInheritHandles=TRUE)`, and combined with append redirection the pclose call ends up blocked, so execution never reaches the QR render or any of the subsequent `twoColumnDetail` lines.

## Fix

Spawn the bridge via `proc_open` with `bypass_shell => true` and explicit file descriptors:

- stdin → `NUL`
- stdout / stderr → the log file

No cmd.exe sits in the middle, so no inheritable pipe is ever created, and `proc_open` returns immediately after `CreateProcess` succeeds. The resource is held on `$this->bridgeProcess` so its blocking destructor doesn't run mid-command. On Ctrl+C, Windows hard-terminates the PHP CLI without running destructors, so the bridge process is left orphaned — matching the existing Mac/Linux behaviour where `exec($cmd . ' &')` also doesn't clean up.

Non-Windows path is unchanged.

## Test plan

- [ ] On Windows: `php artisan native:jump` with multiple network interfaces — confirm the IP-select prompt no longer freezes and the QR renders.
- [ ] On Windows: confirm `storage/logs/jump-bridge.log` shows the bridge server starting and accepting connections.
- [ ] On Windows: confirm Ctrl+C exits cleanly (bridge may remain running — matches Mac/Linux).
- [ ] On macOS / Linux: confirm `native:jump` still works (path is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)