### PR TITLE
Bump Gradle wrapper to 8.14.5 in the Android template

### DIFF
--- a/resources/androidstudio/gradle/wrapper/gradle-wrapper.properties
+++ b/resources/androidstudio/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Feb 10 07:33:27 EST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Bumps the Android template's Gradle wrapper from its previous version to 8.14.5 (`resources/androidstudio/gradle/wrapper/gradle-wrapper.properties`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)