### PR TITLE
feat(edge): @pressDown/@pressUp events + fix Compose BOM 2025.12 compile break

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeUIRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeUIRenderer.kt
@@ -150,8 +150,14 @@ internal fun transitionFor(type: String?): ContentTransform {
         // indistinguishable from slide_from_bottom (the opaque incoming
         // screen covers everything mid-slide anyway). Matches iOS's
         // fixed-drift + `.identity`-removal mapping in ScreenTransitions.swift.
+        // Holding the outgoing screen used ExitTransition
+        // .KeepUntilTransitionsFinished, which newer Compose (BOM
+        // 2025.12+) makes internal. A fade to 0.99 alpha over the same
+        // duration is the public-API equivalent: the outgoing screen
+        // stays visually opaque beneath the incoming one for the whole
+        // transition, then is removed.
         "fade_from_bottom" -> (slideInVertically(intSpec) { it / 8 } + fadeIn(spec)) togetherWith
-            ExitTransition.KeepUntilTransitionsFinished
+            fadeOut(spec, targetAlpha = 0.99f)
         // Scale the incoming screen in from 50% while it stays fully opaque
         // (no fadeIn) so the whole zoom is visible; the outgoing screen fades
         // out beneath it. Combining scaleIn with fadeIn previously hid the

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeModifiers.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeModifiers.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.heightIn
@@ -18,6 +20,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 
 // MARK: - ARGB Color Conversion
@@ -194,10 +197,48 @@ fun Modifier.nodeGestures(
     // Double-tap is carried in props (`on_double_tap`), not a dedicated node
     // field like onPress/onLongPress, so it needs no binary wire-format change.
     val doubleTapId = node.props.getInt("on_double_tap")
+    // Press-down/up ride the props dict the same way. Both reuse the PRESS
+    // wire event — the callback id alone routes to the handler.
+    val pressDownId = node.props.getInt("on_press_down")
+    val pressUpId = node.props.getInt("on_press_up")
 
-    if (callbackId == 0 && longPressId == 0 && doubleTapId == 0) return this
+    if (callbackId == 0 && longPressId == 0 && doubleTapId == 0 &&
+        pressDownId == 0 && pressUpId == 0
+    ) {
+        return this
+    }
 
     val nodeId = node.id
+
+    var mod: Modifier = this
+
+    // Touch-contact tracking for held-button semantics (gamepad d-pads,
+    // push-to-talk): down fires on first contact, up when every pointer
+    // lifts. The `finally` also runs on gesture-coroutine cancellation
+    // (scroll steals the stream, node leaves composition) so a held button
+    // is never left stuck. Observes without consuming, so it composes with
+    // the clickable below when @press is also present.
+    if (pressDownId != 0 || pressUpId != 0) {
+        mod = mod.pointerInput(pressDownId, pressUpId, nodeId) {
+            awaitEachGesture {
+                awaitFirstDown(requireUnconsumed = false)
+                if (pressDownId != 0) {
+                    NativeElementBridge.sendPressEvent(pressDownId, nodeId)
+                }
+                try {
+                    do {
+                        val event = awaitPointerEvent()
+                    } while (event.changes.any { it.pressed })
+                } finally {
+                    if (pressUpId != 0) {
+                        NativeElementBridge.sendPressEvent(pressUpId, nodeId)
+                    }
+                }
+            }
+        }
+    }
+
+    if (callbackId == 0 && longPressId == 0 && doubleTapId == 0) return mod
 
     val onClickAction: () -> Unit = {
         if (callbackId != 0) {
@@ -223,7 +264,7 @@ fun Modifier.nodeGestures(
 
     return if (interactionSource != null) {
         if (needCombined) {
-            this.combinedClickable(
+            mod.combinedClickable(
                 interactionSource = interactionSource,
                 indication = null,
                 onLongClick = onLongClickAction,
@@ -231,7 +272,7 @@ fun Modifier.nodeGestures(
                 onClick = onClickAction,
             )
         } else {
-            this.clickable(
+            mod.clickable(
                 interactionSource = interactionSource,
                 indication = null,
                 onClick = onClickAction,
@@ -239,13 +280,13 @@ fun Modifier.nodeGestures(
         }
     } else {
         if (needCombined) {
-            this.combinedClickable(
+            mod.combinedClickable(
                 onLongClick = onLongClickAction,
                 onDoubleClick = onDoubleClickAction,
                 onClick = onClickAction,
             )
         } else {
-            this.clickable(onClick = onClickAction)
+            mod.clickable(onClick = onClickAction)
         }
     }
 }

--- a/resources/xcode/NativePHP/NativeRender/SwiftUINodeRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/SwiftUINodeRenderer.swift
@@ -215,8 +215,15 @@ private struct NodeGestureModifier: ViewModifier {
     // wire-format change. 0 = no handler.
     private var doubleTapId: Int { node.props.getInt("on_double_tap") }
 
+    // Press-down/up ride the props dict the same way (see
+    // PressDownUpModifier in ViewClickHandlers.swift).
+    private var pressDownId: Int { node.props.getInt("on_press_down") }
+
+    private var pressUpId: Int { node.props.getInt("on_press_up") }
+
     private var hasGesture: Bool {
         node.onPress != 0 || node.onLongPress != 0 || doubleTapId != 0
+            || pressDownId != 0 || pressUpId != 0
     }
 
     func body(content: Content) -> some View {
@@ -230,6 +237,23 @@ private struct NodeGestureModifier: ViewModifier {
                 .modifier(DoubleTapModifier(callbackId: doubleTapId, nodeId: node.id))
                 .modifier(TapModifier(callbackId: node.onPress, nodeId: node.id))
                 .modifier(LongPressModifier(callbackId: node.onLongPress, nodeId: node.id))
+                .modifier(PressDownUpGate(downId: pressDownId, upId: pressUpId, nodeId: node.id))
+        } else {
+            content
+        }
+    }
+}
+
+/// Applies PressDownUpModifier only when a down/up handler exists — mirrors
+/// the callbackId != 0 gating of the tap modifiers above.
+private struct PressDownUpGate: ViewModifier {
+    let downId: Int
+    let upId: Int
+    let nodeId: Int
+
+    func body(content: Content) -> some View {
+        if downId != 0 || upId != 0 {
+            content.modifier(PressDownUpModifier(downId: downId, upId: upId, nodeId: nodeId))
         } else {
             content
         }

--- a/resources/xcode/NativePHP/NativeRender/ViewClickHandlers.swift
+++ b/resources/xcode/NativePHP/NativeRender/ViewClickHandlers.swift
@@ -9,11 +9,71 @@ extension View {
     }
 }
 
+/// Fires press-down the instant the finger makes contact and press-up on
+/// release. The down/up callback ids ride the props dict (`on_press_down` /
+/// `on_press_up`) and reuse the Press event type — the callback id alone
+/// routes to the @pressDown / @pressUp handler on the PHP side.
+///
+/// `DragGesture(minimumDistance: 0)` is SwiftUI's touch-contact primitive:
+/// `.onChanged` fires on first contact (and on every move — gated by
+/// `pressed` so down fires once), `.onEnded` on release. Attached as a
+/// simultaneousGesture so it composes with an @press tap on the same node.
+/// A held button must never stick: `onDisappear` synthesizes the up if the
+/// view is torn down mid-press (navigation, sheet dismiss, re-render drop).
+struct PressDownUpModifier: ViewModifier {
+    let downId: Int
+    let upId: Int
+    let nodeId: Int
+
+    @State private var pressed = false
+
+    func body(content: Content) -> some View {
+        content
+            .contentShape(Rectangle())
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        guard !pressed else { return }
+                        pressed = true
+                        if downId != 0 {
+                            NativeElementBridge.sendPressEvent(downId, nodeId: nodeId)
+                        }
+                    }
+                    .onEnded { _ in
+                        guard pressed else { return }
+                        pressed = false
+                        if upId != 0 {
+                            NativeElementBridge.sendPressEvent(upId, nodeId: nodeId)
+                        }
+                    }
+            )
+            .onDisappear {
+                guard pressed else { return }
+                pressed = false
+                if upId != 0 {
+                    NativeElementBridge.sendPressEvent(upId, nodeId: nodeId)
+                }
+            }
+    }
+}
+
 private struct ClickHandlerModifier: ViewModifier {
     let node: NativeUINode
 
     func body(content: Content) -> some View {
         var view = AnyView(content)
+
+        // Press-down/up: attached first so the zero-distance drag tracks
+        // touch contact without stealing the tap recognizers below.
+        let pressDownId = node.props.getInt("on_press_down")
+        let pressUpId = node.props.getInt("on_press_up")
+        if pressDownId != 0 || pressUpId != 0 {
+            view = AnyView(
+                view.modifier(PressDownUpModifier(
+                    downId: pressDownId, upId: pressUpId, nodeId: node.id
+                ))
+            )
+        }
 
         // Double-tap is carried in props (`on_double_tap`), not a dedicated
         // node field. Attached before the single tap so the 2-count gesture

--- a/src/Edge/Element.php
+++ b/src/Edge/Element.php
@@ -48,6 +48,10 @@ abstract class Element
 
     protected ?string $doubleTapMethod = null;
 
+    protected ?string $pressDownMethod = null;
+
+    protected ?string $pressUpMethod = null;
+
     protected ?string $swipeDeleteMethod = null;
 
     protected ?array $navigateConfig = null;
@@ -489,6 +493,33 @@ abstract class Element
         return $this;
     }
 
+    /**
+     * Touch-down handler — fires the moment the finger makes contact,
+     * unlike `onPress` which is a completed tap (fires on release). Pair
+     * with `onPressUp` for held-button semantics (gamepad d-pads, push-to-
+     * talk). Both travel in the props dict (`on_press_down` /
+     * `on_press_up`) and reuse the PRESS wire event — the callback id
+     * alone routes to the handler — so no binary wire-format change.
+     */
+    public function onPressDown(string $method): static
+    {
+        $this->pressDownMethod = $method;
+
+        return $this;
+    }
+
+    /**
+     * Touch-up handler — fires on release OR gesture cancellation (system
+     * gesture steals the touch, view disappears). Renderers guarantee an
+     * up after every down so a held button is never left stuck.
+     */
+    public function onPressUp(string $method): static
+    {
+        $this->pressUpMethod = $method;
+
+        return $this;
+    }
+
     public function setNavigateConfig(array $config): static
     {
         $this->navigateConfig = $config;
@@ -612,6 +643,14 @@ abstract class Element
 
         if ($this->doubleTapMethod !== null) {
             $props['on_double_tap'] = $registry->register($this->doubleTapMethod);
+        }
+
+        if ($this->pressDownMethod !== null) {
+            $props['on_press_down'] = $registry->register($this->pressDownMethod);
+        }
+
+        if ($this->pressUpMethod !== null) {
+            $props['on_press_up'] = $registry->register($this->pressUpMethod);
         }
 
         if (! empty($this->darkProps)) {

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -143,6 +143,14 @@ class NativeElementCollector
                 $props['on_double_tap'] = $doubleTap;
             }
 
+            // Press-down/up ride the props dict too (see resolveOnPressDown).
+            if (($pressDown = static::resolveOnPressDown($attrs)) !== 0) {
+                $props['on_press_down'] = $pressDown;
+            }
+            if (($pressUp = static::resolveOnPressUp($attrs)) !== 0) {
+                $props['on_press_up'] = $pressUp;
+            }
+
             // ScrollView needs overflow: scroll so Yoga doesn't constrain children
             if ($type === 'scroll_view' && ! isset($layout['overflow'])) {
                 $layout['overflow'] = 2;
@@ -223,6 +231,14 @@ class NativeElementCollector
             // Double-tap rides the props dict (not a dedicated node field).
             if (($doubleTap = static::resolveOnDoubleTap($attrs)) !== 0) {
                 $props['on_double_tap'] = $doubleTap;
+            }
+
+            // Press-down/up ride the props dict too (see resolveOnPressDown).
+            if (($pressDown = static::resolveOnPressDown($attrs)) !== 0) {
+                $props['on_press_down'] = $pressDown;
+            }
+            if (($pressUp = static::resolveOnPressUp($attrs)) !== 0) {
+                $props['on_press_up'] = $pressUp;
             }
 
             nphp_node_leaf(
@@ -570,6 +586,31 @@ class NativeElementCollector
     {
         if (isset($attrs['_doubleTap']) && static::$callbacks) {
             return static::$callbacks->register($attrs['_doubleTap']);
+        }
+
+        return 0;
+    }
+
+    /**
+     * Press-down / press-up callback ids. Like double-tap these travel in
+     * the props dict (`on_press_down` / `on_press_up`) and reuse the PRESS
+     * wire event — the callback id alone routes to the handler — so no
+     * `nphp_node_*` signature or binary wire-format change. Returns 0 when
+     * the corresponding `@pressDown` / `@pressUp` attr is not set.
+     */
+    protected static function resolveOnPressDown(array $attrs): int
+    {
+        if (isset($attrs['_pressDown']) && static::$callbacks) {
+            return static::$callbacks->register($attrs['_pressDown']);
+        }
+
+        return 0;
+    }
+
+    protected static function resolveOnPressUp(array $attrs): int
+    {
+        if (isset($attrs['_pressUp']) && static::$callbacks) {
+            return static::$callbacks->register($attrs['_pressUp']);
         }
 
         return 0;
@@ -1054,6 +1095,12 @@ class NativeElementCollector
         }
         if (isset($attrs['_doubleTap'])) {
             $element->onDoubleTap($attrs['_doubleTap']);
+        }
+        if (isset($attrs['_pressDown'])) {
+            $element->onPressDown($attrs['_pressDown']);
+        }
+        if (isset($attrs['_pressUp'])) {
+            $element->onPressUp($attrs['_pressUp']);
         }
         if (isset($attrs['_change']) && method_exists($element, 'onChange')) {
             $element->onChange($attrs['_change']);

--- a/src/Edge/NativeTagPrecompiler.php
+++ b/src/Edge/NativeTagPrecompiler.php
@@ -231,11 +231,12 @@ class NativeTagPrecompiler
             $value
         );
 
-        // Convert @press, @longPress, @doubleTap, @change, @submit, @dismiss, @refresh,
-        // @endReached, @swipeDelete, @swipe, @pinchEnd to underscored versions before
-        // Blade interprets @ as a directive. `swipeDelete` must precede `swipe` in the
-        // alternation so it wins the longer match.
-        $value = preg_replace('/@(press|longPress|doubleTap|change|submit|dismiss|refresh|endReached|swipeDelete|swipe|pinchEnd)=/', '_$1=', $value);
+        // Convert @press, @pressDown, @pressUp, @longPress, @doubleTap, @change,
+        // @submit, @dismiss, @refresh, @endReached, @swipeDelete, @swipe, @pinchEnd
+        // to underscored versions before Blade interprets @ as a directive.
+        // Longer spellings precede their prefix (`pressDown`/`pressUp` before
+        // `press`, `swipeDelete` before `swipe`) so they win the longer match.
+        $value = preg_replace('/@(pressDown|pressUp|press|longPress|doubleTap|change|submit|dismiss|refresh|endReached|swipeDelete|swipe|pinchEnd)=/', '_$1=', $value);
 
         // The attribute-region pattern below uses possessive quantifiers
         // (`*+`) to keep PCRE from catastrophically backtracking when a

--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -275,6 +275,40 @@ class TestableComponent
         return $this->fireEvent($target, self::EVENT_LONG_PRESS);
     }
 
+    /**
+     * Touch-down on the element bound to a method name or ref
+     * (`@pressDown`). Down/up ride the PRESS wire event with their own
+     * callback ids in the props dict, so dispatch is a plain press at
+     * the `on_press_down` id.
+     */
+    public function pressDown(string $target): static
+    {
+        return $this->firePropsPress($target, 'on_press_down');
+    }
+
+    /** Touch-up counterpart of pressDown() (`@pressUp`). */
+    public function pressUp(string $target): static
+    {
+        return $this->firePropsPress($target, 'on_press_up');
+    }
+
+    /** Fire EVENT_PRESS at the callback id carried in the given props key. */
+    protected function firePropsPress(string $target, string $key): static
+    {
+        $this->startInteraction();
+
+        $callbackId = $this->callbackIdFor($target)
+            ?? $this->propsCallbackIdByRef($this->tree(), $target, $key);
+
+        Assert::assertNotNull(
+            $callbackId,
+            "No callback registered for [{$target}] in the last render. Registered: ".
+            (implode(', ', array_keys($this->callbacks()->expressions())) ?: '(none)')
+        );
+
+        return $this->dispatchUiEvent(['type' => self::EVENT_PRESS, 'callback_id' => $callbackId]);
+    }
+
     /** Type into an input bound to a method, model property, or ref. */
     public function input(string $target, string $text): static
     {
@@ -1373,6 +1407,28 @@ class TestableComponent
     protected function pressableIdByRef(array $node, string $ref): ?int
     {
         return $this->callbackIdByRef($node, $ref, self::EVENT_PRESS);
+    }
+
+    /**
+     * Callback id in a specific props key on the node with the given ref —
+     * for props-dict callbacks that share a wire event type (press-down/up
+     * both ride EVENT_PRESS), where EVENT_CALLBACK_KEYS can't discriminate.
+     */
+    protected function propsCallbackIdByRef(array $node, string $ref, string $key): ?int
+    {
+        if (($node['ref'] ?? null) === $ref) {
+            $id = $node['props'][$key] ?? null;
+
+            return is_int($id) ? $id : null;
+        }
+
+        foreach ($node['children'] ?? [] as $child) {
+            if (($id = $this->propsCallbackIdByRef($child, $ref, $key)) !== null) {
+                return $id;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Feature/TestingSuiteInteractionsTest.php
+++ b/tests/Feature/TestingSuiteInteractionsTest.php
@@ -34,6 +34,29 @@ it('long-presses by ref', function () {
         ->assertSet('held', true);
 });
 
+// ── Press down / press up ───────────────────────────
+
+it('dispatches a press-down then press-up cycle by method name', function () {
+    Native::test(FormScreen::class)
+        ->assertSee('Coasting')
+        ->pressDown('gasDown')
+        ->assertSet('gasHeld', true)
+        ->assertSee('Accelerating')
+        ->pressUp('gasUp')
+        ->assertSet('gasHeld', false)
+        ->assertSee('Coasting');
+});
+
+it('dispatches press-down and press-up by ref, routed by props key', function () {
+    // Both ids live on the same node and ride the same PRESS wire event —
+    // the props key (`on_press_down` vs `on_press_up`) picks the handler.
+    Native::test(FormScreen::class)
+        ->pressDown('gas-button')
+        ->assertSet('gasHeld', true)
+        ->pressUp('gas-button')
+        ->assertSet('gasHeld', false);
+});
+
 // ── Submit ──────────────────────────────────────────
 
 it('submits an input with explicit text', function () {

--- a/tests/Fixtures/Edge/FormScreen.php
+++ b/tests/Fixtures/Edge/FormScreen.php
@@ -27,6 +27,8 @@ class FormScreen extends NativeComponent
 
     public bool $held = false;
 
+    public bool $gasHeld = false;
+
     public bool $agreed = false;
 
     public float $volume = 0.0;
@@ -42,6 +44,16 @@ class FormScreen extends NativeComponent
     public function hold(): void
     {
         $this->held = true;
+    }
+
+    public function gasDown(): void
+    {
+        $this->gasHeld = true;
+    }
+
+    public function gasUp(): void
+    {
+        $this->gasHeld = false;
     }
 
     public function updateDraft(string $text): void
@@ -95,6 +107,8 @@ class FormScreen extends NativeComponent
             Text::make("Color: {$this->color} / Size: {$this->size}"),
             Text::make("Tab: {$this->activeTab}"),
             Button::make('Hold me')->onLongPress('hold')->ref('hold-button'),
+            Text::make($this->gasHeld ? 'Accelerating' : 'Coasting'),
+            Button::make('Gas')->onPressDown('gasDown')->onPressUp('gasUp')->ref('gas-button'),
             TextInput::make()->onChange('updateDraft')->onSubmit('submitDraft')->ref('draft-input'),
             Toggle::make()->onChange('agree')->ref('agree-toggle'),
             Button::make('Volume')->onPress('setVolume'),

--- a/tests/Unit/Edge/NativeTagPrecompilerTest.php
+++ b/tests/Unit/Edge/NativeTagPrecompilerTest.php
@@ -83,6 +83,24 @@ it('rewrites @doubleTap to _doubleTap', function () {
     expect($result)->not->toContain('@doubleTap');
 });
 
+it('rewrites @pressDown and @pressUp to underscored versions', function () {
+    $result = ($this->precompiler)('<native:pressable @pressDown="startLeft" @pressUp="stopLeft">x</native:pressable>');
+
+    expect($result)->toContain("'_pressDown' => 'startLeft'");
+    expect($result)->toContain("'_pressUp' => 'stopLeft'");
+    expect($result)->not->toContain('@pressDown');
+    expect($result)->not->toContain('@pressUp');
+});
+
+it('keeps @press and @pressDown distinct on the same tag', function () {
+    // `pressDown` precedes `press` in the alternation — a plain @press must
+    // still rewrite to _press, never swallow the Down/Up suffix.
+    $result = ($this->precompiler)('<native:pressable @press="fire" @pressDown="charge">x</native:pressable>');
+
+    expect($result)->toContain("'_press' => 'fire'");
+    expect($result)->toContain("'_pressDown' => 'charge'");
+});
+
 it('rewrites @change and @submit', function () {
     $result = ($this->precompiler)('<native:text-input @change="onTextChange" @submit="onTextSubmit" />');
 

--- a/tests/Unit/Edge/PressDownUpPropTest.php
+++ b/tests/Unit/Edge/PressDownUpPropTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Elements\Column;
+
+it('carries onPressDown / onPressUp as props with registered callback ids', function () {
+    $registry = new CallbackRegistry;
+
+    $props = Column::make()
+        ->onPressDown('startLeft')
+        ->onPressUp('stopLeft')
+        ->getResolvedProps($registry);
+
+    // Press-down/up travel in the props dict (not dedicated node fields)
+    // and reuse the PRESS wire event, so no binary wire-format change.
+    expect($props)->toHaveKey('on_press_down');
+    expect($props)->toHaveKey('on_press_up');
+    expect($props['on_press_down'])->toBeInt()->toBeGreaterThan(0);
+    expect($props['on_press_up'])->toBeInt()->toBeGreaterThan(0);
+    expect($props['on_press_down'])->not->toBe($props['on_press_up']);
+
+    // Each id resolves back to its own handler method.
+    expect($registry->resolve($props['on_press_down'])['method'])->toBe('startLeft');
+    expect($registry->resolve($props['on_press_up'])['method'])->toBe('stopLeft');
+});
+
+it('registers press-down without press-up (and vice versa)', function () {
+    $registry = new CallbackRegistry;
+
+    $props = Column::make()->onPressDown('onlyDown')->getResolvedProps($registry);
+    expect($props)->toHaveKey('on_press_down');
+    expect($props)->not->toHaveKey('on_press_up');
+
+    $props = Column::make()->onPressUp('onlyUp')->getResolvedProps(new CallbackRegistry);
+    expect($props)->toHaveKey('on_press_up');
+    expect($props)->not->toHaveKey('on_press_down');
+});
+
+it('omits both props when no handlers are set', function () {
+    $props = Column::make()->getResolvedProps(new CallbackRegistry);
+
+    expect($props)->not->toHaveKey('on_press_down');
+    expect($props)->not->toHaveKey('on_press_up');
+});


### PR DESCRIPTION
## Summary
- **`@pressDown` / `@pressUp` EDGE events** — touch-down and touch-up events for native elements (iOS + Android).
- **Fix Android template compile break on newer Compose** — `ExitTransition.KeepUntilTransitionsFinished` became `internal` in Compose BOM 2025.12+, breaking `NativeUIRenderer.kt` compilation in generated projects. Replaced with `fadeOut(spec, targetAlpha = 0.99f)`, the public-API equivalent: the outgoing screen stays visually opaque beneath the incoming one for the whole `fade_from_bottom` transition, then is removed.

## Why the Compose fix is here
Apps installing `nativephp/mobile` from `dev-main` currently fail `:app:compileDebugKotlin` with:

```
Cannot access 'val KeepUntilTransitionsFinished: ExitTransition': it is internal in 'androidx/compose/animation/ExitTransition.Companion'
```

Bundling it with this branch to land both on `main` in one merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
