### PR TITLE
Enable OPcache in file-cache mode on Android and iOS

### DIFF
--- a/bootstrap/android/native.php
+++ b/bootstrap/android/native.php
@@ -16,6 +16,14 @@ if (function_exists('opcache_get_status')) {
     } else {
         $_opcacheInfo = 'disabled';
     }
+
+    // In file_cache_only mode opcache_get_status() reports disabled (no SHM),
+    // but the file cache IS active — flag it so per-request logs aren't
+    // misleading. (No bin count here: this runs per request.)
+    $opcacheConfig = function_exists('opcache_get_configuration') ? @opcache_get_configuration() : null;
+    if (! empty($opcacheConfig['directives']['opcache.file_cache_only'])) {
+        $_opcacheInfo .= ',file_cache_only=1';
+    }
 } else {
     $_opcacheInfo = 'NOT_AVAILABLE';
 }

--- a/bootstrap/android/persistent.php
+++ b/bootstrap/android/persistent.php
@@ -26,6 +26,26 @@ if (function_exists('opcache_get_status')) {
     } else {
         $_opcacheInfo = 'disabled';
     }
+
+    // In file_cache_only mode opcache_get_status() reports disabled (there is
+    // no SHM to report on) even though the file cache IS active — surface the
+    // file cache state so boot logs aren't misleading.
+    $opcacheConfig = function_exists('opcache_get_configuration') ? @opcache_get_configuration() : null;
+    if (! empty($opcacheConfig['directives']['opcache.file_cache_only'])) {
+        $fileCacheDir = $opcacheConfig['directives']['opcache.file_cache'] ?? '';
+        $fileCacheBins = 0;
+        if ($fileCacheDir && is_dir($fileCacheDir)) {
+            $it = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($fileCacheDir, FilesystemIterator::SKIP_DOTS)
+            );
+            foreach ($it as $f) {
+                if ($f->getExtension() === 'bin') {
+                    $fileCacheBins++;
+                }
+            }
+        }
+        $_opcacheInfo .= ",file_cache_only=1,file_cache_bins={$fileCacheBins}";
+    }
 } else {
     $_opcacheInfo = 'NOT_AVAILABLE';
 }

--- a/bootstrap/ios/persistent.php
+++ b/bootstrap/ios/persistent.php
@@ -26,6 +26,26 @@ if (function_exists('opcache_get_status')) {
     } else {
         $_opcacheInfo = 'disabled';
     }
+
+    // In file_cache_only mode opcache_get_status() reports disabled (there is
+    // no SHM to report on) even though the file cache IS active — surface the
+    // file cache state so boot logs aren't misleading.
+    $opcacheConfig = function_exists('opcache_get_configuration') ? @opcache_get_configuration() : null;
+    if (! empty($opcacheConfig['directives']['opcache.file_cache_only'])) {
+        $fileCacheDir = $opcacheConfig['directives']['opcache.file_cache'] ?? '';
+        $fileCacheBins = 0;
+        if ($fileCacheDir && is_dir($fileCacheDir)) {
+            $it = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($fileCacheDir, FilesystemIterator::SKIP_DOTS)
+            );
+            foreach ($it as $f) {
+                if ($f->getExtension() === 'bin') {
+                    $fileCacheBins++;
+                }
+            }
+        }
+        $_opcacheInfo .= ",file_cache_only=1,file_cache_bins={$fileCacheBins}";
+    }
 } else {
     $_opcacheInfo = 'NOT_AVAILABLE';
 }

--- a/resources/androidstudio/app/src/main/cpp/php_bridge.c
+++ b/resources/androidstudio/app/src/main/cpp/php_bridge.c
@@ -4,6 +4,7 @@
 #include <pthread.h>
 #include <errno.h>
 #include <time.h>
+#include <sys/stat.h>
 #include "php_embed.h"
 #include "PHP.h"
 #include <zend_exceptions.h>
