### PR TITLE
feat(ios): dedicated PHP runtimes for embedded php-mode webviews

### DIFF
--- a/resources/androidstudio/app/src/main/cpp/php_bridge.c
+++ b/resources/androidstudio/app/src/main/cpp/php_bridge.c
@@ -1371,6 +1371,267 @@ JNIEXPORT void JNICALL native_ephemeral_shutdown(JNIEnv *env, jobject thiz) {
     pthread_mutex_unlock(&g_ephemeral_mutex);
 }
 
+
+// ── Webview PHP Runtimes ────────────────────────────
+// One dedicated PHP context per embedded php-mode <webview> element. The
+// persistent lane (phpExecutor → native_persistent_dispatch) is parked
+// inside a native screen's event-loop dispatch for the screen's whole
+// lifetime, so it can never answer the embedded webview's requests.
+//
+// Each Kotlin WebviewPHPRuntime owns a single-thread executor and calls
+// these functions only from that thread — so the TSRM context is
+// implicitly per-webview (thread == context) and no handle bookkeeping is
+// needed. Boots are serialized to avoid concurrent module-startup races.
+// Request state is inlined into the eval and carried by per-thread SAPI
+// globals — never process env — so contexts run concurrently with the
+// persistent lane's env churn without racing it.
+
+static pthread_mutex_t g_webview_boot_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+/* Escape a string for inclusion inside a single-quoted PHP string literal. */
+static char *webview_escape_php(const char *s) {
+    if (!s) {
+        return strdup("");
+    }
+    size_t len = strlen(s);
+    char *out = malloc(len * 2 + 1);
+    if (!out) {
+        return strdup("");
+    }
+    char *p = out;
+    for (size_t i = 0; i < len; i++) {
+        char c = s[i];
+        if (c == '\\' || c == '\'') {
+            *p++ = '\\';
+        }
+        *p++ = c;
+    }
+    *p = '\0';
+    return out;
+}
+
+JNIEXPORT jint JNICALL native_webview_php_boot(JNIEnv *env, jobject thiz, jstring jBootstrapPath) {
+    pthread_mutex_lock(&g_webview_boot_mutex);
+
+    const char *bootstrapPath = (*env)->GetStringUTFChars(env, jBootstrapPath, NULL);
+    LOGI("webview_php_boot: booting dedicated context");
+
+    clear_collected_output();
+
+    if (ephemeral_embed_init() != SUCCESS) {
+        LOGE("webview_php_boot: embed init FAILED");
+        (*env)->ReleaseStringUTFChars(env, jBootstrapPath, bootstrapPath);
+        pthread_mutex_unlock(&g_webview_boot_mutex);
+        return -1;
+    }
+
+    zend_first_try {
+        zend_activate_modules();
+        zend_file_handle fileHandle;
+        zend_stream_init_filename(&fileHandle, bootstrapPath);
+        php_execute_script(&fileHandle);
+    } zend_end_try();
+
+    char *boot_output = get_collected_output();
+    if (boot_output && strstr(boot_output, "FATAL") != NULL) {
+        LOGE("webview_php_boot: bootstrap errors: %.200s", boot_output);
+    }
+
+    (*env)->ReleaseStringUTFChars(env, jBootstrapPath, bootstrapPath);
+    pthread_mutex_unlock(&g_webview_boot_mutex);
+    LOGI("webview_php_boot: ready");
+    return 0;
+}
+
+JNIEXPORT jstring JNICALL native_webview_php_request(JNIEnv *env, jobject thiz,
+                                                     jstring jMethod, jstring jUri,
+                                                     jstring jCookie, jstring jBody,
+                                                     jstring jContentType, jstring jScriptPath) {
+    const char *method = (*env)->GetStringUTFChars(env, jMethod, NULL);
+    const char *uri = (*env)->GetStringUTFChars(env, jUri, NULL);
+    const char *cookieHeader = (*env)->GetStringUTFChars(env, jCookie, NULL);
+    const char *postData = (*env)->GetStringUTFChars(env, jBody, NULL);
+    const char *contentType = (*env)->GetStringUTFChars(env, jContentType, NULL);
+    const char *scriptPath = (*env)->GetStringUTFChars(env, jScriptPath, NULL);
+
+    clear_collected_output();
+
+    // Per-thread SAPI request state (TSRM-local — safe alongside other lanes)
+    SG(headers_sent) = 0;
+    SG(post_read) = 0;
+    SG(read_post_bytes) = 0;
+    SG(request_info).request_method = method;
+    SG(request_info).request_uri = (char *)uri;
+    SG(request_info).proto_num = 1001;
+
+    memset(&SG(sapi_headers), 0, sizeof(sapi_headers_struct));
+    SG(sapi_headers).http_response_code = 200;
+    zend_llist_init(&SG(sapi_headers).headers, sizeof(sapi_header_struct), NULL, 0);
+
+    // POST data → php://input
+    if (postData && strlen(postData) > 0) {
+        php_stream *post_stream = php_stream_memory_create(TEMP_STREAM_DEFAULT);
+        if (post_stream) {
+            php_stream_write(post_stream, postData, strlen(postData));
+            php_stream_seek(post_stream, 0, SEEK_SET);
+
+            if (SG(request_info).request_body) {
+                php_stream_close(SG(request_info).request_body);
+            }
+            SG(request_info).request_body = post_stream;
+            SG(request_info).content_length = strlen(postData);
+
+            if (contentType && strstr(contentType, "json")) {
+                SG(request_info).content_type = "application/json";
+            } else {
+                SG(request_info).content_type = "application/x-www-form-urlencoded";
+            }
+        }
+    } else {
+        if (SG(request_info).request_body) {
+            php_stream_close(SG(request_info).request_body);
+            SG(request_info).request_body = NULL;
+        }
+        SG(request_info).content_length = 0;
+    }
+
+    char *esc_method = webview_escape_php(method);
+    char *esc_uri = webview_escape_php(uri);
+    char *esc_cookie = webview_escape_php(cookieHeader);
+    char *esc_ct = webview_escape_php(contentType);
+    char *esc_script = webview_escape_php(scriptPath);
+
+    char *eval_code = NULL;
+    asprintf(&eval_code,
+        "try {\n"
+        "    while (ob_get_level() > 0) { ob_end_clean(); }\n"
+        "\n"
+        "    foreach ($_SERVER as $__k => $__v) {\n"
+        "        if (str_starts_with($__k, 'HTTP_') || $__k === 'CONTENT_TYPE' || $__k === 'CONTENT_LENGTH') {\n"
+        "            unset($_SERVER[$__k]);\n"
+        "        }\n"
+        "    }\n"
+        "\n"
+        "    $_SERVER['REQUEST_METHOD'] = '%s';\n"
+        "    $_SERVER['REQUEST_URI'] = '%s';\n"
+        "    $_SERVER['SCRIPT_FILENAME'] = '%s';\n"
+        "    $_SERVER['PHP_SELF'] = '/native.php';\n"
+        "    $_SERVER['HTTP_HOST'] = '127.0.0.1';\n"
+        "    $_SERVER['SERVER_NAME'] = '127.0.0.1';\n"
+        "    $_SERVER['SERVER_PORT'] = '80';\n"
+        "    $_SERVER['APP_URL'] = 'http://127.0.0.1';\n"
+        "    $_SERVER['NATIVEPHP_RUNNING'] = 'true';\n"
+        "    $_SERVER['NATIVEPHP_PLATFORM'] = 'android';\n"
+        "    if ('%s' !== '') { $_SERVER['HTTP_COOKIE'] = '%s'; }\n"
+        "    if ('%s' !== '') { $_SERVER['CONTENT_TYPE'] = '%s'; $_SERVER['HTTP_CONTENT_TYPE'] = '%s'; }\n"
+        "\n"
+        "    $__qpos = strpos($_SERVER['REQUEST_URI'], '?');\n"
+        "    if ($__qpos !== false) {\n"
+        "        $_SERVER['QUERY_STRING'] = substr($_SERVER['REQUEST_URI'], $__qpos + 1);\n"
+        "    } else {\n"
+        "        $_SERVER['QUERY_STRING'] = '';\n"
+        "    }\n"
+        "\n"
+        "    $_GET = [];\n"
+        "    $_POST = [];\n"
+        "    $_COOKIE = [];\n"
+        "    $_FILES = [];\n"
+        "    $_REQUEST = [];\n"
+        "\n"
+        "    if (isset($_SERVER['HTTP_COOKIE']) && $_SERVER['HTTP_COOKIE'] !== '') {\n"
+        "        foreach (explode('; ', $_SERVER['HTTP_COOKIE']) as $__pair) {\n"
+        "            $__parts = explode('=', $__pair, 2);\n"
+        "            if (count($__parts) === 2) {\n"
+        "                $_COOKIE[$__parts[0]] = urldecode($__parts[1]);\n"
+        "            }\n"
+        "        }\n"
+        "    }\n"
+        "\n"
+        "    if ($_SERVER['QUERY_STRING'] !== '') {\n"
+        "        parse_str($_SERVER['QUERY_STRING'], $_GET);\n"
+        "    }\n"
+        "\n"
+        "    if (in_array($_SERVER['REQUEST_METHOD'], ['POST', 'PUT', 'PATCH'])) {\n"
+        "        $__rawInput = file_get_contents('php://input');\n"
+        "        if ($__rawInput !== false && $__rawInput !== '') {\n"
+        "            $__ct = $_SERVER['CONTENT_TYPE'] ?? '';\n"
+        "            if (stripos($__ct, 'application/x-www-form-urlencoded') !== false) {\n"
+        "                parse_str($__rawInput, $_POST);\n"
+        "            }\n"
+        "            $_REQUEST = array_merge($_GET, $_POST, $_COOKIE);\n"
+        "        }\n"
+        "    }\n"
+        "\n"
+        "    $__response = \\Native\\Mobile\\Runtime::dispatch(\n"
+        "        \\Illuminate\\Http\\Request::capture()\n"
+        "    );\n"
+        "    $__code = $__response->getStatusCode();\n"
+        "    $__status = \\Symfony\\Component\\HttpFoundation\\Response::$statusTexts[$__code] ?? 'OK';\n"
+        "    echo \"HTTP/1.1 {$__code} {$__status}\\r\\n\";\n"
+        "    foreach ($__response->headers->all() as $__name => $__values) {\n"
+        "        foreach ($__values as $__value) {\n"
+        "            echo \"{$__name}: {$__value}\\r\\n\";\n"
+        "        }\n"
+        "    }\n"
+        "    echo \"\\r\\n\";\n"
+        "    $__response->sendContent();\n"
+        "} catch (\\Throwable $e) {\n"
+        "    echo \"HTTP/1.1 500 Internal Server Error\\r\\n\";\n"
+        "    echo \"Content-Type: text/plain\\r\\n\\r\\n\";\n"
+        "    echo 'Webview dispatch error: ' . $e->getMessage() . \"\\n\";\n"
+        "    echo $e->getTraceAsString();\n"
+        "}\n",
+        esc_method, esc_uri, esc_script,
+        esc_cookie, esc_cookie,
+        esc_ct, esc_ct, esc_ct);
+
+    free(esc_method);
+    free(esc_uri);
+    free(esc_cookie);
+    free(esc_ct);
+    free(esc_script);
+
+    jstring result;
+    if (!eval_code) {
+        result = (*env)->NewStringUTF(env, "HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\nFailed to build webview dispatch.");
+    } else {
+        zend_first_try {
+            zend_eval_string(eval_code, NULL, "webview_dispatch");
+        } zend_end_try();
+        free(eval_code);
+
+        char *out = get_collected_output();
+        result = (*env)->NewStringUTF(env, out ? out : "");
+    }
+
+    (*env)->ReleaseStringUTFChars(env, jMethod, method);
+    (*env)->ReleaseStringUTFChars(env, jUri, uri);
+    (*env)->ReleaseStringUTFChars(env, jCookie, cookieHeader);
+    (*env)->ReleaseStringUTFChars(env, jBody, postData);
+    (*env)->ReleaseStringUTFChars(env, jContentType, contentType);
+    (*env)->ReleaseStringUTFChars(env, jScriptPath, scriptPath);
+
+    return result;
+}
+
+JNIEXPORT void JNICALL native_webview_php_shutdown(JNIEnv *env, jobject thiz) {
+    LOGI("webview_php_shutdown: tearing down dedicated context");
+
+    zend_first_try {
+        zend_eval_string(
+            "\\Native\\Mobile\\Runtime::shutdown();",
+            NULL, "webview_shutdown");
+    } zend_end_try();
+
+    // Webview contexts only exist while the persistent runtime is alive, so
+    // this is always the hot-path teardown: release this thread's request
+    // and TSRM context, leave the process-wide runtime untouched.
+    php_request_shutdown(NULL);
+    ts_free_thread();
+
+    LOGI("webview_php_shutdown: done");
+}
+
 static JNINativeMethod gMethods[] = {
         // PHPBridge
         {"nativeExecuteScript", "(Ljava/lang/String;)Ljava/lang/String;", (void *) native_execute_script},
@@ -1404,6 +1665,11 @@ static JNINativeMethod gMethods[] = {
         {"nativeEphemeralBoot","(Ljava/lang/String;)I",(void *) native_ephemeral_boot},
         {"nativeEphemeralArtisan","(Ljava/lang/String;)Ljava/lang/String;",(void *) native_ephemeral_artisan},
         {"nativeEphemeralShutdown","()V",(void *) native_ephemeral_shutdown},
+
+        // Webview runtime (dedicated context per embedded php-mode webview)
+        {"nativeWebviewPhpBoot","(Ljava/lang/String;)I",(void *) native_webview_php_boot},
+        {"nativeWebviewPhpRequest","(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",(void *) native_webview_php_request},
+        {"nativeWebviewPhpShutdown","()V",(void *) native_webview_php_shutdown},
 };
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved) {

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
@@ -19,6 +19,20 @@ class PHPBridge(private val context: Context) {
     private val nativePhpScript: String
         get() = "${getLaravelPath()}/vendor/nativephp/mobile/bootstrap/android/native.php"
 
+    /**
+     * Serves this bridge's requests on a dedicated per-webview PHP context
+     * instead of phpExecutor — REQUIRED for php-mode webviews embedded in
+     * native screens, where phpExecutor is parked inside the screen's
+     * event-loop dispatch and would never answer.
+     */
+    var dedicatedWebviewRuntime: WebviewPHPRuntime? = null
+
+    internal val webviewBootstrapScript: String
+        get() = "${getLaravelPath()}/vendor/nativephp/mobile/bootstrap/android/persistent.php"
+
+    internal val webviewNativeScript: String
+        get() = nativePhpScript
+
     private val persistentBootstrapScript: String
         get() = "${getLaravelPath()}/vendor/nativephp/mobile/bootstrap/android/persistent.php"
 
@@ -68,6 +82,20 @@ class PHPBridge(private val context: Context) {
     external fun nativeEphemeralBoot(bootstrapPath: String): Int
     external fun nativeEphemeralArtisan(command: String): String
     external fun nativeEphemeralShutdown()
+
+    // Webview runtime (dedicated context per embedded php-mode webview).
+    // Call ONLY from that webview's single-thread executor — the TSRM
+    // context is bound to the calling thread.
+    external fun nativeWebviewPhpBoot(bootstrapPath: String): Int
+    external fun nativeWebviewPhpRequest(
+        method: String,
+        uri: String,
+        cookieHeader: String,
+        body: String,
+        contentType: String,
+        scriptPath: String
+    ): String
+    external fun nativeWebviewPhpShutdown()
 
     fun ensureRuntimeInitialized() {
         if (!runtimeInitialized) {
@@ -262,6 +290,13 @@ class PHPBridge(private val context: Context) {
     }
 
     fun handleLaravelRequest(request: PHPRequest): String {
+        // Embedded php-mode webview — its own context serves the request;
+        // phpExecutor may be parked inside a native screen's event-loop
+        // dispatch and would never answer.
+        dedicatedWebviewRuntime?.let {
+            return processRawPHPResponse(it.request(request))
+        }
+
         val requestStart = System.currentTimeMillis()
 
         val future = phpExecutor.submit<String> {

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/WebviewPHPRuntime.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/WebviewPHPRuntime.kt
@@ -1,0 +1,107 @@
+package com.nativephp.mobile.bridge
+
+import android.util.Log
+import com.nativephp.mobile.network.PHPRequest
+import com.nativephp.mobile.security.LaravelCookieStore
+import java.util.concurrent.Executors
+
+/**
+ * A dedicated PHP context for one embedded php-mode webview.
+ *
+ * phpExecutor — the persistent runtime's single lane — is parked inside the
+ * native screen's event-loop dispatch for the screen's whole lifetime, so it
+ * can never answer requests from a webview embedded in that screen. Each
+ * instance of this class owns a single-thread executor whose thread carries
+ * its own TSRM context in the C bridge (thread == context): boot happens on
+ * first use, requests serialize behind it, and [release] tears the context
+ * down when the webview leaves the view hierarchy.
+ */
+class WebviewPHPRuntime(private val bridge: PHPBridge) {
+    companion object {
+        private const val TAG = "WebviewPHPRuntime"
+    }
+
+    private val executor = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "nativephp-webview-php")
+    }
+
+    @Volatile
+    private var released = false
+
+    // Executor-confined — only ever touched on the runtime's own thread.
+    private var booted = false
+
+    init {
+        executor.execute {
+            val rc = bridge.nativeWebviewPhpBoot(bridge.webviewBootstrapScript)
+            booted = rc == 0
+            Log.i(TAG, if (booted) "boot OK" else "boot FAILED ($rc)")
+        }
+    }
+
+    /**
+     * Serve one request on this webview's own PHP context. Blocks the caller
+     * (shouldInterceptRequest needs a synchronous response); queues behind
+     * the boot and any in-flight request.
+     */
+    fun request(request: PHPRequest): String {
+        if (released) {
+            return unavailable()
+        }
+
+        return try {
+            executor.submit<String> {
+                if (!booted) {
+                    return@submit unavailable()
+                }
+
+                val cookieHeader = LaravelCookieStore.asCookieHeader()
+                val contentType = request.headers["Content-Type"]
+                    ?: request.headers["content-type"]
+                    ?: ""
+
+                val start = System.currentTimeMillis()
+                Log.i(TAG, "--> ${request.method} ${request.uri}")
+
+                val output = bridge.nativeWebviewPhpRequest(
+                    request.method,
+                    request.uri,
+                    cookieHeader,
+                    request.body,
+                    contentType,
+                    bridge.webviewNativeScript
+                )
+
+                val statusLine = output.lineSequence().firstOrNull() ?: ""
+                Log.i(TAG, "<-- $statusLine (${System.currentTimeMillis() - start}ms)")
+
+                output
+            }.get()
+        } catch (e: Exception) {
+            "HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\nWebview runtime error: ${e.message}"
+        }
+    }
+
+    /**
+     * Stop this webview's PHP thread and free its context. Queued behind any
+     * in-flight request; further requests answer 503. Idempotent.
+     */
+    fun release() {
+        if (released) {
+            return
+        }
+        released = true
+
+        executor.execute {
+            if (booted) {
+                bridge.nativeWebviewPhpShutdown()
+                booted = false
+                Log.i(TAG, "context released")
+            }
+        }
+        executor.shutdown()
+    }
+
+    private fun unavailable(): String =
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/plain\r\n\r\nWebview PHP runtime unavailable."
+}

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebViewManager.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebViewManager.kt
@@ -23,7 +23,12 @@ import com.nativephp.mobile.security.LaravelSecurity
 class WebViewManager(
     private val context: Context,
     private val webView: WebView,
-    private val phpBridge: PHPBridge
+    private val phpBridge: PHPBridge,
+    // An embedded webview lives INSIDE the native tree (php-mode <webview>
+    // element). It must never drive app-level state: no native/web mode
+    // flips, no chrome updates from response headers — those belong to the
+    // root webview alone.
+    private val embedded: Boolean = false
 ) {
     private val TAG = "PHPMonitor"
     private var fullscreenView: View? = null
@@ -346,17 +351,22 @@ class WebViewManager(
                 // flip happens in onPageCommitVisible instead, so the swap never
                 // flashes a blank/stale WebView.
                 val activity = context as? MainActivity
-                if (activity?.pendingWebSwap != true) {
+                if (!embedded && activity?.pendingWebSwap != true) {
                     com.nativephp.mobile.ui.nativerender.NativeUIBridge.isActive.value = false
                 }
 
-                // Inject safe area insets IMMEDIATELY when page starts loading
-                // This ensures CSS variables are available before DOM parsing
-                activity?.injectSafeAreaInsetsToWebView()
+                if (!embedded) {
+                    // Inject safe area insets IMMEDIATELY when page starts loading
+                    // This ensures CSS variables are available before DOM parsing
+                    activity?.injectSafeAreaInsetsToWebView()
+                }
             }
 
             override fun onPageCommitVisible(view: WebView, url: String) {
                 super.onPageCommitVisible(view, url)
+                if (embedded) {
+                    return
+                }
                 val activity = context as? MainActivity
                 if (activity?.pendingWebSwap == true) {
                     activity.pendingWebSwap = false
@@ -377,6 +387,13 @@ class WebViewManager(
                 request: WebResourceRequest
             ) {
                 if (response == null) {
+                    return
+                }
+
+                // Embedded webviews must not drive the app's chrome: a plain
+                // web page here would otherwise clearAll() the native UI state
+                // (top bar / tabs) out from under the native screen hosting it.
+                if (embedded) {
                     return
                 }
 

--- a/resources/xcode/Include/Bridge/PHP.c
+++ b/resources/xcode/Include/Bridge/PHP.c
@@ -1222,3 +1222,413 @@ void ephemeral_php_shutdown(void) {
 int ephemeral_php_is_booted(void) {
     return ephemeral_initialized;
 }
+
+// ── Webview PHP Runtimes ────────────────────────────
+// One dedicated PHP context per embedded php-mode <webview> element. The
+// persistent runtime's serial queue is parked inside a native screen's
+// event-loop dispatch for the screen's whole lifetime, so it can never
+// answer php:// requests from an embedded webview — each webview gets its
+// own thread + TSRM context instead, started when the webview mounts and
+// stopped when it leaves the view hierarchy.
+//
+// Request state is passed by inlining into the eval and via per-thread
+// SAPI globals — never via setenv() — so slots can run concurrently with
+// the persistent lane's env churn without racing it.
+
+#define WEBVIEW_PHP_MAX_SLOTS 4
+
+typedef enum {
+    WEBVIEW_WORK_REQUEST = 1,
+    WEBVIEW_WORK_SHUTDOWN = 2,
+} webview_work_type_t;
+
+typedef struct {
+    const char *method;
+    const char *uri;
+    const char *cookieHeader;
+    const char *postData;
+    const char *contentType;
+    const char *scriptPath;
+} webview_request_params_t;
+
+typedef struct {
+    int in_use;        // slot allocated (guarded by webview_pool_mutex)
+    int initialized;   // context booted on its thread
+    int boot_result;
+    dispatch_semaphore_t work_sem;
+    dispatch_semaphore_t done_sem;
+    webview_work_type_t work_type;
+    webview_request_params_t params;
+    char *result;      // strdup'd raw HTTP response, ownership passes to caller
+    char bootstrap_path[1024];
+} webview_php_slot_t;
+
+static webview_php_slot_t webview_slots[WEBVIEW_PHP_MAX_SLOTS];
+static pthread_mutex_t webview_pool_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+/* Escape a string for inclusion inside a single-quoted PHP string literal. */
+static char *webview_escape_php(const char *s) {
+    if (!s) {
+        return strdup("");
+    }
+    size_t len = strlen(s);
+    char *out = malloc(len * 2 + 1);
+    if (!out) {
+        return strdup("");
+    }
+    char *p = out;
+    for (size_t i = 0; i < len; i++) {
+        char c = s[i];
+        if (c == '\\' || c == '\'') {
+            *p++ = '\\';
+        }
+        *p++ = c;
+    }
+    *p = '\0';
+    return out;
+}
+
+static void do_webview_dispatch(webview_php_slot_t *slot) {
+    clear_output_buffer();
+
+    const webview_request_params_t *params = &slot->params;
+
+    // Per-thread SAPI request state (TSRM-local — safe alongside other lanes)
+    SG(headers_sent) = 0;
+    SG(post_read) = 0;
+    SG(read_post_bytes) = 0;
+    SG(request_info).request_method = params->method;
+    SG(request_info).request_uri = (char *)params->uri;
+    SG(request_info).proto_num = 1001;
+
+    memset(&SG(sapi_headers), 0, sizeof(sapi_headers_struct));
+    SG(sapi_headers).http_response_code = 200;
+    zend_llist_init(&SG(sapi_headers).headers, sizeof(sapi_header_struct), NULL, 0);
+
+    // POST data → php://input
+    if (params->postData && strlen(params->postData) > 0) {
+        php_stream *post_stream = php_stream_memory_create(TEMP_STREAM_DEFAULT);
+        if (post_stream) {
+            php_stream_write(post_stream, params->postData, strlen(params->postData));
+            php_stream_seek(post_stream, 0, SEEK_SET);
+
+            if (SG(request_info).request_body) {
+                php_stream_close(SG(request_info).request_body);
+            }
+            SG(request_info).request_body = post_stream;
+            SG(request_info).content_length = strlen(params->postData);
+
+            if (params->contentType && strstr(params->contentType, "json")) {
+                SG(request_info).content_type = "application/json";
+            } else {
+                SG(request_info).content_type = "application/x-www-form-urlencoded";
+            }
+        }
+    } else {
+        if (SG(request_info).request_body) {
+            php_stream_close(SG(request_info).request_body);
+            SG(request_info).request_body = NULL;
+        }
+        SG(request_info).content_length = 0;
+    }
+
+    char *esc_method = webview_escape_php(params->method);
+    char *esc_uri = webview_escape_php(params->uri);
+    char *esc_cookie = webview_escape_php(params->cookieHeader);
+    char *esc_ct = webview_escape_php(params->contentType);
+    char *esc_script = webview_escape_php(params->scriptPath);
+
+    // Same dispatch shape as the persistent lane, but every request value is
+    // inlined — no getenv() merge, so the persistent lane's transient
+    // request env vars can never bleed into (or race) this context.
+    char *eval_code = NULL;
+    asprintf(&eval_code,
+        "try {\n"
+        "    while (ob_get_level() > 0) { ob_end_clean(); }\n"
+        "\n"
+        "    foreach ($_SERVER as $__k => $__v) {\n"
+        "        if (str_starts_with($__k, 'HTTP_') || $__k === 'CONTENT_TYPE' || $__k === 'CONTENT_LENGTH') {\n"
+        "            unset($_SERVER[$__k]);\n"
+        "        }\n"
+        "    }\n"
+        "\n"
+        "    $_SERVER['REQUEST_METHOD'] = '%s';\n"
+        "    $_SERVER['REQUEST_URI'] = '%s';\n"
+        "    $_SERVER['SCRIPT_FILENAME'] = '%s';\n"
+        "    $_SERVER['PHP_SELF'] = '/native.php';\n"
+        "    $_SERVER['HTTP_HOST'] = '127.0.0.1';\n"
+        "    $_SERVER['SERVER_NAME'] = '127.0.0.1';\n"
+        "    $_SERVER['SERVER_PORT'] = '80';\n"
+        "    $_SERVER['APP_URL'] = 'php://127.0.0.1';\n"
+        "    $_SERVER['NATIVEPHP_RUNNING'] = 'true';\n"
+        "    $_SERVER['NATIVEPHP_PLATFORM'] = 'ios';\n"
+        "    if ('%s' !== '') { $_SERVER['HTTP_COOKIE'] = '%s'; }\n"
+        "    if ('%s' !== '') { $_SERVER['CONTENT_TYPE'] = '%s'; $_SERVER['HTTP_CONTENT_TYPE'] = '%s'; }\n"
+        "\n"
+        "    $__qpos = strpos($_SERVER['REQUEST_URI'], '?');\n"
+        "    if ($__qpos !== false) {\n"
+        "        $_SERVER['QUERY_STRING'] = substr($_SERVER['REQUEST_URI'], $__qpos + 1);\n"
+        "    } else {\n"
+        "        $_SERVER['QUERY_STRING'] = '';\n"
+        "    }\n"
+        "\n"
+        "    $_GET = [];\n"
+        "    $_POST = [];\n"
+        "    $_COOKIE = [];\n"
+        "    $_FILES = [];\n"
+        "    $_REQUEST = [];\n"
+        "\n"
+        "    if (isset($_SERVER['HTTP_COOKIE']) && $_SERVER['HTTP_COOKIE'] !== '') {\n"
+        "        foreach (explode('; ', $_SERVER['HTTP_COOKIE']) as $__pair) {\n"
+        "            $__parts = explode('=', $__pair, 2);\n"
+        "            if (count($__parts) === 2) {\n"
+        "                $_COOKIE[$__parts[0]] = urldecode($__parts[1]);\n"
+        "            }\n"
+        "        }\n"
+        "    }\n"
+        "\n"
+        "    if ($_SERVER['QUERY_STRING'] !== '') {\n"
+        "        parse_str($_SERVER['QUERY_STRING'], $_GET);\n"
+        "    }\n"
+        "\n"
+        "    if (in_array($_SERVER['REQUEST_METHOD'], ['POST', 'PUT', 'PATCH'])) {\n"
+        "        $__rawInput = file_get_contents('php://input');\n"
+        "        if ($__rawInput !== false && $__rawInput !== '') {\n"
+        "            $__ct = $_SERVER['CONTENT_TYPE'] ?? '';\n"
+        "            if (stripos($__ct, 'application/x-www-form-urlencoded') !== false) {\n"
+        "                parse_str($__rawInput, $_POST);\n"
+        "            }\n"
+        "            $_REQUEST = array_merge($_GET, $_POST, $_COOKIE);\n"
+        "        }\n"
+        "    }\n"
+        "\n"
+        "    $__response = \\Native\\Mobile\\Runtime::dispatch(\n"
+        "        \\Illuminate\\Http\\Request::capture()\n"
+        "    );\n"
+        "    $__code = $__response->getStatusCode();\n"
+        "    $__status = \\Symfony\\Component\\HttpFoundation\\Response::$statusTexts[$__code] ?? 'OK';\n"
+        "    echo \"HTTP/1.1 {$__code} {$__status}\\r\\n\";\n"
+        "    foreach ($__response->headers->all() as $__name => $__values) {\n"
+        "        foreach ($__values as $__value) {\n"
+        "            echo \"{$__name}: {$__value}\\r\\n\";\n"
+        "        }\n"
+        "    }\n"
+        "    echo \"\\r\\n\";\n"
+        "    $__response->sendContent();\n"
+        "} catch (\\Throwable $e) {\n"
+        "    echo \"HTTP/1.1 500 Internal Server Error\\r\\n\";\n"
+        "    echo \"Content-Type: text/plain\\r\\n\\r\\n\";\n"
+        "    echo 'Webview dispatch error: ' . $e->getMessage() . \"\\n\";\n"
+        "    echo $e->getTraceAsString();\n"
+        "}\n",
+        esc_method, esc_uri, esc_script,
+        esc_cookie, esc_cookie,
+        esc_ct, esc_ct, esc_ct);
+
+    free(esc_method);
+    free(esc_uri);
+    free(esc_cookie);
+    free(esc_ct);
+    free(esc_script);
+
+    if (!eval_code) {
+        slot->result = strdup("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\nFailed to build webview dispatch.");
+        return;
+    }
+
+    zend_first_try {
+        zend_eval_string(eval_code, NULL, "webview_dispatch");
+    } zend_end_try();
+
+    free(eval_code);
+
+    char *out = get_collected_output();
+    slot->result = out ? strdup(out) : strdup("");
+}
+
+static void *webview_thread_main(void *arg) {
+    webview_php_slot_t *slot = (webview_php_slot_t *)arg;
+
+    fprintf(stderr, "WEBVIEW-PHP: thread started tid=%p\n", (void *)pthread_self());
+    fflush(stderr);
+
+    clear_output_buffer();
+
+    if (ephemeral_embed_init() != SUCCESS) {
+        fprintf(stderr, "WEBVIEW-PHP: embed init FAILED\n");
+        fflush(stderr);
+        slot->boot_result = -1;
+        dispatch_semaphore_signal(slot->done_sem);
+        return NULL;
+    }
+
+    // Boot Laravel on this context so Runtime::dispatch() serves warm requests
+    zend_first_try {
+        zend_activate_modules();
+        zend_file_handle fileHandle;
+        zend_stream_init_filename(&fileHandle, slot->bootstrap_path);
+        php_execute_script(&fileHandle);
+    } zend_end_try();
+
+    char *boot_output = get_collected_output();
+    if (boot_output && strstr(boot_output, "FATAL") != NULL) {
+        fprintf(stderr, "WEBVIEW-PHP: bootstrap errors: %.200s\n", boot_output);
+        fflush(stderr);
+    }
+
+    slot->initialized = 1;
+    slot->boot_result = 0;
+
+    fprintf(stderr, "WEBVIEW-PHP: boot complete, entering work loop\n");
+    fflush(stderr);
+
+    dispatch_semaphore_signal(slot->done_sem);
+
+    while (1) {
+        dispatch_semaphore_wait(slot->work_sem, DISPATCH_TIME_FOREVER);
+
+        switch (slot->work_type) {
+            case WEBVIEW_WORK_REQUEST:
+                do_webview_dispatch(slot);
+                break;
+            case WEBVIEW_WORK_SHUTDOWN:
+                zend_first_try {
+                    zend_eval_string(
+                        "\\Native\\Mobile\\Runtime::shutdown();",
+                        NULL, "webview_shutdown");
+                } zend_end_try();
+                ephemeral_embed_shutdown();
+                slot->initialized = 0;
+                fprintf(stderr, "WEBVIEW-PHP: thread shut down\n");
+                fflush(stderr);
+                dispatch_semaphore_signal(slot->done_sem);
+                return NULL;
+        }
+
+        dispatch_semaphore_signal(slot->done_sem);
+    }
+
+    return NULL;
+}
+
+int webview_php_start(const char *bootstrapPath) {
+    int gate = wait_for_persistent_boot(10);
+    if (gate != 0) {
+        fprintf(stderr, "webview_php_start: persistent runtime not ready (gate=%d)\n", gate);
+        fflush(stderr);
+        return -4;
+    }
+
+    pthread_mutex_lock(&webview_pool_mutex);
+    int handle = -1;
+    for (int i = 0; i < WEBVIEW_PHP_MAX_SLOTS; i++) {
+        if (!webview_slots[i].in_use) {
+            handle = i;
+            webview_slots[i].in_use = 1;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&webview_pool_mutex);
+
+    if (handle < 0) {
+        fprintf(stderr, "webview_php_start: no free slots (max %d)\n", WEBVIEW_PHP_MAX_SLOTS);
+        fflush(stderr);
+        return -2;
+    }
+
+    webview_php_slot_t *slot = &webview_slots[handle];
+    slot->initialized = 0;
+    slot->boot_result = -1;
+    slot->result = NULL;
+    slot->work_sem = dispatch_semaphore_create(0);
+    slot->done_sem = dispatch_semaphore_create(0);
+    snprintf(slot->bootstrap_path, sizeof(slot->bootstrap_path), "%s", bootstrapPath);
+
+    pthread_t thread;
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+    pthread_attr_setstacksize(&attr, 8 * 1024 * 1024);
+    pthread_attr_set_qos_class_np(&attr, QOS_CLASS_USER_INITIATED, 0);
+
+    int rc = pthread_create(&thread, &attr, webview_thread_main, slot);
+    pthread_attr_destroy(&attr);
+
+    if (rc != 0) {
+        fprintf(stderr, "webview_php_start: pthread_create FAILED: %d\n", rc);
+        fflush(stderr);
+        pthread_mutex_lock(&webview_pool_mutex);
+        slot->in_use = 0;
+        pthread_mutex_unlock(&webview_pool_mutex);
+        return -1;
+    }
+
+    // Block until the context finishes booting
+    dispatch_semaphore_wait(slot->done_sem, DISPATCH_TIME_FOREVER);
+
+    if (slot->boot_result != 0) {
+        pthread_mutex_lock(&webview_pool_mutex);
+        slot->in_use = 0;
+        pthread_mutex_unlock(&webview_pool_mutex);
+        return -3;
+    }
+
+    fprintf(stderr, "webview_php_start: slot %d ready\n", handle);
+    fflush(stderr);
+    return handle;
+}
+
+const char *webview_php_request(int handle,
+                                const char *method,
+                                const char *uri,
+                                const char *cookieHeader,
+                                const char *postData,
+                                const char *contentType,
+                                const char *scriptPath) {
+    if (handle < 0 || handle >= WEBVIEW_PHP_MAX_SLOTS) {
+        return strdup("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\nInvalid webview runtime handle.");
+    }
+
+    webview_php_slot_t *slot = &webview_slots[handle];
+    if (!slot->in_use || !slot->initialized) {
+        return strdup("HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/plain\r\n\r\nWebview runtime not booted.");
+    }
+
+    slot->params.method = method;
+    slot->params.uri = uri;
+    slot->params.cookieHeader = cookieHeader;
+    slot->params.postData = postData;
+    slot->params.contentType = contentType;
+    slot->params.scriptPath = scriptPath;
+    slot->result = NULL;
+    slot->work_type = WEBVIEW_WORK_REQUEST;
+
+    dispatch_semaphore_signal(slot->work_sem);
+    dispatch_semaphore_wait(slot->done_sem, DISPATCH_TIME_FOREVER);
+
+    return slot->result ? slot->result : strdup("");
+}
+
+void webview_php_stop(int handle) {
+    if (handle < 0 || handle >= WEBVIEW_PHP_MAX_SLOTS) {
+        return;
+    }
+
+    webview_php_slot_t *slot = &webview_slots[handle];
+    if (!slot->in_use) {
+        return;
+    }
+
+    if (slot->initialized) {
+        slot->work_type = WEBVIEW_WORK_SHUTDOWN;
+        dispatch_semaphore_signal(slot->work_sem);
+        dispatch_semaphore_wait(slot->done_sem, DISPATCH_TIME_FOREVER);
+    }
+
+    pthread_mutex_lock(&webview_pool_mutex);
+    slot->in_use = 0;
+    pthread_mutex_unlock(&webview_pool_mutex);
+
+    fprintf(stderr, "webview_php_stop: slot %d released\n", handle);
+    fflush(stderr);
+}

--- a/resources/xcode/Include/Bridge/PHP.h
+++ b/resources/xcode/Include/Bridge/PHP.h
@@ -39,6 +39,16 @@ const char *ephemeral_php_artisan(const char *command);
 void ephemeral_php_shutdown(void);
 int  ephemeral_php_is_booted(void);
 
+// Webview PHP Runtimes — one dedicated thread + TSRM context per embedded
+// php-mode webview. The persistent lane is parked inside a native screen's
+// event-loop dispatch, so it can never answer php:// requests from an
+// embedded webview; these slots serve them concurrently instead.
+int  webview_php_start(const char *bootstrapPath);   // → handle ≥ 0, or negative error
+const char *webview_php_request(int handle, const char *method, const char *uri,
+                                const char *cookieHeader, const char *postData,
+                                const char *contentType, const char *scriptPath);
+void webview_php_stop(int handle);
+
 // Phase 0 — Element runtime instrumentation. Exported from the PHP nativephp
 // extension (nphp_element.c, linked into libphp.a). Swift calls these
 // directly via C interop; format_version mismatch must fail loud at region

--- a/resources/xcode/NativePHP/Bridge/WebviewPHPRuntime.swift
+++ b/resources/xcode/NativePHP/Bridge/WebviewPHPRuntime.swift
@@ -31,16 +31,26 @@ private func _webview_php_stop(_ handle: Int32)
 /// behind the (asynchronous) boot, and `release()` behind in-flight
 /// requests — no explicit state machine needed.
 final class WebviewPHPRuntime {
+    /// Queue-confined runtime state, boxed separately from the runtime
+    /// object so queued blocks — including the deinit backstop — capture
+    /// the box, never `self`. A cleanup block queued from `deinit` that
+    /// captured `self` would resurrect a deallocating object ("deallocated
+    /// with non-zero retain count") and crash.
+    private final class State {
+        var handle: Int32 = -1
+        var released = false
+    }
+
     private let queue = DispatchQueue(label: "com.nativephp.webview-php", qos: .userInitiated)
-    private var handle: Int32 = -1
-    private var released = false
+    private let state = State()
 
     init() {
-        queue.async { [self] in
+        let state = self.state
+        queue.async {
             let appPath = AppUpdateManager.shared.getAppPath()
             let bootstrap = appPath + "/vendor/nativephp/mobile/bootstrap/ios/persistent.php"
-            handle = _webview_php_start(bootstrap)
-            print("[NativePHP] webview runtime: boot \(handle >= 0 ? "OK (slot \(handle))" : "FAILED (\(handle))")")
+            state.handle = _webview_php_start(bootstrap)
+            print("[NativePHP] webview runtime: boot \(state.handle >= 0 ? "OK (slot \(state.handle))" : "FAILED (\(state.handle))")")
         }
     }
 
@@ -48,8 +58,9 @@ final class WebviewPHPRuntime {
     /// receives the raw HTTP response (headers + body), matching the format
     /// `PHPSchemeHandler` already parses.
     func dispatch(request: RequestData, completion: @escaping (String) -> Void) {
-        queue.async { [self] in
-            guard !released, handle >= 0 else {
+        let state = self.state
+        queue.async {
+            guard !state.released, state.handle >= 0 else {
                 completion("HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/plain\r\n\r\nWebview PHP runtime unavailable.")
                 return
             }
@@ -65,10 +76,10 @@ final class WebviewPHPRuntime {
             let contentType = request.headers["Content-Type"] ?? request.headers["content-type"] ?? ""
 
             let start = CFAbsoluteTimeGetCurrent()
-            NSLog("%@", "[NativePHP] [WEBVIEW:\(handle)] --> \(request.method) \(uri)")
+            NSLog("%@", "[NativePHP] [WEBVIEW:\(state.handle)] --> \(request.method) \(uri)")
 
             guard let resultPtr = _webview_php_request(
-                handle, request.method, uri, cookieHeader,
+                state.handle, request.method, uri, cookieHeader,
                 request.data ?? "", contentType, scriptPath
             ) else {
                 completion("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\nNull response from webview runtime.")
@@ -80,7 +91,7 @@ final class WebviewPHPRuntime {
 
             let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
             let statusLine = response.prefix(while: { $0 != "\r" && $0 != "\n" })
-            NSLog("%@", "[NativePHP] [WEBVIEW:\(handle)] <-- \(statusLine) (\(String(format: "%.1f", elapsed))ms)")
+            NSLog("%@", "[NativePHP] [WEBVIEW:\(state.handle)] <-- \(statusLine) (\(String(format: "%.1f", elapsed))ms)")
 
             completion(response)
         }
@@ -89,18 +100,24 @@ final class WebviewPHPRuntime {
     /// Stop this webview's PHP thread and free its slot. Queued after any
     /// in-flight request; further dispatches answer 503. Idempotent.
     func release() {
-        queue.async { [self] in
-            guard !released else { return }
-            released = true
-            if handle >= 0 {
-                _webview_php_stop(handle)
-                print("[NativePHP] webview runtime: slot \(handle) released")
-                handle = -1
-            }
-        }
+        Self.releaseAsync(state: state, queue: queue)
     }
 
     deinit {
-        release()
+        // Backstop for paths where dismantleUIView never ran. Captures only
+        // the state box and queue — never `self`.
+        Self.releaseAsync(state: state, queue: queue)
+    }
+
+    private static func releaseAsync(state: State, queue: DispatchQueue) {
+        queue.async {
+            guard !state.released else { return }
+            state.released = true
+            if state.handle >= 0 {
+                _webview_php_stop(state.handle)
+                print("[NativePHP] webview runtime: slot \(state.handle) released")
+                state.handle = -1
+            }
+        }
     }
 }

--- a/resources/xcode/NativePHP/Bridge/WebviewPHPRuntime.swift
+++ b/resources/xcode/NativePHP/Bridge/WebviewPHPRuntime.swift
@@ -1,0 +1,106 @@
+import Foundation
+
+@_silgen_name("webview_php_start")
+private func _webview_php_start(_ bootstrapPath: UnsafePointer<CChar>) -> Int32
+
+@_silgen_name("webview_php_request")
+private func _webview_php_request(
+    _ handle: Int32,
+    _ method: UnsafePointer<CChar>,
+    _ uri: UnsafePointer<CChar>,
+    _ cookieHeader: UnsafePointer<CChar>,
+    _ postData: UnsafePointer<CChar>,
+    _ contentType: UnsafePointer<CChar>,
+    _ scriptPath: UnsafePointer<CChar>
+) -> UnsafeMutablePointer<CChar>?
+
+@_silgen_name("webview_php_stop")
+private func _webview_php_stop(_ handle: Int32)
+
+/// A dedicated PHP context for one embedded php-mode webview.
+///
+/// The persistent runtime's serial queue is parked inside the native
+/// screen's event-loop dispatch for the screen's whole lifetime, so it can
+/// never answer php:// requests from an embedded webview. Each instance of
+/// this class owns a separate thread + TSRM context in the C bridge
+/// (`webview_php_start`), boots Laravel on it, serves that webview's
+/// requests, and tears the whole context down in `release()` when the
+/// webview leaves the view hierarchy.
+///
+/// All work is serialized on a private queue: requests naturally queue
+/// behind the (asynchronous) boot, and `release()` behind in-flight
+/// requests — no explicit state machine needed.
+final class WebviewPHPRuntime {
+    private let queue = DispatchQueue(label: "com.nativephp.webview-php", qos: .userInitiated)
+    private var handle: Int32 = -1
+    private var released = false
+
+    init() {
+        queue.async { [self] in
+            let appPath = AppUpdateManager.shared.getAppPath()
+            let bootstrap = appPath + "/vendor/nativephp/mobile/bootstrap/ios/persistent.php"
+            handle = _webview_php_start(bootstrap)
+            print("[NativePHP] webview runtime: boot \(handle >= 0 ? "OK (slot \(handle))" : "FAILED (\(handle))")")
+        }
+    }
+
+    /// Dispatch a request on this webview's own PHP context. The completion
+    /// receives the raw HTTP response (headers + body), matching the format
+    /// `PHPSchemeHandler` already parses.
+    func dispatch(request: RequestData, completion: @escaping (String) -> Void) {
+        queue.async { [self] in
+            guard !released, handle >= 0 else {
+                completion("HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/plain\r\n\r\nWebview PHP runtime unavailable.")
+                return
+            }
+
+            var uri = request.uri
+            if let query = request.query, !query.isEmpty {
+                uri += "?" + query
+            }
+
+            let appPath = AppUpdateManager.shared.getAppPath()
+            let scriptPath = appPath + "/vendor/nativephp/mobile/bootstrap/ios/native.php"
+            let cookieHeader = request.headers["Cookie"] ?? ""
+            let contentType = request.headers["Content-Type"] ?? request.headers["content-type"] ?? ""
+
+            let start = CFAbsoluteTimeGetCurrent()
+            NSLog("%@", "[NativePHP] [WEBVIEW:\(handle)] --> \(request.method) \(uri)")
+
+            guard let resultPtr = _webview_php_request(
+                handle, request.method, uri, cookieHeader,
+                request.data ?? "", contentType, scriptPath
+            ) else {
+                completion("HTTP/1.1 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\nNull response from webview runtime.")
+                return
+            }
+
+            let response = String(cString: resultPtr)
+            free(UnsafeMutableRawPointer(mutating: resultPtr))
+
+            let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
+            let statusLine = response.prefix(while: { $0 != "\r" && $0 != "\n" })
+            NSLog("%@", "[NativePHP] [WEBVIEW:\(handle)] <-- \(statusLine) (\(String(format: "%.1f", elapsed))ms)")
+
+            completion(response)
+        }
+    }
+
+    /// Stop this webview's PHP thread and free its slot. Queued after any
+    /// in-flight request; further dispatches answer 503. Idempotent.
+    func release() {
+        queue.async { [self] in
+            guard !released else { return }
+            released = true
+            if handle >= 0 {
+                _webview_php_stop(handle)
+                print("[NativePHP] webview runtime: slot \(handle) released")
+                handle = -1
+            }
+        }
+    }
+
+    deinit {
+        release()
+    }
+}

--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -3,6 +3,12 @@ import WebKit
 class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
     let domain = "127.0.0.1"
 
+    /// When set, requests are served by this webview's own PHP context
+    /// instead of the persistent runtime's serial queue. Embedded php-mode
+    /// webviews inside native screens MUST set this: the persistent queue is
+    /// parked in the screen's event-loop dispatch and would never answer.
+    var dedicatedRuntime: WebviewPHPRuntime?
+
     // Shared session for Jump WebView-mode forwards. Reused across requests so
     // HTTP keep-alive / connection pooling kicks in — a fresh session per
     // request re-did the TCP handshake every time and made navigation crawl.
@@ -655,8 +661,47 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
         }
     }
 
+    /// Push a raw response's Set-Cookie headers into the shared WebView
+    /// cookie store (same rebinding the persistent path does inline).
+    private func storeSetCookies(from rawResponse: String) {
+        let components = rawResponse.components(separatedBy: "\r\n\r\n")
+        let headersList = components[0].components(separatedBy: "\n").filter { !$0.isEmpty }
+        let setCookieHeaders = headersList.filter { $0.hasPrefix("Set-Cookie:") || $0.hasPrefix("set-cookie:") }
+        guard !setCookieHeaders.isEmpty else { return }
+
+        DispatchQueue.main.async {
+            for header in setCookieHeaders {
+                var cookieString = header
+                if let range = cookieString.range(of: "Set-Cookie: ", options: .caseInsensitive) {
+                    cookieString = String(cookieString[range.upperBound...])
+                }
+                cookieString = cookieString
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .replacingOccurrences(of: ";\\s+", with: ";", options: .regularExpression)
+
+                if let cookie = HTTPCookie(properties: self.parseSetCookieHeader(cookieString: cookieString)) {
+                    WebView.dataStore.httpCookieStore.setCookie(cookie)
+                }
+            }
+        }
+    }
+
     private func getResponse(request: RequestData,
                               completion: @escaping (Result<Data, Error>) -> Void) {
+        // Embedded php-mode webview — serve on its own dedicated PHP context.
+        if let dedicated = dedicatedRuntime {
+            dedicated.dispatch(request: request) { [weak self] response in
+                guard let self else { return }
+                self.storeSetCookies(from: response)
+                if let responseData = response.data(using: .utf8) {
+                    completion(.success(responseData))
+                } else {
+                    completion(.failure(self.error(code: 500, description: "Failed to encode PHP response")))
+                }
+            }
+            return
+        }
+
         // PROTOTYPE: in a Jump WebView session, forward to the remote dev server
         // instead of the local embedded PHP. The WebView still believes it is
         // loading php://127.0.0.1, so no origin/ATS/nav-policy change is needed.


### PR DESCRIPTION
## Problem

An embedded `<webview php>` inside a native screen can never load. Its `php://` requests dispatch through the persistent runtime's serial queue — but in an EDGE app that queue is parked inside the screen's event-loop dispatch (`nativephp_element_wait_event()`) for the screen's entire lifetime. The request queues forever: scheme handler fires, dispatch never runs, no error, permanently blank webview. (The hot-reload path already documents this exact hazard and dodges it by firing a wake event first.)

Traced end-to-end on device in super-native: `webview(php): loading` → `policy — allow` → `scheme handler start` → **nothing** — the `--> GET` dispatch log never fires.

## Design

One dedicated PHP lane per embedded webview, started when the webview mounts and stopped when it leaves the view hierarchy:

- **`PHP.c` — `webview_php_start/request/stop`**: a slot pool (max 4 concurrent), each slot a dedicated pthread + TSRM context (same recipe as the ephemeral lane: `ts_resource` + module/request startup, gated on persistent boot). Boots Laravel via the persistent bootstrap so `Runtime::dispatch()` serves warm requests.
- **No process-env marshaling**: request state is inlined into the dispatch eval (single-quote-escaped) and carried by per-thread SAPI globals (`SG(request_info)`, body via `php://input` stream). The persistent lane's `setenv` churn can't race a slot and vice versa.
- **`WebviewPHPRuntime.swift`**: per-webview wrapper. Boot runs asynchronously on a private serial queue; requests naturally queue behind it; `release()` queues behind in-flight requests, stops the thread, frees the slot. Idempotent, also fired from `deinit`.
- **`PHPSchemeHandler.dedicatedRuntime`**: when set, requests route to the webview's own context, with the same Set-Cookie rebinding into the shared `WebView.dataStore` cookie store — so the embedded page rides the same Laravel session as the app (file session store + shared cookies).

Companion change in nativephp/mobile-ui: the webview renderer creates a `WebviewPHPRuntime` in `makeUIView`, hands it to its scheme handler, and releases it in `dismantleUIView`.

## Verified

- Full super-native app (scaffold patched identically) compiles clean via `xcodebuild` (device target).
- Suite: all green (change is C/Swift; PHP-side untouched — `Runtime::dispatch` already existed).
- Known shared-state caveats (documented design): two Laravel contexts share storage/ (file sessions serialize via locking; SQLite via WAL is untested under concurrent write load).

## Follow-ups

- Android parity (same architecture applies — the Kotlin renderer's php mode will need its own executor lane).
- Optional: slot reuse/LRU rather than boot-per-mount if boot latency shows in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)