### PR TITLE
Fix iOS LaunchImage Contents.json mixing Any-scale + specific scales

### DIFF
--- a/src/Traits/InstallsSplashScreen.php
+++ b/src/Traits/InstallsSplashScreen.php
@@ -18,6 +18,24 @@ trait InstallsSplashScreen
             'splash-dark@3x.png' => ['filename' => 'splash-dark@3x.png', 'idiom' => 'universal', 'scale' => '3x', 'appearances' => [['appearance' => 'luminosity', 'value' => 'dark']]],
         ];
 
+        // Xcode's asset compiler rejects Image Sets that mix entries with no
+        // `scale` key ("Any" scale) and entries with specific scales (1x/2x/3x)
+        // when the "Any" entries reference bitmap content. If the project ships
+        // any scaled variants, drop the unscaled ones so the generated
+        // Contents.json doesn't trigger:
+        //   error: Image set has a child with bitmap content and the "Any"
+        //   scale. The image set also has children with specific scales...
+        $hasScaledVariants = false;
+        foreach (['splash@2x.png', 'splash-dark@2x.png', 'splash@3x.png', 'splash-dark@3x.png'] as $scaledFilename) {
+            if (File::exists(public_path($scaledFilename))) {
+                $hasScaledVariants = true;
+                break;
+            }
+        }
+        if ($hasScaledVariants) {
+            unset($splashVariants['splash.png'], $splashVariants['splash-dark.png']);
+        }
+
         $foundVariants = [];
         $images = [];
 


### PR DESCRIPTION
Fixes #141.

## What

`InstallsSplashScreen::installIosSplashScreen()` builds `LaunchImage.imageset/Contents.json` from whichever of six hard-coded splash variants exist in `public/`. The first two (`splash.png`, `splash-dark.png`) have no `scale` key, so Xcode treats them as `"Any"` scale. When `@2x` and/or `@3x` variants also exist, the generated Contents.json has a mix Xcode's asset compiler rejects:

```
error: Image set has a child with bitmap content and the "Any" scale.
The image set also has children with specific scales and content.
Please remove the content with specific scales or change the content
of the "Any" scale to vector content.
** ARCHIVE FAILED **
```

Simulator builds skip `GenerateAssetSymbols` so the bug stays invisible until a release archive runs the asset compiler. That made it survive in our project until Bifrost's first App Store build hit it.

## How

If any scaled variant exists, drop the unscaled ones from the candidate set before the existence loop:

```php
$hasScaledVariants = false;
foreach (['splash@2x.png', 'splash-dark@2x.png', 'splash@3x.png', 'splash-dark@3x.png'] as $scaledFilename) {
    if (File::exists(public_path($scaledFilename))) {
        $hasScaledVariants = true;
        break;
    }
}
if ($hasScaledVariants) {
    unset($splashVariants['splash.png'], $splashVariants['splash-dark.png']);
}
```

## Behavior matrix

| `public/` contains | Before | After |
|---|---|---|
| only `splash.png` (± `-dark`) | one "Any"-scale entry (valid) | unchanged — one "Any"-scale entry (valid) |
| only `@2x` and `@3x` variants | scaled-only entries (valid) | unchanged — scaled-only entries (valid) |
| all six variants | mixed Any + scaled (invalid → archive fails) | scaled-only entries (valid) |

The 1x splash files are effectively ignored when scaled variants are present. iOS handles a missing 1x by downsampling from 2x; no currently-supported iOS device uses 1x scale anyway (the original iPhone is the only 1x device and is unsupported by modern iOS).

## Alternative considered

I considered just adding `'scale' => '1x'` to the two unscaled entries in `$splashVariants`. Simpler diff, but it changes the meaning for projects that ship a single `splash.png` and rely on it being the "Any" fallback across densities — `scale: 1x` would constrain it to 1x devices only. The conditional-skip approach in this PR avoids that behavior change.

## Test plan

- [x] Manually verified with all six variants: generated Contents.json now contains only `@2x` and `@3x` entries; archive succeeds.
- [x] Manually verified with only `splash.png` (no scaled variants): generated Contents.json contains the single unscaled entry; archive succeeds.
- [ ] No existing iOS splash unit tests in this repo (`tests/Unit/Traits/InstallsAndroidSplashScreenTest.php` covers Android only). Happy to add an `InstallsIosSplashScreenTest` in a follow-up if you'd like — the Android test gives a clear pattern to follow.