### PR TITLE
padding-bottom prop for iOS 26+ Tab bar with Liquid Glass

### DIFF
--- a/resources/xcode/NativePHP/NativeUI/NativeBottomNav.swift
+++ b/resources/xcode/NativePHP/NativeUI/NativeBottomNav.swift
@@ -271,6 +271,8 @@ struct NativeBottomNavigation: View {
     var body: some View {
         if let bottomNavData = uiState.bottomNavData,
            let items = bottomNavData.children, !items.isEmpty {
+           
+            let customBottomPadding = CGFloat(bottomNavData.paddingBottom ?? 20)
 
             if #available(iOS 26.0, *) {
                 // iOS 26+: Tab bar with Liquid Glass effect
@@ -284,7 +286,7 @@ struct NativeBottomNavigation: View {
                     }
                 )
                 .frame(height: 49)
-                .padding(.bottom, 20)
+                .padding(.bottom, customBottomPadding)
                 .onAppear {
                     ensureSelectedTabInitialized(items: items)
                 }

--- a/resources/xcode/NativePHP/NativeUI/NativeUIModels.swift
+++ b/resources/xcode/NativePHP/NativeUI/NativeUIModels.swift
@@ -48,12 +48,14 @@ struct BottomNavData: Codable, Equatable {
     let dark: Bool?
     let labelVisibility: String?
     let activeColor: String?
+    let paddingBottom: Int?
     let children: [BottomNavItemComponent]?
 
     enum CodingKeys: String, CodingKey {
         case dark
         case labelVisibility = "label_visibility"
         case activeColor = "active_color"
+        case paddingBottom = "padding_bottom"
         case children
     }
 }

--- a/src/Edge/Components/Navigation/BottomNav.php
+++ b/src/Edge/Components/Navigation/BottomNav.php
@@ -14,6 +14,7 @@ class BottomNav extends EdgeComponent
         public ?bool $dark = null,
         public string $labelVisibility = 'labeled',
         public ?string $activeColor = null,
+        public ?int $paddingBottom = null,
     ) {}
 
     protected function toNativeProps(): array
@@ -22,6 +23,7 @@ class BottomNav extends EdgeComponent
             'dark' => $this->dark,
             'label_visibility' => $this->labelVisibility,
             'active_color' => $this->activeColor,
+            'padding_bottom' => $this->paddingBottom,
             'id' => 'bottom_nav',
         ];
     }


### PR DESCRIPTION
## Summary

> [!NOTE]  
> I added a disclaimer by the end of this PR description to explain that, upon further testing, this new feature (although "usable") probably doesn't need to exist as it was just a Bifrost Jump visual behavior

I was testing NativePHP on an iOS device with Liquid Glass through Jump and I noticed the [Bottom Navigation bar](https://nativephp.com/docs/mobile/3/edge-components/bottom-nav) was "too high" (to the point of being in the way of some visual elements)

<img width="303" height="611" alt="Screenshot 2026-05-25 at 17 07 20" src="https://github.com/user-attachments/assets/558ac5ea-f49c-4b38-a2dd-b151c2e422e1" />

## Suggested Change

A new 'padding-bottom' property that can be used in the Bottom Navigation EDGE component to move the tab bar vertically if needed, for iOS 26+ Tab bar with Liquid Glass only. The default 20 is still used in case it is not set.

## Disclaimers

### AI Usage

The original changes were made with Gemini 3.1 Pro and additional changes were made by a human (me).

### Wether or not it is relevant

After I was done with this PR, I tried running the `php artisan native:watch ios` and tested on the iOS emulator (previously I had only tried using Bifrost Jump), and realized the Bottom Nav only shows up at the height it does on the previous screenshot when running on a real device through Jump (or at least that's my conclusion so far). 

So this entire PR became pointless but I had already went through the trouble trying to do it and testing it out so I thought I might as well submit it anyway in case anybody ever need this one day and someone chooses to reopen this PR.

The screenshot below is from when I tried running the same project though `native:watch`

<img width="303" height="611" alt="simulator_screenshot_4BBD61AE-F8C7-484B-BFA6-04A5E05F3086" src="https://github.com/user-attachments/assets/ae1c7912-85ad-4189-9a8b-5a928972c7d4" />

