### PR TITLE
fix: stale stack root shown during back transitions after leaving native chrome

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeElementBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeElementBridge.kt
@@ -296,6 +296,20 @@ class NativeElementBridge private constructor() {
                             (prevRootType == "native_root_stack" && newRootType == "native_root_stack") ||
                             (prevRootType == "native_root_tabs"  && newRootType == "native_root_tabs")
 
+                        // A `native_root_stack` renderer is about to COLD-mount
+                        // (previous publish was a different root sentinel —
+                        // tabs, WebView, or nothing). NavigationCoordinator is
+                        // a singleton that survives renderer teardown, so it
+                        // still holds the PREVIOUS stack session's rootUri and
+                        // per-URI tree cache. Without a reset, the new stack's
+                        // first publish falls through receive()'s seed/root
+                        // checks into the PUSH branch — stacking the new screen
+                        // on a stale root — and every subsequent pop animates
+                        // through the OLD page. Reset on main below, atomically
+                        // with the tree swap.
+                        val isFreshStackMount =
+                            newRootType == "native_root_stack" && prevRootType != "native_root_stack"
+
                         val newUri = tree.root.props.getString("current_uri", "")
                         val diffedTree: NativeUITree
 
@@ -358,6 +372,7 @@ class NativeElementBridge private constructor() {
                             // screenKey would trigger the AnimatedContent at
                             // NativeUIContent's root, replacing the system
                             // animation with a slide overlay.
+                            if (isFreshStackMount) NavigationCoordinator.reset()
                             if (isNav && !nativeChromeContinuation) NativeUIBridge.screenKey.intValue++
                             NativeUIBridge.currentTree.value = diffedTree
                             // First publish after a hot-reload dismisses

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NavigationCoordinator.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NavigationCoordinator.kt
@@ -153,7 +153,11 @@ object NavigationCoordinator {
     }
 
     /**
-     * Reset on app launch or when explicitly leaving native chrome.
+     * Clear all stack state. Called by NativeElementBridge's shadow loop
+     * when a `native_root_stack` tree cold-mounts (previous publish was a
+     * different root sentinel) — the singleton survives renderer teardown,
+     * so without this the next stack session would treat its first URI as
+     * a push on top of the previous session's stale root.
      */
     fun reset() {
         rootUri.value = null

--- a/resources/xcode/NativePHP/NativeRender/NativeElementBridge.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeElementBridge.swift
@@ -391,6 +391,20 @@ final class NativeElementBridge {
                 (prevRootType == "native_root_stack" && newRootType == "native_root_stack") ||
                 (prevRootType == "native_root_tabs"  && newRootType == "native_root_tabs")
 
+            // A `native_root_stack` renderer is about to COLD-mount (the
+            // previous publish was a different root sentinel — tabs,
+            // WebView, or nothing). `NavigationCoordinator.shared` is a
+            // singleton that survives renderer teardown, so at this point
+            // it still holds the PREVIOUS stack session's `rootUri` and
+            // per-URI tree cache. Without a reset, the new stack's first
+            // publish falls through `receive()`'s seed/root checks into
+            // the PUSH branch — stacking the new screen on top of a stale
+            // root — and every subsequent pop animates through the OLD
+            // page (e.g. a product screen visited minutes ago). Reset on
+            // main below, atomically with the tree swap.
+            let isFreshStackMount =
+                newRootType == "native_root_stack" && prevRootType != "native_root_stack"
+
             // Diff against previous tree (reuse unchanged subtrees so
             // NodeView's `===` equality short-circuits and SwiftUI skips
             // re-rendering them).
@@ -488,6 +502,7 @@ final class NativeElementBridge {
                     }
                     bridge.screenKey += 1
                 }
+                if isFreshStackMount { NavigationCoordinator.shared.reset() }
                 bridge.currentTree = finalTree
                 // First publish after a hot-reload dismisses the
                 // "Reloading…" pill. Set by `ContentView.reloadWebView`

--- a/resources/xcode/NativePHP/NativeRender/NavigationCoordinator.swift
+++ b/resources/xcode/NativePHP/NativeRender/NavigationCoordinator.swift
@@ -180,7 +180,11 @@ final class NavigationCoordinator: ObservableObject {
         }
     }
 
-    /// Reset on app launch or when explicitly leaving native chrome.
+    /// Clear all stack state. Called by `NativeElementBridge`'s shadow
+    /// loop when a `native_root_stack` tree cold-mounts (previous publish
+    /// was a different root sentinel) — the singleton survives renderer
+    /// teardown, so without this the next stack session would treat its
+    /// first URI as a push on top of the previous session's stale root.
     func reset() {
         rootUri = nil
         path = []


### PR DESCRIPTION
## The bug

On both iOS and Android, `NavigationCoordinator` is a singleton that survives `native_root_stack` renderer teardown — and its `reset()` had **zero call sites**. `rootUri` and the per-URI tree cache were seeded on the very first stack publish and never cleared.

So after leaving a stack screen (back to tabs), the next stack screen's URI failed `receive()`'s seed/root checks (`rootUri` non-nil, URI ≠ `rootUri`, not in `path`) and fell through to the **PUSH branch** — mounting the new screen as a push on top of the previous session's stale root. Every subsequent pop then animated a reveal of the old cached page during the back transition.

## Repro

1. Tabs screen → open product A (`StackLayout`) → back
2. Switch to another tab → open product B → **back**: the pop transition renders **product A** underneath instead of the destination
3. Same with any other stack screen (e.g. More tab → Account → back shows product A again)

The tabs renderer is unaffected — it uses a per-renderer `@StateObject` / fresh per-tab coordinators. The stack renderer's singleton was the asymmetry.

## The fix

In both element bridges' shadow loops (where `nativeChromeContinuation` is already computed), detect a **stack cold-mount** — the root sentinel switching from tabs/WebView/none to `native_root_stack` — and call `NavigationCoordinator.reset()` on the main thread atomically with the tree swap. Each stack session now seeds a fresh root; pushes/pops *within* a continuing stack are untouched.

Applied identically to iOS (`NativeElementBridge.swift`) and Android (`NativeElementBridge.kt`), plus doc-comment updates on both `reset()` implementations pointing at the new call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)