### PR TITLE
Substitute ${ENV_VAR} placeholders in Android plugin meta-data

### DIFF
--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -496,6 +496,9 @@ class AndroidPluginCompiler
         // Handle different value types
         if (is_bool($value)) {
             $value = $value ? 'true' : 'false';
+        } elseif (is_string($value)) {
+            // Substitute ${ENV_VAR} placeholders, mirroring iOS info_plist handling
+            $value = $this->substituteEnvPlaceholders($value);
         }
 
         return "<meta-data android:name=\"{$name}\" android:value=\"{$value}\" />";
@@ -648,6 +651,9 @@ class AndroidPluginCompiler
             } elseif ($value !== null) {
                 if (is_bool($value)) {
                     $value = $value ? 'true' : 'false';
+                } elseif (is_string($value)) {
+                    // Substitute ${ENV_VAR} placeholders, mirroring iOS info_plist handling
+                    $value = $this->substituteEnvPlaceholders($value);
                 }
                 $xml .= "            <meta-data android:name=\"{$name}\" android:value=\"{$value}\" />\n";
             }

--- a/tests/Feature/Plugins/AndroidCompilerTest.php
+++ b/tests/Feature/Plugins/AndroidCompilerTest.php
@@ -696,6 +696,90 @@ object TestFunctions {
     /**
      * @test
      *
+     * Application-level meta-data values should have ${ENV_VAR} placeholders
+     * substituted from the environment, matching iOS info_plist handling.
+     */
+    public function it_substitutes_env_placeholders_in_application_meta_data(): void
+    {
+        putenv('NATIVEPHP_TEST_META_KEY=resolved-secret');
+        $_ENV['NATIVEPHP_TEST_META_KEY'] = 'resolved-secret';
+
+        try {
+            $plugin = $this->createTestPlugin([
+                'android' => [
+                    'permissions' => [],
+                    'dependencies' => [],
+                    'meta_data' => [
+                        ['name' => 'com.example.API_KEY', 'value' => '${NATIVEPHP_TEST_META_KEY}'],
+                    ],
+                ],
+            ]);
+
+            $this->mockRegistry
+                ->shouldReceive('all')
+                ->andReturn(collect([$plugin]));
+
+            $this->compiler->compile();
+
+            $manifestPath = $this->testBasePath.'/android/app/src/main/AndroidManifest.xml';
+            $content = $this->files->get($manifestPath);
+
+            $this->assertStringContainsString('<meta-data android:name="com.example.API_KEY" android:value="resolved-secret" />', $content);
+            $this->assertStringNotContainsString('${NATIVEPHP_TEST_META_KEY}', $content);
+        } finally {
+            putenv('NATIVEPHP_TEST_META_KEY');
+            unset($_ENV['NATIVEPHP_TEST_META_KEY']);
+        }
+    }
+
+    /**
+     * @test
+     *
+     * Component-level (service) meta-data values should also have ${ENV_VAR}
+     * placeholders substituted from the environment.
+     */
+    public function it_substitutes_env_placeholders_in_service_meta_data(): void
+    {
+        putenv('NATIVEPHP_TEST_META_KEY=resolved-secret');
+        $_ENV['NATIVEPHP_TEST_META_KEY'] = 'resolved-secret';
+
+        try {
+            $plugin = $this->createTestPlugin([
+                'android' => [
+                    'permissions' => [],
+                    'dependencies' => [],
+                    'services' => [
+                        [
+                            'name' => 'com.example.MyService',
+                            'exported' => false,
+                            'meta_data' => [
+                                ['name' => 'com.example.API_KEY', 'value' => '${NATIVEPHP_TEST_META_KEY}'],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+
+            $this->mockRegistry
+                ->shouldReceive('all')
+                ->andReturn(collect([$plugin]));
+
+            $this->compiler->compile();
+
+            $manifestPath = $this->testBasePath.'/android/app/src/main/AndroidManifest.xml';
+            $content = $this->files->get($manifestPath);
+
+            $this->assertStringContainsString('<meta-data android:name="com.example.API_KEY" android:value="resolved-secret" />', $content);
+            $this->assertStringNotContainsString('${NATIVEPHP_TEST_META_KEY}', $content);
+        } finally {
+            putenv('NATIVEPHP_TEST_META_KEY');
+            unset($_ENV['NATIVEPHP_TEST_META_KEY']);
+        }
+    }
+
+    /**
+     * @test
+     *
      * Should add meta-data entries inside a service component using resource attribute.
      */
     public function it_adds_meta_data_with_resource_inside_service(): void


### PR DESCRIPTION
## Problem

The iOS compiler resolves `${ENV_VAR}` placeholders in `info_plist` values (`IOSPluginCompiler::substituteEnvPlaceholders`), but the Android compiler writes `meta_data` values verbatim. A plugin declaring:

```json
"meta_data": [{ "name": "com.example.API_KEY", "value": "${SOME_KEY}" }]
```

ships the literal `${SOME_KEY}` into `AndroidManifest.xml`, where the manifest merger then fails the build with:

```
Attribute meta-data#com.example.API_KEY@value requires a placeholder
substitution but no value for <SOME_KEY> is provided.
```

## Fix

Resolve `${ENV_VAR}` placeholders for both application-level (`buildMetaDataEntry`) and component-level (`buildComponentMetaData`) string meta-data values, mirroring the existing iOS `info_plist` behaviour. Unset variables are left as-is, matching `substituteEnvPlaceholders`' documented "validation will catch this" contract.

## Tests

Adds two tests covering application- and service-level meta-data substitution. The full `AndroidCompilerTest` suite (33 tests) passes.