### PR TITLE
Fix permanent re-extraction loop — bundle re-extracted on every cold boot

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
@@ -254,10 +254,19 @@ class LaravelEnvironment(private val context: Context) {
 
         Log.d(TAG, "🔍 DEBUG: embeddedId from bundle = '$embeddedId'")
 
-        // Build composite from extracted .env if it exists
+        // Identity of what's currently extracted. The .version marker written
+        // after extraction is authoritative — it records the embedded composite
+        // verbatim. Recomputing from the extracted .env is only a legacy
+        // fallback, and it MUST NOT be preferred: .env carries no
+        // NATIVEPHP_APP_VERSION_CODE line, so the recompute yields "…b0"
+        // against bundle_meta.json's "…b1" and the app re-extracts the whole
+        // bundle on EVERY cold boot — several seconds of splash each launch.
         val currentId = if (laravelDir.exists()) {
+            val versionFile = File(laravelDir, VERSION_FILE)
             val envFile = File(laravelDir, ENV_FILE)
-            if (envFile.exists()) {
+            if (versionFile.exists()) {
+                versionFile.readText().trim().ifEmpty { null }
+            } else if (envFile.exists()) {
                 buildVersionId(getVersionFromEnvFile(envFile), getVersionCodeFromEnvFile(envFile))
             } else {
                 null
@@ -312,14 +321,13 @@ class LaravelEnvironment(private val context: Context) {
                 otaMarkerFile.delete()
             }
 
-            // Update .version file with the composite identity so it stays in sync
-            // with the bundled .version (and survives a re-read for the staleness check).
-            val envFile = File(laravelDir, ENV_FILE)
-            val installedId = buildVersionId(getVersionFromEnvFile(envFile), getVersionCodeFromEnvFile(envFile))
-            if (installedId != null) {
-                File(laravelDir, VERSION_FILE).writeText(installedId)
-                Log.d(TAG, "✅ Updated .version file to: $installedId")
-            }
+            // Record WHAT WAS JUST EXTRACTED: the embedded composite, verbatim.
+            // Recomputing from the extracted .env loses the version code (no
+            // NATIVEPHP_APP_VERSION_CODE line) and wrote "…b0" here while the
+            // staleness check compared against "…b1" — a permanent
+            // re-extraction loop.
+            File(laravelDir, VERSION_FILE).writeText(embeddedId)
+            Log.d(TAG, "✅ Updated .version file to: $embeddedId")
 
             Log.d(TAG, "✅ Extraction complete to ${laravelDir.absolutePath}")
 


### PR DESCRIPTION
## Summary

Every cold boot re-extracted the entire 77MB Laravel bundle. The staleness check compares the extracted tree's identity against the embedded composite from `bundle_meta.json` (e.g. `1.0.13b1`), but both the current-identity read **and** the post-extraction `.version` write recomputed the composite from the extracted `.env` — which has no `NATIVEPHP_APP_VERSION_CODE` line, so both always produced `1.0.13b0`. `b0 != b1` on every boot: rm -rf + full unzip behind the splash on every cold start, plus a per-boot window for extraction races.

**User impact:** ~3.5s of "Loading…" splash on every launch where apps used to boot straight to content.

## Fix

Write the embedded composite verbatim to the `.version` marker after extraction, and read the marker for the staleness check (falling back to the `.env` recompute only for legacy installs without one).

## Measured (Pixel 9, profileable build)

| | Fully drawn (cold boot, already extracted) |
|---|---|
| Before | 3,511 ms — re-extracting every launch |
| After | **279 ms** median over 3 runs — "Laravel already up to date", splash imperceptible |

🤖 Generated with [Claude Code](https://claude.com/claude-code)