### PR TITLE
Fix iOS extraction of emoji-named files (Livewire 4 ⚡️ components)

### DIFF
--- a/resources/xcode/NativePHP/AppUpdateManager.swift
+++ b/resources/xcode/NativePHP/AppUpdateManager.swift
@@ -107,7 +107,18 @@ class AppUpdateManager {
         var fileDataMap: [(path: URL, data: Data)] = []
 
         for entry in archive {
-            let destinationPath = destinationURL.appendingPathComponent(entry.path)
+            // ZIPFoundation 0.9.19's `entry.path` decodes as CP437 unless the EFS bit
+            // is set on the entry — and macOS `zip` often omits that flag even for
+            // UTF-8 names, producing mojibake (⚡️ → ΓÜí∩╕Å). Force UTF-8 decode via
+            // path(using:); fall back to `entry.path` only if the bytes aren't valid
+            // UTF-8 (which shouldn't happen for archives we build).
+            let utf8Path = entry.path(using: .utf8)
+            let rawPath = utf8Path.isEmpty ? entry.path : utf8Path
+
+            // Normalize to NFC: macOS sources may emit NFD filenames; iOS APFS stores
+            // bytes verbatim, but PHP autoloaders look up the NFC form.
+            let normalizedPath = (rawPath as NSString).precomposedStringWithCanonicalMapping
+            let destinationPath = destinationURL.appendingPathComponent(normalizedPath)
 
             switch entry.type {
             case .directory:

--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -906,7 +906,8 @@ class BuildIosAppCommand extends Command
         $result = Process::run($command);
 
         if (! $result->successful()) {
-            throw new \Exception('Failed to create ZIP file');
+            $error = trim($result->errorOutput()) ?: trim($result->output());
+            throw new \Exception('Failed to create ZIP file: '.($error ?: 'exit code '.$result->exitCode()));
         }
 
         $this->createBundledVersionFile($zipPath);

--- a/src/Commands/SimCommand.php
+++ b/src/Commands/SimCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Native\Mobile\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Process;
+
+class SimCommand extends Command
+{
+    protected $signature = 'native:sim {target=data : What to do (data, app, or uninstall)} {--bundle-id= : Override the app bundle identifier}';
+
+    protected $description = 'Inspect or manage the app on the booted iOS simulator';
+
+    public function handle(): int
+    {
+        if (PHP_OS_FAMILY !== 'Darwin') {
+            $this->error('native:sim is only supported on macOS.');
+
+            return Command::FAILURE;
+        }
+
+        $target = strtolower($this->argument('target'));
+
+        if (! in_array($target, ['data', 'app', 'uninstall'], true)) {
+            $this->error("Invalid target '{$target}'. Use 'data', 'app', or 'uninstall'.");
+
+            return Command::FAILURE;
+        }
+
+        $bundleId = $this->option('bundle-id') ?: config('nativephp.app_id');
+
+        if (! $bundleId) {
+            $this->error('No bundle id found. Set NATIVEPHP_APP_ID or pass --bundle-id.');
+
+            return Command::FAILURE;
+        }
+
+        if ($target === 'uninstall') {
+            return $this->uninstall($bundleId);
+        }
+
+        return $this->openContainer($target, $bundleId);
+    }
+
+    private function openContainer(string $target, string $bundleId): int
+    {
+        $result = Process::run([
+            'xcrun', 'simctl', 'get_app_container', 'booted', $bundleId, $target,
+        ]);
+
+        if (! $result->successful()) {
+            $this->printSimctlError($result->errorOutput(), $bundleId);
+
+            return Command::FAILURE;
+        }
+
+        $path = trim($result->output());
+
+        // For `app`, simctl returns the path to the .app bundle itself.
+        // We want to open the parent so the user sees app.zip alongside the .app.
+        $pathToOpen = $target === 'app' ? dirname($path) : $path;
+
+        $this->info("Opening last-used simulator's {$target} folder in Finder...");
+
+        Process::run(['open', $pathToOpen]);
+
+        return Command::SUCCESS;
+    }
+
+    private function uninstall(string $bundleId): int
+    {
+        if (! $this->confirm("Uninstall {$bundleId} from the booted simulator?", false)) {
+            $this->line('Aborted.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->info("Uninstalling {$bundleId} from last-used simulator...");
+
+        $result = Process::run([
+            'xcrun', 'simctl', 'uninstall', 'booted', $bundleId,
+        ]);
+
+        if (! $result->successful()) {
+            $this->printSimctlError($result->errorOutput(), $bundleId);
+
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function printSimctlError(string $stderr, string $bundleId): void
+    {
+        $stderr = trim($stderr);
+
+        if (str_contains($stderr, 'No such file or directory') || str_contains($stderr, 'code=2')) {
+            $this->error("{$bundleId} is not installed on the booted simulator.");
+
+            return;
+        }
+
+        if (str_contains($stderr, 'Booted') || str_contains($stderr, 'No devices')) {
+            $this->error('No simulator is currently booted.');
+
+            return;
+        }
+
+        $this->error($stderr ?: "simctl failed for {$bundleId}.");
+    }
+}

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -26,6 +26,7 @@ use Native\Mobile\Commands\PluginUninstallCommand;
 use Native\Mobile\Commands\PluginValidateCommand;
 use Native\Mobile\Commands\ReleaseCommand;
 use Native\Mobile\Commands\RunCommand;
+use Native\Mobile\Commands\SimCommand;
 use Native\Mobile\Commands\TailCommand;
 use Native\Mobile\Commands\VersionCommand;
 use Native\Mobile\Commands\WatchCommand;
@@ -58,6 +59,7 @@ class NativeServiceProvider extends PackageServiceProvider
                 RunCommand::class,
                 OpenProjectCommand::class,
                 LaunchEmulatorCommand::class,
+                SimCommand::class,
                 ReleaseCommand::class,
                 JumpCommand::class,
                 WatchCommand::class,


### PR DESCRIPTION
## Summary

PHP files with non-ASCII names — most visibly Livewire 4 components prefixed with `⚡️` — were unusable on iOS. The extracted Laravel app on the simulator contained files named e.g. `ΓÜí∩╕Åcounter.blade.php` instead of `⚡️counter.blade.php`, so autoloading and view resolution silently failed.

Root cause: ZIPFoundation 0.9.19's `entry.path` ignores the archive's `preferredEncoding` and falls back to CP437 whenever the entry's EFS bit (general-purpose bit 11) is unset. macOS `zip` often omits that flag even when the bytes are valid UTF-8, so every non-ASCII filename came out mojibake'd.

## Changes

**`resources/xcode/NativePHP/AppUpdateManager.swift`**
- Force UTF-8 decode via `entry.path(using: .utf8)`, with a fallback to `entry.path` only if the bytes aren't valid UTF-8.
- NFC-normalize entry paths before writing, so NFD filenames coming from macOS sources don't land on iOS APFS in a form PHP autoloaders can't look up.

**`src/Commands/BuildIosAppCommand.php`**
- Surface the actual zip stderr when `createAppZip()` fails, instead of throwing a bare "Failed to create ZIP file".

**`src/Commands/SimCommand.php` + `src/NativeServiceProvider.php`** (new command)
- `php artisan native:sim data` — opens the booted simulator's data container in Finder
- `php artisan native:sim app` — opens the parent of the `.app` bundle (so `app.zip` is visible next to `NativePHP.app`)
- `php artisan native:sim uninstall` — uninstalls the app from the booted simulator (with confirmation)
- `--bundle-id=` overrides the configured `NATIVEPHP_APP_ID`
- Friendly errors for the common "no sim booted" / "app not installed" cases

The `native:sim` command was built to diagnose this bug, but it's broadly useful for inspecting simulator state during development, so it's included here.

## Heads-up for reviewers

Changes under `resources/xcode/` only reach consumer projects via `php artisan native:install`, which snapshots the template into `nativephp/ios/`. Anyone iterating on this fix locally needs to re-run `native:install` (or `--force`) for the Swift changes to actually get compiled.

## Test plan

- [x] Add a file with emoji in the name to a Laravel app (e.g. a Livewire 4 component named `⚡️counter.blade.php`)
- [x] Run `php artisan native:install --force` to copy the updated Swift into the iOS project
- [x] Run `php artisan native:sim uninstall` to clear any stale extraction
- [x] Run `php artisan native:run ios`
- [x] `php artisan native:sim data` → confirm the file name shows with the real emoji, and that `xxd` of the filename shows `e2 9a a1 ef b8 8f` (UTF-8 for ⚡️)
- [x] Confirm Livewire/autoload can resolve the component at runtime
- [x] `php artisan native:sim app` opens Finder at the `.app` parent dir
- [x] `php artisan native:sim uninstall` prompts for confirmation and successfully removes the app

🤖 Generated with [Claude Code](https://claude.com/claude-code)