### PR TITLE
Fix navigation transition flicker and rebuild exit animations (two-layer swap)

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeUIRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeUIRenderer.kt
@@ -2,6 +2,7 @@ package com.nativephp.mobile.ui.nativerender
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -142,7 +143,15 @@ internal fun transitionFor(type: String?): ContentTransform {
         "slide_from_bottom" -> slideInVertically(intSpec) { it } togetherWith
             slideOutVertically(intSpec) { -it }
         "fade" -> fadeIn(spec) togetherWith fadeOut(spec)
-        "fade_from_bottom" -> (slideInVertically(intSpec) { it } + fadeIn(spec)) togetherWith fadeOut(spec)
+        // Short upward drift (1/8 screen height) + fade over the HELD
+        // outgoing screen — the conventional "fade from bottom" (React
+        // Navigation's fadeFromBottom, classic Android activity open).
+        // Previously a full-height slide + fade, which was visually
+        // indistinguishable from slide_from_bottom (the opaque incoming
+        // screen covers everything mid-slide anyway). Matches iOS's
+        // fixed-drift + `.identity`-removal mapping in ScreenTransitions.swift.
+        "fade_from_bottom" -> (slideInVertically(intSpec) { it / 8 } + fadeIn(spec)) togetherWith
+            ExitTransition.KeepUntilTransitionsFinished
         // Scale the incoming screen in from 50% while it stays fully opaque
         // (no fadeIn) so the whole zoom is visible; the outgoing screen fades
         // out beneath it. Combining scaleIn with fadeIn previously hid the

--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -24,18 +24,43 @@ struct ContentView: View {
         // WebView's `SharedWebView.shared` cache keeps that fast.
         Group {
             if nativeUIBridge.isActive, let tree = nativeUIBridge.currentTree {
-                NativeTreeRenderer(tree: tree)
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color(.systemBackground))
-                    .id(nativeUIBridge.screenKey)
-                    .transition(nativeScreenTransition(for: nativeUIBridge.pendingTransition))
-                    // Each new screen sits above the previous one during the
-                    // `.id`-driven swap. Without this the two full-screen,
-                    // opaque trees share the same z-position, so an `.opacity`
-                    // (fade) cross-dissolve has no defined front/back and reads
-                    // as an instant cut. Slides are unaffected (incoming on top
-                    // is the correct push ordering).
-                    .zIndex(Double(nativeUIBridge.screenKey))
+                // Two-layer swap. Screens are keyed by their screenKey in a
+                // ForEach so a screen keeps its IDENTITY when it changes
+                // role from "current" to "outgoing" — no removal transition
+                // fires at swap time and its view state survives. The
+                // incoming screen (new key) animates in via its insertion
+                // transition — the reliable half of SwiftUI's transition
+                // system — while the held outgoing screen's exit (parallax
+                // drift + dim, or static hold) is driven by ordinary
+                // animated modifiers in `ScreenExitModifier`. The outgoing
+                // entry is dropped by the bridge after the transition,
+                // invisibly beneath the opaque new screen.
+                ZStack {
+                    ForEach(activeScreens(currentTree: tree)) { screen in
+                        NativeTreeRenderer(tree: screen.tree)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .background(Color(.systemBackground))
+                            .modifier(ScreenExitModifier(
+                                isExiting: screen.isOutgoing,
+                                transition: nativeUIBridge.outgoingScreen?.transition
+                            ))
+                            // Parallax depth cue that survives dark mode:
+                            // the INCOMING screen casts a soft shadow onto
+                            // the outgoing one at its leading edge (the
+                            // scrim alone is black-on-black there). Active
+                            // only during the parallax transition window.
+                            .shadow(
+                                color: .black.opacity(incomingShadowOpacity(for: screen)),
+                                radius: 18,
+                                x: -10
+                            )
+                            .transition(nativeScreenTransition(for: nativeUIBridge.pendingTransition))
+                            // Each new screen sits above the previous one
+                            // (keys increment), so slides cover in push
+                            // order and a fade has a defined front/back.
+                            .zIndex(Double(screen.id))
+                    }
+                }
             } else {
                 NativeSideNavigation(onNavigate: handleNavigation) {
                     WebViewLayoutContainer(onTabSelected: handleNavigation)
@@ -60,7 +85,13 @@ struct ContentView: View {
                     .zIndex(1)
             }
         }
-        .animation(.easeInOut(duration: 0.25), value: nativeUIBridge.screenKey)
+        // Per-transition swap animation — this ambient animation is what
+        // actually paces `.move` insertions (attached transition animations
+        // are ignored for `.move`; see nativeScreenSwapAnimation).
+        .animation(
+            nativeScreenSwapAnimation(for: nativeUIBridge.pendingTransition),
+            value: nativeUIBridge.screenKey
+        )
         .animation(.easeInOut(duration: 0.2), value: nativeUIBridge.isActive)
         .animation(.easeInOut(duration: 0.2), value: nativeUIBridge.isReloading)
         // Global 3-finger swipe-right escape hatch (attaches a recognizer to the
@@ -75,6 +106,40 @@ struct ContentView: View {
             let mode = newScheme == .dark ? "dark" : "light"
             LaravelBridge.shared.send?("Native\\Mobile\\Events\\System\\AppearanceChanged", ["mode": mode])
         }
+    }
+
+    /// One layer of the two-layer native screen swap. `id` is the screen's
+    /// stable screenKey — ForEach identity, so a screen moving from the
+    /// "current" role to the "outgoing" role is the SAME view to SwiftUI.
+    private struct ActiveNativeScreen: Identifiable {
+        let id: Int
+        let tree: NativeUITree
+        let isOutgoing: Bool
+    }
+
+    /// Outgoing (held) screen first, current screen last. The outgoing
+    /// entry is present only during a transition window; the bridge clears
+    /// it ~0.6s after the swap.
+    private func activeScreens(currentTree: NativeUITree) -> [ActiveNativeScreen] {
+        var screens: [ActiveNativeScreen] = []
+        if let out = nativeUIBridge.outgoingScreen, out.key != nativeUIBridge.screenKey {
+            screens.append(ActiveNativeScreen(id: out.key, tree: out.tree, isOutgoing: true))
+        }
+        screens.append(ActiveNativeScreen(
+            id: nativeUIBridge.screenKey,
+            tree: currentTree,
+            isOutgoing: false
+        ))
+        return screens
+    }
+
+    /// Shadow the incoming screen casts on the held outgoing screen during
+    /// a parallax_push — zero (no shadow layer) at all other times.
+    private func incomingShadowOpacity(for screen: ActiveNativeScreen) -> Double {
+        guard !screen.isOutgoing,
+              let out = nativeUIBridge.outgoingScreen,
+              out.transition == "parallax_push" else { return 0 }
+        return 0.45
     }
 
     /// Handle navigation from any UI component

--- a/resources/xcode/NativePHP/NativeRender/NativeElementBridge.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeElementBridge.swift
@@ -452,33 +452,48 @@ final class NativeElementBridge {
                 let wasActive = bridge.isActive
                 bridge.isActive = true
 
-                // Router-level swap between two native screens. The OUTGOING
-                // screen must commit the transition staged by
-                // `NativeUI.Transition.Set` (pendingTransition) for its
-                // REMOVAL before we bump screenKey. If the stage + the
-                // screenKey bump land in the same SwiftUI transaction, SwiftUI
-                // removes the old screen using its LAST committed transition —
-                // the PREVIOUS nav's — so e.g. a fade nav shows the old screen
-                // sliding out (its earlier slide-in) while the new one fades
-                // in, and a parallax nav's outgoing screen never drifts.
-                // Deferring the swap one runloop lets SwiftUI render the old
-                // screen once with the new pendingTransition, so its exit
-                // matches the entrance.
-                if isNav && !nativeChromeContinuation && wasActive {
-                    DispatchQueue.main.async {
-                        bridge.screenKey += 1
-                        bridge.currentTree = finalTree
-                        if bridge.isReloading { bridge.isReloading = false }
+                // Router-level swap between two native screens: two-layer
+                // swap. The old screen is NOT removed — it's reclassified as
+                // `outgoingScreen` so ContentView keeps it mounted (same
+                // ForEach identity, so no removal transition fires and view
+                // state survives) beneath the incoming screen, and drives
+                // its exit with plain animated modifiers. The incoming
+                // screen gets a fresh key and animates in via its insertion
+                // transition — the ONE side of SwiftUI's transition system
+                // that works reliably (removal transitions are captured at
+                // insertion and ignore later updates; AnyTransition.modifier
+                // removals don't interpolate — both verified on-device).
+                // The outgoing entry is dropped after the transition window,
+                // invisibly beneath the opaque new screen. Staging order is
+                // guaranteed: `NativeUI.Transition.Set` runs via main.sync
+                // before PHP publishes the tree.
+                if isNav && !nativeChromeContinuation {
+                    if wasActive, let oldTree = bridge.currentTree {
+                        let outgoingKey = bridge.screenKey
+                        bridge.outgoingScreen = NativeUIBridge.OutgoingScreen(
+                            tree: oldTree,
+                            key: outgoingKey,
+                            transition: bridge.pendingTransition
+                        )
+                        // Drop the held screen once the transition is over
+                        // (longest is parallax_push at ~0.7s). Key-guarded
+                        // so a rapid follow-up navigation (which overwrites
+                        // `outgoingScreen`) isn't clobbered by this earlier
+                        // cleanup firing late.
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                            if bridge.outgoingScreen?.key == outgoingKey {
+                                bridge.outgoingScreen = nil
+                            }
+                        }
                     }
-                } else {
-                    if isNav && !nativeChromeContinuation { bridge.screenKey += 1 }
-                    bridge.currentTree = finalTree
-                    // First publish after a hot-reload dismisses the
-                    // "Reloading…" pill. Set by `ContentView.reloadWebView`
-                    // at the start of the reboot; cleared here when the
-                    // fresh tree from the rebooted PHP runtime lands.
-                    if bridge.isReloading { bridge.isReloading = false }
+                    bridge.screenKey += 1
                 }
+                bridge.currentTree = finalTree
+                // First publish after a hot-reload dismisses the
+                // "Reloading…" pill. Set by `ContentView.reloadWebView`
+                // at the start of the reboot; cleared here when the
+                // fresh tree from the rebooted PHP runtime lands.
+                if bridge.isReloading { bridge.isReloading = false }
             }
         }
     }

--- a/resources/xcode/NativePHP/NativeRender/NativeUIBridge.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeUIBridge.swift
@@ -24,6 +24,28 @@ final class NativeUIBridge: ObservableObject {
     /// Pending transition type
     @Published var pendingTransition: String?
 
+    /// The screen being navigated away from, kept mounted (same identity)
+    /// beneath the incoming screen for the duration of the transition.
+    ///
+    /// This is the exit half of the two-layer swap: SwiftUI's transition
+    /// system reliably animates INSERTIONS but not removals (removal
+    /// transitions are captured at insertion and ignore later updates, and
+    /// AnyTransition.modifier-based removals don't interpolate here —
+    /// both verified frame-by-frame on-device). So the outgoing screen is
+    /// never "removed" at swap time: ContentView keeps rendering it under
+    /// the new screen and drives its exit (parallax drift + dim, or a
+    /// static hold) with ordinary animated modifiers, then the bridge
+    /// drops it ~0.6s later — invisibly, beneath the opaque new screen.
+    struct OutgoingScreen {
+        let tree: NativeUITree
+        let key: Int
+        /// The transition staged for the navigation that displaced this
+        /// screen — drives the exit effect (e.g. parallax drift).
+        let transition: String?
+    }
+
+    @Published var outgoingScreen: OutgoingScreen?
+
     /// Flag set by UI.SetTransition bridge function
     var navigationPending = false
 

--- a/resources/xcode/NativePHP/NativeRender/NavigationCoordinator.swift
+++ b/resources/xcode/NativePHP/NativeRender/NavigationCoordinator.swift
@@ -104,7 +104,7 @@ final class NavigationCoordinator: ObservableObject {
                 path = []
             }
             phpSnapshot = path
-            evictStaleCacheEntries()
+            scheduleEviction()
             return
         }
 
@@ -119,7 +119,7 @@ final class NavigationCoordinator: ObservableObject {
             let nextPath = Array(path.prefix(idx + 1))
             phpSnapshot = nextPath
             path = nextPath
-            evictStaleCacheEntries()
+            scheduleEviction()
             return
         }
 
@@ -127,7 +127,7 @@ final class NavigationCoordinator: ObservableObject {
         let nextPath = path + [uri]
         phpSnapshot = nextPath
         path = nextPath
-        evictStaleCacheEntries()
+        scheduleEviction()
     }
 
     /// Called from the renderer's `.onChange(of: path)`. If the new path
@@ -152,6 +152,22 @@ final class NavigationCoordinator: ObservableObject {
             }
         }
         phpSnapshot = newPath
