### PR TITLE
Move Firebase/google-services ownership from core template to plugins

### DIFF
--- a/resources/androidstudio/app/build.gradle.kts
+++ b/resources/androidstudio/app/build.gradle.kts
@@ -205,9 +205,6 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 
-    implementation(platform(libs.firebase.bom))
-    implementation("com.google.firebase:firebase-messaging")
-
     // AndroidX Security for encrypted storage
     implementation(libs.androidx.security.crypto)
 

--- a/resources/androidstudio/app/proguard-rules.pro
+++ b/resources/androidstudio/app/proguard-rules.pro
@@ -32,10 +32,9 @@
     native <methods>;
 }
 
-# Firebase/Google Play Services
--keep class com.google.firebase.** { *; }
+# Google Play Services (used by several plugins: geolocation, scanner, ...)
+# Firebase rules live in the firebase plugin's nativephp.json proguard_rules.
 -keep class com.google.android.gms.** { *; }
--dontwarn com.google.firebase.**
 -dontwarn com.google.android.gms.**
 
 # AndroidX Security (for secure storage)

--- a/resources/androidstudio/build.gradle.kts
+++ b/resources/androidstudio/build.gradle.kts
@@ -3,5 +3,4 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
-    id("com.google.gms.google-services") version "4.4.3" apply false
 }

--- a/resources/androidstudio/gradle/libs.versions.toml
+++ b/resources/androidstudio/gradle/libs.versions.toml
@@ -13,8 +13,6 @@ espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.04.01"
-firebaseMessagingKtx = "24.1.1"
-firebaseBom = "33.12.0"
 browser = "1.7.0"
 biometric = "1.1.0"
 playServicesLocation = "21.0.1"
@@ -28,7 +26,6 @@ androidx-webkit = { group = "androidx.webkit", name = "webkit", version.ref = "w
 androidx-security-crypto = { group = "androidx.security", name = "security-crypto", version.ref = "securityCrypto" }
 androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "biometric" }
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
@@ -42,7 +39,6 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-firebase-messaging-ktx = { group = "com.google.firebase", name = "firebase-messaging-ktx", version.ref = "firebaseMessagingKtx" }
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "browser" }
 
 [plugins]

--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -144,6 +144,10 @@ class AndroidPluginCompiler
         // list is empty so a removed plugin's stale rules are cleared).
         $this->injectPluginProguardRules($allPlugins);
 
+        // Declare plugin-required Gradle plugins in the root build file (runs
+        // even when the list is empty so a removed plugin's declaration is cleared).
+        $this->injectGradlePlugins($allPlugins);
+
         if ($allPlugins->isEmpty()) {
             $this->generateEmptyRegistration();
             $this->generateEmptyRendererRegistration();
@@ -242,6 +246,116 @@ class AndroidPluginCompiler
         }
 
         $this->files->put($proguardPath, $content);
