### PR TITLE
feat(edge): raw-slot capture for <webview> + @navigated event wiring

### DIFF
--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -1126,6 +1126,9 @@ class NativeElementCollector
         if (isset($attrs['_pinchEnd']) && method_exists($element, 'onPinchEnd')) {
             $element->onPinchEnd($attrs['_pinchEnd']);
         }
+        if (isset($attrs['_navigated']) && method_exists($element, 'onNavigated')) {
+            $element->onNavigated($attrs['_navigated']);
+        }
         if (isset($attrs['_navigate'])) {
             $element->setNavigateConfig($attrs['_navigate']);
         }

--- a/src/Edge/NativeTagPrecompiler.php
+++ b/src/Edge/NativeTagPrecompiler.php
@@ -19,6 +19,17 @@ class NativeTagPrecompiler
     ];
 
     /**
+     * Elements that capture their slot content as a raw markup prop —
+     * no strip_tags or entity decoding, because the markup itself is the
+     * payload (e.g. <webview> renders its slot as an inline HTML document).
+     * An explicit `:prop` attribute takes precedence over the slot.
+     * tag name => prop name for the captured markup
+     */
+    private const RAW_SLOT_ELEMENTS = [
+        'webview' => 'html',
+    ];
+
+    /**
      * Edge navigation components — handled via Edge::add()/startContext()/endContext()
      * instead of NativeElementCollector, so Edge.Set bridge calls work in WebView mode.
      */
@@ -232,11 +243,12 @@ class NativeTagPrecompiler
         );
 
         // Convert @press, @pressDown, @pressUp, @longPress, @doubleTap, @change,
-        // @submit, @dismiss, @refresh, @endReached, @swipeDelete, @swipe, @pinchEnd
-        // to underscored versions before Blade interprets @ as a directive.
+        // @submit, @dismiss, @refresh, @endReached, @swipeDelete, @swipe,
+        // @pinchEnd, @navigated to underscored versions before Blade
+        // interprets @ as a directive.
         // Longer spellings precede their prefix (`pressDown`/`pressUp` before
         // `press`, `swipeDelete` before `swipe`) so they win the longer match.
-        $value = preg_replace('/@(pressDown|pressUp|press|longPress|doubleTap|change|submit|dismiss|refresh|endReached|swipeDelete|swipe|pinchEnd)=/', '_$1=', $value);
+        $value = preg_replace('/@(pressDown|pressUp|press|longPress|doubleTap|change|submit|dismiss|refresh|endReached|swipeDelete|swipe|pinchEnd|navigated)=/', '_$1=', $value);
 
         // The attribute-region pattern below uses possessive quantifiers
         // (`*+`) to keep PCRE from catastrophically backtracking when a
@@ -427,6 +439,12 @@ class NativeTagPrecompiler
             return "<?php \$__nativeSlotAttrs = {$attrs}; ob_start(); ?>";
         }
 
+        // Raw-slot elements: same buffering, but the slot is kept verbatim
+        // on close — the markup itself is the payload.
+        if (isset(self::RAW_SLOT_ELEMENTS[$tag])) {
+            return "<?php \$__nativeSlotAttrs = {$attrs}; ob_start(); ?>";
+        }
+
         // Container: push onto collector stack
         return '<?php '.self::C."::open('{$type}', {$attrs}); ?>";
     }
@@ -461,6 +479,19 @@ class NativeTagPrecompiler
                 $code .= " if (\$__nativeSlot !== '') { \$__nativeSlotAttrs['{$propName}'] = \$__nativeSlot; }";
             }
 