@@ -126,6 +127,54 @@ static int ephemeral_cold_booted = 0;
 static pthread_mutex_t g_ephemeral_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /**
+ * Build the SAPI hardcoded-ini string, appending OPcache file-cache settings
+ * when the host app has provided a cache directory (NATIVEPHP_OPCACHE_PATH).
+ *
+ * OPcache must run in file_cache_only mode here: its shared-memory mode
+ * crashes on Android ("FORTIFY: pthread_mutex_lock called on a destroyed
+ * mutex") because OPcache's PTHREAD_PROCESS_SHARED mutexes conflict with the
+ * NativePHP extension's own shared-memory mutexes. file_cache_only bypasses
+ * SHM entirely.
+ *
+ * validate_timestamps=0 is safe because app code is immutable between
+ * deployments — the host wipes the cache dir on app update, and
+ * native_persistent_reboot wipes it on hot reload.
+ *
+ * The returned pointer must stay valid until php_embed_init() has run, so the
+ * ini string lives in a static buffer. All boot paths already serialize
+ * startup (request/ephemeral mutexes + persistent boot gate), and the buffer
+ * content is identical on every call.
+ */
+static char g_ini_entries_buf[2048];
+
+static const char *build_ini_entries(const char *base_entries) {
+    const char *cache_dir = getenv("NATIVEPHP_OPCACHE_PATH");
+    if (!cache_dir || cache_dir[0] == '\0') {
+        return base_entries;
+    }
+
+    // OPcache requires the file cache directory to exist (it creates only
+    // its own subdirectories). Ignore EEXIST — the host normally pre-creates it.
+    mkdir(cache_dir, 0700);
+
+    // No quotes around the path: hardcoded ini entries are parsed with the RAW
+    // scanner, which takes unquoted values to end-of-line (spaces included).
+    int written = snprintf(g_ini_entries_buf, sizeof(g_ini_entries_buf),
+        "%s"
+        "opcache.enable=1\n"
+        "opcache.enable_cli=1\n"
+        "opcache.file_cache_only=1\n"
+        "opcache.file_cache=%s\n"
+        "opcache.validate_timestamps=0\n",
+        base_entries, cache_dir);
+    if (written < 0 || (size_t)written >= sizeof(g_ini_entries_buf)) {
+        LOGE("build_ini_entries: ini string overflow, leaving OPcache disabled");
+        return base_entries;
+    }
+    return g_ini_entries_buf;
+}
+
+/**
  * Configure the embed SAPI module with host-registered functions.
  * Must be called before each php_embed_init().
  */
@@ -133,10 +182,11 @@ static void setup_embed_module(void) {
     php_embed_module.ub_write = capture_php_output;
     php_embed_module.phpinfo_as_text = 1;
     php_embed_module.php_ini_ignore = 0;
-    php_embed_module.ini_entries = "output_buffering=4096\n"
-                                   "implicit_flush=0\n"
-                                   "display_errors=1\n"
-                                   "error_reporting=E_ALL\n";
+    php_embed_module.ini_entries = build_ini_entries(
+        "output_buffering=4096\n"
+        "implicit_flush=0\n"
+        "display_errors=1\n"
+        "error_reporting=E_ALL\n");
     php_embed_module.header_handler = android_header_handler;
 }
 
@@ -710,6 +760,26 @@ JNIEXPORT jint JNICALL native_persistent_reboot(JNIEnv *env, jobject thiz) {
     } zend_end_try();
     LOGI("persistent_reboot: opcache cleared");
 
