### PR TITLE
Restore Android SDK versions config items

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -220,6 +220,9 @@ return [
         | target_sdk:  The SDK version your app is designed and tested for
         |
         */
+        'compile_sdk'      => env('NATIVEPHP_ANDROID_COMPILE_SDK', 36),
+        'min_sdk'          => env('NATIVEPHP_ANDROID_MIN_SDK', 33),
+        'target_sdk'       => env('NATIVEPHP_ANDROID_TARGET_SDK', 36),
 
         /*
         |--------------------------------------------------------------------------

--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -220,9 +220,9 @@ return [
         | target_sdk:  The SDK version your app is designed and tested for
         |
         */
-        'compile_sdk'      => env('NATIVEPHP_ANDROID_COMPILE_SDK', 36),
-        'min_sdk'          => env('NATIVEPHP_ANDROID_MIN_SDK', 33),
-        'target_sdk'       => env('NATIVEPHP_ANDROID_TARGET_SDK', 36),
+        'compile_sdk' => env('NATIVEPHP_ANDROID_COMPILE_SDK', 36),
+        'min_sdk' => env('NATIVEPHP_ANDROID_MIN_SDK', 33),
+        'target_sdk' => env('NATIVEPHP_ANDROID_TARGET_SDK', 36),
 
         /*
         |--------------------------------------------------------------------------


### PR DESCRIPTION
The config had a documentation comment about the Android SDK versions, but the actual items were missing.

The config values were still being used in the codebase, but always fell back on defaults. Project specific overrides in `.env` couldn't be applied either.

This PR restores the config keys and values.