+    }
+
+    /**
+     * Declare Gradle plugins required by installed plugins in the root
+     * build.gradle.kts plugins {} block, inside a marker-delimited block
+     * rebuilt on every compile (idempotent; a removed plugin's declaration
+     * is dropped). Declared from `android.gradle_plugins` in nativephp.json.
+     *
+     * Entries default to `apply false`: the plugin lands on the build
+     * classpath only, and the app module decides whether to apply it (e.g.
+     * google-services is applied only when a google-services.json exists).
+     */
+    protected function injectGradlePlugins(Collection $plugins): void
+    {
+        $rootGradlePath = $this->androidProjectPath.'/build.gradle.kts';
+
+        if (! $this->files->exists($rootGradlePath)) {
+            return;
+        }
+
+        $content = $this->files->get($rootGradlePath);
+
+        $begin = '// BEGIN nativephp-plugin-gradle-plugins';
+        $end = '// END nativephp-plugin-gradle-plugins';
+
+        $block = $this->buildGradlePluginsBlock($plugins, $content);
+
+        if (str_contains($content, $begin) && str_contains($content, $end)) {
+            $content = preg_replace(
+                '/[ \t]*'.preg_quote($begin, '/').'.*?'.preg_quote($end, '/').'\n?/s',
+                $block,
+                $content,
+                1
+            );
+        } elseif ($block !== '') {
+            // Insert at the end of the plugins {} block. The root build file's
+            // plugins block contains no nested braces, so the first closing
+            // brace on its own line terminates it.
+            $content = preg_replace(
+                '/(plugins\s*\{.*?)(\n\})/s',
+                '$1'."\n".rtrim($block).'$2',
+                $content,
+                1
+            );
+        } else {
+            // Nothing to declare and no stale block to clear
+            return;
+        }
+
+        $this->files->put($rootGradlePath, $content);
+    }
+
+    /**
+     * Build the marker-delimited plugins declarations. Pure (no IO on the
+     * android project) so it is unit-testable. Returns '' when no plugin
+     * declares anything. $existingContent is used to skip ids the build
+     * file already declares outside our markers.
+     */
+    public function buildGradlePluginsBlock(Collection $plugins, string $existingContent = ''): string
+    {
+        $entries = [];
+
+        foreach ($plugins as $plugin) {
+            foreach ($plugin->getAndroidGradlePlugins() as $gradlePlugin) {
+                $id = $gradlePlugin['id'] ?? null;
+                $version = $gradlePlugin['version'] ?? null;
+
+                if (! $id || ! $version) {
+                    $this->warn("Plugin '{$plugin->name}' declares a gradle plugin without id/version — skipping");
+
+                    continue;
+                }
+
+                // Guard against injecting arbitrary Kotlin into the build script
+                if (! preg_match('/^[A-Za-z0-9._-]+$/', $id) || ! preg_match('/^[A-Za-z0-9._+-]+$/', $version)) {
+                    $this->warn("Plugin '{$plugin->name}' declares gradle plugin with invalid id/version '{$id}:{$version}' — skipping");
+
+                    continue;
+                }
+
+                // First declaration wins across plugins
+                if (isset($entries[$id])) {
+                    continue;
+                }
+
+                // Skip ids already declared outside our marker block
+                if ($existingContent !== '' && str_contains($existingContent, "id(\"{$id}\")")) {
+                    $withoutBlock = preg_replace(
+                        '/\/\/ BEGIN nativephp-plugin-gradle-plugins.*?\/\/ END nativephp-plugin-gradle-plugins/s',
+                        '',
+                        $existingContent
+                    );
+                    if (str_contains($withoutBlock, "id(\"{$id}\")")) {
+                        continue;
+                    }
+                }
+
+                $apply = $gradlePlugin['apply'] ?? false;
+                $entries[$id] = "    id(\"{$id}\") version \"{$version}\" apply ".($apply ? 'true' : 'false');
+            }
+        }
+
+        if (empty($entries)) {
+            return '';
+        }
+
+        return "    // BEGIN nativephp-plugin-gradle-plugins\n"
+            ."    // Auto-generated on every build from installed plugins — do not edit.\n"
+            .implode("\n", $entries)."\n"
+            ."    // END nativephp-plugin-gradle-plugins\n";
     }
 
     /**

--- a/src/Plugins/Plugin.php
+++ b/src/Plugins/Plugin.php
@@ -148,6 +148,19 @@ class Plugin
         return $this->manifest->android['repositories'] ?? [];
     }
 
+    /**
+     * Gradle plugins this plugin needs declared in the root build.gradle.kts
+     * plugins {} block, as `android.gradle_plugins` in nativephp.json.
+     * Each entry: ['id' => string, 'version' => string, 'apply' => bool (default false)].
+     * `apply => false` puts the plugin on the build classpath only, so the
+     * app module can apply it conditionally (e.g. google-services when a
+     * google-services.json is present).
+     */
+    public function getAndroidGradlePlugins(): array
+    {
+        return $this->manifest->android['gradle_plugins'] ?? [];
+    }
+
     public function getAndroidFeatures(): array
     {
         return $this->manifest->android['features'] ?? [];

--- a/src/Plugins/PluginManifest.php
+++ b/src/Plugins/PluginManifest.php
@@ -127,6 +127,7 @@ class PluginManifest implements JsonSerializable
             isset($data['android']['services']) ||
             isset($data['android']['receivers']) ||
             isset($data['android']['providers']) ||
+            isset($data['android']['gradle_plugins']) ||
             isset($data['android']['min_version'])
         );
 

--- a/tests/Feature/Plugins/AndroidCompilerTest.php
+++ b/tests/Feature/Plugins/AndroidCompilerTest.php
@@ -82,6 +82,15 @@ dependencies {
 }'
         );
 
