### PR TITLE
Bug: show_navigation_icon: false is filtered out in TopBar::toNativeProps()

### DIFF
--- a/src/Edge/Components/Navigation/TopBar.php
+++ b/src/Edge/Components/Navigation/TopBar.php
@@ -28,6 +28,6 @@ class TopBar extends EdgeComponent
             'background_color' => $this->backgroundColor,
             'text_color' => $this->textColor,
             'elevation' => $this->elevation,
-        ], fn ($value) => $value !== null && $value !== false);
+        ], fn ($value) => $value !== null);
     }
 }


### PR DESCRIPTION
The toNativeProps() method in TopBar uses array_filter with fn ($value) => $value !== null && $value !== false, which silently drops boolean false values before sending props to the native layer. This
  makes it impossible to disable show_navigation_icon — the prop is never transmitted, so the native side always falls back to its default (showing the icon).

 Fix: align the filter with SideNavHeader, which correctly uses fn ($value) => $value !== null.

  // Before
  ], fn ($value) => $value !== null && $value !== false);

  // After
  ], fn ($value) => $value !== null);

  Reproducible with:

  <native:top-bar title="Test" :show-navigation-icon="false" />
  {{-- hamburger still visible despite false --}}