+    }
+
+    /// Evict AFTER the transition window, never synchronously. PHP
+    /// republishes the destination screen within ~10ms of a back event —
+    /// far inside the ~350ms pop animation — so evicting in `receive()`
+    /// yanks the popping screen's cache entry mid-flight and its
+    /// destination re-resolves to `Color.clear`: the screen blanks
+    /// instantly (flashing the level below) before the animation has
+    /// visibly run. Eviction is only memory hygiene; delaying it past any
+    /// possible animation costs nothing. `evictStaleCacheEntries()`
+    /// recomputes liveness from the path at fire time, so overlapping
+    /// schedules are harmless.
+    private func scheduleEviction() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
+            self?.evictStaleCacheEntries()
+        }
     }
 
     /// Drop cache entries whose URI is no longer on the stack. Keeps

--- a/resources/xcode/NativePHP/NativeRender/PerTabNavigationCoordinator.swift
+++ b/resources/xcode/NativePHP/NativeRender/PerTabNavigationCoordinator.swift
@@ -67,7 +67,7 @@ final class PerTabNavigationCoordinator: ObservableObject {
                 path = []
             }
             phpSnapshot = path
-            evictStaleCacheEntries()
+            scheduleEviction()
             return
         }
 
@@ -82,7 +82,7 @@ final class PerTabNavigationCoordinator: ObservableObject {
             let nextPath = Array(path.prefix(idx + 1))
             phpSnapshot = nextPath
             path = nextPath
-            evictStaleCacheEntries()
+            scheduleEviction()
             return
         }
 