+    // 2b. Wipe the OPcache file cache. opcache_reset() only resets SHM (a
+    // no-op in file_cache_only mode), and with validate_timestamps=0 stale
+    // bytecode would keep being served for files changed by hot reload.
+    zend_first_try {
+        zend_eval_string(
+            "$__opdir = getenv('NATIVEPHP_OPCACHE_PATH');"
+            "if ($__opdir && is_dir($__opdir)) {"
+            "    $__it = new \\RecursiveIteratorIterator("
+            "        new \\RecursiveDirectoryIterator($__opdir, \\FilesystemIterator::SKIP_DOTS),"
+            "        \\RecursiveIteratorIterator::CHILD_FIRST"
+            "    );"
+            "    foreach ($__it as $__f) {"
+            "        $__f->isDir() ? @rmdir($__f->getPathname()) : @unlink($__f->getPathname());"
+            "    }"
+            "}",
+            NULL, "persistent_reboot_opcache_files"
+        );
+    } zend_end_try();
+    LOGI("persistent_reboot: opcache file cache wiped");
+
     // 3. Clear compiled views and cached config
     zend_first_try {
         zend_eval_string(
@@ -889,7 +959,8 @@ JNIEXPORT jstring JNICALL native_run_artisan_command(JNIEnv *env, jobject thiz, 
         // Cold path: no live runtime (e.g. install-time setup, or a WorkManager
         // cold start after the app was killed) — full embed init is safe.
         setup_embed_module();
-        php_embed_module.ini_entries = "display_errors=1\nimplicit_flush=1\noutput_buffering=0\n";
+        php_embed_module.ini_entries = build_ini_entries(
+            "display_errors=1\nimplicit_flush=1\noutput_buffering=0\n");
         if (php_embed_init(0, NULL) != SUCCESS) {
             LOGE("Failed to initialize PHP for artisan");
             pthread_mutex_unlock(&g_ephemeral_mutex);

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
@@ -758,6 +758,17 @@ class LaravelEnvironment(private val context: Context) {
     }
 
     /**
+     * True when the extracted bundle is a DEBUG build (hot reload enabled).
+     * Reads the .version marker written during extraction.
+     */
+    private fun isDebugBuild(): Boolean = try {
+        val versionFile = File(appStorageDir, "$DIR_LARAVEL/$VERSION_FILE")
+        versionFile.exists() && versionFile.readText().trim() == VERSION_DEBUG
+    } catch (e: Exception) {
+        false
+    }
+
+    /**
      * Delete all cached OPcache bytecode. Called whenever the app bundle is
      * (re-)extracted: OPcache runs with validate_timestamps=0, so cached .bin
      * files for changed sources would never be revalidated.
@@ -860,10 +871,6 @@ class LaravelEnvironment(private val context: Context) {
                 "PHP_INI_SCAN_DIR" to appStorageDir.absolutePath,
                 "CA_CERT_DIR" to context.filesDir.absolutePath,
                 "PHPRC" to context.filesDir.absolutePath,
-                // OPcache file cache (file_cache_only mode — SHM crashes on
-                // Android). The C bridge reads this and enables OPcache at
-                // php_embed_init time; see build_ini_entries() in php_bridge.c.
-                "NATIVEPHP_OPCACHE_PATH" to "${appStorageDir.absolutePath}/$DIR_OPCACHE",
                 // PHP/Server environment
                 "REMOTE_ADDR" to "127.0.0.1",
                 "SERVER_NAME" to "127.0.0.1",
@@ -871,6 +878,20 @@ class LaravelEnvironment(private val context: Context) {
                 "SERVER_PROTOCOL" to "HTTP/1.1",
                 "REQUEST_SCHEME" to "http"
             )
+
+            // OPcache file cache (file_cache_only mode — SHM crashes on
+            // Android). Production builds only: DEBUG builds re-extract the
+            // bundle on every launch and wipe the cache on every hot reload,
+            // so cached bytecode would never be reused — compiling and
+            // writing .bin files would be pure overhead. The C bridge reads
+            // this and enables OPcache at php_embed_init time; see
+            // build_ini_entries() in php_bridge.c.
+            if (!isDebugBuild()) {
+                setEnvironmentVariable(
+                    "NATIVEPHP_OPCACHE_PATH",
+                    "${appStorageDir.absolutePath}/$DIR_OPCACHE"
+                )
+            }
 
             Log.d(TAG, "✅ Environment variables configured")
 
@@ -885,12 +906,7 @@ class LaravelEnvironment(private val context: Context) {
 
             try {
                 // Check if we're in DEBUG mode to force certificate refresh
-                val isDebugMode = try {
-                    val versionFile = File(appStorageDir, "$DIR_LARAVEL/$VERSION_FILE")
-                    versionFile.exists() && versionFile.readText().trim() == VERSION_DEBUG
-                } catch (e: Exception) {
-                    false
-                }
+                val isDebugMode = isDebugBuild()
 
                 Log.d(TAG, "🔍 Certificate copy - DEBUG mode: $isDebugMode")
                 copyAssetToInternalStorage(CACERT_FILE, CACERT_FILE, forceUpdate = isDebugMode)

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
@@ -66,6 +66,7 @@ class LaravelEnvironment(private val context: Context) {
         private const val DIR_APP = "persisted_data/storage/app"
         private const val DIR_PUBLIC = "persisted_data/storage/app/public"
         private const val DIR_DATABASE = "persisted_data/database/"
+        private const val DIR_OPCACHE = "persisted_data/opcache"
         private const val DIR_PHP_SESSIONS = "php_sessions"
 
         // API URLs
@@ -169,6 +170,13 @@ class LaravelEnvironment(private val context: Context) {
             //     extractLaravelBundle()
             // }
             val didExtract = extractLaravelBundle()
+
+            // App code changed — wipe the OPcache file cache. It's compiled
+            // with validate_timestamps=0, so stale bytecode would otherwise
+            // be served for the freshly extracted files.
+            if (didExtract) {
+                clearOpcacheFileCache()
+            }
 
             setupEnvironment()
 
@@ -749,6 +757,23 @@ class LaravelEnvironment(private val context: Context) {
         phpBridge.runArtisanCommand("migrate --force")
     }
 
+    /**
+     * Delete all cached OPcache bytecode. Called whenever the app bundle is
+     * (re-)extracted: OPcache runs with validate_timestamps=0, so cached .bin
+     * files for changed sources would never be revalidated.
+     */
+    private fun clearOpcacheFileCache() {
+        try {
+            val opcacheDir = File(appStorageDir, DIR_OPCACHE)
+            if (opcacheDir.exists()) {
+                opcacheDir.listFiles()?.forEach { it.deleteRecursively() }
+                Log.d(TAG, "🗑️ Cleared OPcache file cache at ${opcacheDir.absolutePath}")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to clear OPcache file cache", e)
+        }
+    }
+
     private fun setupDirectories() {
         try {
             // Create directories with permissions as needed
@@ -760,6 +785,7 @@ class LaravelEnvironment(private val context: Context) {
             createDirectory(DIR_APP)
             createDirectory(DIR_PUBLIC)
             createDirectory(DIR_DATABASE)
+            createDirectory(DIR_OPCACHE, withPermissions = true)
 
             // Set permissions on parent storage directory (owner-only)
             File(appStorageDir, DIR_STORAGE).setWritable(true, true)
@@ -834,6 +860,10 @@ class LaravelEnvironment(private val context: Context) {
                 "PHP_INI_SCAN_DIR" to appStorageDir.absolutePath,
                 "CA_CERT_DIR" to context.filesDir.absolutePath,
                 "PHPRC" to context.filesDir.absolutePath,
+                // OPcache file cache (file_cache_only mode — SHM crashes on
+                // Android). The C bridge reads this and enables OPcache at
+                // php_embed_init time; see build_ini_entries() in php_bridge.c.
+                "NATIVEPHP_OPCACHE_PATH" to "${appStorageDir.absolutePath}/$DIR_OPCACHE",
                 // PHP/Server environment
                 "REMOTE_ADDR" to "127.0.0.1",
                 "SERVER_NAME" to "127.0.0.1",
@@ -948,6 +978,11 @@ openssl.cafile="${context.filesDir.absolutePath}/$CACERT_FILE"
             // If we arrived first (WorkManager cold start after an app update), we
             // do the extraction ourselves before the ephemeral runtime touches vendor/.
             val didExtract = extractLaravelBundle()
+            // Same as initialize(): extracted code invalidates the OPcache
+            // file cache (validate_timestamps=0 never revalidates).
+            if (didExtract) {
+                clearOpcacheFileCache()
+            }
             setupEnvironment()
             // Only run install-time artisan commands when we actually extracted AND no
             // persistent runtime is already live. In a warm process the live app booted

--- a/resources/xcode/Include/Bridge/PHP.c
+++ b/resources/xcode/Include/Bridge/PHP.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <time.h>
+#include <sys/stat.h>
 #include <zend_exceptions.h>
 
 static phpOutputCallback swiftOutputCallback = NULL;
@@ -247,14 +248,63 @@ static void do_artisan(const char *command);
 static void do_shutdown(void);
 static void do_reboot(void);
 
+// ── OPcache file cache ──────────────────────────────
+// Build the SAPI hardcoded-ini string, appending OPcache file-cache settings
+// when the host app has provided a cache directory (NATIVEPHP_OPCACHE_PATH).
+//
+// OPcache runs in file_cache_only mode, mirroring Android: OPcache's
+// shared-memory mode uses PTHREAD_PROCESS_SHARED mutexes that conflict with
+// the NativePHP extension's own shared-memory mutexes. file_cache_only
+// bypasses SHM entirely.
+//
+// validate_timestamps=0 is safe because app code is immutable between
+// deployments — AppUpdateManager wipes the cache dir on app update, and
+// do_reboot() wipes it on hot reload.
+//
+// The returned pointer must stay valid through module startup, so the ini
+// string lives in a static buffer. All boot paths serialize startup (worker
+// thread + persistent boot gate) and the buffer content is identical on
+// every call.
+static char g_ini_entries_buf[2048];
+
+static const char *build_ini_entries(const char *base_entries) {
+    const char *cache_dir = getenv("NATIVEPHP_OPCACHE_PATH");
+    if (!cache_dir || cache_dir[0] == '\0') {
+        return base_entries;
+    }
+
+    // OPcache requires the file cache directory to exist (it creates only
+    // its own subdirectories). Ignore EEXIST — Swift normally pre-creates it.
+    mkdir(cache_dir, 0700);
+
+    // No quotes around the path (which contains a space on iOS —
+    // ".../Library/Application Support/opcache"): hardcoded ini entries are
+    // parsed with the RAW scanner, which takes unquoted values to end-of-line.
+    int written = snprintf(g_ini_entries_buf, sizeof(g_ini_entries_buf),
+        "%s"
+        "opcache.enable=1\n"
+        "opcache.enable_cli=1\n"
+        "opcache.file_cache_only=1\n"
+        "opcache.file_cache=%s\n"
+        "opcache.validate_timestamps=0\n",
+        base_entries, cache_dir);
+    if (written < 0 || (size_t)written >= sizeof(g_ini_entries_buf)) {
+        fprintf(stderr, "build_ini_entries: ini string overflow, leaving OPcache disabled\n");
+        fflush(stderr);
+        return base_entries;
+    }
+    return g_ini_entries_buf;
+}
+
 static void setup_persistent_sapi(void) {
     php_embed_module.ub_write       = capture_php_output;
     php_embed_module.phpinfo_as_text = 1;
     php_embed_module.php_ini_ignore  = 0;
-    php_embed_module.ini_entries     = "output_buffering=4096\n"
-                                       "implicit_flush=0\n"
-                                       "display_errors=1\n"
-                                       "error_reporting=E_ALL\n";
+    php_embed_module.ini_entries     = build_ini_entries(
+        "output_buffering=4096\n"
+        "implicit_flush=0\n"
+        "display_errors=1\n"
+        "error_reporting=E_ALL\n");
     php_embed_module.header_handler  = ios_header_handler;
 }
 
@@ -649,6 +699,25 @@ static void do_reboot(void) {
         zend_eval_string(
             "if (function_exists('opcache_reset')) { opcache_reset(); }",
             NULL, "persistent_reboot_opcache"
+        );
+    } zend_end_try();
+
+    // 2b. Wipe the OPcache file cache. opcache_reset() only resets SHM (a
+    // no-op in file_cache_only mode), and with validate_timestamps=0 stale
+    // bytecode would keep being served for files changed by hot reload.
+    zend_first_try {
+        zend_eval_string(
+            "$__opdir = getenv('NATIVEPHP_OPCACHE_PATH');"
+            "if ($__opdir && is_dir($__opdir)) {"
+            "    $__it = new \\RecursiveIteratorIterator("
+            "        new \\RecursiveDirectoryIterator($__opdir, \\FilesystemIterator::SKIP_DOTS),"
+            "        \\RecursiveIteratorIterator::CHILD_FIRST"
+            "    );"
+            "    foreach ($__it as $__f) {"
+            "        $__f->isDir() ? @rmdir($__f->getPathname()) : @unlink($__f->getPathname());"
+            "    }"
+            "}",
+            NULL, "persistent_reboot_opcache_files"
         );
     } zend_end_try();
 

--- a/resources/xcode/NativePHP/AppUpdateManager.swift
+++ b/resources/xcode/NativePHP/AppUpdateManager.swift
@@ -86,6 +86,9 @@ class AppUpdateManager {
             try extractZipParallel(from: sourceURL, to: destinationURL)
             print("✅ Bundled app extracted successfully")
 
+            // App code changed — stale OPcache bytecode must go (validate_timestamps=0)
+            clearOpcacheFileCache()
+
             // Create installed.version file after successful extraction
             createInstalledVersionFile()
 
@@ -207,6 +210,9 @@ class AppUpdateManager {
 
             // Move new app into place
             try FileManager.default.moveItem(atPath: extractPath, toPath: appPath)
+
+            // App code changed — stale OPcache bytecode must go (validate_timestamps=0)
+            clearOpcacheFileCache()
 
             // Create installed.version file for the new version
             createInstalledVersionFile()
@@ -708,6 +714,22 @@ class AppUpdateManager {
         } catch {
             print("❌ Failed to create installed.version file: \(error)")
         }
+    }
+
+    /// Delete all cached OPcache bytecode. Called whenever app code is
+    /// extracted or updated: OPcache runs with validate_timestamps=0, so
+    /// cached .bin files for changed sources would never be revalidated.
+    private func clearOpcacheFileCache() {
+        let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let opcacheDir = appSupportURL.appendingPathComponent("opcache")
+
+        guard let entries = try? FileManager.default.contentsOfDirectory(at: opcacheDir, includingPropertiesForKeys: nil) else {
+            return
+        }
+        for entry in entries {
+            try? FileManager.default.removeItem(at: entry)
+        }
+        print("🗑️ Cleared OPcache file cache at \(opcacheDir.path)")
     }
 
     private func runMigrationsAndClearCaches() {

--- a/resources/xcode/NativePHP/Bridge/PersistentPHPRuntime.swift
+++ b/resources/xcode/NativePHP/Bridge/PersistentPHPRuntime.swift
@@ -71,6 +71,13 @@ final class PersistentPHPRuntime {
         setenv("NATIVEPHP_PLATFORM", "ios", 1)
         setenv("REMOTE_ADDR", "0.0.0.0", 1)
 
+        // OPcache file cache (file_cache_only mode — SHM conflicts with the
+        // NativePHP extension's shared-memory mutexes). The C bridge reads
+        // this and enables OPcache at startup; see build_ini_entries() in PHP.c.
+        let opcacheDir = storageDir.appendingPathComponent("opcache")
+        try? FileManager.default.createDirectory(at: opcacheDir, withIntermediateDirectories: true)
+        setenv("NATIVEPHP_OPCACHE_PATH", opcacheDir.path, 1)
+
         // Composer autoloader and bootstrap paths (used by persistent.php)
         setenv("COMPOSER_AUTOLOADER_PATH", appPath + "/vendor/autoload.php", 1)
         setenv("LARAVEL_BOOTSTRAP_PATH", appPath + "/bootstrap", 1)

--- a/resources/xcode/NativePHP/Bridge/PersistentPHPRuntime.swift
+++ b/resources/xcode/NativePHP/Bridge/PersistentPHPRuntime.swift
@@ -72,11 +72,16 @@ final class PersistentPHPRuntime {
         setenv("REMOTE_ADDR", "0.0.0.0", 1)
 
         // OPcache file cache (file_cache_only mode — SHM conflicts with the
-        // NativePHP extension's shared-memory mutexes). The C bridge reads
-        // this and enables OPcache at startup; see build_ini_entries() in PHP.c.
-        let opcacheDir = storageDir.appendingPathComponent("opcache")
-        try? FileManager.default.createDirectory(at: opcacheDir, withIntermediateDirectories: true)
-        setenv("NATIVEPHP_OPCACHE_PATH", opcacheDir.path, 1)
+        // NativePHP extension's shared-memory mutexes). Production builds
+        // only: DEBUG builds wipe the cache on every hot reload, so cached
+        // bytecode would never be reused — writing .bin files would be pure
+        // overhead. The C bridge reads this and enables OPcache at startup;
+        // see build_ini_entries() in PHP.c.
+        if AppUpdateManager.shared.getAppVersion() != "DEBUG" {
+            let opcacheDir = storageDir.appendingPathComponent("opcache")
+            try? FileManager.default.createDirectory(at: opcacheDir, withIntermediateDirectories: true)
+            setenv("NATIVEPHP_OPCACHE_PATH", opcacheDir.path, 1)
+        }
 
         // Composer autoloader and bootstrap paths (used by persistent.php)
         setenv("COMPOSER_AUTOLOADER_PATH", appPath + "/vendor/autoload.php", 1)

--- a/resources/xcode/NativePHP/NativePHPApp.swift
+++ b/resources/xcode/NativePHP/NativePHPApp.swift
@@ -406,6 +406,11 @@ struct NativePHPApp: App {
         setenv("VIEW_COMPILED_PATH", viewCacheDir, 1)
         setenv("DB_DATABASE", "\(databaseDir)/database.sqlite", 1)
 
+        // OPcache file cache (file_cache_only mode — SHM conflicts with the
+        // NativePHP extension's shared-memory mutexes). The C bridge reads
+        // this and enables OPcache at startup; see build_ini_entries() in PHP.c.
+        setenv("NATIVEPHP_OPCACHE_PATH", getAppSupportDir(dir: "opcache"), 1)
+
         // Set APP_KEY from secure storage (generates on first run)
         if let appKey = getOrGenerateAppKey() {
             setenv("APP_KEY", appKey, 1)

--- a/resources/xcode/NativePHP/NativePHPApp.swift
+++ b/resources/xcode/NativePHP/NativePHPApp.swift
@@ -407,9 +407,15 @@ struct NativePHPApp: App {
         setenv("DB_DATABASE", "\(databaseDir)/database.sqlite", 1)
 
         // OPcache file cache (file_cache_only mode — SHM conflicts with the
-        // NativePHP extension's shared-memory mutexes). The C bridge reads
-        // this and enables OPcache at startup; see build_ini_entries() in PHP.c.
-        setenv("NATIVEPHP_OPCACHE_PATH", getAppSupportDir(dir: "opcache"), 1)
+        // NativePHP extension's shared-memory mutexes). Production builds
+        // only: DEBUG builds wipe the cache on every hot reload, so cached
+        // bytecode would never be reused. See build_ini_entries() in PHP.c.
+        // Note: on the very first launch this runs before extraction, when
+        // getAppVersion() falls back to "DEBUG" — the persistent runtime's
+        // own boot() re-checks after extraction and enables it there.
+        if AppUpdateManager.shared.getAppVersion() != "DEBUG" {
+            setenv("NATIVEPHP_OPCACHE_PATH", getAppSupportDir(dir: "opcache"), 1)
+        }
 
         // Set APP_KEY from secure storage (generates on first run)
         if let appKey = getOrGenerateAppKey() {


### PR DESCRIPTION
## What

Wires up the OPcache configuration that was validated in `php-bin-mobile/optimization.md` — `opcache.enable=1` + `opcache.file_cache_only=1` + `opcache.validate_timestamps=0` — on both platforms, enabled at runtime by the host apps **in production builds only**. Those measurements showed warm persistent-runtime boot dropping from ~420ms to ~110ms (3.8x) with the file cache populated.

## Why file-cache-only mode

OPcache's shared-memory mode crashes on Android (`FORTIFY: pthread_mutex_lock called on a destroyed mutex`) — its `PTHREAD_PROCESS_SHARED` mutexes conflict with the NativePHP extension's own shared-memory mutexes. `file_cache_only=1` bypasses SHM entirely. The php-bin-mobile builds already compile OPcache in with `opcache.enable` patched to `0`, so enabling it is purely a host-app runtime concern (this PR).

## How it works

**C bridges** (`php_bridge.c`, `PHP.c`): a new `build_ini_entries()` helper appends the OPcache settings to the embed SAPI's hardcoded ini entries whenever `NATIVEPHP_OPCACHE_PATH` is set. Because every boot path funnels through the shared SAPI setup function, this covers persistent, classic per-request, queue worker, ephemeral, and artisan contexts. If the env var is absent, behaviour is exactly as before. On PHP 8.4 builds (OPcache compiled out) the extra entries are inert.

**Host apps** set the env var and create the cache dir — production builds only:
- Android: `app_storage/persisted_data/opcache` (`LaravelEnvironment.setupEnvironment()`, gated on `isDebugBuild()`)
- iOS: `Library/Application Support/opcache` (`NativePHPApp.setupEnvironment()` + `PersistentPHPRuntime.boot()`, gated on `getAppVersion() != "DEBUG"`)

**DEBUG builds skip OPcache entirely.** In debug, the cache never survives long enough to be read — Android re-extracts the bundle every launch (wiping it) and every hot reload wipes it on both platforms — while populating it costs real write I/O (~1,100 `.bin` files / ~25MB per cold compile). That would make launches and hot reloads slower for zero benefit, so the env var simply isn't set.

**Cache invalidation** — with `validate_timestamps=0` sources are never revalidated, so the cache is wiped whenever app code changes:
- Bundle extraction / OTA update: `LaravelEnvironment.clearOpcacheFileCache()` (foreground + WorkManager background paths) and `AppUpdateManager.clearOpcacheFileCache()`
- Hot reload: `native_persistent_reboot` / `do_reboot` now wipe the file cache dir in addition to `opcache_reset()` (which only touches SHM and is a no-op in file-cache mode)

These wipe paths also clear leftover cache when a device flips between debug and release builds.

**Observability**: `opcache_get_status()` misleadingly reports `opcache_enabled=false` in file-cache-only mode (there's no SHM to report on), so the `PerfTiming` boot logs in `persistent.php` now also report `file_cache_only=1,file_cache_bins=<n>`. Watching `file_cache_bins` grow across boots (and boot times drop) is the easiest way to confirm it's working.

## Testing notes

- Test with a **non-debug build** — DEBUG builds intentionally run with OPcache off.
- First boot after install is the cold path (cache empty, bins get written); subsequent boots should hit the cache — compare `PerfTiming` lines in logcat / Xcode console.
- iOS was configured identically in the original experiment but never measured (`optimization.md` "What's Not Yet Measured") — worth watching for any SHM-adjacent surprises there even though file-cache mode shouldn't touch SHM at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7NGnU8t6EpdMPnxuVpKc3