### PR TITLE
Add video and audio MIME types to scheme handlers

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPWebViewClient.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPWebViewClient.kt
@@ -334,6 +334,9 @@ class PHPWebViewClient(
             "png" -> "image/png"
             "jpg", "jpeg" -> "image/jpeg"
             "gif" -> "image/gif"
+            "webp" -> "image/webp"
+            "heic" -> "image/heic"
+            "heif" -> "image/heif"
             "svg" -> "image/svg+xml"
             "json" -> "application/json"
             "pdf" -> "application/pdf"
@@ -345,6 +348,26 @@ class PHPWebViewClient(
             "eot" -> "application/vnd.ms-fontobject"
             "otf" -> "font/otf"
             "ico" -> "image/x-icon"
+            // Video — Chromium WebView refuses to play <video src> without an
+            // explicit video/* Content-Type. Without these entries the asset
+            // handler returned application/octet-stream and the player
+            // stayed black on Android.
+            "mp4" -> "video/mp4"
+            "m4v" -> "video/x-m4v"
+            "mov" -> "video/quicktime"
+            "webm" -> "video/webm"
+            "mkv" -> "video/x-matroska"
+            "avi" -> "video/x-msvideo"
+            "3gp" -> "video/3gpp"
+            // HLS playlist + segments for locally served streams.
+            "m3u8" -> "application/vnd.apple.mpegurl"
+            "ts" -> "video/mp2t"
+            // Audio
+            "mp3" -> "audio/mpeg"
+            "wav" -> "audio/wav"
+            "m4a" -> "audio/mp4"
+            "aac" -> "audio/aac"
+            "ogg" -> "audio/ogg"
             else -> {
                 Log.w(TAG, "⚠️ Unknown file extension for: $fileName. Defaulting to application/octet-stream")
                 "application/octet-stream"

--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -255,10 +255,47 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
             return "image/jpeg"
         case "gif":
             return "image/gif"
+        case "webp":
+            return "image/webp"
+        case "heic":
+            return "image/heic"
+        case "heif":
+            return "image/heif"
         case "svg":
             return "image/svg+xml"
+        // Video — keep parity with the Android handler so plugin-staged media
+        // (and any other locally served clips) play with the correct
+        // Content-Type. WKWebView byte-sniffs in some cases, but stricter
+        // clients still need an explicit video/* type.
+        case "mp4":
+            return "video/mp4"
+        case "m4v":
+            return "video/x-m4v"
+        case "mov":
+            return "video/quicktime"
+        case "webm":
+            return "video/webm"
+        case "mkv":
+            return "video/x-matroska"
+        case "avi":
+            return "video/x-msvideo"
+        case "3gp":
+            return "video/3gpp"
+        case "m3u8":
+            return "application/vnd.apple.mpegurl"
+        case "ts":
+            return "video/mp2t"
+        // Audio
         case "m4a":
             return "audio/mp4"
+        case "mp3":
+            return "audio/mpeg"
+        case "wav":
+            return "audio/wav"
+        case "aac":
+            return "audio/aac"
+        case "ogg":
+            return "audio/ogg"
         default:
             return "application/octet-stream"
         }


### PR DESCRIPTION
The asset handlers in PHPWebViewClient (Android) and PHPSchemeHandler
(iOS) only knew a handful of image/font extensions and defaulted
everything else to application/octet-stream. Chromium WebView on
Android refuses to play <video src> without an explicit video/*
Content-Type, so locally served clips (camera capture, plugin-staged
media, HLS playlists) stayed black on Android even though the bytes
were delivered correctly.

Adds mp4, m4v, mov, webm, mkv, avi, 3gp, m3u8, ts and common audio
types to both handlers. iOS WKWebView byte-sniffs in most cases, but
the explicit Content-Type keeps parity between platforms and protects
against stricter clients.