### PR TITLE
Fix fresh-install build failure with zero plugins

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootStackRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootStackRenderer.kt
@@ -17,13 +17,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.MaterialTheme
@@ -42,9 +39,12 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.nativephp.mobile.ui.MaterialIcon
 
@@ -223,7 +223,13 @@ fun NativeRootStackRenderer(node: NativeUINode, modifier: Modifier = Modifier) {
                     NativeElementBridge.sendSystemBackEvent()
                 }
             }) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                // Font glyphs don't auto-mirror like AutoMirrored ImageVectors; flip for RTL.
+                val rtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+                MaterialIcon(
+                    name = "arrow_back",
+                    contentDescription = "Back",
+                    modifier = if (rtl) Modifier.scale(scaleX = -1f, scaleY = 1f) else Modifier
+                )
             }
         }
     }

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootTabsRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootTabsRenderer.kt
@@ -26,13 +26,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -55,11 +52,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.nativephp.mobile.ui.MaterialIcon
@@ -220,7 +220,13 @@ fun NativeRootTabsRenderer(node: NativeUINode, modifier: Modifier = Modifier) {
                     navigationIcon = {
                         if (navBack) {
                             IconButton(onClick = { NativeElementBridge.sendSystemBackEvent() }) {
-                                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                                // Font glyphs don't auto-mirror like AutoMirrored ImageVectors; flip for RTL.
+                                val rtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+                                MaterialIcon(
+                                    name = "arrow_back",
+                                    contentDescription = "Back",
+                                    modifier = if (rtl) Modifier.scale(scaleX = -1f, scaleY = 1f) else Modifier
+                                )
                             }
                         }
                     },

--- a/resources/xcode/NativePHP/Bridge/Plugins/PluginRendererRegistration.swift
+++ b/resources/xcode/NativePHP/Bridge/Plugins/PluginRendererRegistration.swift
@@ -1,8 +1,8 @@
-package com.nativephp.mobile.bridge.plugins
+import Foundation
 
 // AUTO-GENERATED FILE - DO NOT EDIT
 // No NativePHP UI plugins installed
 
-fun registerPluginRenderers() {
+func registerPluginRenderers() {
     // No UI plugin renderers to register
 }

--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -1206,9 +1206,8 @@ class BuildIosAppCommand extends Command
     {
         $plugins = app(PluginRegistry::class);
 
-        if ($plugins->count() === 0) {
-            return true;
-        }
+        // Always compile, even with zero plugins — the compiler regenerates the
+        // registration files with empty stubs so stale plugin references never build.
 
         // Validate plugin secrets before compilation
         $secretsValidator = new PluginSecretsValidator($plugins->all());

--- a/src/Traits/RunsAndroid.php
+++ b/src/Traits/RunsAndroid.php
@@ -973,9 +973,8 @@ XML;
     {
         $plugins = app(PluginRegistry::class);
 
-        if ($plugins->count() === 0) {
-            return true;
-        }
+        // Always compile, even with zero plugins — the compiler regenerates the
+        // registration files with empty stubs so stale plugin references never build.
 
         // Validate plugin secrets before compilation
         $secretsValidator = new PluginSecretsValidator($plugins->all());


### PR DESCRIPTION
Fixes #178

Fresh `4.0.0-rc.1` installs with no plugins failed the Android build with dozens of unresolved renderer references, and had the same failure waiting on iOS.

## Root cause
- The Android template shipped a dev-generated `PluginRendererRegistration.kt` importing `com.nativephp.plugins.native_ui.ui.*` instead of the empty placeholder.
- `compileAndroidPlugins()` / `compileIosPlugins()` early-returned when zero plugins were installed, so the compilers never regenerated the file with the empty stub — the stale artifact compiled as-is.
- The Xcode template had no `PluginRendererRegistration.swift` at all, while `BridgeFunctionRegistration.swift` calls `registerPluginRenderers()` unconditionally.
- The core root-chrome renderers used `androidx.compose.material.icons`, a dependency only supplied via native-ui's gradle deps.

## Changes
- Ship the empty `PluginRendererRegistration` placeholders in both templates.
- Remove the zero-plugin early returns — `compile()` already generates empty stubs for that case, so every build now self-heals stale registrations.
- Render the root-chrome back arrow through the bundled Material icon font (`MaterialIcon("arrow_back")`) with a manual RTL flip, removing the material-icons dependency from core entirely.

## Testing
- Verified in a fresh starter app with zero plugins (`~/Herd/pluginlesstest`): both platforms build and serve.
- Pest (571 passing), Pint, and PHPStan all clean relative to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)