### PR TITLE
Fix persistent-boot corruption from concurrent extraction/artisan races

### DIFF
--- a/resources/androidstudio/app/src/main/cpp/php_bridge.c
+++ b/resources/androidstudio/app/src/main/cpp/php_bridge.c
@@ -416,6 +416,35 @@ JNIEXPORT jint JNICALL native_persistent_boot(JNIEnv *env, jobject thiz, jstring
         LOGE("persistent_boot: bootstrap produced errors: %.200s", boot_output);
     }
 
+    // Verify the bootstrap actually left the runtime in place before blessing
+    // the interpreter as booted. php_execute_script gives no usable signal
+    // here: a bailed script (bootstrap file missing mid-extraction, fatal
+    // during Laravel boot) unwinds through zend_end_try and used to fall
+    // through to persistent_initialized = 1 — a ~10ms "boot" with no classes
+    // loaded, after which every dispatch 500s with `Class
+    // "Native\Mobile\Runtime" not found` until the process dies.
+    int boot_verified = 0;
+    zend_first_try {
+        zval verify_result;
+        if (zend_eval_string(
+                "(int) (class_exists('Native\\\\Mobile\\\\Runtime', false)"
+                " && \\Native\\Mobile\\Runtime::isBooted())",
+                &verify_result, "persistent_boot_verify") == SUCCESS) {
+            boot_verified = (Z_TYPE(verify_result) == IS_LONG && Z_LVAL(verify_result) == 1);
+            zval_ptr_dtor(&verify_result);
+        }
+    } zend_end_try();
+
+    if (!boot_verified) {
+        LOGE("persistent_boot: bootstrap did NOT boot the runtime (Runtime class/boot state missing) — tearing down");
+        safe_php_embed_shutdown();
+        php_initialized = 0;
+        set_persistent_boot_state(PERSISTENT_BOOT_FAILED);
+        (*env)->ReleaseStringUTFChars(env, jBootstrapPath, bootstrapPath);
+        pthread_mutex_unlock(&g_php_request_mutex);
+        return -2;
+    }
+
     persistent_initialized = 1;
     set_persistent_boot_state(PERSISTENT_BOOT_SUCCEEDED);
     LOGI("persistent_boot: PHP interpreter is now persistent and Laravel is booted");

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
@@ -39,7 +39,15 @@ class LaravelEnvironment(private val context: Context) {
         // APK + queued WorkManager job can run an ephemeral PHP task against a
         // mid-delete / mid-extract vendor/ tree and fail with
         // `Class "Native\Mobile\Runtime" not found`.
-        private val extractionLock = ReentrantLock()
+        //
+        // Internal (not private): PHPBridge.bootPersistentRuntime takes this
+        // same lock so the persistent php_embed_init can never overlap the
+        // classic embed init/shutdown cycles of runBaseArtisanCommands from a
+        // concurrently-created activity — the two paths use different native
+        // mutexes, and a classic php_embed_shutdown mid-boot guts the
+        // persistent interpreter's module/class state (boots "in 13ms", then
+        // every dispatch 500s with `Class "Native\Mobile\Runtime" not found`).
+        internal val extractionLock = ReentrantLock()
 
         // Classic (embed-per-command) artisan cannot run a second time in a
         // process where the persistent PHP runtime has been shut down — the
@@ -189,16 +197,25 @@ class LaravelEnvironment(private val context: Context) {
             // } else {
             //     extractLaravelBundle()
             // }
-            val didExtract = extractLaravelBundle()
 
-            setupEnvironment(didExtract)
+            // Hold the lock across extraction AND the post-extraction steps
+            // (.env writes + classic artisan). A second activity's init thread
+            // otherwise unblocks after the extraction alone, skips artisan via
+            // baseArtisanRanThisProcess, and boots the persistent runtime
+            // while THIS thread is still cycling classic embeds — see the
+            // extractionLock comment for the failure that causes.
+            extractionLock.withLock {
+                val didExtract = extractLaravelBundleUnlocked()
 
-            // Only run artisan commands when files were actually extracted/changed
-            if (didExtract) {
-                Log.d(TAG, "📦 Running post-extraction artisan commands...")
-                runBaseArtisanCommands()
-            } else {
-                Log.d(TAG, "⚡ Skipping artisan commands — no extraction needed")
+                setupEnvironment(didExtract)
+
+                // Only run artisan commands when files were actually extracted/changed
+                if (didExtract) {
+                    Log.d(TAG, "📦 Running post-extraction artisan commands...")
+                    runBaseArtisanCommands()
+                } else {
+                    Log.d(TAG, "⚡ Skipping artisan commands — no extraction needed")
+                }
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error initializing Laravel environment", e)

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
@@ -9,6 +9,7 @@ import org.json.JSONObject
 import java.util.concurrent.ConcurrentHashMap
 import com.nativephp.mobile.network.PHPRequest
 import com.nativephp.mobile.security.LaravelCookieStore
+import kotlin.concurrent.withLock
 
 class PHPBridge(private val context: Context) {
     private var lastPostData: String? = null
@@ -110,7 +111,15 @@ class PHPBridge(private val context: Context) {
      * Boot the persistent PHP runtime. Call once during app startup.
      * PHP interpreter stays alive — no init/shutdown per request.
      */
-    fun bootPersistentRuntime(): Boolean {
+    fun bootPersistentRuntime(): Boolean = LaravelEnvironment.extractionLock.withLock {
+        // The lock is shared with LaravelEnvironment.initialize(): a
+        // concurrently-created activity may still be extracting the bundle or
+        // cycling classic-embed artisan commands, and the persistent
+        // php_embed_init must not overlap either (different native mutexes;
+        // a classic php_embed_shutdown mid-boot guts the persistent
+        // interpreter — it "boots" in ~10ms with no classes loaded and every
+        // dispatch 500s until the process dies).
+
         // Process reuse: a plugin foreground service kept the process alive
         // past the previous activity, which parked (not tore down) the
         // runtime. Reuse it — native PHP re-init in a used process is


### PR DESCRIPTION
## Summary

Two concurrently-created activities (deep-link relaunch, system recreate) could interleave three process-global operations that must never overlap:

1. bundle extraction (rm -rf + unzip of the laravel tree)
2. classic-embed artisan cycles (`php_embed_init`/`shutdown` per command)
3. the persistent runtime's `php_embed_init`

The extraction lock only covered (1): a second activity's init thread unblocked after extraction, skipped artisan via `baseArtisanRanThisProcess`, and booted the persistent runtime while the first thread was still cycling classic embeds. Those paths use different native mutexes, so a classic `php_embed_shutdown` mid-boot guts the persistent interpreter's module/class state — it "boots" in ~10ms with no classes loaded, and every dispatch afterwards 500s with `Class "Native\Mobile\Runtime" not found` until the process dies. Reproduced on a Pixel 9 via fast double activity creation while re-extraction was pending (which #195 made a per-boot occurrence).

## Fixes

- `LaravelEnvironment.initialize()` holds the (now shared) lock across extraction + .env writes + classic artisan, not just extraction.
- `PHPBridge.bootPersistentRuntime()` takes the same lock, so the persistent boot serializes behind any in-flight init from another activity.
- `native_persistent_boot` verifies the bootstrap actually booted the runtime (`class_exists` + `Runtime::isBooted()`) before setting `persistent_initialized`; a bailed bootstrap now tears down and returns an error so Kotlin's classic-mode fallback engages instead of blessing a gutted interpreter.

## Verified

Kill-mid-extraction → rapid double-launch + deep link on a Pixel 9: single serialized extraction, real 134ms boot, zero dispatch errors (previously: 10ms fake boot, permanent 500s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)