### PR TITLE
Fix BGTask SIGSEGV from re-running php_embed_init under a live runtime

### DIFF
--- a/resources/androidstudio/app/src/main/cpp/php_bridge.c
+++ b/resources/androidstudio/app/src/main/cpp/php_bridge.c
@@ -843,19 +843,64 @@ JNIEXPORT jstring JNICALL native_run_artisan_command(JNIEnv *env, jobject thiz, 
     jstring jLaravelPath = (jstring)(*env)->CallObjectMethod(env, thiz, method);
     const char *cLaravelPath = (*env)->GetStringUTFChars(env, jLaravelPath, NULL);
 
-    // Full init per artisan command
-    setup_embed_module();
-    php_embed_module.ini_entries = "display_errors=1\nimplicit_flush=1\noutput_buffering=0\n";
-    if (php_embed_init(0, NULL) != SUCCESS) {
-        LOGE("Failed to initialize PHP for artisan");
+    // PHP startup must respect any already-initialized TSRM context. When the
+    // persistent runtime (or the queue worker) is alive — e.g. a WorkManager
+    // scheduler job firing while the app process is still up — php_embed_init()
+    // has already run tsrm_startup() process-wide. Calling it again re-runs
+    // php_tsrm_startup_ex → zend_ini_refresh_caches → OnUpdateBool against
+    // half-initialized globals and SIGSEGVs. Mirror ephemeral_embed_init():
+    // hot path attaches to the existing TSRM, cold path does a full embed init.
+    if (wait_for_persistent_boot_settled(10) != 0) {
+        LOGE("runArtisanCommand: timed out waiting for persistent boot to settle");
         pthread_mutex_unlock(&g_ephemeral_mutex);
         (*env)->ReleaseStringUTFChars(env, jcommand, command);
         (*env)->ReleaseStringUTFChars(env, jLaravelPath, cLaravelPath);
         (*env)->DeleteLocalRef(env, jLaravelPath);
         return (*env)->NewStringUTF(env, "");
     }
-    sapi_module.header_handler = android_header_handler;
-    php_initialized = 1;
+
+    int artisan_hot_path = php_initialized;
+    if (artisan_hot_path) {
+        // Hot path: a PHP runtime is already live on another thread. Allocate a
+        // thread-local TSRM context instead of re-running global startup.
+        LOGI("runArtisanCommand: hot path — attaching to existing TSRM");
+        ts_resource(0);
+        setup_embed_module();
+        if (php_embed_module.startup(&php_embed_module) == FAILURE) {
+            LOGE("runArtisanCommand: hot-path module startup failed");
+            pthread_mutex_unlock(&g_ephemeral_mutex);
+            (*env)->ReleaseStringUTFChars(env, jcommand, command);
+            (*env)->ReleaseStringUTFChars(env, jLaravelPath, cLaravelPath);
+            (*env)->DeleteLocalRef(env, jLaravelPath);
+            return (*env)->NewStringUTF(env, "");
+        }
+        if (php_request_startup() == FAILURE) {
+            LOGE("runArtisanCommand: hot-path request startup failed");
+            php_request_shutdown(NULL);
+            ts_free_thread();
+            pthread_mutex_unlock(&g_ephemeral_mutex);
+            (*env)->ReleaseStringUTFChars(env, jcommand, command);
+            (*env)->ReleaseStringUTFChars(env, jLaravelPath, cLaravelPath);
+            (*env)->DeleteLocalRef(env, jLaravelPath);
+            return (*env)->NewStringUTF(env, "");
+        }
+        sapi_module.header_handler = android_header_handler;
+    } else {
+        // Cold path: no live runtime (e.g. install-time setup, or a WorkManager
+        // cold start after the app was killed) — full embed init is safe.
+        setup_embed_module();
+        php_embed_module.ini_entries = "display_errors=1\nimplicit_flush=1\noutput_buffering=0\n";
+        if (php_embed_init(0, NULL) != SUCCESS) {
+            LOGE("Failed to initialize PHP for artisan");
+            pthread_mutex_unlock(&g_ephemeral_mutex);
+            (*env)->ReleaseStringUTFChars(env, jcommand, command);
+            (*env)->ReleaseStringUTFChars(env, jLaravelPath, cLaravelPath);
+            (*env)->DeleteLocalRef(env, jLaravelPath);
+            return (*env)->NewStringUTF(env, "");
+        }
+        sapi_module.header_handler = android_header_handler;
+        php_initialized = 1;
+    }
 
     char artisanPath[1024];
     snprintf(artisanPath, sizeof(artisanPath), "%s/../artisan.php", cLaravelPath);
@@ -903,8 +948,15 @@ JNIEXPORT jstring JNICALL native_run_artisan_command(JNIEnv *env, jobject thiz, 
     zend_stream_init_filename(&file_handle, artisanPath);
     php_execute_script(&file_handle);
 
-    safe_php_embed_shutdown();
-    php_initialized = 0;
+    if (artisan_hot_path) {
+        // Tear down only this thread's context — leave the live runtime's
+        // global TSRM (and php_initialized) intact.
+        php_request_shutdown(NULL);
+        ts_free_thread();
+    } else {
+        safe_php_embed_shutdown();
+        php_initialized = 0;
+    }
 
     pthread_mutex_unlock(&g_ephemeral_mutex);
 
@@ -915,6 +967,17 @@ JNIEXPORT jstring JNICALL native_run_artisan_command(JNIEnv *env, jobject thiz, 
 
     char *cmd_output = get_collected_output();
     return (*env)->NewStringUTF(env, cmd_output ? cmd_output : "");
+}
+
+/**
+ * Report whether the persistent PHP runtime is currently booted in this process.
+ * Process-wide signal (the C global is the single source of truth across the
+ * MainActivity thread and any WorkManager worker thread, which each hold their
+ * own PHPBridge instance). Lets the background path skip install-time artisan
+ * commands that the live app already ran at boot.
+ */
+JNIEXPORT jboolean JNICALL native_is_persistent_runtime_live(JNIEnv *env, jobject thiz) {
+    return persistent_initialized ? JNI_TRUE : JNI_FALSE;
 }
 
 JNIEXPORT jstring JNICALL native_get_laravel_root_path(JNIEnv *env, jobject thiz) {
@@ -1423,6 +1486,7 @@ static JNINativeMethod gMethods[] = {
         {"runArtisanCommand", "(Ljava/lang/String;)Ljava/lang/String;", (void *) native_run_artisan_command},
         {"getLaravelPublicPath", "()Ljava/lang/String;", (void *) native_get_laravel_public_path},
         {"getLaravelRootPath", "()Ljava/lang/String;", (void *) native_get_laravel_root_path},
+        {"nativeIsPersistentRuntimeLive", "()Z", (void *) native_is_persistent_runtime_live},
 
         // LaravelEnvironment
         {"nativeSetEnv", "(Ljava/lang/String;Ljava/lang/String;I)I", (void *) native_set_env},

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
@@ -949,9 +949,17 @@ openssl.cafile="${context.filesDir.absolutePath}/$CACERT_FILE"
             // do the extraction ourselves before the ephemeral runtime touches vendor/.
             val didExtract = extractLaravelBundle()
             setupEnvironment()
-            if (didExtract) {
+            // Only run install-time artisan commands when we actually extracted AND no
+            // persistent runtime is already live. In a warm process the live app booted
+            // by MainActivity already ran these at startup; re-running them here would
+            // route through the classic native_run_artisan_command path and, worse,
+            // re-migrate/relink under a running interpreter. (In DEBUG builds every
+            // extraction reports a change, so this guard fires on every background tick.)
+            if (didExtract && !phpBridge.nativeIsPersistentRuntimeLive()) {
                 Log.d(TAG, "📦 Running post-extraction artisan commands (background path)...")
                 runBaseArtisanCommands()
+            } else if (didExtract) {
+                Log.i(TAG, "⏭️ Skipping base artisan commands — persistent runtime already live (handled at app boot)")
             }
             Log.d(TAG, "Background environment initialized")
         } catch (e: Exception) {

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
@@ -60,6 +60,9 @@ class PHPBridge(private val context: Context) {
     external fun nativePersistentShutdown()
     external fun nativePersistentReboot(): Int
 
+    /** True when the persistent PHP runtime is booted anywhere in this process. */
+    external fun nativeIsPersistentRuntimeLive(): Boolean
+
     // Worker (background queue) JNI methods — runs on a separate thread with its own TSRM context
     external fun nativeWorkerBoot(bootstrapPath: String): Int
     external fun nativeWorkerArtisan(command: String): String


### PR DESCRIPTION
## Problem

A WorkManager scheduler job (`PHPSchedulerWorker`) firing **while the app process is alive** SIGSEGVs in `php_tsrm_startup_ex`. Tombstone:

```
PHPSchedulerWorker.doWork → LaravelEnvironment.initializeForBackground → runBaseArtisanCommands
  → native_run_artisan_command → php_embed_init → php_tsrm_startup_ex → ts_resource_ex
  → zend_ini_refresh_caches → OnUpdateBool → null-pointer deref
```

The worker's `initializeForBackground()` runs `runBaseArtisanCommands()` (`optimize:clear`, `storage:unlink`, `storage:link`, `migrate --force`) whenever `extractLaravelBundle()` reports a change. Those route through `native_run_artisan_command`, which called `php_embed_init()` **unconditionally**. When the persistent runtime and/or the database queue worker already hold a process-wide TSRM context, the second `php_embed_init()` re-runs `php_tsrm_startup_ex → zend_ini_refresh_caches → OnUpdateBool` against live globals and null-derefs. WorkManager then retry-loops it (~2 min apart). It only stops if both the persistent runtime and the queue worker are disabled.

In DEBUG builds (`NATIVEPHP_APP_VERSION="DEBUG"`) every extraction reports a change, so this fires on every background tick.

## Fix

1. **`native_run_artisan_command` is now TSRM-aware** (`php_bridge.c`), mirroring `ephemeral_embed_init`:
   - `wait_for_persistent_boot_settled()` to avoid racing a mid-boot persistent thread;
   - **hot path** (a runtime is live): `ts_resource(0)` + `php_embed_module.startup()` + `php_request_startup()`, teardown via `php_request_shutdown(NULL)` + `ts_free_thread()` — leaving the global TSRM and `php_initialized` intact;
   - **cold path** (no live runtime — install-time setup or a WorkManager cold start): unchanged full `php_embed_init()` / `safe_php_embed_shutdown()`.

   This is the root-cause fix and makes the classic artisan path safe for every caller.

2. **Warm-path guard** — new `nativeIsPersistentRuntimeLive()` JNI accessor (reads the process-wide `persistent_initialized`) lets `initializeForBackground()` skip the install-time artisan commands when a persistent runtime is already live — those were already run by MainActivity at app boot. The C fix remains the backstop if the guard ever races a mid-boot runtime.

## Files
- `resources/androidstudio/app/src/main/cpp/php_bridge.c` — hot/cold TSRM split + JNI accessor + registration
- `resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt` — `nativeIsPersistentRuntimeLive` binding
- `resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt` — guard in `initializeForBackground()`

## Testing
Verified on an Android emulator with a DEBUG build, `runtime_mode: persistent`, and `QUEUE_CONNECTION=database`: firing a scheduled background task while the app is open no longer SIGSEGVs; logcat shows `⏭️ Skipping base artisan commands — persistent runtime already live`. Reverting the fix reproduces `Fatal signal 11 (SIGSEGV)` in `php_tsrm_startup`.

iOS is unaffected — its scheduler already routes background work through `ephemeral_php_boot` / `ephemeral_embed_init`, which attaches to the existing TSRM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)