### PR TITLE
Force R8 minification for profileable builds

### DIFF
--- a/resources/androidstudio/app/build.gradle.kts
+++ b/resources/androidstudio/app/build.gradle.kts
@@ -98,6 +98,12 @@ android {
             initWith(getByName("release"))
             isDebuggable = false
             isProfileable = true
+            // Always R8-minify, regardless of the app's minify_enabled config.
+            // Play-delivered releases run R8, so an unminified profileable build
+            // measures a cold start no user ever sees — with the native-ui
+            // plugin's icon/coil deps that's ~58MB of dex vs ~9MB and ~+90ms
+            // of bindApplication on a Pixel 9.
+            isMinifyEnabled = true
             signingConfig = signingConfigs.getByName("debug")
             matchingFallbacks += listOf("release")
         }


### PR DESCRIPTION
## Summary

`profileable` inherits release's `isMinifyEnabled`, which defaults to the app's `NATIVEPHP_ANDROID_MINIFY_ENABLED` (false). Unminified, the native-ui plugin's icon/coil deps push an app to ~58MB across 4 dex files and cold start pays ~90ms of extra `bindApplication` (dex open + a discarded ART app image).

Play-delivered releases run R8, so an unminified profileable build measures a startup no user ever sees.

## Measured (Pixel 9, mobile-bench app)

| | dex | cold start TTID median |
|---|---|---|
| minify off | 58.4 MB / 4 files | 246 ms |
| minify on | 8.9 MB / 1 file | **156 ms** |

(156 → 152 ms further with the regenerated baseline profile, see the companion PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)