### PR TITLE
Fix dropped plugin events on iOS native-direct boots (main)

### DIFF
--- a/resources/xcode/NativePHP/Bridge/NativePHP.swift
+++ b/resources/xcode/NativePHP/Bridge/NativePHP.swift
@@ -1,5 +1,18 @@
+import Foundation
+
 final class LaravelBridge {
     static let shared = LaravelBridge()
 
-    var send: ((_ event: String, _ payload: [String: Any?]) -> Void)?
+    /// Delivers device-API events (plugins, system events) into PHP. WebView
+    /// boots overwrite this in makeUIView with the coordinator closure (JS
+    /// injection + element queue). This default covers native-direct boots,
+    /// which never construct a WKWebView — without it, every plugin dispatch
+    /// (`LaravelBridge.shared.send?(...)`) is an optional call on nil and
+    /// events like ServerFound / CodeScanned are silently dropped.
+    var send: ((_ event: String, _ payload: [String: Any?]) -> Void)? = { event, payload in
+        let dict = payload.reduce(into: [String: Any]()) { $0[$1.key] = $1.value ?? NSNull() }
+        let json = (try? JSONSerialization.data(withJSONObject: dict))
+            .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+        NativeElementBridge.sendNativeEvent(eventName: event, payloadJson: json)
+    }
 }


### PR DESCRIPTION
## Summary
Cherry-pick of #203 onto main. PR #201 (feat/native-first-boot) landed the iOS native-direct boot on main, which never constructs a WKWebView — but `LaravelBridge.shared.send` was only assigned during WebView creation (`makeUIView`), so on native-direct boots it stays nil and every plugin event dispatch (`ServerFound`, `CodeScanned`, device-API events) is silently dropped. Symptom: Jump's "servers nearby" pill never appears and QR scans do nothing.

Fix: default `send` to a closure forwarding into the element event queue via `NativeElementBridge.sendNativeEvent` (the same second leg `notifyLaravel` performs). WebView boots still overwrite it in `makeUIView`; web apps unchanged.

## Test plan
Verified on-device (iPhone, native-direct boot) on the integration branch: discovery pill appears, QR scan connects, WS bridge shows the device connecting. This is the identical one-file change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)