@@ -90,7 +90,7 @@ final class PerTabNavigationCoordinator: ObservableObject {
         let nextPath = path + [uri]
         phpSnapshot = nextPath
         path = nextPath
-        evictStaleCacheEntries()
+        scheduleEviction()
     }
 
     /// Called from the renderer's `.onChange(of: coord.path)` for this
@@ -109,6 +109,18 @@ final class PerTabNavigationCoordinator: ObservableObject {
             }
         }
         phpSnapshot = newPath
+    }
+
+    /// Evict AFTER the transition window, never synchronously — same
+    /// rationale as `NavigationCoordinator.scheduleEviction()`: PHP
+    /// republishes within ~10ms of a back event, so a synchronous evict
+    /// blanks the popping screen to `Color.clear` mid-animation and
+    /// flashes the level below. Liveness is recomputed at fire time, so
+    /// overlapping schedules are harmless.
+    private func scheduleEviction() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) { [weak self] in
+            self?.evictStaleCacheEntries()
+        }
     }
 
     /// Drop cache entries whose URI is no longer on this tab's stack.

--- a/resources/xcode/NativePHP/NativeRender/ScreenTransitions.swift
+++ b/resources/xcode/NativePHP/NativeRender/ScreenTransitions.swift
@@ -1,5 +1,91 @@
 import SwiftUI
 
