### PR TITLE
Fix repeated query parameters in Android WebView requests

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPRequest.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPRequest.kt
@@ -6,16 +6,20 @@ data class PHPRequest(
     val body: String = "",
     val headers: Map<String, String> = emptyMap(),
     val getParameters: Map<String, String> = emptyMap(),
+    val queryString: String = "",
     val postParameters: Map<String, String> = emptyMap(),
     val cookies: Map<String, String> = emptyMap()
 ) {
     val uri: String
         get() {
-            val queryString = if (getParameters.isNotEmpty()) {
-                "?" + getParameters.entries.joinToString("&") { (key, value) ->
+            return if (queryString.isNotBlank()) {
+                "$url?$queryString"
+            } else if (getParameters.isNotEmpty()) {
+                "$url?" + getParameters.entries.joinToString("&") { (key, value) ->
                     "$key=$value"
                 }
-            } else ""
-            return url + queryString
+            } else {
+                url
+            }
         }
 }

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPWebViewClient.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPWebViewClient.kt
@@ -121,7 +121,7 @@ class PHPWebViewClient(
                     method = "GET",
                     body = "",
                     headers = mapOf("Accept" to "*/*"),
-                    getParameters = emptyMap()
+                    queryString = Uri.parse(url).encodedQuery ?: ""
                 )
 
                 val response = phpBridge.handleLaravelRequest(phpRequest)
@@ -183,9 +183,7 @@ class PHPWebViewClient(
             method = request.method,
             body = if (method in listOf("POST", "PUT", "PATCH")) postData ?: "" else "",
             headers = headers,
-            getParameters = request.url.queryParameterNames?.associateWith {
-                request.url.getQueryParameter(it) ?: ""
-            } ?: emptyMap()
+            queryString = request.url.encodedQuery ?: ""
         )
 
         val prepTime = System.currentTimeMillis() - requestStart
@@ -217,7 +215,12 @@ class PHPWebViewClient(
             if (!location.isNullOrEmpty()) {
                 val redirectUrl = when {
                     location.startsWith("/") -> location
-                    location.startsWith("http") -> Uri.parse(location).encodedPath ?: "/"
+                    location.startsWith("http") -> {
+                        val parsedUri = Uri.parse(location)
+                        val path = parsedUri.encodedPath ?: "/"
+                        val query = parsedUri.encodedQuery
+                        if (!query.isNullOrEmpty()) "$path?$query" else path
+                    }
                     else -> "/$location"
                 }
 


### PR DESCRIPTION
This PR fixes Android request forwarding so repeated query parameters are preserved when NativePHP forwards WebView requests to Laravel.

Previously, query parameters were converted through a `Map`-based structure, which collapsed duplicate keys such as `symptoms[]` into a single value. This caused multi-select form fields to lose data on Android even though the backend and form submission logic were working correctly.

### Changes
- Preserve the raw encoded query string in `PHPRequest`
- Use `request.url.encodedQuery` in `PHPWebViewClient` for PHP requests and asset fallbacks
- Preserve query strings when handling redirects with absolute URLs
- Keep backward compatibility by retaining `getParameters` as a fallback

### Validation
- Verified on Android emulator that multi-select checkbox values now arrive correctly
- Confirmed Laravel/backend persistence still stores multiple symptom values
- Local regression tests passed