+        // Create minimal root build.gradle.kts (target for gradle plugin injection)
+        $this->files->put(
+            $this->testBasePath.'/android/build.gradle.kts',
+            'plugins {
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.kotlin.android) apply false
+}'
+        );
+
         $this->compiler = new AndroidPluginCompiler(
             $this->files,
             $this->mockRegistry,
@@ -1105,6 +1114,159 @@ object TestFunctions {
     /**
      * Helper method to create a test Plugin instance.
      */
+    /**
+     * @test
+     *
+     * A plugin's android.gradle_plugins should be declared in the root
+     * build.gradle.kts plugins {} block, defaulting to apply false.
+     */
+    public function it_declares_plugin_gradle_plugins_in_root_build_file(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'gradle_plugins' => [
+                    ['id' => 'com.google.gms.google-services', 'version' => '4.4.3'],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $content = $this->files->get($this->testBasePath.'/android/build.gradle.kts');
+
+        $this->assertStringContainsString('// BEGIN nativephp-plugin-gradle-plugins', $content);
+        $this->assertStringContainsString('id("com.google.gms.google-services") version "4.4.3" apply false', $content);
+        $this->assertStringContainsString('// END nativephp-plugin-gradle-plugins', $content);
+
+        // Declaration must land inside the plugins {} block
+        $this->assertMatchesRegularExpression(
+            '/plugins\s*\{.*id\("com\.google\.gms\.google-services"\).*\n\}/s',
+            $content
+        );
+    }
+
+    /**
+     * @test
+     *
+     * Recompiling must not duplicate gradle plugin declarations.
+     */
+    public function it_does_not_duplicate_gradle_plugin_declarations(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'gradle_plugins' => [
+                    ['id' => 'com.google.gms.google-services', 'version' => '4.4.3'],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+        $this->compiler->compile();
+
+        $content = $this->files->get($this->testBasePath.'/android/build.gradle.kts');
+
+        $this->assertEquals(1, substr_count($content, 'id("com.google.gms.google-services")'));
+    }
+
+    /**
+     * @test
+     *
+     * Removing a plugin must clear its gradle plugin declaration on the
+     * next compile.
+     */
+    public function it_clears_gradle_plugin_declarations_when_plugin_removed(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'gradle_plugins' => [
+                    ['id' => 'com.google.gms.google-services', 'version' => '4.4.3'],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+        $this->compiler->compile();
+
+        // Recompile with the plugin removed
+        $emptyRegistry = Mockery::mock(PluginRegistry::class);
+        $emptyRegistry->shouldReceive('detectConflicts')->andReturn([]);
+        $emptyRegistry->shouldReceive('all')->andReturn(collect([]));
+
+        (new AndroidPluginCompiler($this->files, $emptyRegistry, $this->testBasePath))->compile();
+
+        $content = $this->files->get($this->testBasePath.'/android/build.gradle.kts');
+
+        $this->assertStringNotContainsString('com.google.gms.google-services', $content);
+    }
+
+    /**
+     * @test
+     *
+     * A gradle plugin id already declared outside the marker block (e.g.
+     * hand-added by the developer) must not be declared a second time.
+     */
+    public function it_skips_gradle_plugins_already_declared_outside_markers(): void
+    {
+        $rootPath = $this->testBasePath.'/android/build.gradle.kts';
+        $this->files->put(
+            $rootPath,
+            'plugins {
+    alias(libs.plugins.android.application) apply false
+    id("com.google.gms.google-services") version "4.4.0" apply false
+}'
+        );
+
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'gradle_plugins' => [
+                    ['id' => 'com.google.gms.google-services', 'version' => '4.4.3'],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $content = $this->files->get($rootPath);
+
+        $this->assertEquals(1, substr_count($content, 'id("com.google.gms.google-services")'));
+        $this->assertStringContainsString('version "4.4.0"', $content);
+    }
+
+    /**
+     * @test
+     *
+     * Malformed gradle plugin declarations (missing version, id with
+     * characters that could inject Kotlin) are skipped.
+     */
+    public function it_skips_invalid_gradle_plugin_declarations(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'gradle_plugins' => [
+                    ['id' => 'com.example.missing-version'],
+                    ['id' => 'bad") ; System.exit(0) //', 'version' => '1.0.0'],
+                    ['id' => 'com.example.valid', 'version' => '2.0.0', 'apply' => true],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $content = $this->files->get($this->testBasePath.'/android/build.gradle.kts');
+
+        $this->assertStringNotContainsString('missing-version', $content);
+        $this->assertStringNotContainsString('System.exit', $content);
+        $this->assertStringContainsString('id("com.example.valid") version "2.0.0" apply true', $content);
+    }
+
     private function createTestPlugin(array $manifestData = [], ?string $path = null): Plugin
     {
         $defaultData = [


### PR DESCRIPTION
## Summary
- The Android template unconditionally declared the `com.google.gms.google-services` Gradle plugin and shipped firebase-messaging (+BOM, +proguard keep rules) in every app, whether or not it used Firebase — forcing a plugin download that could fail builds and ~1.5–2.5MB of unused Firebase in every APK.
- Plugins can now declare Gradle plugins via `android.gradle_plugins` in `nativephp.json` (`[{id, version, apply?}]`, `apply` defaults to `false` so the app module can apply conditionally). The compiler injects them into the root `build.gradle.kts` `plugins {}` block inside a marker-delimited section rebuilt on every compile: idempotent, cleared when the plugin is removed, skips ids already declared outside the markers, and rejects malformed ids/versions.
- The firebase plugin now owns the google-services declaration, the firebase-messaging dependencies, and the Firebase proguard rules.

## Test plan
- [x] New `AndroidCompilerTest` coverage for Gradle plugin injection (idempotency, removal, malformed input, pre-existing declarations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)