+/// Exit effect for the outgoing screen of a router-level swap.
+///
+/// ContentView applies this to the screen held in
+/// `NativeUIBridge.outgoingScreen` (the two-layer swap — see that property's
+/// doc). Because the outgoing screen keeps its identity and stays mounted,
+/// its exit is driven by ORDINARY animated modifiers, which SwiftUI animates
+/// reliably — unlike removal transitions, which are captured at insertion
+/// and ignore later updates, and unlike AnyTransition.modifier removals,
+/// which don't interpolate in this setup (both verified frame-by-frame
+/// on-device).
+///
+/// Effects by staged transition:
+///   - `parallax_push` — the outgoing screen drifts ~1/3 screen-width to
+///     the leading edge and dims under a darkening scrim while the incoming
+///     screen slides over it (UIKit's native push look).
+///   - everything else — static hold: the old screen simply stays put,
+///     fully opaque, until the incoming screen has covered it.
+struct ScreenExitModifier: ViewModifier {
+    /// Flips false → true (same view identity) when the screen becomes
+    /// the outgoing layer — the value change is what animates the effect.
+    let isExiting: Bool
+    /// The transition staged for the navigation that displaced this screen.
+    let transition: String?
+
+    private var isParallax: Bool { isExiting && transition == "parallax_push" }
+
+    func body(content: Content) -> some View {
+        // "Old drifts BACK underneath": the outgoing screen recedes in
+        // depth — scales down, drifts toward the leading edge, dims, and
+        // separates from the background with a shadow — while the incoming
+        // screen sweeps over it. UIKit's flat 1/3-width drift alone is
+        // nearly imperceptible (verified frame-by-frame: the drift ran on
+        // schedule and still read as a plain slide), so this uses the
+        // Material-style recede, which stays legible in dark mode too.
+        //
+        // `.easeOut` (front-loaded), unlike the incoming screen's
+        // `.easeInOut`: the recede spends its motion budget EARLY, while
+        // the old screen is still mostly uncovered — by the halfway point
+        // of an easeInOut scrim the screen was already 90% hidden.
+        content
+            .scaleEffect(isParallax ? 0.88 : 1.0)
+            .offset(x: isParallax ? -120 : 0)
+            .overlay(
+                Color.black
+                    .opacity(isParallax ? 0.40 : 0)
+                    .ignoresSafeArea()
+                    .allowsHitTesting(false)
+            )
+            .shadow(
+                color: .black.opacity(isParallax ? 0.35 : 0),
+                radius: 24
+            )
+            // Starts IMMEDIATELY on the swap, while the incoming screen's
+            // insertion is delayed (see the parallax_push case) — the old
+            // screen visibly drops back FIRST, then the new one sweeps
+            // over it. Without that beat of sequencing the recede happens
+            // entirely underneath the cover and reads as a plain slide.
+            .animation(.easeOut(duration: 0.50), value: isExiting)
+    }
+}
+
+/// The TRANSACTION animation for a router-level screen swap — passed to
+/// ContentView's ambient `.animation(_:value: screenKey)`.
+///
+/// This function exists because `.animation(_:)` attached to an
+/// `AnyTransition` is IGNORED for `.move` insertions (measured on-device:
+/// a `.move` with an attached 0.55s+0.15s-delay animation swept in ~150ms
+/// — the ambient transaction animation's pace). The ambient animation is
+/// what actually drives `.move`, so it must be computed per staged
+/// transition rather than hardcoded. Effects with scoped animations
+/// (`ScreenExitModifier`'s recede, `value: isExiting`) are unaffected.
+func nativeScreenSwapAnimation(for type: String?) -> Animation {
+    switch type {
+    case "parallax_push":
+        // Delayed sweep: the outgoing screen's recede (starts immediately,
+        // scoped animation) gets a visible beat before the cover moves.
+        return .easeInOut(duration: 0.40).delay(0.10)
+    case "none":
+        return .linear(duration: 0)
+    case "fade", "fade_from_bottom", "scale_from_center":
+        return .easeInOut(duration: 0.3)
+    default:
+        return .easeInOut(duration: 0.25)
+    }
+}
+
 /// Map a PHP-side `Edge\Transition` value to a SwiftUI `AnyTransition`.
 ///
 /// Screen transitions are core navigation behavior, so the mapper lives in
