### PR TITLE
feat(testing): plugin-extensible test suite via FakeBridge macros

### DIFF
--- a/src/Testing/FakeBridge.php
+++ b/src/Testing/FakeBridge.php
@@ -2,6 +2,7 @@
 
 namespace Native\Mobile\Testing;
 
+use Illuminate\Support\Traits\Macroable;
 use Native\Mobile\Support\NativeCallbacks;
 use PHPUnit\Framework\Assert;
 
@@ -17,9 +18,24 @@ use PHPUnit\Framework\Assert;
  *
  * The instance is bound into the Laravel container, so each test's fresh
  * application gets a fresh bridge and state can never leak across tests.
+ *
+ * Plugins can teach the bridge their own test vocabulary via macros, so
+ * app tests read in domain terms instead of raw bridge method strings:
+ *
+ *     FakeBridge::macro('assertCopied', function (?string $text = null) {
+ *         return $this->assertCalled('Clipboard.WriteText',
+ *             fn ($p) => $text === null || $p['text'] === $text);
+ *     });
+ *
+ *     Native::test(ShareSheet::class)->tap('copy')->assertCopied('https://…');
+ *
+ * TestableComponent forwards unknown methods here, so macros (and the
+ * built-in helpers) chain straight off the harness.
  */
 class FakeBridge
 {
+    use Macroable;
+
     /** Every tree passed to nativephp_element_publish(), oldest first. */
     public array $publishes = [];
 

--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -1203,6 +1203,31 @@ class TestableComponent
         return $this;
     }
 
+    // ── Bridge delegation ───────────────────────────
+
+    /**
+     * Forward unknown methods to this test's FakeBridge — its built-in
+     * helpers and any macros plugins registered (e.g. a clipboard plugin's
+     * assertCopied()). When the bridge answers fluently (returns itself),
+     * the harness returns $this instead so the test chain stays on the
+     * component.
+     */
+    public function __call(string $method, array $arguments): mixed
+    {
+        if (FakeBridge::hasMacro($method) || method_exists($this->bridge, $method)) {
+            $result = $this->bridge->{$method}(...$arguments);
+
+            return $result === $this->bridge ? $this : $result;
+        }
+
+        throw new \BadMethodCallException(sprintf(
+            'Method %s::%s does not exist, and the FakeBridge has no method or macro named [%s].',
+            static::class,
+            $method,
+            $method
+        ));
+    }
+
     // ── Internals ───────────────────────────────────
 
     /**

--- a/tests/Feature/FakeBridgeMacroTest.php
+++ b/tests/Feature/FakeBridgeMacroTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * Plugin-authored test vocabulary: FakeBridge macros and their forwarding
+ * through the TestableComponent harness. This is the extension point that
+ * lets a plugin ship sugar like assertCopied() instead of exposing raw
+ * bridge method strings to app tests.
+ */
+
+use Native\Mobile\Testing\FakeBridge;
+use Native\Mobile\Testing\Native;
+use Tests\Fixtures\Edge\CounterScreen;
+
+// ── Macros on the bridge itself ─────────────────────
+
+it('runs a plugin-registered assertion macro on the bridge', function () {
+    FakeBridge::macro('assertLocateRequested', function () {
+        return $this->assertCalled('Geolocation.GetCurrentPosition');
+    });
+
+    $bridge = Native::fakeBridge();
+
+    Native::test(CounterScreen::class)->call('locate');
+
+    $bridge->assertLocateRequested();
+});
+
+it('binds macros to the bridge instance so scripting helpers work', function () {
+    FakeBridge::macro('withLocation', function (float $lat) {
+        return $this->respondTo('Geolocation.GetCurrentPosition', ['latitude' => $lat]);
+    });
+
+    Native::fakeBridge()->withLocation(48.85);
+
+    Native::test(CounterScreen::class)
+        ->call('locate')
+        ->assertSet('lat', 48.85);
+});
+
+it('fails macro assertions with the underlying bridge message', function () {
+    FakeBridge::macro('assertLocatedOnce', function () {
+        return $this->assertCalledTimes('Geolocation.GetCurrentPosition', 1);
+    });
+
+    Native::fakeBridge();
+
+    expect(fn () => Native::test(CounterScreen::class)->assertLocatedOnce())
+        ->toThrow(PHPUnit\Framework\AssertionFailedError::class);
+});
+
+// ── Forwarding through the harness ──────────────────
+
+it('forwards macros through the harness and keeps the chain fluent', function () {
+    FakeBridge::macro('assertAskedForPosition', function () {
+        return $this->assertCalled('Geolocation.GetCurrentPosition');
+    });
+
+    Native::fakeBridge()->respondTo('Geolocation.GetCurrentPosition', ['latitude' => 51.5]);
+
+    Native::test(CounterScreen::class)
+        ->call('locate')
+        ->assertAskedForPosition()   // macro resolved on the bridge...
+        ->assertSet('lat', 51.5);    // ...chain continues on the harness
+});
+
+it('forwards built-in bridge helpers through the harness', function () {
+    Native::test(CounterScreen::class)
+        ->call('locate')
+        ->assertCalled('Geolocation.GetCurrentPosition')
+        ->assertSet('lat', null);
+});
+
+it('returns non-fluent macro results verbatim', function () {
+    FakeBridge::macro('locateCallCount', function () {
+        return count($this->callsTo('Geolocation.GetCurrentPosition'));
+    });
+
+    $count = Native::test(CounterScreen::class)
+        ->call('locate')
+        ->locateCallCount();
+
+    expect($count)->toBe(1);
+});
+
+it('throws a BadMethodCallException for unknown methods', function () {
+    expect(fn () => Native::test(CounterScreen::class)->assertTeleported())
+        ->toThrow(BadMethodCallException::class, 'assertTeleported');
+});

