### PR TITLE
fix / side nav header status bar inset

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/NativeSideNav.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/NativeSideNav.kt
@@ -90,7 +90,10 @@ fun NativeSideDrawer(
         gesturesEnabled = hasData && gesturesEnabled,  // Controlled via Laravel
         drawerContent = {
             ModalDrawerSheet {
-                Column(modifier = Modifier.fillMaxHeight()) {
+                // The activity is edge-to-edge (setDecorFitsSystemWindows(false)),
+                // so without statusBarsPadding the drawer content — including the
+                // pinned header — is drawn underneath the status bar and clipped.
+                Column(modifier = Modifier.fillMaxHeight().statusBarsPadding()) {
                     // Render pinned headers at the top (non-scrollable)
                     pinnedHeaders.forEach { child ->
                         if (child.type == "side_nav_header") {

--- a/resources/xcode/NativePHP/NativeUI/NativeSideNav.swift
+++ b/resources/xcode/NativePHP/NativeUI/NativeSideNav.swift
@@ -147,6 +147,11 @@ struct NativeSideNavigation<Content: View>: View {
                 if uiState.hasSideNav() {
                     drawerContent
                         .frame(width: drawerWidth)
+                        // The drawer renders edge-to-edge; pad the top by the
+                        // safe-area inset so the header clears the status bar /
+                        // notch instead of being drawn underneath it. Placed
+                        // before .background so the drawer fill still covers it.
+                        .padding(.top, geometry.safeAreaInsets.top)
                         .background(Color(.systemBackground))
                         .offset(x: drawerXOffset)
                         .zIndex(2)


### PR DESCRIPTION
Side-nav drawer header is clipped under the status bar — the drawer renders edge-to-edge but its content doesn't consume the top safe-area inset