### PR TITLE
Fix crash when the app is backgrounded during deferred boot

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/utils/NativeActionCoordinator.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/utils/NativeActionCoordinator.kt
@@ -109,9 +109,14 @@ class NativeActionCoordinator : Fragment() {
         fun install(activity: FragmentActivity): NativeActionCoordinator =
             activity.supportFragmentManager.findFragmentByTag("NativeActionCoordinator") as? NativeActionCoordinator
                 ?: NativeActionCoordinator().also {
+                    // install() is reached from the deferred boot callback, which can
+                    // land after the user backgrounds the app mid-boot — i.e. after
+                    // onSaveInstanceState. A plain commitNow() then throws
+                    // IllegalStateException and kills the app. State loss is fine:
+                    // this fragment is headless and install() re-adds it on demand.
                     activity.supportFragmentManager.beginTransaction()
                         .add(it, "NativeActionCoordinator")
-                        .commitNow()
+                        .commitNowAllowingStateLoss()
                 }
 
         /**


### PR DESCRIPTION
## Summary

`NativeActionCoordinator.install()` runs from the boot callback that is deferred past first paint (and from `dispatchEvent()`, which alert-dialog button callbacks use). If the user backgrounds the app — or the screen locks — before that lands, `onSaveInstanceState` has already run and `commitNow()` throws:

```
java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
```

Reproduced organically on a Pixel 9 (screen dozed during boot with a dialog involved); it's a hard crash.

## Fix

`commitNowAllowingStateLoss()` — matches the existing `onDestroy` cleanup for this same fragment. State loss is harmless: the fragment is headless and `install()` re-adds it whenever it's missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)