@@ -9,60 +95,85 @@ import SwiftUI
 /// `NativeUI.Transition.Set`); it does not own the mapping. This mirrors the
 /// Android side, where `transitionFor(_:)` already lives in core.
 ///
+/// **Insertion-only.** These transitions animate the INCOMING screen; the
+/// outgoing screen's exit is handled by `ScreenExitModifier` on the held
+/// `outgoingScreen` layer, never by a removal transition (see above). Every
+/// removal here is `.identity`: the only view removal that ever happens is
+/// the held outgoing layer being dropped AFTER the transition, fully covered
+/// by the opaque new screen — so the unclocked instant removal is invisible.
+///
+/// Non-`.move` insertions (opacity / scale / offset) carry their own
+/// `.animation(...)` — the ambient `.animation(value: screenKey)` in
+/// ContentView only drives `.move`.
+///
 /// Recognised: slide_from_right, slide_from_left, slide_from_bottom, fade,
 /// fade_from_bottom, scale_from_center, parallax_push, none. Unknown values
-/// fall back to opacity.
+/// fall back to fade.
 func nativeScreenTransition(for type: String?) -> AnyTransition {
     switch type {
     case "slide_from_right":
         return .asymmetric(
             insertion: .move(edge: .trailing),
-            removal:   .move(edge: .leading)
+            removal:   .identity
         )
+        .animation(.easeInOut(duration: 0.25))
     case "slide_from_left":
         return .asymmetric(
             insertion: .move(edge: .leading),
-            removal:   .move(edge: .trailing)
+            removal:   .identity
         )
+        .animation(.easeInOut(duration: 0.25))
     case "slide_from_bottom":
-        return .move(edge: .bottom)
+        // Sheet-like rise: the incoming screen covers the held old screen
+        // from the bottom edge.
+        return .asymmetric(
+            insertion: .move(edge: .bottom),
+            removal:   .identity
+        )
+        .animation(.easeInOut(duration: 0.25))
     case "fade":
-        // The ambient `.animation(value: screenKey)` in ContentView drives
-        // geometric transitions (`.move`, `.scale`) but NOT a bare opacity
-        // change on the `.id`-swapped opaque screen — so pure fade collapsed
-        // to an instant cut, and combining it with a scale just produced a
-        // (mini) scale transition with the opacity still not animating.
-        // Attaching the animation directly to the transition forces SwiftUI
-        // to animate the opacity itself, giving a true cross-fade with no
-        // geometric/zoom component.
-        return .opacity.animation(.easeInOut(duration: 0.3))
+        // True cross-fade: incoming fades in over the held old screen — no
+        // background flash-through, since the old screen stays opaque
+        // beneath for the whole window.
+        return .asymmetric(insertion: .opacity, removal: .identity)
+            .animation(.easeInOut(duration: 0.3))
     case "fade_from_bottom":
-        return .move(edge: .bottom).combined(with: .opacity)
+        // Short upward drift + fade over the held outgoing screen — the
+        // conventional "fade from bottom" (React Navigation's fadeFromBottom,
+        // classic Android activity open). Fixed 96pt drift, same no-UIScreen
+        // rationale as parallax_push. Clearly distinct from the full-height
+        // slide_from_bottom.
+        return .asymmetric(
+            insertion: .offset(y: 96).combined(with: .opacity),
+            removal:   .identity
+        )
+        .animation(.easeOut(duration: 0.3))
     case "scale_from_center":
         // Scale the incoming screen in (from 0.1), fully opaque, over the held
-        // outgoing screen. Two gotchas this avoids:
-        //  • The old `.scale` (from 0) `.combined(with: .opacity)` hid the zoom
-        //    — near-transparent while small, so only the last sliver of growth
-        //    registered. Dropping the opacity shows the whole zoom.
-        //  • Like `fade`, a scale is NOT animated by ContentView's ambient
-        //    `.animation(value:)` (only `.move` is). Without attaching the
-        //    animation directly, the screen just snaps to full size and the
-        //    `scale:` value has no visible effect. `.animation(_:)` fixes that.
+        // outgoing screen. The old `.scale` (from 0) `.combined(with: .opacity)`
+        // hid the zoom — near-transparent while small, so only the last sliver
+        // of growth registered. Dropping the opacity shows the whole zoom.
         return .asymmetric(insertion: .scale(scale: 0.1), removal: .identity)
             .animation(.easeInOut(duration: 0.3))
     case "parallax_push":
-        // iOS-style native push: the incoming screen slides fully in from the
-        // trailing edge while the outgoing screen drifts a short distance to
-        // the leading edge underneath (a layered depth cue, not a flat slide).
-        // A fixed ~30%-of-phone-width drift keeps this warning-free (no
-        // deprecated UIScreen.main) and the incoming screen covers most of it.
+        // Layered push: the incoming screen slides in from the trailing
+        // edge; the outgoing screen's recede (scale + drift + dim + shadow)
+        // is applied by `ScreenExitModifier` on the held outgoing layer.
+        // The insertion is DELAYED ~120ms so the recede — which starts
+        // immediately — gets a clear beat before the cover sweeps over it;
+        // that sequencing is what makes the two layers legible. Total
+        // ~0.7s: deliberately slower than a stock push so the depth reads.
         return .asymmetric(
             insertion: .move(edge: .trailing),
-            removal:   .offset(x: -120)
+            removal:   .identity
         )
+        .animation(.easeInOut(duration: 0.55).delay(0.15))
     case "none":
+        // Instant cut. The incoming screen renders fully opaque on the same
+        // frame (zIndexed above), so nothing flashes.
         return .identity
     default:
-        return .opacity
+        return .asymmetric(insertion: .opacity, removal: .identity)
+            .animation(.easeInOut(duration: 0.3))
     }
 }


