### PR TITLE
Fix Jump hot reload ignoring nativephp.hot_reload.watch_paths (Issue #160)

### DIFF
--- a/resources/jump/websocket-server.php
+++ b/resources/jump/websocket-server.php
@@ -189,7 +189,8 @@ $wsWorker->onWorkerStart = function () use (&$deviceConnections, &$pendingCalls,
     // page props, scroll position). Only watch them when Vite isn't running.
     $lastModTimes = [];
     $lastReloadTime = 0;
-    $watchPaths = ['app', 'resources', 'routes', 'config'];
+    $watchPaths = jumpResolveWatchPaths();
+    jumpLog('File watcher paths: '.implode(', ', $watchPaths));
     $serverExtensions = ['php', 'blade.php'];
     $clientExtensions = ['js', 'jsx', 'ts', 'tsx', 'vue', 'css', 'scss', 'sass', 'less'];
 
@@ -250,6 +251,20 @@ $wsWorker->onWorkerStart = function () use (&$deviceConnections, &$pendingCalls,
 function jumpLog($message)
 {
     fwrite(STDERR, '['.date('H:i:s').'] [Jump] '.$message."\n");
+}
+
+function jumpResolveWatchPaths(): array
+{
+    $defaults = ['app', 'resources', 'routes', 'config'];
+    $fromEnv = getenv('JUMP_WATCH_PATHS');
+    if ($fromEnv !== false) {
+        $decoded = json_decode($fromEnv, true);
+        if (is_array($decoded) && $decoded !== []) {
+            return $decoded;
+        }
+    }
+
+    return $defaults;
 }
 
 /**

--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -359,6 +359,10 @@ class JumpCommand extends Command
         $logFile = $logDir.'/jump-bridge.log';
         @file_put_contents($logFile, '=== '.date('Y-m-d H:i:s')." bridge server starting (ws={$wsPort} tcp={$bridgePort} vite_proxy={$viteProxyPort}) ===\n", FILE_APPEND);
 
+        $watchPaths = config('nativephp.hot_reload.watch_paths', [
+            'app', 'resources', 'routes', 'config',
+        ]);
+
         // Run in background (not Workerman daemon mode — it breaks the event loop).
         if (PHP_OS_FAMILY === 'Windows') {
             // `&` is a command separator on Windows (not "background"), and the
@@ -390,10 +394,15 @@ class JumpCommand extends Command
             // mid-command (proc_close blocks waiting for the long-lived child).
             // On Ctrl+C the PHP process is hard-terminated by Windows and the
             // bridge stays running, matching Mac/Linux behaviour.
-            $this->bridgeProcess = @proc_open($cmd, $desc, $pipes, base_path(), null, ['bypass_shell' => true]);
+            $env = array_merge(getenv() ?: [], [
+                'JUMP_WATCH_PATHS' => json_encode($watchPaths),
+            ]);
+            $this->bridgeProcess = @proc_open($cmd, $desc, $pipes, base_path(), $env, ['bypass_shell' => true]);
         } else {
+            $envPrefix = 'JUMP_WATCH_PATHS='.escapeshellarg(json_encode($watchPaths));
             $cmd = sprintf(
-                '%s %s %s %d %d %d start >> %s 2>&1 &',
+                '%s %s %s %s %d %d %d start >> %s 2>&1 &',
+                $envPrefix,
                 escapeshellarg($phpBinary),
                 escapeshellarg($serverPath),
                 escapeshellarg(base_path()),


### PR DESCRIPTION
Fixes #160

## Summary
Jump's bridge file watcher used a hardcoded path list (`app`, `resources`, `routes`, `config`) and ignored `config/nativephp.php` → `hot_reload.watch_paths`.
`native:watch` already reads this config (see `WatchesAndroid` / `WatchesIos`), so custom directories like `modules/` reload on device builds but not via Jump.

## Changes
- Pass `nativephp.hot_reload.watch_paths` from `JumpCommand` to the bridge server via `JUMP_WATCH_PATHS`
- Read that env in `websocket-server.php` with the existing paths as fallback
- Log resolved watch paths on bridge startup for easier debugging
