### PR TITLE
Fix: Remove stray tag

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -1,12 +1,14 @@
 ## NativePHP Mobile
 
-- NativePHP Mobile is a Laravel package for building native iOS and Android apps using PHP and native UI components. It runs a full PHP runtime directly on the device with SQLite — no web server required.
+- NativePHP Mobile is a Laravel package for building native iOS and Android apps using PHP and native UI components. It
+runs a full PHP runtime directly on the device with SQLite — no web server required.
 - Documentation: `https://nativephp.com/docs/mobile/3/**`
 - IMPORTANT: Always activate the `nativephp-mobile` skill every time you work on any NativePHP functionality.
 
 ### Build Commands — Tell the User, Never Run
 
-**CRITICAL: Never execute any of these commands yourself. Always instruct the user to run them manually in their terminal.**
+**CRITICAL: Never execute any of these commands yourself. Always instruct the user to run them manually in their
+terminal.**
 
 | Command | Purpose |
 |---|---|
@@ -18,7 +20,8 @@
 | `php artisan native:watch` | Hot reload (watch for file changes) |
 | `php artisan native:open` | Open project in Xcode or Android Studio |
 
-**Always ask which platform before giving any build or run command.** If the user hasn't specified iOS or Android, ask: "Which platform do you want to build/test on — iOS or Android?" Never assume a platform.
+**Always ask which platform before giving any build or run command.** If the user hasn't specified iOS or Android, ask:
+"Which platform do you want to build/test on — iOS or Android?" Never assume a platform.
 
-When the platform is confirmed, give the relevant command(s) above and tell the user to run it in their terminal. Do not run it yourself.
-</laravel-boost-guidelines>
+When the platform is confirmed, give the relevant command(s) above and tell the user to run it in their terminal. Do not
+run it yourself.


### PR DESCRIPTION
Removes `</laravel-boost-guidelines>` from Boost guideline which is causing duplicate entries on each `boost:update`.