--- a/tests/Feature/FakeBridgeMacroTest.php
+++ b/tests/Feature/FakeBridgeMacroTest.php
@@ -9,6 +9,7 @@
 
 use Native\Mobile\Testing\FakeBridge;
 use Native\Mobile\Testing\Native;
+use PHPUnit\Framework\AssertionFailedError;
 use Tests\Fixtures\Edge\CounterScreen;
 
 // ── Macros on the bridge itself ─────────────────────
@@ -45,7 +46,7 @@ it('fails macro assertions with the underlying bridge message', function () {
     Native::fakeBridge();
 
     expect(fn () => Native::test(CounterScreen::class)->assertLocatedOnce())
-        ->toThrow(PHPUnit\Framework\AssertionFailedError::class);
+        ->toThrow(AssertionFailedError::class);
 });
 
 // ── Forwarding through the harness ──────────────────


### PR DESCRIPTION
## What

Lets plugins ship first-class test vocabulary for app developers, so app tests read in domain terms instead of raw bridge method strings:

```php
// registered by the clipboard plugin:
FakeBridge::macro('assertCopied', function (?string $text = null) {
    return $this->assertCalled('Clipboard.WriteText',
        fn ($p) => $text === null || $p['text'] === $text);
});

// app test:
Native::fakeBridge()->withClipboard();

Native::test(ShareSheet::class)
    ->tap('Copy link')
    ->assertCopied('https://example.com/invite/abc');
```

## How

Two small changes:

- **`FakeBridge` is now `Macroable`** — plugins register macros (typically from their service provider, guarded by `runningUnitTests()` + `method_exists(FakeBridge::class, 'macro')` so older cores stay fatal-free).
- **`TestableComponent::__call`** forwards unknown methods to the test's FakeBridge — macros *and* built-in helpers (`assertCalled`, `respondTo`, …). When the bridge returns itself, the harness returns `$this` instead, so fluent chains stay on the component. Genuinely unknown methods throw a `BadMethodCallException` naming the method.

Keeping one shared FakeBridge (rather than per-plugin fakes) means cross-plugin assertions like `assertCallOrder()` still see all native traffic.

## Tests

`tests/Feature/FakeBridgeMacroTest.php` covers: assertion macros, instance-bound scripting macros, failure messages bubbling from the underlying assertions, chain fluency through the harness, non-fluent return values passing through verbatim, and the unknown-method exception. Full suite green: 578 passed (1960 assertions).

## Reference implementation

The clipboard plugin has a ready branch registering `withClipboard()` / `assertCopied()` / `assertNothingCopied()` on top of this, as the pattern for other plugins (geolocation `assertWatchStarted()`, biometrics `assertPrompted()`, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)