### PR TITLE
fix(android): generate APP_KEY locally instead of booting PHP

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
@@ -881,18 +881,17 @@ openssl.cafile="${context.filesDir.absolutePath}/$CACERT_FILE"
         }
     }
 
+    // APP_KEY is just 32 random bytes, base64-encoded — generate it locally
+    // instead of booting PHP just to run key:generate (matches iOS).
     private fun generateAndSaveAppKey(file: File): String {
-        val result = phpBridge.runArtisanCommand("key:generate --show")
-        var generatedKey = result.trim()
-
-        if (!generatedKey.startsWith("base64:")) {
-            generatedKey = "base64:3a3I14QgnAhKUHROy1bn6A/UpTeELNI2flsl+Ud0bF4="
-        }
+        val keyBytes = ByteArray(32)
+        java.security.SecureRandom().nextBytes(keyBytes)
+        val generatedKey = "base64:" + android.util.Base64.encodeToString(keyBytes, android.util.Base64.NO_WRAP)
 
         file.parentFile?.mkdirs()
         file.writeText(generatedKey)
 
-        Log.d(TAG, "🔐 Generated and stored new APP_KEY: $generatedKey")
+        Log.d(TAG, "🔐 Generated and stored new APP_KEY locally (no PHP boot)")
         return generatedKey
     }
 


### PR DESCRIPTION
On Android, `generateAndSaveAppKey()` calls `phpBridge.runArtisanCommand("key:generate --show")` on fresh install / whenever the APP_KEY file doesn't exist yet — a full `php_embed_init`/`shutdown` cycle purely to produce 32 random bytes. This runs on top of the batched extraction artisan boot and the persistent runtime boot, so cold start on a fresh install ends up doing three separate PHP interpreter boots before the WebView ever loads a URL.

Laravel's APP_KEY format is just 32 random bytes, base64-encoded with a `base64:` prefix — no PHP needed to produce that. This PR generates it locally with `SecureRandom` instead, mirroring the iOS side (`getOrGenerateAppKey()` in `NativePHPApp.swift`), which already derives its key via `SecRandomCopyBytes` without booting PHP at all.

### Changes
- Replace the `key:generate --show` artisan call with local `SecureRandom` + `Base64` generation in `LaravelEnvironment.generateAndSaveAppKey()`
- No change to the APP_KEY format or how it's consumed downstream — only where the bytes come from

### Validation
- Verified on Android emulator: fresh install still produces a valid `base64:` APP_KEY, app boots and functions normally
- Confirmed measurable reduction in cold-start time on fresh install (one fewer PHP interpreter boot cycle)