### PR TITLE
Use encodedQuery for deep link URLs in MainActivity

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
@@ -329,7 +329,7 @@ class MainActivity : FragmentActivity(), WebViewProvider {
             val route = if (scheme != null && scheme != "http" && scheme != "https") {
                 val host = uri.host ?: ""
                 val path = uri.path ?: ""
-                val query = uri.query?.let { "?$it" } ?: ""
+                val query = uri.encodedQuery?.let { "?$it" } ?: ""
                 if (host.isNotEmpty()) "/$host$path$query" else "$path$query"
             } else {
                 fcmUrl
@@ -370,7 +370,7 @@ class MainActivity : FragmentActivity(), WebViewProvider {
             }
         }
 
-        val query = uri.query
+        val query = uri.encodedQuery
         val laravelUrl = if (uri.scheme != "http" && uri.scheme != "https") {
             // Custom scheme (e.g., myapp://profile/settings): treat host as first path segment
             // This matches iOS behavior where the entire URI after scheme:// is the path


### PR DESCRIPTION
`handleDeepLinkIntent` builds the in-app URL from `uri.query`, which returns the **decoded** query string. That corrupts URL-encoded parameters - e.g. bracketed array keys like `foo[0][bar]` (how Livewire serialises array `#[Url]` props) - when the URL is rebuilt and reloaded into the WebView, so those params arrive empty on deep-linked pages while plain scalars survive.

Switching to `uri.encodedQuery` preserves the original encoding. This matches the `queryString = request.url.encodedQuery` handling already on `main` in `PHPWebViewClient`; this just applies the same to the two URL builders in `MainActivity` (universal link + FCM).