### PR TITLE
Fix dropped plugin events on iOS native-direct boots

### DIFF
--- a/resources/xcode/NativePHP/Bridge/NativePHP.swift
+++ b/resources/xcode/NativePHP/Bridge/NativePHP.swift
@@ -1,5 +1,18 @@
+import Foundation
+
 final class LaravelBridge {
     static let shared = LaravelBridge()
 
-    var send: ((_ event: String, _ payload: [String: Any?]) -> Void)?
+    /// Delivers device-API events (plugins, system events) into PHP. WebView
+    /// boots overwrite this in makeUIView with the coordinator closure (JS
+    /// injection + element queue). This default covers native-direct boots,
+    /// which never construct a WKWebView — without it, every plugin dispatch
+    /// (`LaravelBridge.shared.send?(...)`) is an optional call on nil and
+    /// events like ServerFound / CodeScanned are silently dropped.
+    var send: ((_ event: String, _ payload: [String: Any?]) -> Void)? = { event, payload in
+        let dict = payload.reduce(into: [String: Any]()) { $0[$1.key] = $1.value ?? NSNull() }
+        let json = (try? JSONSerialization.data(withJSONObject: dict))
+            .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+        NativeElementBridge.sendNativeEvent(eventName: event, payloadJson: json)
+    }
 }


### PR DESCRIPTION
## Summary
- The iOS native-first boot port (65da067) left `LaravelBridge.shared.send` unassigned on native-direct boots: the closure was only installed inside `makeUIView`, which never runs when no WKWebView is constructed. Every plugin event dispatch (`ServerFound`/`ServerLost` from discovery, `CodeScanned` from the scanner, all device-API events) became an optional call on nil — silently dropped. Symptom: the Jump app's "servers nearby" pill never appears and QR scans do nothing, while native discovery itself keeps polling `/jump/info`.
- Fix: default `send` to a closure forwarding into the element event queue via `NativeElementBridge.sendNativeEvent` — the same second leg `notifyLaravel` already performs. WebView boots still overwrite it in `makeUIView` with the full coordinator closure, so web apps are byte-identical.

## Test plan
- Verified on-device (iPhone, native-direct boot): discovery pill appears when a `native:jump` server starts, QR scan connects, and the WS bridge shows the device connecting.
- Web-legacy boot path unchanged (assignment in `makeUIView` still wins once a WebView exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)