### PR TITLE
fix(plugins): clean generated plugin copies before compiling

### DIFF
--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -140,6 +140,14 @@ class AndroidPluginCompiler
         // Run pre-compile hooks
         $hookRunner->runPreCompileHooks();
 
+        // The generated plugin tree is fully derived from the installed
+        // plugins, so start from a clean slate. Copying over the previous
+        // output would leave stale files behind when a plugin deletes or
+        // renames a source file (or is removed entirely), producing
+        // duplicate-class build failures in Gradle.
+        $this->clean();
+        $this->files->ensureDirectoryExists($this->generatedPath);
+
         // Emit ProGuard/R8 keep rules for every plugin (runs even when the
         // list is empty so a removed plugin's stale rules are cleared).
         $this->injectPluginProguardRules($allPlugins);
@@ -165,9 +173,6 @@ class AndroidPluginCompiler
         $hasInitFunctions = $allPlugins->filter(function (Plugin $p) {
             return $p->getAndroidInitFunction() !== null;
         })->isNotEmpty();
-
-        // Ensure generated directory exists
-        $this->files->ensureDirectoryExists($this->generatedPath);
 
         // Copy plugin source files for plugins that have Android code
         $allPlugins->filter(fn (Plugin $p) => $p->hasAndroidCode())

--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -99,6 +99,14 @@ class IOSPluginCompiler
         // Run pre-compile hooks
         $hookRunner->runPreCompileHooks();
 
+        // The generated plugin tree is fully derived from the installed
+        // plugins, so start from a clean slate. Copying over the previous
+        // output would leave stale files behind when a plugin deletes or
+        // renames a source file (or is removed entirely), producing
+        // duplicate-symbol build failures in Xcode.
+        $this->clean();
+        $this->files->ensureDirectoryExists($this->generatedPath);
+
         // Get plugins with iOS code (for copying files)
         $pluginsWithCode = $allPlugins->filter(fn (Plugin $p) => $p->hasIosCode());
 
@@ -148,9 +156,6 @@ class IOSPluginCompiler
 
             return;
         }
-
-        // Ensure generated directory exists
-        $this->files->ensureDirectoryExists($this->generatedPath);
 
         // Copy plugin source files
         $pluginsWithCode->each(fn (Plugin $plugin) => $this->copyPluginSources($plugin));

--- a/tests/Feature/Plugins/AndroidCompilerTest.php
+++ b/tests/Feature/Plugins/AndroidCompilerTest.php
@@ -264,6 +264,31 @@ object TestFunctions {
     /**
      * @test
      *
+     * Fallback copies under bridge/plugins from a plugin that is no longer
+     * installed must be removed — a stale copy re-declares its classes and
+     * breaks the Gradle build.
+     */
+    public function it_prunes_stale_generated_plugin_copies(): void
+    {
+        $staleDir = $this->testBasePath.'/android/app/src/main/java/com/nativephp/mobile/bridge/plugins/removed_plugin';
+        $this->files->ensureDirectoryExists($staleDir);
+        $this->files->put($staleDir.'/Zombie.kt', 'class Zombie {}');
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect());
+
+        $this->compiler->compile();
+
+        $this->assertDirectoryDoesNotExist($staleDir);
+        $this->assertFileExists(
+            $this->testBasePath.'/android/app/src/main/java/com/nativephp/mobile/bridge/plugins/PluginBridgeFunctionRegistration.kt'
+        );
+    }
+
+    /**
+     * @test
+     *
      * Should preserve directory structure when copying Kotlin files.
      */
     public function it_preserves_directory_structure_when_copying(): void

--- a/tests/Feature/Plugins/IOSCompilerTest.php
+++ b/tests/Feature/Plugins/IOSCompilerTest.php
@@ -257,6 +257,62 @@ class NestedClass {}');
     /**
      * @test
      *
+     * A file deleted (or renamed) in the plugin source must not survive in the
+     * copied tree — a stale copy re-declares its types and breaks the Xcode
+     * build with "ambiguous use of" errors.
+     */
+    public function it_prunes_stale_copies_when_a_plugin_source_file_is_removed(): void
+    {
+        $pluginPath = $this->testBasePath.'/plugins/test-plugin';
+        $swiftPath = $pluginPath.'/resources/ios/Sources';
+        $this->files->ensureDirectoryExists($swiftPath);
+        $this->files->put($swiftPath.'/OldRenderer.swift', 'struct OldRenderer {}');
+
+        $plugin = $this->createTestPlugin([], $pluginPath);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $copiedDir = $this->testBasePath.'/ios/NativePHP/Bridge/Plugins/TestPlugin';
+        $this->assertFileExists($copiedDir.'/OldRenderer.swift');
+
+        // The type moves into a differently-named file; the old source is deleted.
+        $this->files->delete($swiftPath.'/OldRenderer.swift');
+        $this->files->put($swiftPath.'/Renderers.swift', 'struct OldRenderer {}');
+
+        $this->compiler->compile();
+
+        $this->assertFileExists($copiedDir.'/Renderers.swift');
+        $this->assertFileDoesNotExist($copiedDir.'/OldRenderer.swift');
+    }
+
+    /**
+     * @test
+     *
+     * Copies belonging to a plugin that is no longer installed must be removed,
+     * including when no plugins remain at all.
+     */
+    public function it_prunes_copies_of_removed_plugins(): void
+    {
+        $staleDir = $this->testBasePath.'/ios/NativePHP/Bridge/Plugins/RemovedPlugin';
+        $this->files->ensureDirectoryExists($staleDir);
+        $this->files->put($staleDir.'/Zombie.swift', 'struct Zombie {}');
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect());
+
+        $this->compiler->compile();
+
+        $this->assertDirectoryDoesNotExist($staleDir);
+    }
+
+    /**
+     * @test
+     *
      * Should merge Info.plist entries from plugins.
      */
     public function it_merges_info_plist_entries(): void


### PR DESCRIPTION
Replaces #187, rebased onto `main`.

## Problem

The iOS/Android plugin compilers copy plugin sources into the generated tree (`ios/NativePHP/Bridge/Plugins/…`, `android/…/bridge/plugins/…`) but never remove previous output. Deleting or renaming a file in a plugin — or uninstalling a plugin — leaves the old copy behind forever.

Hit in practice in super-native: a renderer moved between Swift files in the ui plugin, the stale copy kept re-declaring the same struct, and the Xcode build failed with:

```
error: ambiguous use of 'init(node:)'
```

(the generated `PluginRendererRegistration.swift` call site couldn't choose between the two identical synthesized initializers)

## Fix

Both compilers already ship a `clean()` method that deletes the generated tree — it was just never invoked. Call it at the start of `compile()` (before the early no-plugins return, so stale trees are pruned even when the last plugin is uninstalled), then recreate the directory. Everything under the generated path is derived per-compile, so a wipe is safe.

## Tests

- iOS: stale copy pruned when a source file is removed/renamed between compiles; removed plugin's whole directory pruned (including via the empty-registration path)
- Android: stale fallback dir pruned + registration still generated

Full suite on main: 588 passed / 4 risky / 3 skipped (risky/skipped pre-existing).

## Known gap (follow-up?)

Android sources with a `package` declaration are copied to package-derived paths under `java/` — *outside* the generated tree — and are still not pruned. Fixing that safely needs the compiler to record what it copied (a manifest of generated files) rather than a directory wipe, since plugin packages can interleave with app code. Happy to do that as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)