### PR TITLE
Fix: make iOS bundle extraction atomic and self-healing

### DIFF
--- a/resources/xcode/NativePHP/AppUpdateManager.swift
+++ b/resources/xcode/NativePHP/AppUpdateManager.swift
@@ -50,9 +50,14 @@ class AppUpdateManager {
     }
 
     private func hasApp() -> Bool {
-        let envFile = appPath + "/.env"
+        // Use installed.version as the readiness marker: it is written only AFTER a
+        // fully successful extraction. A partial/interrupted extraction may have
+        // written .env (and some vendor files) but not all of them, so keying off
+        // .env would treat a broken half-install as complete and crash on a missing
+        // require. The marker is only present when extraction finished cleanly.
+        let marker = appPath + "/installed.version"
 
-        if FileManager.default.fileExists(atPath: envFile) {
+        if FileManager.default.fileExists(atPath: marker) {
             print("📦 An app bundle has already been extracted");
             return true
         }
@@ -93,6 +98,12 @@ class AppUpdateManager {
             runMigrationsAndClearCaches()
         } catch {
             print("❌ Failed to extract bundled app: \(error)")
+
+            // Never leave a half-extracted bundle behind. Without this, a partial app
+            // (e.g. .env present but vendor files missing) survives on disk and the next
+            // launch treats it as installed, crashing forever on a missing require.
+            // Removing it forces a clean re-extraction on the next launch (self-healing).
+            try? FileManager.default.removeItem(atPath: appPath)
         }
     }
 
@@ -137,12 +148,26 @@ class AppUpdateManager {
             }
         }
 
-        // Phase 2: Create all directories (sequential, fast)
+        // Phase 2: Create all directories (sequential, fast). Include every file's
+        // parent directory up front so the concurrent writers in Phase 3 never race
+        // to create the same intermediate directories. Concurrent
+        // createDirectory(withIntermediateDirectories:) on overlapping paths is a
+        // TOCTOU race on APFS that can spuriously fail and abort the whole extraction,
+        // leaving a partial app on disk.
+        var directoriesToCreate = Set<String>()
         for dirPath in directoryPaths {
-            try FileManager.default.createDirectory(at: dirPath, withIntermediateDirectories: true)
+            directoriesToCreate.insert(dirPath.path)
+        }
+        for (path, _) in fileDataMap {
+            directoriesToCreate.insert(path.deletingLastPathComponent().path)
+        }
+        for dir in directoriesToCreate {
+            try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
         }
 
-        // Phase 3: Write all files in parallel (the slow part)
+        // Phase 3: Write all files in parallel (the slow part). All parent directories
+        // already exist, so each writer only touches its own leaf file, with no shared
+        // mutable filesystem state.
         let queue = DispatchQueue(label: "zip.write", attributes: .concurrent)
         let group = DispatchGroup()
         let errorLock = NSLock()
@@ -154,8 +179,6 @@ class AppUpdateManager {
                 defer { group.leave() }
 
                 do {
-                    // Ensure parent directory exists
-                    try FileManager.default.createDirectory(at: path.deletingLastPathComponent(), withIntermediateDirectories: true)
                     try data.write(to: path, options: .atomic)
                 } catch {
                     errorLock.lock()
@@ -171,6 +194,20 @@ class AppUpdateManager {
 
         if let error = writeError {
             throw error
+        }
+
+        // Phase 4: Verify every expected file actually landed on disk. Guards against
+        // silent truncation or a jetsam-killed writer so that a missing file aborts
+        // extraction (and triggers cleanup + retry) instead of being mistaken for a
+        // complete install.
+        for (path, _) in fileDataMap {
+            if !FileManager.default.fileExists(atPath: path.path) {
+                throw NSError(
+                    domain: "AppUpdateManager",
+                    code: 2,
+                    userInfo: [NSLocalizedDescriptionKey: "Extraction incomplete: missing \(path.lastPathComponent)"]
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

On first launch (and on bundle updates) the iOS app unzips `app.zip` into `Documents/app` via `AppUpdateManager.extractZipParallel()`. Under certain device timing / memory conditions this can leave a **permanently broken install** that crashes on a missing `require` on every launch, e.g.:

```
Warning: require(.../app/vendor/composer/../symfony/deprecation-contracts/function.php):
Failed to open stream: No such file or directory in .../vendor/composer/autoload_real.php
Fatal error: Uncaught Error: Failed opening required '.../symfony/deprecation-contracts/function.php'
```

The file is present in the bundle but missing on the device. Seen on App Store / TestFlight installs, intermittently.

## Root cause

1. **Directory creation race.** Phase 3 writes files on a `.concurrent` `DispatchQueue`, and every writer also calls `createDirectory(withIntermediateDirectories: true)` for its own parent. Many files share parent directories (`vendor/symfony/...`), so concurrent writers race to create the same intermediate directories — a TOCTOU race on APFS that can spuriously fail and abort the whole extraction. The error is caught in `copyBundledApp()`, but the half-written app (often already including `.env`) is left on disk and `installed.version` is never written.

2. **Readiness keyed off `.env`.** `hasApp()` returns `true` as soon as `.env` exists. After a partial extraction `.env` may be present while other files are missing, so the next launch treats the broken install as complete and never re-extracts → crashes forever until reinstall.

## Fix

- **Phase 2:** pre-create all unique parent directories sequentially (deduped via a `Set`), so Phase 3 writers only touch leaf files — the directory race is gone.
- **Phase 4:** after writing, verify every expected file exists on disk; a missing file throws instead of silently leaving a partial install.
- **`copyBundledApp()`:** on any extraction failure, remove the partial app directory so the next launch re-extracts cleanly (self-healing).
- **`hasApp()`:** key readiness off `installed.version` (written only after a fully successful extraction) instead of `.env`.

Net effect: extraction is now all-or-nothing. A failed/interrupted extract self-heals on the next launch instead of poisoning the install — including installs already broken by this bug in the field, which recover on the next app update.

## Possible follow-up (not in this PR)

Phase 1 still buffers every file's bytes in memory simultaneously (`fileDataMap`), a jetsam risk on large vendor dirs / low-memory devices. Left out to keep the diff focused; with this change such a failure now self-heals rather than persisting, but bounding peak memory (stream/chunk writes) would be a worthwhile separate improvement.

## Testing

Verified by inspection; the changed paths are guarded by existing `print`/`throw` diagnostics. There is no automated coverage for the native extraction path in the repo.