### PR TITLE
LaravelBridge.localSend: dispatch-time local event channel

### DIFF
--- a/resources/xcode/NativePHP/Bridge/NativePHP.swift
+++ b/resources/xcode/NativePHP/Bridge/NativePHP.swift
@@ -3,16 +3,28 @@ import Foundation
 final class LaravelBridge {
     static let shared = LaravelBridge()
 
-    /// Delivers device-API events (plugins, system events) into PHP. WebView
-    /// boots overwrite this in makeUIView with the coordinator closure (JS
-    /// injection + element queue). This default covers native-direct boots,
-    /// which never construct a WKWebView — without it, every plugin dispatch
-    /// (`LaravelBridge.shared.send?(...)`) is an optional call on nil and
-    /// events like ServerFound / CodeScanned are silently dropped.
-    var send: ((_ event: String, _ payload: [String: Any?]) -> Void)? = { event, payload in
+    /// The CURRENT local delivery channel for device-API events. Starts as
+    /// the element-queue forwarder (native-direct boots have no WKWebView);
+    /// ContentView.makeUIView upgrades it to the coordinator closure (JS
+    /// injection + element queue) when a WebView materializes.
+    ///
+    /// Wrappers around `send` (e.g. Jump's remote-session fork) must fall
+    /// back to THIS, read at dispatch time — capturing `send` at install
+    /// time goes stale when the WebView materializes mid-session, and the
+    /// captured element-queue closure then swallows every event meant for
+    /// the page (async device results in a forwarded WebView app).
+    var localSend: (_ event: String, _ payload: [String: Any?]) -> Void = { event, payload in
         let dict = payload.reduce(into: [String: Any]()) { $0[$1.key] = $1.value ?? NSNull() }
         let json = (try? JSONSerialization.data(withJSONObject: dict))
             .flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
         NativeElementBridge.sendNativeEvent(eventName: event, payloadJson: json)
+    }
+
+    /// Public dispatch every plugin calls. Defaults to routing through
+    /// `localSend` dynamically — never nil, so native-direct boots deliver
+    /// events from birth (ServerFound / CodeScanned were silently dropped
+    /// when this was only assigned at WebView creation).
+    var send: ((_ event: String, _ payload: [String: Any?]) -> Void)? = { event, payload in
+        LaravelBridge.shared.localSend(event, payload)
     }
 }

--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -831,8 +831,12 @@ struct WebView: UIViewRepresentable {
             }
         }
 
-        // Setup Laravel bridge - use shared coordinator so it persists
-        LaravelBridge.shared.send = { [weak shared] event, payload in
+        // Setup Laravel bridge - use shared coordinator so it persists.
+        // Upgrade the LOCAL delivery channel rather than overwriting `send`:
+        // `send` may be wrapped (Jump's remote-session fork), and wrappers
+        // fall back to localSend at dispatch time — so events reach the
+        // WebView the moment it materializes, even mid-session.
+        LaravelBridge.shared.localSend = { [weak shared] event, payload in
             Task { @MainActor in
                 shared?.coordinator?.notifyLaravel(event: event, payload: payload as [String : Any])
             }


### PR DESCRIPTION
## Summary
Native-first boot made "the WebView materializes later, maybe never" a real state, and assigning `LaravelBridge.send` only at WebView creation broke event delivery around it twice:

1. Native-direct boots dropped every plugin event until #205 defaulted `send` to the element-queue forwarder.
2. Wrappers that capture `send` as their fallback (Jump's remote-session fork) go stale when the WebView materializes mid-session — async device results (biometrics, location, camera) meant for a forwarded WebView app land in the parked local element queue instead of the page. Verified on-device against a v3 (`mobile` 3.3.6) server through Jump: calls reached the phone, results never came back.

## Fix
Split the concerns: `localSend` is the always-current local delivery channel — element-queue forwarder by default, upgraded to the coordinator closure (JS injection + element queue) in `makeUIView` — and `send` defaults to routing through it at dispatch time. `makeUIView` now upgrades `localSend` instead of overwriting `send`, so installed wrappers survive WebView materialization and their fallback is always correct.

## Test plan
- On-device (iPhone, native-direct boot Jump client): biometric auth and location permission/request results now land in a forwarded WebView app (v3 server); native-ui streaming, pill discovery, and QR connect unchanged.
- Web-legacy boots: `send` still ends up delivering through the coordinator closure exactly as before — same dual dispatch, one indirection deeper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)