### PR TITLE
fix(ios): use persistent WKWebsiteDataStore so cookies survive cold launch

### DIFF
--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -146,7 +146,7 @@ struct WebViewLayoutContainer: View {
 }
 
 struct WebView: UIViewRepresentable {
-    static let dataStore = WKWebsiteDataStore.nonPersistent()
+    static let dataStore = WKWebsiteDataStore.default()
     let shared: SharedWebView
     let horizontalSizeClass: UserInterfaceSizeClass?
 


### PR DESCRIPTION
## Summary

- Switch iOS WKWebView from `WKWebsiteDataStore.nonPersistent()` to `.default()` so cookies persist across cold launches.
- Aligns iOS behavior with Android, which already uses persistent storage via `CookieManager.getInstance()`.
- Fixes the Laravel session loss documented in #139.

## Why

`WKWebsiteDataStore.nonPersistent()` is in-memory storage — the WKWebView starts with an empty cookie jar on every cold launch. For Laravel apps this wipes the `laravel_session` cookie, so even though the session file is still on disk in `storage/framework/sessions/`, Laravel can't find it. The user appears signed-out, and any `session(...)` state (auth user, flash messages, dismissed prompts) is reset.

Android already does the right thing — `CookieManager.getInstance()` is persistent and shared by default. Same Laravel code, two different behaviors. This patch brings iOS in line.

## Risk

`WKWebsiteDataStore.default()` is the shared, app-wide persistent jar. Not an issue for NativePHP apps (they own their entire WebView), but flagging in case reviewers want it on the radar.

## Test plan

- [ ] Cold-launch a NativePHP iOS app that signs the user in via Laravel auth. Confirm `auth()->check()` is `true` on next cold launch (was `false` before this change).
- [ ] Confirm `session(...)` state survives cold launch.
- [ ] Verify behavior matches Android same-app behavior.

## Notes

Refs #139, which raised the open question of unconditional flip vs. config option. This PR is the unconditional flip — happy to amend to a config option (e.g. `'cookies' => 'persistent'|'ephemeral'` defaulting to persistent) if you'd rather preserve the current behavior as an opt-in.