+            $code .= ' '.self::C."::leaf('{$type}', \$__nativeSlotAttrs); ?>";
+
+            return $code;
+        }
+
+        if (isset(self::RAW_SLOT_ELEMENTS[$tag])) {
+            $propName = self::RAW_SLOT_ELEMENTS[$tag];
+            $type = $this->tagToType($tag);
+
+            // No strip_tags/entity decoding — the markup is the payload. An
+            // explicit attribute (e.g. `:html`) wins over the captured slot.
+            $code = '<?php $__nativeSlot = trim(ob_get_clean());';
+            $code .= " if (\$__nativeSlot !== '' && !isset(\$__nativeSlotAttrs['{$propName}'])) { \$__nativeSlotAttrs['{$propName}'] = \$__nativeSlot; }";
             $code .= ' '.self::C."::leaf('{$type}', \$__nativeSlotAttrs); ?>";
 
             return $code;

--- a/tests/Unit/Edge/NativeElementCollectorTest.php
+++ b/tests/Unit/Edge/NativeElementCollectorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Element;
 use Native\Mobile\Edge\Elements\Column;
 use Native\Mobile\Edge\Elements\Text;
 use Native\Mobile\Edge\NativeElementCollector;
@@ -244,4 +245,42 @@ it('applies dark companion props from programmatic class()', function () {
     expect($tree['style']['bg_color'] ?? $tree['props']['bg_color'] ?? null)->not->toBeNull();
     expect($tree['props']['dark_bg_color'])->toBe('#050714');
     expect($tree['children'][0]['props']['dark_color'])->toBe('#FFFFFF');
+});
+
+// ── Callback attribute wiring ────────────
+
+it('wires _navigated to onNavigated when the element supports it', function () {
+    $element = new class extends Element
+    {
+        public ?string $navigatedMethod = null;
+
+        public function getType(): string
+        {
+            return 'webview';
+        }
+
+        public function onNavigated(string $method): static
+        {
+            $this->navigatedMethod = $method;
+
+            return $this;
+        }
+    };
+
+    $apply = new ReflectionMethod(NativeElementCollector::class, 'applyCallbacks');
+    $apply->invoke(null, $element, ['_navigated' => 'urlChanged']);
+
+    expect($element->navigatedMethod)->toBe('urlChanged');
+});
+
+it('ignores _navigated on elements without an onNavigated method', function () {
+    $element = new class extends Element
+    {
+        protected string $type = 'column';
+    };
+
+    $apply = new ReflectionMethod(NativeElementCollector::class, 'applyCallbacks');
+    $apply->invoke(null, $element, ['_navigated' => 'urlChanged']);
+
+    expect($element->toArray(new CallbackRegistry))->not->toHaveKey('on_navigated');
 });

--- a/tests/Unit/Edge/NativeTagPrecompilerTest.php
+++ b/tests/Unit/Edge/NativeTagPrecompilerTest.php
@@ -62,6 +62,33 @@ it('compiles button elements with label slot capture', function () {
     expect($result)->toContain("'label'");
 });
 
+it('compiles self-closing webview to a leaf', function () {
+    $result = ($this->precompiler)('<native:webview src="https://example.com" @navigated="urlChanged" />');
+
+    expect($result)->toContain("::leaf('webview',");
+    expect($result)->toContain("'src' => 'https://example.com'");
+    expect($result)->toContain("'_navigated' => 'urlChanged'");
+    expect($result)->not->toContain('@navigated');
+});
+
+it('captures webview slot markup verbatim into the html prop', function () {
+    $result = ($this->precompiler)('<native:webview><h1>Hi</h1><p>Hello <em>world</em></p></native:webview>');
+
+    expect($result)->toContain('ob_start();');
+    expect($result)->toContain("::leaf('webview',");
+    expect($result)->toContain("\$__nativeSlotAttrs['html']");
+    // The slot is an HTML document, not display text — it must never go
+    // through the strip_tags/entity-decode path text elements use.
+    expect($result)->not->toContain('strip_tags');
+});
+
+it('lets an explicit :html attribute win over webview slot content', function () {
+    $result = ($this->precompiler)('<native:webview :html="$doc"><h1>fallback</h1></native:webview>');
+
+    expect($result)->toContain("'html' => (\$doc)");
+    expect($result)->toContain("!isset(\$__nativeSlotAttrs['html'])");
+});
+
 it('rewrites @press to _press', function () {
     $result = ($this->precompiler)('<native:button label="+" @press="increment" />');
 


### PR DESCRIPTION
## Problem

The `<webview>` element (nativephp/mobile-ui) renders inline HTML documents, but the precompiler had no slot path that preserves markup: the only slot capture (text/button) runs `strip_tags` + entity decoding — the opposite of what an HTML payload needs. Container-form `<native:webview>…</native:webview>` compiled as a generic container, so the slot was silently discarded and the node reached the renderer with **no `html` prop at all**. In super-native's webview demo, the "Inline HTML" mode rendered an empty webview — indistinguishable from "nothing happened".

`@navigated` was also unwired end to end: not in the precompiler's `@event` rewrite list, and the collector never routed `_navigated` to the element.

## Changes

1. **`RAW_SLOT_ELEMENTS` in `NativeTagPrecompiler`** — webview's slot is buffered (`ob_start()`) and delivered **verbatim** as the `html` prop on close; an explicit `:html` attribute takes precedence over slot content. Self-closing form was already fine (generic leaf).
2. **`@navigated`** added to the `@event` → `_event` attribute rewrites.
3. **`NativeElementCollector::applyCallbacks`** wires `_navigated` → `onNavigated()` on elements implementing it (same `method_exists` pattern as `_change`/`_submit`/etc.). The webview element in nativephp/mobile-ui implements it.

## Tests

- Precompiler: self-closing webview leaf with `_navigated`; slot captured verbatim (asserts **no** `strip_tags` in the compiled output); `:html` precedence guard.
- Collector: `_navigated` wired when `onNavigated()` exists; safely ignored when it doesn't.

Full suite: 590 passed / 4 risky / 3 skipped (risky/skipped pre-existing).

Verified end-to-end in super-native (webview demo screen): with this branch installed, the demo's four red TDD tests for this feature go green and the local-HTML mode's tree carries the inline document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)