### PR TITLE
Fix silent install failure on version downgrade in native:run android

### DIFF
--- a/src/Traits/RunsAndroid.php
+++ b/src/Traits/RunsAndroid.php
@@ -531,18 +531,22 @@ XML;
             $apkPath = $this->buildType === 'profileable'
                 ? base_path('nativephp/android/app/build/outputs/apk/profileable/app-profileable.apk')
                 : base_path('nativephp/android/app/build/outputs/apk/debug/app-debug.apk');
-            $installCmd = "$adbCommand -s $targetDeviceId install -r \"$apkPath\"";
+            // -d allows version-code downgrades on debuggable builds, e.g. a
+            // NATIVEPHP_APP_VERSION=DEBUG build (code 1) over a versioned install.
+            $installCmd = "$adbCommand -s $targetDeviceId install -r -d \"$apkPath\"";
             $this->logToFile("Installing APK: $installCmd");
             // Debug APKs are large (~200MB+); a cold emulator can exceed the
             // default 60s Process timeout mid-install. Give it room.
             $installResult = Process::timeout(300)->run($installCmd);
 
             // A previously-installed release-key-signed build blocks an -r update
-            // (signature mismatch). Uninstall and retry so switching to a
-            // profileable build "just works".
+            // (signature mismatch), and -d can't downgrade a non-debuggable
+            // (profileable) build. Uninstall and retry so switching builds
+            // "just works".
             if (! $installResult->successful()
-                && str_contains($installResult->errorOutput().$installResult->output(), 'INSTALL_FAILED_UPDATE_INCOMPATIBLE')) {
-                $this->logToFile('Signature mismatch on update; uninstalling and retrying install');
+                && Str::contains($installResult->errorOutput().$installResult->output(),
+                    ['INSTALL_FAILED_UPDATE_INCOMPATIBLE', 'INSTALL_FAILED_VERSION_DOWNGRADE'])) {
+                $this->logToFile('Incompatible installed build (signature or version downgrade); uninstalling and retrying install');
                 Process::timeout(120)->run("$adbCommand -s $targetDeviceId uninstall $appId");
                 $installResult = Process::timeout(300)->run($installCmd);
             }


### PR DESCRIPTION
## Problem

`php artisan native:run android` reports a successful build but the app never installs or launches when the APK's versionCode is lower than the build already on the device. The adb error (`INSTALL_FAILED_VERSION_DOWNGRADE`) is only written to `nativephp/android-build.log`, so the command looks like it succeeded.

Easiest way to hit this: `NATIVEPHP_APP_VERSION=DEBUG` produces versionCode 1, so any device that previously had a versioned build (e.g. versionCode 26) rejects the install.

## Fix

- Install with `adb install -r -d` so debuggable builds can downgrade in place, preserving app data.
- Extend the existing uninstall-and-retry fallback (previously only for `INSTALL_FAILED_UPDATE_INCOMPATIBLE` signature mismatches) to also cover `INSTALL_FAILED_VERSION_DOWNGRADE` — needed for profileable builds, where Android refuses `-d` because the installed app isn't debuggable.

## Testing

Reproduced on a Pixel 9 with a versionCode 26 build installed and a fresh `DEBUG` (versionCode 1) build:
- `install -r` fails with `INSTALL_FAILED_VERSION_DOWNGRADE` (the reported bug)
- `install -r -d` alone still refused (installed build not debuggable) — confirms the retry path is required
- uninstall + `install -r -d` succeeds; app launches and boots cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)