### PR DESCRIPTION
## Summary

Fixes the "first page of the stack flashes before the transition" report, plus the family of exit-animation glitches uncovered while chasing it. Everything below was diagnosed from frame-by-frame simulator recordings.

### 1. Pop-animation flash (NavigationStack chrome)
PHP republishes the destination within ~10ms of a back event — far inside the ~350ms pop animation — and `receive()` evicted the popped URI's cache synchronously, blanking the popping screen to `Color.clear` mid-flight (the stack root "appeared for a split second"). Eviction is now deferred past the transition window in both `NavigationCoordinator` and `PerTabNavigationCoordinator`; liveness is recomputed at fire time so overlapping schedules stay correct.

### 2. Router-level exits rebuilt as an explicit two-layer swap
Recordings showed SwiftUI's removal-side transition machinery failing four different ways (all reproduced on-device):
- removal transitions are captured at view **insertion** and ignore later `.transition` updates — every screen exited with the animation it *entered* with (e.g. leaving a `slide_from_bottom` screen slid it down under a `slide_from_left` cover, collapsing into the corner)
- unclocked (`.identity`) removals drop the view on frame one → blank/black background flash under the incoming animation
- `AnyTransition.modifier` removals hold the view but never render their animated effects
- `.animation()` attached to a transition is ignored for `.move` insertions — the ambient transaction animation paces them

