### PR TITLE
Potential jump win fix

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -265,8 +265,10 @@ return [
         // Build output directory (where the ZIP will be created)
         'build_path' => env('NATIVEPHP_BUILD_PATH', 'storage/app/native-build'),
 
-        // Automatically open browser with QR code when server starts
-        'open_browser' => env('NATIVEPHP_OPEN_BROWSER', true),
+        // Automatically open browser with QR code when server starts.
+        // Default off — the terminal renders a scannable QR. Pass --browser
+        // to native:jump (or set NATIVEPHP_OPEN_BROWSER=true) to opt in.
+        'open_browser' => env('NATIVEPHP_OPEN_BROWSER', false),
 
         // Watch these directories for changes
         'watch_paths' => [

--- a/resources/jump/http-server.php
+++ b/resources/jump/http-server.php
@@ -120,7 +120,7 @@ $worker->name = 'JumpHttpProxy';
 $worker->onMessage = function (TcpConnection $connection, Request $request) {
     try {
         $response = jumpHandleRequest($request);
-    } catch (\Throwable $e) {
+    } catch (Throwable $e) {
         jumpRouterLog($request->method().' '.$request->uri().' [500 handler-exception] '.$e->getMessage());
         $response = new Response(500, ['Content-Type' => 'text/plain; charset=utf-8'], 'Internal proxy error: '.$e->getMessage());
     }
@@ -240,7 +240,7 @@ function jumpRenderQrPage(string $method, string $uri): Response
 
     try {
         if (! class_exists(Builder::class)) {
-            throw new \RuntimeException('QR Code library not available. Make sure endroid/qr-code is installed.');
+            throw new RuntimeException('QR Code library not available. Make sure endroid/qr-code is installed.');
         }
 
         $qrData = "jump://connect?host={$JUMP['displayHost']}&port={$JUMP['httpPort']}";
@@ -276,7 +276,7 @@ function jumpRenderQrPage(string $method, string $uri): Response
         jumpRouterLog($method.' '.$uri.' [200]');
 
         return new Response(200, ['Content-Type' => 'text/html; charset=utf-8'], $html);
-    } catch (\Throwable $e) {
+    } catch (Throwable $e) {
         jumpRouterLog($method.' '.$uri.' [500 qr] '.$e->getMessage());
 
         return new Response(500, ['Content-Type' => 'text/plain; charset=utf-8'], 'Error generating QR code: '.$e->getMessage());

--- a/resources/jump/http-server.php
+++ b/resources/jump/http-server.php
@@ -1,0 +1,626 @@
+<?php
+
+/**
+ * Jump HTTP Proxy Server (Workerman-based)
+ *
+ * Functional twin of `router.php` but built on Workerman instead of PHP's
+ * built-in `php -S` server. Used on Windows where `php -S` exhibits a
+ * dead-socket pathology: the phone WebView holds HTTP/1.1 keep-alive
+ * connections open after page load; PHP -S has no SO_KEEPALIVE on its
+ * listen socket, so when the phone goes away without a clean FIN, those
+ * sockets stay Established for Windows' default 2-hour TCP keepalive
+ * window. Each one consumes a select() slot, and once enough pile up the
+ * single-threaded router stops accepting new requests entirely — browser
+ * visits and subsequent phone scans both hang.
+ *
+ * Workerman gives us:
+ *   - Proper connection lifecycle (we $connection->close() after each
+ *     response, so the dead-peer case can't accumulate state).
+ *   - A real event loop that keeps accepting new connections while
+ *     individual requests are processed.
+ *   - Stable behaviour under the parallel-asset fan-out that Vite HMR
+ *     produces during dev mode.
+ *
+ * Routing logic (path matchers, header forwarding, URL rewriting, Vite
+ * client patching, Set-Cookie multiplexing, etc.) is intentionally a
+ * line-for-line port from router.php so the two stay behaviourally
+ * identical for any path. router.php remains the implementation on
+ * macOS/Linux where `php -S` doesn't hit the dead-socket bug.
+ *
+ * Usage:
+ *   php http-server.php <base_path> <listen_host> <http_port> start [-d]
+ *
+ * Environment (passed by JumpCommand):
+ *   JUMP_DISPLAY_HOST, JUMP_HTTP_PORT, JUMP_LARAVEL_PORT, JUMP_BRIDGE_PORT,
+ *   JUMP_WS_PORT, JUMP_VITE_PORT, JUMP_VITE_PROXY_PORT, JUMP_BASE_PATH,
+ *   APP_NAME
+ */
+
+declare(strict_types=1);
+
+use Endroid\QrCode\Builder\Builder;
+use Workerman\Connection\TcpConnection;
+use Workerman\Protocols\Http\Request;
+use Workerman\Protocols\Http\Response;
+use Workerman\Worker;
+
+// --- Argument + environment parsing -------------------------------------
+
+// Mirror websocket-server.php's positional-arg pattern so Workerman's
+// `start`/`-d` tokens don't get treated as values.
+$args = array_slice($argv, 1);
+$positional = [];
+foreach ($args as $arg) {
+    if (in_array($arg, ['start', 'stop', 'restart', '-d', '-g'], true)) {
+        continue;
+    }
+    $positional[] = $arg;
+}
+
+$basePath = $positional[0] ?? getenv('JUMP_BASE_PATH') ?: null;
+$listenHost = $positional[1] ?? '0.0.0.0';
+$httpPort = (int) ($positional[2] ?? getenv('JUMP_HTTP_PORT') ?: 3000);
+
+if (! $basePath || ! file_exists($basePath.'/vendor/autoload.php')) {
+    fwrite(STDERR, "[Jump] http-server.php: base_path not provided or vendor/autoload.php missing\n");
+    exit(1);
+}
+
+require_once $basePath.'/vendor/autoload.php';
+
+// Shared globals read from the environment. Captured once at process start
+// (these are set by JumpCommand and don't change for the life of the run).
+$JUMP = [
+    'basePath' => $basePath,
+    'displayHost' => getenv('JUMP_DISPLAY_HOST') ?: 'localhost',
+    'httpPort' => $httpPort,
+    'laravelPort' => (int) (getenv('JUMP_LARAVEL_PORT') ?: 8000),
+    'bridgePort' => (int) (getenv('JUMP_BRIDGE_PORT') ?: 3002),
+    'wsPort' => (int) (getenv('JUMP_WS_PORT') ?: 3001),
+    'vitePort' => (int) (getenv('JUMP_VITE_PORT') ?: 5173),
+    'viteProxyPort' => (int) (getenv('JUMP_VITE_PROXY_PORT') ?: 3003),
+    'appName' => getenv('APP_NAME') ?: 'Laravel',
+];
+
+// --- Logging ------------------------------------------------------------
+
+/**
+ * Append a request line to storage/logs/jump-router.log. Matches the
+ * format jumpRequestLog() in router.php so existing tail/grep workflows
+ * keep working.
+ */
+function jumpRouterLog(string $message): void
+{
+    global $JUMP;
+    $logFile = $JUMP['basePath'].'/storage/logs/jump-router.log';
+    $now = microtime(true);
+    $ms = substr(sprintf('%.3f', $now - floor($now)), 2, 3);
+    @file_put_contents(
+        $logFile,
+        '['.date('H:i:s.').$ms.'] [Jump] '.$message."\n",
+        FILE_APPEND
+    );
+}
+
+// --- Workerman setup ----------------------------------------------------
+
+// Workerman writes Worker boot/status banners to its log file by default,
+// which on Windows defaults to the current directory. Pin it to the
+// project's storage/logs/ so it lands somewhere the developer can find.
+Worker::$logFile = $JUMP['basePath'].'/storage/logs/jump-http.log';
+// stdoutFile is where Workerman redirects child-process stdout when
+// daemonised. We're not daemonising on Windows (no fork), but set it
+// anyway so any errant `echo` from a handler doesn't disappear silently.
+Worker::$stdoutFile = $JUMP['basePath'].'/storage/logs/jump-http.log';
+
+$worker = new Worker("http://{$listenHost}:{$httpPort}");
+$worker->count = 1;
+$worker->name = 'JumpHttpProxy';
+
+$worker->onMessage = function (TcpConnection $connection, Request $request) {
+    try {
+        $response = jumpHandleRequest($request);
+    } catch (\Throwable $e) {
+        jumpRouterLog($request->method().' '.$request->uri().' [500 handler-exception] '.$e->getMessage());
+        $response = new Response(500, ['Content-Type' => 'text/plain; charset=utf-8'], 'Internal proxy error: '.$e->getMessage());
+    }
+
+    // Force connection teardown after every response. PHP -S can't do this
+    // (it decides keep-alive purely from the request); Workerman can, and
+    // that's the whole point of moving to it for the Windows code path.
+    // Setting the response header is for client correctness; the actual
+    // close happens via $connection->close() once send() drains.
+    $response = $response->withHeader('Connection', 'close');
+    $connection->close($response);
+};
+
+// --- Dispatch -----------------------------------------------------------
+
+function jumpHandleRequest(Request $request): Response
+{
+    global $JUMP;
+
+    $method = $request->method();
+    $uri = $request->uri();
+    $path = parse_url($uri, PHP_URL_PATH) ?: '/';
+    $path = rtrim($path, '/');
+    if ($path === '') {
+        $path = '/';
+    }
+
+    // Mirror router.php: log every non-trivial request at start so we can
+    // distinguish "request arrived but upstream hung" from "request never
+    // landed". Skip favicon/sourcemap to keep the log signal:noise high.
+    $isNoise = $path === '/favicon.ico' || str_ends_with($path, '.map');
+    if (! $isNoise) {
+        jumpRouterLog($method.' '.$uri.' [start]');
+    }
+
+    // Quick-reject paths -------------------------------------------------
+
+    if ($isNoise) {
+        return new Response(204);
+    }
+
+    // WebSocket upgrades hitting the HTTP port are wrong by construction
+    // — HMR goes to viteProxyPort, the device bridge to wsPort. A 404
+    // here keeps Laravel's `/` from being invoked with an Upgrade header
+    // (which under Inertia/Fortify rotates CSRF and breaks subsequent
+    // POSTs). Same behaviour as router.php.
+    if (strtolower($request->header('upgrade', '')) === 'websocket') {
+        return new Response(404);
+    }
+
+    // /jump/info — internal status endpoint (no upstream) ----------------
+
+    if ($path === '/jump/info') {
+        $info = [
+            'name' => 'NativePHP Server',
+            'app_name' => $JUMP['appName'],
+            'version' => '1.0.0',
+            'type' => 'nativephp-server',
+        ];
+        if ($JUMP['wsPort']) {
+            $info['ws_port'] = (string) $JUMP['wsPort'];
+        }
+
+        jumpRouterLog($method.' '.$uri.' [200]');
+
+        return new Response(200, ['Content-Type' => 'application/json'], json_encode($info));
+    }
+
+    // /jump/qr — QR landing page ---------------------------------------
+
+    if ($path === '/jump/qr' || $path === '/jump') {
+        return jumpRenderQrPage($method, $uri);
+    }
+
+    // Vite vs Laravel routing --------------------------------------------
+
+    $hotFile = $JUMP['basePath'].'/public/hot';
+    $viteRunning = file_exists($hotFile);
+    $vitePort = $JUMP['vitePort'];
+    if ($viteRunning) {
+        $hotContent = trim((string) @file_get_contents($hotFile));
+        if (preg_match('/:(\d+)\/?$/', $hotContent, $m)) {
+            $vitePort = (int) $m[1];
+        }
+    }
+
+    if ($viteRunning) {
+        // Inertia's resolvePageComponent keys modules by absolute filesystem
+        // path; HMR updates therefore land here as `/<abs-path>` and Vite
+        // serves those at `/@fs/<abs>`. Rewrite before proxying.
+        $isFsPath = str_starts_with($path, $JUMP['basePath'].'/');
+        if ($isFsPath) {
+            $uri = '/@fs'.$uri;
+
+            return jumpProxyToVite($request, $method, $uri, '/@fs'.$path, $vitePort);
+        }
+
+        $isViteRequest = str_starts_with($path, '/@')
+            || str_starts_with($path, '/resources/')
+            || str_starts_with($path, '/node_modules/')
+            || str_starts_with($path, '/vendor/')
+            || str_contains($path, '.hot-update.');
+
+        if ($isViteRequest) {
+            return jumpProxyToVite($request, $method, $uri, $path, $vitePort);
+        }
+    }
+
+    return jumpProxyToLaravel($request, $method, $uri);
+}
+
+// --- /jump/qr renderer --------------------------------------------------
+
+function jumpRenderQrPage(string $method, string $uri): Response
+{
+    global $JUMP;
+
+    try {
+        if (! class_exists(Builder::class)) {
+            throw new \RuntimeException('QR Code library not available. Make sure endroid/qr-code is installed.');
+        }
+
+        $qrData = "jump://connect?host={$JUMP['displayHost']}&port={$JUMP['httpPort']}";
+
+        $result = (new Builder(
+            data: $qrData,
+            size: 300,
+            margin: 10,
+        ))->build();
+
+        $qrCodeDataUri = $result->getDataUri();
+
+        // Prefer the shared blade template — it's the canonical design.
+        // The inline fallback in router.php is intentionally NOT ported
+        // here: in practice the template is always present (it ships in
+        // the package), and duplicating ~1000 lines of inline HTML would
+        // be a maintenance trap that drifts between code paths.
+        $viewPath = __DIR__.'/views/qr.blade.php';
+        if (file_exists($viewPath)) {
+            $html = file_get_contents($viewPath);
+            $html = str_replace('{{ $qrCodeDataUri }}', $qrCodeDataUri, $html);
+            $html = str_replace('{{ $displayHost }}', $JUMP['displayHost'], $html);
+            $html = str_replace('{{ $port }}', (string) $JUMP['httpPort'], $html);
+        } else {
+            // Minimal fallback. router.php has a richer inline page; if
+            // someone is hitting this branch on Windows they're better
+            // served by getting a working link than a fancy 500.
+            $html = '<!doctype html><meta charset="utf-8"><title>Jump</title>'
+                .'<p>Scan this URL with the Jump app: <code>'.htmlspecialchars($qrData).'</code></p>'
+                .'<p><img alt="QR" src="'.htmlspecialchars($qrCodeDataUri).'"></p>';
+        }
+
+        jumpRouterLog($method.' '.$uri.' [200]');
+
+        return new Response(200, ['Content-Type' => 'text/html; charset=utf-8'], $html);
+    } catch (\Throwable $e) {
+        jumpRouterLog($method.' '.$uri.' [500 qr] '.$e->getMessage());
+
+        return new Response(500, ['Content-Type' => 'text/plain; charset=utf-8'], 'Error generating QR code: '.$e->getMessage());
+    }
+}
+
+// --- Vite proxy ---------------------------------------------------------
+
+function jumpProxyToVite(Request $request, string $method, string $uri, string $path, int $vitePort): Response
+{
+    global $JUMP;
+
+    $viteUrl = jumpResolveViteOrigin($vitePort).$uri;
+
+    $headers = jumpBuildUpstreamHeaders($request);
+    if ($ct = $request->header('content-type')) {
+        $headers[] = 'Content-Type: '.$ct;
+    }
+
+    $body = null;
+    if (in_array($method, ['POST', 'PUT', 'PATCH'], true)) {
+        $body = $request->rawBody();
+    }
+
+    $ch = curl_init($viteUrl);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HEADER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    // 30s matches router.php after its bump from 10s — Vite cold transforms
+    // (Vue SFC compile, first-hit module graph) routinely exceed 10s on
+    // Windows + Herd.
+    curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+    if ($body !== null) {
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+    }
+
+    $start = microtime(true);
+    $raw = curl_exec($ch);
+    $upstreamMs = (int) ((microtime(true) - $start) * 1000);
+    $error = curl_error($ch);
+    $errno = curl_errno($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+    curl_close($ch);
+
+    if ($raw === false) {
+        if ($errno === CURLE_COULDNT_CONNECT) {
+            $detail = "Vite dev server is not listening on {$viteUrl}. Is `npm run dev` running?";
+        } elseif ($errno === CURLE_OPERATION_TIMEDOUT) {
+            $detail = "Vite request to {$viteUrl} timed out after 30s ({$upstreamMs}ms).";
+        } else {
+            $detail = "Could not reach Vite at {$viteUrl}. cURL error ({$errno}): {$error}";
+        }
+
+        jumpRouterLog("{$method} {$uri} [502 vite] {$detail}");
+
+        return new Response(502, ['Content-Type' => 'text/plain; charset=utf-8'], "Bad Gateway: {$detail}");
+    }
+
+    $rawHeaders = substr((string) $raw, 0, $headerSize);
+    $body = substr((string) $raw, $headerSize);
+
+    // /@vite/client patching — same regex pair as router.php's
+    // patchViteClient(). We rewrite the HMR endpoint in Vite's client to
+    // point at our Workerman HMR proxy port (3003) instead of Vite's
+    // own port, so the phone's WebSocket actually has somewhere on the
+    // LAN to connect.
+    if ($path === '/@vite/client') {
+        $body = jumpPatchViteClient($body);
+    }
+
+    $response = new Response($httpCode);
+
+    foreach (explode("\r\n", $rawHeaders) as $line) {
+        if ($line === '' || str_starts_with($line, 'HTTP/')) {
+            continue;
+        }
+        $colon = strpos($line, ':');
+        if ($colon === false) {
+            continue;
+        }
+        $name = trim(substr($line, 0, $colon));
+        $value = trim(substr($line, $colon + 1));
+        $lower = strtolower($name);
+
+        // Strip transfer-encoding (we're not chunking back to the client),
+        // connection/keep-alive (we force our own Connection: close in
+        // onMessage), and stale content-length for the patched client.
+        if (in_array($lower, ['transfer-encoding', 'connection', 'keep-alive'], true)) {
+            continue;
+        }
+        if ($path === '/@vite/client' && $lower === 'content-length') {
+            continue;
+        }
+        // Skip Vite's cache headers — we'll set no-store ourselves below.
+        // Without this, Android WebView would re-use cached HMR modules
+        // even with `?t=` busters.
+        if (in_array($lower, ['cache-control', 'pragma', 'expires'], true)) {
+            continue;
+        }
+
+        $response = $response->withHeader($name, $value);
+    }
+
+    $response = $response
+        ->withHeader('Cache-Control', 'no-store, no-cache, must-revalidate, max-age=0')
+        ->withHeader('Pragma', 'no-cache')
+        ->withHeader('Expires', '0')
+        ->withBody($body);
+
+    jumpRouterLog("{$method} {$uri} [{$httpCode} vite {$upstreamMs}ms]");
+
+    return $response;
+}
+
+// --- Laravel proxy ------------------------------------------------------
+
+function jumpProxyToLaravel(Request $request, string $method, string $uri): Response
+{
+    global $JUMP;
+
+    $laravelUrl = "http://127.0.0.1:{$JUMP['laravelPort']}{$uri}";
+
+    $headers = jumpBuildUpstreamHeaders($request);
+    if ($ct = $request->header('content-type')) {
+        $headers[] = 'Content-Type: '.$ct;
+    }
+
+    // Tell Laravel the real public-facing host so any URL it generates
+    // (redirects, asset URLs, etc.) is reachable from the phone.
+    $headers[] = "Host: {$JUMP['displayHost']}:{$JUMP['httpPort']}";
+    $headers[] = "X-Forwarded-Host: {$JUMP['displayHost']}:{$JUMP['httpPort']}";
+    $headers[] = 'X-Forwarded-Proto: http';
+    $headers[] = 'X-Forwarded-Port: '.$JUMP['httpPort'];
+
+    $body = null;
+    if (in_array($method, ['POST', 'PUT', 'PATCH'], true)) {
+        $body = $request->rawBody();
+    }
+
+    $ch = curl_init($laravelUrl);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HEADER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 90);
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    if ($body !== null) {
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+    }
+
+    $start = microtime(true);
+    $raw = curl_exec($ch);
+    $upstreamMs = (int) ((microtime(true) - $start) * 1000);
+    $error = curl_error($ch);
+    $errno = curl_errno($ch);
+    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+    curl_close($ch);
+
+    if ($raw === false) {
+        if ($errno === CURLE_COULDNT_CONNECT) {
+            $detail = "Laravel dev server is not listening on 127.0.0.1:{$JUMP['laravelPort']}. Is `artisan serve` running?";
+        } elseif ($errno === CURLE_OPERATION_TIMEDOUT) {
+            $detail = "Request to Laravel on port {$JUMP['laravelPort']} timed out. The handler took longer than 90s to respond.";
+        } else {
+            $detail = "Could not reach Laravel on port {$JUMP['laravelPort']}. cURL error ({$errno}): {$error}";
+        }
+
+        jumpRouterLog("{$method} {$uri} [502] {$detail}");
+
+        return new Response(502, ['Content-Type' => 'text/plain; charset=utf-8'], "Bad Gateway: {$detail}");
+    }
+
+    $rawHeaders = substr((string) $raw, 0, $headerSize);
+    $body = substr((string) $raw, $headerSize);
+
+    $laravelOrigin = "http://127.0.0.1:{$JUMP['laravelPort']}";
+    $jumpOrigin = "http://{$JUMP['displayHost']}:{$JUMP['httpPort']}";
+
+    $response = new Response($httpCode);
+    $setCookies = [];
+
+    foreach (explode("\r\n", $rawHeaders) as $line) {
+        if ($line === '' || str_starts_with($line, 'HTTP/')) {
+            continue;
+        }
+        $colon = strpos($line, ':');
+        if ($colon === false) {
+            continue;
+        }
+        $name = trim(substr($line, 0, $colon));
+        $value = trim(substr($line, $colon + 1));
+        $lower = strtolower($name);
+
+        if (in_array($lower, ['transfer-encoding', 'connection', 'keep-alive'], true)) {
+            continue;
+        }
+
+        if ($lower === 'location') {
+            $value = str_replace($laravelOrigin, $jumpOrigin, $value);
+        }
+
+        if ($lower === 'set-cookie') {
+            // Laravel sends multiple Set-Cookie headers (XSRF-TOKEN +
+            // session). Workerman's Response::withHeader replaces by
+            // name, so we batch and pass the array at the end to keep
+            // all of them. Without this the session cookie disappears
+            // and POST/PATCH/DELETE break with 419.
+            $setCookies[] = $value;
+
+            continue;
+        }
+
+        $response = $response->withHeader($name, $value);
+    }
+
+    if (! empty($setCookies)) {
+        $response = $response->withHeader('Set-Cookie', $setCookies);
+    }
+
+    // Rewrite any Vite dev-server origins the Inertia template emitted,
+    // so the phone routes those assets through our proxy.
+    if ($JUMP['vitePort']) {
+        $body = str_replace(
+            [
+                "http://localhost:{$JUMP['vitePort']}",
+                "http://127.0.0.1:{$JUMP['vitePort']}",
+                "http://[::1]:{$JUMP['vitePort']}",
+                "http://[::]:{$JUMP['vitePort']}",
+                "http://{$JUMP['displayHost']}:{$JUMP['vitePort']}",
+            ],
+            "http://{$JUMP['displayHost']}:{$JUMP['httpPort']}",
+            $body
+        );
+    }
+
+    $response = $response->withBody($body);
+
+    jumpRouterLog("{$method} {$uri} [{$httpCode}]");
+
+    return $response;
+}
+
+// --- Helpers ------------------------------------------------------------
+
+/**
+ * Collect HTTP-forwardable request headers, stripping hop-by-hop ones.
+ * Workerman's Request normalises header names to lowercase already.
+ */
+function jumpBuildUpstreamHeaders(Request $request): array
+{
+    $skip = ['connection', 'keep-alive', 'transfer-encoding', 'upgrade', 'host', 'content-type'];
+    $out = [];
+
+    foreach ($request->header() as $name => $value) {
+        if (in_array(strtolower($name), $skip, true)) {
+            continue;
+        }
+        // Workerman returns header() values as strings (last value wins
+        // for repeated headers — same as PHP-S behaviour). Forward as-is.
+        $out[] = $name.': '.$value;
+    }
+
+    return $out;
+}
+
+/**
+ * Decide the host:port we should curl Vite at. Reads public/hot since
+ * the Laravel Vite plugin records the real bind address there, including
+ * IPv6-only binds (`[::1]`) which 127.0.0.1 doesn't reach.
+ */
+function jumpResolveViteOrigin(int $vitePort): string
+{
+    global $JUMP;
+
+    $hotFile = $JUMP['basePath'].'/public/hot';
+    if (is_file($hotFile)) {
+        $origin = rtrim(trim((string) @file_get_contents($hotFile)), '/');
+        $parts = parse_url($origin);
+        if (! empty($parts['host']) && ! empty($parts['port'])) {
+            $hostRaw = trim($parts['host'], '[]');
+            // Wildcard binds aren't valid connect targets; localhost is.
+            if (in_array($hostRaw, ['0.0.0.0', '::', '::0'], true)) {
+                return 'http://localhost:'.$parts['port'];
+            }
+            $host = str_contains($hostRaw, ':') ? '['.$hostRaw.']' : $hostRaw;
+
+            return 'http://'.$host.':'.$parts['port'];
+        }
+    }
+
+    return 'http://localhost:'.$vitePort;
+}
+
+/**
+ * Patch the HMR endpoint inside Vite's `/@vite/client` so the phone
+ * opens its HMR WebSocket against our Workerman HMR proxy port rather
+ * than dialling Vite directly (which is on localhost/[::1] and isn't
+ * reachable from the device).
+ */
+function jumpPatchViteClient(string $body): string
+{
+    global $JUMP;
+
+    $proxyPort = $JUMP['viteProxyPort'];
+    $displayHost = $JUMP['displayHost'];
+    $totalReplaced = 0;
+
+    $body = preg_replace(
+        '/const hmrPort = (null|\d+);/',
+        'const hmrPort = '.(int) $proxyPort.';',
+        $body,
+        1,
+        $count
+    );
+    $totalReplaced += $count;
+
+    $body = preg_replace(
+        '/const directSocketHost = "[^"]*";/',
+        'const directSocketHost = "'.$displayHost.':'.(int) $proxyPort.'/";',
+        $body,
+        1,
+        $count
+    );
+    $totalReplaced += $count;
+
+    if ($totalReplaced === 0) {
+        jumpRouterLog('WARN /@vite/client patching matched no patterns — Vite may have refactored the client template');
+    }
+
+    return $body;
+}
+
+// --- Run ----------------------------------------------------------------
+
+@file_put_contents(
+    $JUMP['basePath'].'/storage/logs/jump-router.log',
+    '=== '.date('Y-m-d H:i:s').' http-server (workerman) starting on '.$listenHost.':'.$httpPort." ===\n",
+    FILE_APPEND
+);
+
+Worker::runAll();

--- a/resources/jump/router.php
+++ b/resources/jump/router.php
@@ -41,8 +41,13 @@ function jumpRequestLog($message)
     if (! $basePath) {
         return;
     }
-    $logFile = $basePath.'/storage/logs/jump-bridge.log';
-    @file_put_contents($logFile, '['.date('H:i:s').'] [Jump] '.$message."\n", FILE_APPEND);
+    // Router writes to its own file so concurrent appends from the Workerman
+    // bridge (which logs device connects to jump-bridge.log) don't interleave
+    // with our request lines — on Windows, two processes appending to the
+    // same file regularly produced clobbered/truncated lines that hid the
+    // actual request flow during debugging.
+    $logFile = $basePath.'/storage/logs/jump-router.log';
+    @file_put_contents($logFile, '['.date('H:i:s.').substr((string) (microtime(true) - floor(microtime(true))), 2, 3).'] [Jump] '.$message."\n", FILE_APPEND);
 }
 
 // Helper function to format bytes
@@ -85,6 +90,15 @@ function jumpLog($message)
         fwrite($stderr, "[Jump] {$message}\n");
         fclose($stderr);
     }
+}
+
+// Log the START of every non-trivial request. Pairs with the completion log
+// at the end of each proxy function so we can see which request is in-flight
+// when the router wedges — without entry logs we only see successful
+// completions, which makes "stuck on upstream" look identical to "request
+// never arrived".
+if ($path !== '/favicon.ico' && ! str_ends_with($path, '.map')) {
+    jumpRequestLog($_SERVER['REQUEST_METHOD'].' '.$_SERVER['REQUEST_URI'].' [start]');
 }
 
 // Ignore favicon and sourcemap requests
@@ -959,16 +973,36 @@ function proxyToVite($vitePort)
     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+    // Vite can take well over 10s for cold transforms (Vue SFC compile,
+    // first-hit module graph build, large /@vite/client at ~200KB). The
+    // original 10s timeout was producing 502s under `npm run dev` cold load
+    // on Windows where PHP startup + Vite first-compile compounds.
+    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 
+    $upstreamStart = microtime(true);
     $response = curl_exec($ch);
+    $upstreamMs = (int) ((microtime(true) - $upstreamStart) * 1000);
+    $error = curl_error($ch);
+    $errno = curl_errno($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
     curl_close($ch);
 
     if ($response === false) {
         http_response_code(502);
-        echo 'Vite dev server not reachable on port '.$vitePort;
+
+        if ($errno === CURLE_COULDNT_CONNECT) {
+            $detail = "Vite dev server is not listening on {$viteUrl}. Is `npm run dev` running?";
+        } elseif ($errno === CURLE_OPERATION_TIMEDOUT) {
+            $detail = "Vite request to {$viteUrl} timed out after 30s ({$upstreamMs}ms).";
+        } else {
+            $detail = "Could not reach Vite at {$viteUrl}. cURL error ({$errno}): {$error}";
+        }
+
+        header('Content-Type: text/plain; charset=utf-8');
+        echo "Bad Gateway: {$detail}";
+        jumpRequestLog("{$method} {$uri} [502 vite] {$detail}");
 
         return;
     }
@@ -996,6 +1030,11 @@ function proxyToVite($vitePort)
         if (stripos($headerLine, 'transfer-encoding:') === 0) {
             continue;
         }
+        // Strip upstream's connection-management headers — see Connection: close
+        // note below.
+        if (stripos($headerLine, 'connection:') === 0 || stripos($headerLine, 'keep-alive:') === 0) {
+            continue;
+        }
         // If we patched the body, the original Content-Length is stale.
         if ($path === '/@vite/client' && stripos($headerLine, 'content-length:') === 0) {
             continue;
@@ -1015,7 +1054,21 @@ function proxyToVite($vitePort)
     header('Pragma: no-cache');
     header('Expires: 0');
 
+    // Tell the client to close after this response. `php -S` doesn't honour
+    // this on its own, but the client does — and that's what matters: idle
+    // keep-alive sockets from the phone WebView were piling up after page
+    // load and wedging the single-threaded server. See proxyToLaravel for
+    // the full rationale.
+    header('Connection: close');
+
     echo $responseBody;
+
+    // Log successful Vite proxy completions to match the proxyToLaravel
+    // logging shape. Without this, the router log was showing only
+    // `[start]` lines for Vite-proxied paths (and only fonts/Laravel
+    // routes had visible completions), which made it look like Vite
+    // requests were hanging when they were actually completing silently.
+    jumpRequestLog("{$method} {$uri} [{$httpCode} vite {$upstreamMs}ms]");
 }
 
 /**
@@ -1135,7 +1188,11 @@ function proxyToLaravel($laravelPort)
     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+    // Generous transfer timeout — PHP's built-in server is single-threaded,
+    // so a cold first request (opcache empty, Inertia/Wayfinder boot) can
+    // easily exceed 30s on Windows + Herd. JumpCommand pre-warms Laravel
+    // before printing the QR, but keep headroom here for slow handlers.
+    curl_setopt($ch, CURLOPT_TIMEOUT, 90);
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
 
     if ($body !== null) {
@@ -1144,14 +1201,28 @@ function proxyToLaravel($laravelPort)
 
     $response = curl_exec($ch);
     $error = curl_error($ch);
+    $errno = curl_errno($ch);
     $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
     curl_close($ch);
 
     if ($response === false) {
         http_response_code(502);
-        echo "Bad Gateway: Could not connect to Laravel on port {$laravelPort}. Error: {$error}";
-        jumpRequestLog("{$method} {$uri} [502]");
+
+        // Differentiate "Laravel isn't there" from "Laravel is too slow" —
+        // the original message blamed both on the same cause and made the
+        // common slow-cold-start case look like a server failure.
+        if ($errno === CURLE_COULDNT_CONNECT) {
+            $detail = "Laravel dev server is not listening on 127.0.0.1:{$laravelPort}. Is `artisan serve` running?";
+        } elseif ($errno === CURLE_OPERATION_TIMEDOUT) {
+            $detail = "Request to Laravel on port {$laravelPort} timed out. The handler took longer than 90s to respond.";
+        } else {
+            $detail = "Could not reach Laravel on port {$laravelPort}. cURL error ({$errno}): {$error}";
+        }
+
+        header('Content-Type: text/plain; charset=utf-8');
+        echo "Bad Gateway: {$detail}";
+        jumpRequestLog("{$method} {$uri} [502] {$detail}");
 
         return;
     }
@@ -1183,6 +1254,12 @@ function proxyToLaravel($laravelPort)
         if (stripos($headerLine, 'transfer-encoding:') === 0) {
             continue;
         }
+        // Strip upstream's connection-management headers so we can emit our
+        // own `Connection: close` below — see the close-after-response note
+        // at the end of this function for why.
+        if (stripos($headerLine, 'connection:') === 0 || stripos($headerLine, 'keep-alive:') === 0) {
+            continue;
+        }
         // Rewrite Location headers that still point to Laravel's internal address
         if (stripos($headerLine, 'location:') === 0) {
             $headerLine = str_replace($laravelOrigin, $jumpOrigin, $headerLine);
@@ -1198,6 +1275,17 @@ function proxyToLaravel($laravelPort)
             header($headerLine);
         }
     }
+
+    // Force the client to close the TCP connection after this response. PHP's
+    // built-in dev server (`php -S`) does not honour `Connection: close` on
+    // outgoing responses — it decides keep-alive based on the *request* — but
+    // the WebView / browser does. Without this, the phone WebView holds
+    // 10+ idle keep-alive sockets to the router after a page load, which on
+    // Windows starves PHP -S of the ability to accept any new connections
+    // (browser visits to the same proxy hang indefinitely). Closing per
+    // response trades reusable keep-alive (negligible on localhost/LAN) for
+    // a router that stays responsive after the phone is done loading.
+    header('Connection: close');
 
     // Rewrite Vite dev server URLs so the phone routes them through the Jump proxy.
     // Vite can generate URLs with localhost, 127.0.0.1, [::], or the network IP.

--- a/resources/jump/vite-hmr-server.php
+++ b/resources/jump/vite-hmr-server.php
@@ -1,0 +1,197 @@
+<?php
+
+/**
+ * Jump Vite HMR Proxy (standalone)
+ *
+ * This is the Vite-side of the Jump WebSocket bridge: the phone opens a
+ * WebSocket to `ws://<lan>:<viteProxyPort>/`, we open an upstream
+ * WebSocket to Vite's HMR endpoint on 127.0.0.1/[::1], and we relay
+ * frames in both directions.
+ *
+ * Why a separate file: Workerman on Windows cannot start multiple
+ * `Worker` instances declared in a single PHP file (no fork; you get the
+ * "multi workers init in one php file are not support" warning and only
+ * the first Worker actually binds). The companion `websocket-server.php`
+ * declares two workers (JumpBridge on the device port, JumpViteProxy
+ * here), which means on Windows the Vite proxy never came up and HMR was
+ * silently broken. Extracting this worker into its own process makes the
+ * Windows path work without disturbing the macOS/Linux setup where
+ * websocket-server.php's fork model already starts both workers.
+ *
+ * JumpCommand spawns this script on Windows in addition to
+ * websocket-server.php. On other platforms websocket-server.php still
+ * runs the Vite proxy via fork — see project_jump_router_split memory.
+ *
+ * Usage:
+ *   php vite-hmr-server.php <base_path> <vite_proxy_port> start [-d]
+ */
+
+declare(strict_types=1);
+
+use Workerman\Connection\AsyncTcpConnection;
+use Workerman\Connection\TcpConnection;
+use Workerman\Worker;
+
+// --- Argument parsing --------------------------------------------------
+
+$args = array_slice($argv, 1);
+$positional = [];
+foreach ($args as $arg) {
+    if (in_array($arg, ['start', 'stop', 'restart', '-d', '-g'], true)) {
+        continue;
+    }
+    $positional[] = $arg;
+}
+
+$basePath = $positional[0] ?? getenv('JUMP_BASE_PATH') ?: null;
+$viteProxyPort = (int) ($positional[1] ?? getenv('JUMP_VITE_PROXY_PORT') ?: 3003);
+
+if (! $basePath || ! file_exists($basePath.'/vendor/autoload.php')) {
+    fwrite(STDERR, "[Jump] vite-hmr-server.php: base_path not provided or vendor/autoload.php missing\n");
+    exit(1);
+}
+
+require_once $basePath.'/vendor/autoload.php';
+
+$GLOBALS['basePath'] = $basePath;
+
+// --- Helpers (port from websocket-server.php) --------------------------
+
+function jumpLog($message): void
+{
+    fwrite(STDERR, '['.date('H:i:s').'] [Jump] '.$message."\n");
+}
+
+/**
+ * Resolve the live Vite dev-server origin (host + port) from the Laravel
+ * Vite hot file. Returns [host, port] — host is what we should actually
+ * connect to. macOS Node binds `localhost` to IPv6 [::1] only, so dialing
+ * 127.0.0.1 would fail; we respect the file. Wildcard binds (0.0.0.0 / ::)
+ * collapse to `localhost` since they're listener-only addresses.
+ */
+function jumpResolveViteTarget(string $basePath): array
+{
+    $hot = $basePath.'/public/hot';
+    if (is_file($hot)) {
+        $origin = rtrim(trim((string) @file_get_contents($hot)), '/');
+        $parts = parse_url($origin);
+        if (! empty($parts['host']) && ! empty($parts['port'])) {
+            $hostRaw = trim($parts['host'], '[]');
+            if (in_array($hostRaw, ['0.0.0.0', '::', '::0'], true)) {
+                return ['localhost', (int) $parts['port']];
+            }
+            $host = str_contains($hostRaw, ':') ? '['.$hostRaw.']' : $hostRaw;
+
+            return [$host, (int) $parts['port']];
+        }
+    }
+
+    return ['localhost', 5173];
+}
+
+// --- Vite HMR proxy worker ---------------------------------------------
+
+// Pin Workerman's log files into storage/logs/ so they end up alongside
+// the bridge/router logs — otherwise on Windows they land in cwd which
+// is normally the Laravel project root.
+Worker::$logFile = $basePath.'/storage/logs/jump-vite-hmr.log';
+Worker::$stdoutFile = $basePath.'/storage/logs/jump-vite-hmr.log';
+
+$viteProxy = new Worker("websocket://0.0.0.0:{$viteProxyPort}");
+$viteProxy->count = 1;
+$viteProxy->name = 'JumpViteProxy';
+
+$viteProxy->onWebSocketConnect = function (TcpConnection $phone, $httpBuffer) use ($basePath) {
+    $requestUri = $_SERVER['REQUEST_URI'] ?? '/';
+    $query = parse_url($requestUri, PHP_URL_QUERY) ?: '';
+    [$viteHost, $vitePort] = jumpResolveViteTarget($basePath);
+
+    // Echo the client's requested subprotocol back in the handshake response.
+    // Chrome/Android WebView (per RFC 6455) aborts with "Sent non-empty
+    // Sec-WebSocket-Protocol header but no response was received" if we
+    // don't — iOS WebKit is forgiving, so only Android fails visibly.
+    // Workerman doesn't do this automatically; inject via $connection->headers
+    // which gets added to the 101 response at Protocols/Websocket.php:468.
+    $requestedProto = $_SERVER['HTTP_SEC_WEBSOCKET_PROTOCOL'] ?? '';
+    if ($requestedProto !== '') {
+        // Server must pick exactly one of the offered subprotocols. Vite
+        // only uses 'vite-hmr' / 'vite-ping', so echo the first offered.
+        $chosen = trim(explode(',', $requestedProto)[0]);
+        $phone->headers = ['Sec-WebSocket-Protocol: '.$chosen];
+    }
+
+    // Forward the exact path + query the phone used so Vite sees the same
+    // token (?token=…) it baked into /@vite/client.
+    $upstreamUrl = "ws://{$viteHost}:{$vitePort}".($query ? "/?{$query}" : '/');
+    $upstream = new AsyncTcpConnection($upstreamUrl);
+    $upstream->websocketClientProtocol = 'vite-hmr';
+
+    // Hold frames sent by the phone until Vite finishes its handshake.
+    // Vite HMR's wire protocol is text-only (JSON payloads); control frames
+    // (ping/pong) are handled by Workerman internally and don't fire
+    // onMessage. Forcing "\x81" (text) in both directions avoids a stale
+    // websocketType from leaking in — Android's WebView WS parser is
+    // stricter about opcode correctness than iOS WebKit's.
+    $phoneBuffer = [];
+    $upstreamReady = false;
+
+    $phone->upstream = $upstream;
+    $upstream->phone = $phone;
+
+    $upstream->onWebSocketConnect = function ($upstream) use (&$upstreamReady, &$phoneBuffer, $phone) {
+        $upstreamReady = true;
+        foreach ($phoneBuffer as $data) {
+            $upstream->websocketType = "\x81";
+            $upstream->send($data);
+        }
+        $phoneBuffer = [];
+        jumpLog('Vite HMR proxy: upstream connected for device '.$phone->id);
+    };
+
+    $upstream->onMessage = function ($upstream, $data) use ($phone) {
+        $phone->websocketType = "\x81";
+        $phone->send($data);
+    };
+
+    $upstream->onClose = function ($upstream) use ($phone) {
+        if ($phone->getStatus() !== TcpConnection::STATUS_CLOSED) {
+            $phone->close();
+        }
+    };
+
+    $upstream->onError = function ($upstream, $code, $msg) use ($phone) {
+        jumpLog("Vite HMR proxy: upstream error [{$code}] {$msg}");
+        if ($phone->getStatus() !== TcpConnection::STATUS_CLOSED) {
+            $phone->close();
+        }
+    };
+
+    // Re-route phone → upstream. Must assign per-connection so other phones
+    // don't stomp this one's upstream reference.
+    $phone->onMessage = function ($phone, $data) use (&$phoneBuffer, &$upstreamReady) {
+        if (! $upstreamReady) {
+            $phoneBuffer[] = $data;
+
+            return;
+        }
+        $phone->upstream->websocketType = "\x81";
+        $phone->upstream->send($data);
+    };
+
+    $phone->onClose = function ($phone) {
+        if (isset($phone->upstream) && $phone->upstream->getStatus() !== TcpConnection::STATUS_CLOSED) {
+            $phone->upstream->close();
+        }
+    };
+
+    jumpLog("Vite HMR proxy: device {$phone->id} connecting to {$upstreamUrl}");
+    $upstream->connect();
+};
+
+@file_put_contents(
+    $basePath.'/storage/logs/jump-bridge.log',
+    '=== '.date('Y-m-d H:i:s').' vite-hmr proxy starting (port='.$viteProxyPort.") ===\n",
+    FILE_APPEND
+);
+
+Worker::runAll();

--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -94,12 +94,14 @@ class JumpCommand extends Command
             $this->startLaravelServer($this->laravelPort, $bridgePort, $wsPort);
         }
 
-        // Open the browser-rendered QR page only when explicitly requested
-        // via --browser, or when the user has set the config opt-in. The
-        // terminal QR is the default visual; the browser fallback is for
+        // Open the browser-rendered QR page only when --browser is passed.
+        // Terminal QR is the default; the browser page is the fallback for
         // environments where terminal rendering can't produce a scannable
         // image (font/line-height issues, narrow viewports, etc.).
-        $openQr = $this->option('browser') || config('nativephp.server.open_browser', false);
+        // Intentionally ignore config('nativephp.server.open_browser') —
+        // published consumer configs default it to true, which would
+        // override the flag-driven UX we want here.
+        $openQr = (bool) $this->option('browser');
 
         // Get the local IP for dev server config
         $ipOption = $this->option('ip');
@@ -711,6 +713,8 @@ class JumpCommand extends Command
 
             $this->newLine();
             $this->line("  <fg=gray>{$qrData}</>");
+            $this->newLine();
+            $this->line("  <fg=yellow>Can't scan the QR code? Try it in the browser by re-running with <fg=cyan>--browser</></>");
             $this->newLine();
         } catch (\Throwable $e) {
             // QR display is optional — don't break the server

--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -31,6 +31,8 @@ class JumpCommand extends Command
 
     private array $laravelPipes = [];
 
+    private $bridgeProcess = null;
+
     private bool $verbose = false;
 
     public function handle()
@@ -299,21 +301,37 @@ class JumpCommand extends Command
         @file_put_contents($logFile, '=== '.date('Y-m-d H:i:s')." bridge server starting (ws={$wsPort} tcp={$bridgePort} vite_proxy={$viteProxyPort}) ===\n", FILE_APPEND);
 
         // Run in background (not Workerman daemon mode — it breaks the event loop).
-        // Windows: `&` is a command separator (not "background"), so exec() would
-        // block here forever waiting on the long-lived server. Use `start /B` to
-        // detach properly.
         if (PHP_OS_FAMILY === 'Windows') {
+            // `&` is a command separator on Windows (not "background"), and the
+            // previous `pclose(popen("start /B ..."))` approach hangs: cmd.exe's
+            // stdout pipe (created by popen) gets inherited by the grandchild
+            // PHP via CreateProcess(bInheritHandles=TRUE) and the pipe never
+            // sees EOF, so pclose blocks until the long-lived bridge exits.
+            //
+            // Use proc_open with explicit file handles (no inheritable pipes)
+            // and bypass_shell so no cmd.exe sits in the middle. Intentionally
+            // do NOT proc_close the resource — that would wait on the
+            // long-running child. The OS process is independent and the PHP
+            // resource is cleaned up at script shutdown.
             $cmd = sprintf(
-                'start "" /B %s %s %s %d %d %d start >> %s 2>&1',
+                '%s %s %s %d %d %d start',
                 escapeshellarg($phpBinary),
                 escapeshellarg($serverPath),
                 escapeshellarg(base_path()),
                 $wsPort,
                 $bridgePort,
-                $viteProxyPort,
-                escapeshellarg($logFile)
+                $viteProxyPort
             );
-            pclose(popen($cmd, 'r'));
+            $desc = [
+                0 => ['file', 'NUL', 'r'],
+                1 => ['file', $logFile, 'a'],
+                2 => ['file', $logFile, 'a'],
+            ];
+            // Keep the resource on the instance so its destructor doesn't fire
+            // mid-command (proc_close blocks waiting for the long-lived child).
+            // On Ctrl+C the PHP process is hard-terminated by Windows and the
+            // bridge stays running, matching Mac/Linux behaviour.
+            $this->bridgeProcess = @proc_open($cmd, $desc, $pipes, base_path(), null, ['bypass_shell' => true]);
         } else {
             $cmd = sprintf(
                 '%s %s %s %d %d %d start >> %s 2>&1 &',

--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -3,6 +3,7 @@
 namespace Native\Mobile\Commands;
 
 use Endroid\QrCode\Builder\Builder;
+use Endroid\QrCode\ErrorCorrectionLevel;
 use Illuminate\Console\Command;
 
 use function Laravel\Prompts\intro;
@@ -19,7 +20,8 @@ class JumpCommand extends Command
                             {--vite-proxy-port= : The port Jump uses to proxy Vite HMR to the phone}
                             {--no-serve : Do not start artisan serve automatically (use if running your own server)}
                             {--laravel-port= : The Laravel dev server port (auto-detected when artisan serve is managed)}
-                            {--no-mdns : Disable mDNS service advertisement}';
+                            {--no-mdns : Disable mDNS service advertisement}
+                            {--browser : Open the QR code page in the default browser (useful when terminal rendering is unreliable)}';
 
     protected $description = 'Start the NativePHP development server for testing mobile apps';
 
@@ -32,6 +34,10 @@ class JumpCommand extends Command
     private array $laravelPipes = [];
 
     private $bridgeProcess = null;
+
+    // Windows-only: separate process for the Vite HMR proxy because
+    // Workerman can't fork two Workers from one file on Windows.
+    private $viteHmrProcess = null;
 
     private bool $verbose = false;
 
@@ -88,8 +94,12 @@ class JumpCommand extends Command
             $this->startLaravelServer($this->laravelPort, $bridgePort, $wsPort);
         }
 
-        // Check if we should open browser
-        $openQr = config('nativephp.server.open_browser', true);
+        // Open the browser-rendered QR page only when explicitly requested
+        // via --browser, or when the user has set the config opt-in. The
+        // terminal QR is the default visual; the browser fallback is for
+        // environments where terminal rendering can't produce a scannable
+        // image (font/line-height issues, narrow viewports, etc.).
+        $openQr = $this->option('browser') || config('nativephp.server.open_browser', false);
 
         // Get the local IP for dev server config
         $ipOption = $this->option('ip');
@@ -130,10 +140,25 @@ class JumpCommand extends Command
      */
     private function startPhpServer(string $host, int $httpPort, bool $openQr, int $bridgePort = 3002, int $wsPort = 3001, int $viteProxyPort = 3003): void
     {
-        $routerPath = __DIR__.'/../../resources/jump/router.php';
+        // On Windows we run a Workerman-based HTTP proxy instead of `php -S`.
+        // `php -S` on Windows holds dead HTTP/1.1 keep-alive sockets in
+        // Established state for the OS's full 2-hour TCP keepalive window
+        // (no SO_KEEPALIVE on the listen socket), and a few of those exhaust
+        // the single-threaded server's accept loop — browser visits and
+        // subsequent phone scans hang. Workerman manages connection
+        // lifecycle correctly and closes after each response.
+        //
+        // macOS/Linux keep using `php -S` + router.php because they don't
+        // hit the dead-socket pathology and we don't want to introduce a
+        // new code path on platforms that already work.
+        $useWorkerman = PHP_OS_FAMILY === 'Windows';
 
-        if (! file_exists($routerPath)) {
-            $this->error("Router script not found at: {$routerPath}");
+        $routerPath = __DIR__.'/../../resources/jump/router.php';
+        $workermanServerPath = __DIR__.'/../../resources/jump/http-server.php';
+        $serverScriptPath = $useWorkerman ? $workermanServerPath : $routerPath;
+
+        if (! file_exists($serverScriptPath)) {
+            $this->error("Server script not found at: {$serverScriptPath}");
 
             return;
         }
@@ -170,13 +195,29 @@ class JumpCommand extends Command
             2 => ['pipe', 'w'],  // stderr
         ];
 
-        $cmd = sprintf(
-            '%s -S %s:%d %s',
-            escapeshellarg($phpBinary),
-            $serverHost,
-            $httpPort,
-            escapeshellarg($routerPath)
-        );
+        if ($useWorkerman) {
+            // Workerman script takes positional args: base_path, host, port,
+            // then the Workerman `start` token. Env vars are also read by
+            // the script for everything beyond host/port.
+            $cmd = sprintf(
+                '%s %s %s %s %d start',
+                escapeshellarg($phpBinary),
+                escapeshellarg($serverScriptPath),
+                escapeshellarg(base_path()),
+                escapeshellarg($serverHost),
+                $httpPort
+            );
+
+            $this->components->twoColumnDetail('HTTP proxy', '<fg=cyan>workerman</> (windows: avoids `php -S` dead-socket wedge)');
+        } else {
+            $cmd = sprintf(
+                '%s -S %s:%d %s',
+                escapeshellarg($phpBinary),
+                $serverHost,
+                $httpPort,
+                escapeshellarg($serverScriptPath)
+            );
+        }
 
         $process = proc_open($cmd, $descriptorSpec, $pipes, base_path(), $fullEnv);
 
@@ -210,6 +251,22 @@ class JumpCommand extends Command
             };
             pcntl_signal(SIGINT, $shutdown);
             pcntl_signal(SIGTERM, $shutdown);
+        }
+
+        // Open the browser-rendered QR page once the HTTP server is up.
+        // Terminal-rendered QR codes are unreliable across font/terminal
+        // combinations (line-height gaps in half-blocks, or oversized
+        // full-block renderings that don't fit the visible viewport), so the
+        // browser page at /jump/qr is the canonical scan target. The
+        // terminal QR above is a best-effort fallback for headless/SSH use.
+        if ($openQr) {
+            for ($i = 0; $i < 50; $i++) {
+                if ($this->isPortInUse($httpPort)) {
+                    break;
+                }
+                usleep(100000); // 100ms; up to 5s total
+            }
+            $this->openBrowser($host, $httpPort);
         }
 
         // Main loop - read output from the server
@@ -350,6 +407,62 @@ class JumpCommand extends Command
         usleep(500000);
 
         $this->components->twoColumnDetail('Bridge log', "tail -f {$logFile}");
+
+        // On Windows, Workerman cannot start multiple Worker instances from
+        // one PHP file (no fork() — the second Worker is silently dropped
+        // with the "multi workers init in one php file are not support"
+        // warning). websocket-server.php declares both JumpBridge (this
+        // process) and JumpViteProxy, so on Windows the Vite HMR proxy
+        // never binds and `npm run dev` file changes never reach the phone.
+        // Launch the Vite HMR proxy as its own process to work around that.
+        // macOS/Linux don't need this — fork in websocket-server.php starts
+        // both Workers correctly.
+        if (PHP_OS_FAMILY === 'Windows') {
+            $this->startViteHmrProxyForWindows($viteProxyPort, $logFile);
+        }
+    }
+
+    /**
+     * Launch the standalone Vite HMR proxy Workerman process. Windows only —
+     * see startBridgeServer for the multi-worker-in-one-file rationale.
+     */
+    private function startViteHmrProxyForWindows(int $viteProxyPort, string $logFile): void
+    {
+        $serverPath = __DIR__.'/../../resources/jump/vite-hmr-server.php';
+
+        if (! file_exists($serverPath)) {
+            $this->warn('Vite HMR proxy script not found, HMR will not work on Windows.');
+
+            return;
+        }
+
+        $phpBinary = PHP_BINARY;
+        $cmd = sprintf(
+            '%s %s %s %d start',
+            escapeshellarg($phpBinary),
+            escapeshellarg($serverPath),
+            escapeshellarg(base_path()),
+            $viteProxyPort
+        );
+        $desc = [
+            0 => ['file', 'NUL', 'r'],
+            1 => ['file', $logFile, 'a'],
+            2 => ['file', $logFile, 'a'],
+        ];
+
+        // Same proc_open pattern as the bridge: keep the resource alive on
+        // the instance so its destructor doesn't proc_close (which would
+        // block waiting on the long-lived child). The OS process is
+        // independent and Windows hard-terminates everything on Ctrl+C.
+        $this->viteHmrProcess = @proc_open($cmd, $desc, $pipes, base_path(), null, ['bypass_shell' => true]);
+
+        usleep(500000);
+
+        if ($this->isPortInUse($viteProxyPort)) {
+            $this->components->twoColumnDetail('Vite HMR proxy', "ws://0.0.0.0:{$viteProxyPort}/ (windows: separate process)");
+        } else {
+            $this->warn("Vite HMR proxy did not bind to port {$viteProxyPort} — file changes will not hot-reload on the phone.");
+        }
     }
 
     /**
@@ -366,8 +479,15 @@ class JumpCommand extends Command
             2 => ['pipe', 'w'],
         ];
 
+        // --no-reload is required on Windows/Herd: without it, Laravel's
+        // ServeCommand strips most env vars from the spawned `php -S` child
+        // (only a small allowlist survives), which on Windows can break PHP's
+        // socket initialization and produces the opaque
+        // "Failed to listen on 127.0.0.1:<port> (reason: ?)" error across
+        // every port it tries. We're managing this server's lifecycle from
+        // Jump anyway, so the env-reload watcher provides no value here.
         $cmd = sprintf(
-            '%s %s serve --port=%d --host=127.0.0.1 --no-interaction',
+            '%s %s serve --port=%d --host=127.0.0.1 --no-interaction --no-reload',
             escapeshellarg($phpBinary),
             escapeshellarg($artisan),
             $port
@@ -407,6 +527,58 @@ class JumpCommand extends Command
         }
 
         $this->components->twoColumnDetail('Laravel server', "http://127.0.0.1:{$port}");
+
+        // Warm Laravel before the phone arrives. PHP's first request is cold:
+        // opcache empty, Wayfinder/Inertia/service-provider boot, autoload
+        // scan — easily >30s on Windows + Herd for an Inertia app. The
+        // router's curl proxy has a fixed transfer timeout, so a cold first
+        // request lands in the phone as "Could not connect to Laravel on
+        // port 8000". Pre-warming here trades a one-time delay during
+        // startup (where it's expected) for a fast first scan.
+        $this->warmLaravelServer($port);
+    }
+
+    /**
+     * Issue a single throwaway GET / to the managed Laravel server so the
+     * opcache, Inertia/Wayfinder bootstrap, and config caching are primed
+     * before the device proxies its first request.
+     */
+    private function warmLaravelServer(int $port): void
+    {
+        if (! function_exists('curl_init')) {
+            return;
+        }
+
+        $start = microtime(true);
+        $ch = curl_init("http://127.0.0.1:{$port}/");
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_NOBODY, false);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 120);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+        // Identify ourselves so logs can attribute the warmup hit.
+        curl_setopt($ch, CURLOPT_USERAGENT, 'NativePHP-Jump-Warmup/1.0');
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $error = curl_error($ch);
+        curl_close($ch);
+
+        $elapsed = round(microtime(true) - $start, 2);
+
+        if ($response === false) {
+            $this->components->twoColumnDetail(
+                'Laravel warmup',
+                "<fg=yellow>failed after {$elapsed}s: {$error}</>"
+            );
+
+            return;
+        }
+
+        $this->components->twoColumnDetail(
+            'Laravel warmup',
+            "<fg=green>ready in {$elapsed}s (HTTP {$httpCode})</>"
+        );
     }
 
     /**
@@ -485,10 +657,20 @@ class JumpCommand extends Command
 
             $qrData = "jump://connect?host={$host}&port={$port}";
 
+            // High error correction is required when we pack the QR into
+            // terminal half-blocks: font line-height variations on Windows
+            // cmd/PowerShell can cause individual modules to be misread by
+            // scanners. The QR still decodes "successfully" (it doesn't
+            // checksum-fail), but the data is wrong, so the receiving app
+            // gets a garbage host/port and hangs trying to connect. High EC
+            // adds redundancy that fixes those flipped modules in-scanner.
+            // Margin stays at 1 since the surrounding terminal background
+            // gives the scanner additional effective quiet zone.
             $result = (new Builder(
                 data: $qrData,
+                errorCorrectionLevel: ErrorCorrectionLevel::High,
                 size: 300,
-                margin: 2,
+                margin: 1,
             ))->build();
 
             $matrix = $result->getMatrix();
@@ -498,11 +680,16 @@ class JumpCommand extends Command
             $this->line('  <fg=white;bg=black>Scan with your camera to open in Jump</>');
             $this->newLine();
 
-            // Render two rows at a time using Unicode half-block characters:
-            // ▀ (upper half) = top black, bottom white
-            // ▄ (lower half) = top white, bottom black
-            // █ (full block) = both black
-            //   (space)      = both white
+            // Half-block packing: each terminal row carries TWO QR matrix
+            // rows. ▀ = top module on, ▄ = bottom module on, █ = both on,
+            // space = both off. Cuts the rendered height in half and gives
+            // approximately square cells (most terminal cells are ~1:2
+            // aspect, so 1 char wide × 0.5 char tall ≈ square).
+            //
+            // Caveat: depends on the font drawing half-blocks with no
+            // vertical gap. Modern Windows Terminal (Cascadia Code) and most
+            // monospace fonts on macOS/Linux handle this correctly. Older
+            // cmd.exe with Consolas may leave a thin gap between rows.
             for ($y = 0; $y < $size; $y += 2) {
                 $line = '  '; // left margin
                 for ($x = 0; $x < $size; $x++) {

--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -714,7 +714,10 @@ class JumpCommand extends Command
             $this->newLine();
             $this->line("  <fg=gray>{$qrData}</>");
             $this->newLine();
-            $this->line("  <fg=yellow>Can't scan the QR code? Try it in the browser by re-running with <fg=cyan>--browser</></>");
+            $browserHost = $host === '0.0.0.0' ? 'localhost' : $host;
+            $browserUrl = "http://{$browserHost}:{$port}/jump/qr";
+            $this->line("  <fg=yellow>Can't scan the QR code? Try it in the browser: <fg=cyan>{$browserUrl}</></>");
+            $this->line('  <fg=gray>Use the --browser option to auto-open your default browser on future runs.</>');
             $this->newLine();
         } catch (\Throwable $e) {
             // QR display is optional — don't break the server


### PR DESCRIPTION
All changes scoped to nativephp/mobile (Herd\mobile-air). macOS/Linux code paths untouched (PHP_OS_FAMILY === 'Windows' gates).

src/Commands/JumpCommand.php

warmLaravelServer(): curls GET / after artisan serve boots so the first phone request hits warm Laravel (cold boot was exceeding the proxy's curl timeout → opaque 502 in the phone reading "Could not connect to Laravel on port 8000").
startPhpServer is platform-gated: Windows spawns php http-server.php; Mac/Linux still spawns php -S … router.php.
startViteHmrProxyForWindows(): additionally spawns vite-hmr-server.php because Workerman silently drops the 2nd Worker declared in websocket-server.php on Windows (no fork), which is why HMR never bound to 3003.
resources/jump/router.php (Mac/Linux only now, but improvements apply both)

Diagnostic 502 bodies (CURLE_COULDNT_CONNECT vs CURLE_OPERATION_TIMEDOUT vs other), [start] + completion logs, proxyToVite timeout 10→30s, proxyToLaravel 30→90s, Connection: close to drain keepalive sockets, request logs split to storage/logs/jump-router.log with ms precision.
New: resources/jump/http-server.php — Workerman HTTP worker, feature-for-feature port of router.php. Closes TCP after each response, eliminating the dead-socket wedge php -S on Windows hits because it doesn't set SO_KEEPALIVE.

New: resources/jump/vite-hmr-server.php — standalone copy of the JumpViteProxy Worker from websocket-server.php so it can run as its own Windows process.