Exits no longer touch the transition system: the old screen is reclassified as `NativeUIBridge.outgoingScreen`, kept mounted with the same ForEach identity (no removal fires, view state survives) beneath the incoming screen, and animated out with plain modifiers (`ScreenExitModifier`). The ambient swap animation is computed per staged transition (`nativeScreenSwapAnimation`).

### 3. Transition polish
- **parallax_push** is a real layered push now: ~100ms solo recede beat (scale 0.88, 120pt drift, dim, shadow) before a 0.40s sweep — legible in dark mode via an edge shadow on the incoming screen
- **fade_from_bottom** was visually identical to `slide_from_bottom`; now a short 96pt rise + fade over the held old screen, with matching Compose behavior on Android (`KeepUntilTransitionsFinished`)
- **fade** is a true cross-fade over the held old screen instead of dissolving to window background

## Test plan
- [x] Stack push/pop (chrome): no root flash on back — chevron, swipe, and in-page `back()`
- [x] `slide_from_bottom` enter/exit: no corner-collapse, no black flash in dark mode
- [x] `fade` / `fade_from_bottom` / `scale_from_center`: animate over held old screen
- [x] `parallax_push`: two-layer recede + sweep visible in dark and light mode
- [x] Rapid double-navigation: key-guarded cleanup, no stale held screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)