### PR TITLE
Android: Jump webview-forward session (port of iOS JumpWebViewSession)

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/JumpWebViewSession.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/JumpWebViewSession.kt
@@ -1,0 +1,42 @@
+package com.nativephp.mobile.network
+
+/**
+ * "Render a remote WebView app over Jump" — Android port of the iOS
+ * `JumpWebViewSession`.
+ *
+ * When active, [WebViewManager]'s request interception forwards
+ * `http://127.0.0.1` requests (pages AND assets) to the remote Jump dev
+ * server (`host:port`) instead of the local embedded PHP. The WebView keeps
+ * loading `127.0.0.1`, so there is NO change to the rendering surface, no
+ * remote origin, and the existing render + JS bridge paths are untouched —
+ * responses just come from a different source.
+ *
+ * Started by the discovery plugin's `JumpBridgeRelay` when `/jump/info`
+ * reports (or implies) a WebView app; stopped by the escape hatch / session
+ * teardown.
+ */
+object JumpWebViewSession {
+    @Volatile private var _host = ""
+
+    @Volatile private var _port = ""
+
+    @Volatile private var _active = false
+
+    val host: String get() = _host
+    val port: String get() = _port
+    val isActive: Boolean get() = _active
+
+    @Synchronized
+    fun start(host: String, port: String) {
+        _host = host
+        _port = port
+        _active = true
+    }
+
+    @Synchronized
+    fun stop() {
+        _active = false
+        _host = ""
+        _port = ""
+    }
+}

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPWebViewClient.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPWebViewClient.kt
@@ -316,6 +316,135 @@ class PHPWebViewClient(
 
 
 
+    /**
+     * Jump webview-forward: proxy a 127.0.0.1 request (page or asset) to the
+     * remote Jump dev server over the LAN and wrap its response for the
+     * WebView. Mirrors iOS `PHPSchemeHandler.forwardToRemote`, plus binary
+     * bodies (bytes end-to-end, so images/fonts work).
+     *
+     * Runs on the WebView's intercept thread (network allowed). Remote
+     * Set-Cookies are persisted through the same stores as the local path
+     * (LaravelCookieStore + WebCookieMirror) so Livewire sessions/CSRF
+     * survive across forwards. Redirects are followed manually (max 5) as
+     * GETs because WebResourceResponse rejects 3xx status codes outright.
+     */
+    fun forwardToRemote(request: WebResourceRequest, postData: String?): WebResourceResponse {
+        val remoteHost = JumpWebViewSession.host
+        val remotePort = JumpWebViewSession.port
+        val path = request.url.encodedPath ?: "/"
+        val query = request.url.encodedQuery
+        var urlString = "http://$remoteHost:$remotePort$path" +
+            if (query.isNullOrEmpty()) "" else "?$query"
+        var method = request.method.uppercase()
+        var body: String? = postData
+
+        try {
+            var redirects = 0
+            while (true) {
+                val conn = java.net.URL(urlString).openConnection() as java.net.HttpURLConnection
+                conn.requestMethod = method
+                conn.connectTimeout = 10_000
+                conn.readTimeout = 15_000
+                // Manual redirect handling: HttpURLConnection won't reliably
+                // convert POST→GET across a 302, and WebResourceResponse
+                // rejects 3xx codes, so we must resolve them here either way.
+                conn.instanceFollowRedirects = false
+                for ((k, v) in request.requestHeaders) {
+                    val lk = k.lowercase()
+                    // Skip hop-by-hop headers the stack owns. Dropping
+                    // accept-encoding makes the platform handle gzip
+                    // transparently, so the body arrives decoded.
+                    if (lk == "host" || lk == "content-length" || lk == "accept-encoding") continue
+                    conn.setRequestProperty(k, v)
+                }
+                conn.setRequestProperty("Cookie", LaravelCookieStore.asCookieHeader())
+
+                if (method in listOf("POST", "PUT", "PATCH") && body != null) {
+                    conn.doOutput = true
+                    conn.outputStream.use { it.write(body!!.toByteArray()) }
+                }
+
+                val status = conn.responseCode
+
+                // Persist remote session cookies exactly like the local path.
+                conn.headerFields.entries
+                    .filter { it.key?.equals("Set-Cookie", ignoreCase = true) == true }
+                    .flatMap { it.value }
+                    .forEach { v ->
+                        LaravelCookieStore.storeFromSetCookieHeader(v)
+                        com.nativephp.mobile.security.WebCookieMirror.set(v)
+                    }
+                com.nativephp.mobile.security.WebCookieMirror.flush()
+
+                if (status in 300..399 && redirects < 5) {
+                    val location = conn.getHeaderField("Location") ?: break
+                    urlString = when {
+                        location.startsWith("http") -> {
+                            // Rebind absolute redirects onto the dev server —
+                            // the remote app believes it lives at 127.0.0.1.
+                            val u = Uri.parse(location)
+                            "http://$remoteHost:$remotePort${u.encodedPath ?: "/"}" +
+                                if (u.encodedQuery.isNullOrEmpty()) "" else "?${u.encodedQuery}"
+                        }
+                        location.startsWith("/") -> "http://$remoteHost:$remotePort$location"
+                        else -> "http://$remoteHost:$remotePort/$location"
+                    }
+                    method = "GET"
+                    body = null
+                    redirects++
+                    conn.disconnect()
+                    continue
+                }
+
+                var bytes = (if (status >= 400) conn.errorStream else conn.inputStream)
+                    ?.use { it.readBytes() } ?: ByteArray(0)
+
+                Log.d(TAG, "🛰️ [JUMP-FORWARD] $method $urlString → $status (${bytes.size} bytes)")
+
+                val contentType = conn.contentType ?: guessMimeType(path)
+
+                // Rewrite the dev server's origin to 127.0.0.1 in text bodies.
+                // The served app bakes ABSOLUTE URLs into its HTML/JS/JSON
+                // (Livewire's update endpoint, asset links, Boost's logger…).
+                // The WebView's origin is 127.0.0.1, so those would be
+                // cross-origin: XHR/fetch then sends a CORS preflight straight
+                // over the LAN, the jump router answers without CORS headers,
+                // and the browser blocks the real request — every wire:click
+                // silently dies. Same-origin URLs flow through the
+                // interception forward (with captured POST bodies) instead.
+                val isText = contentType.contains("html", true) ||
+                    contentType.contains("json", true) ||
+                    contentType.contains("javascript", true) ||
+                    contentType.contains("css", true)
+                if (isText && bytes.isNotEmpty()) {
+                    val rewritten = String(bytes, Charsets.UTF_8)
+                        .replace("http://$remoteHost:$remotePort", "http://127.0.0.1")
+                    bytes = rewritten.toByteArray(Charsets.UTF_8)
+                }
+                val mime = contentType.substringBefore(';').trim()
+                val encoding = if (contentType.contains("charset=", ignoreCase = true)) {
+                    contentType.substringAfter("charset=").trim()
+                } else "utf-8"
+                val responseHeaders = conn.headerFields.entries
+                    .filter { (k, _) ->
+                        k != null && k.lowercase() !in listOf(
+                            "set-cookie", "transfer-encoding", "content-encoding", "content-length",
+                        )
+                    }
+                    .associate { (k, v) -> k!! to v.joinToString(", ") }
+                val reason = conn.responseMessage?.takeIf { it.isNotBlank() } ?: "OK"
+
+                return WebResourceResponse(
+                    mime, encoding, status, reason, responseHeaders, ByteArrayInputStream(bytes)
+                )
+            }
+            return errorResponse(502, "Unresolvable redirect from Jump dev server")
+        } catch (e: Exception) {
+            Log.e(TAG, "❌ [JUMP-FORWARD] $urlString failed: ${e.message}")
+            return errorResponse(502, "Jump dev server unreachable")
+        }
+    }
+
     private fun errorResponse(code: Int, message: String): WebResourceResponse {
         return WebResourceResponse(
             "text/html",

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebViewManager.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebViewManager.kt
@@ -213,6 +213,23 @@ class WebViewManager(
                     return true // prevent WebView from loading it
                 }
 
+                // Jump webview-forward session: the served app generates
+                // absolute links with ITS host (http://<devhost>:<port>/…).
+                // The WebView's origin is 127.0.0.1, so without this those
+                // links classify as "external site" below and open the system
+                // browser. Rewrite them onto 127.0.0.1 — the interception
+                // layer forwards them back to the dev server.
+                if (JumpWebViewSession.isActive &&
+                    request.url.host == JumpWebViewSession.host &&
+                    (if (request.url.port == -1) "80" else request.url.port.toString()) == JumpWebViewSession.port
+                ) {
+                    val rewritten = "http://127.0.0.1${request.url.encodedPath ?: "/"}" +
+                        (request.url.encodedQuery?.let { "?$it" } ?: "")
+                    Log.d(TAG, "🛰️ [JUMP-FORWARD] Rewriting session link → $rewritten")
+                    view.loadUrl(rewritten)
+                    return true
+                }
+
                 if ((url.startsWith("http://") || url.startsWith("https://")) &&
                     !url.contains("127.0.0.1") &&
                     !url.contains("localhost") &&
@@ -294,8 +311,14 @@ class WebViewManager(
                             url.contains("/css/") ||
                             url.contains("/fonts/") ||
                             url.contains("/images/") -> {
-                        Log.d(TAG, "🖼️ Handling asset request")
-                        phpHandler.handleAssetRequest(url, request.requestHeaders)
+                        // Jump webview-forward session: assets live on the
+                        // remote dev server, not in the local bundle.
+                        if (JumpWebViewSession.isActive) {
+                            phpHandler.forwardToRemote(request, null)
+                        } else {
+                            Log.d(TAG, "🖼️ Handling asset request")
+                            phpHandler.handleAssetRequest(url, request.requestHeaders)
+                        }
                     }
                     // Regular PHP requests
                     url.contains("127.0.0.1") -> {
@@ -322,7 +345,14 @@ class WebViewManager(
                                 data
                             }
                         } else null
-                        phpHandler.handlePHPRequest(request, postData)
+                        // Jump webview-forward session: hand the request
+                        // (with any consumed POST body) to the remote dev
+                        // server instead of the embedded PHP runtime.
+                        if (JumpWebViewSession.isActive) {
+                            phpHandler.forwardToRemote(request, postData)
+                        } else {
+                            phpHandler.handlePHPRequest(request, postData)
+                        }
                     }
                     else -> {
                         Log.d(TAG, "↪️ Delegating to system handler: $url")

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
@@ -383,6 +383,18 @@ class MainActivity : FragmentActivity(), WebViewProvider {
     }
 
     /**
+     * Jump webview-forward session entry: same commit-gated swap as
+     * EXIT_WEB — the native tree (Jump home) stays visible through Chromium
+     * init until the forwarded page's first commit. Called by the discovery
+     * plugin's JumpBridgeRelay after JumpWebViewSession.start(); requests
+     * from the loaded page are forwarded to the remote dev server by
+     * WebViewManager while the session is active.
+     */
+    fun jumpWebViewSwap(path: String = "/") {
+        exitToWeb(path)
+    }
+
+    /**
      * Renderer-agnostic first-content signal: fired by the first framed
      * native element tree (MainScreen LaunchedEffect) or the first web page
      * commit (WebViewManager.onPageCommitVisible). One-shot.
@@ -761,11 +773,8 @@ class MainActivity : FragmentActivity(), WebViewProvider {
                 .commitNowAllowingStateLoss()
         }
 
-        webRenderer?.webView?.webChromeClient?.let { chromeClient ->
-            if (chromeClient is WebChromeClient) {
-                chromeClient.onHideCustomView()
-            }
-        }
+        // Dismiss any fullscreen custom view (video) before teardown.
+        webRenderer?.webView?.webChromeClient?.onHideCustomView()
 
         // Stop hot reload watcher thread
         shouldStopWatcher = true

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/NativeSideNav.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/NativeSideNav.kt
@@ -272,6 +272,15 @@ private fun SideNavItemView(
  * Check if a URL is external (not a relative path or localhost)
  */
 private fun isExternalUrl(url: String): Boolean {
+    // A Jump webview-forward session's host:port counts as internal: the
+    // served app generates absolute URLs with its dev-server host, and the
+    // internal path reduces them to paths the forward layer handles. Without
+    // this, native-chrome links (top bar / bottom nav / side nav) on a
+    // forwarded app open the system browser.
+    val session = com.nativephp.mobile.network.JumpWebViewSession
+    if (session.isActive && url.contains("${session.host}:${session.port}")) {
+        return false
+    }
     return (url.startsWith("http://") || url.startsWith("https://"))
             && !url.contains("127.0.0.1")
             && !url.contains("localhost")

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/NativeTopBar.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/NativeTopBar.kt
@@ -175,6 +175,15 @@ fun NativeTopBar(
  * Check if a URL is external (not a relative path or localhost)
  */
 private fun isExternalUrl(url: String): Boolean {
+    // A Jump webview-forward session's host:port counts as internal: the
+    // served app generates absolute URLs with its dev-server host, and the
+    // internal path reduces them to paths the forward layer handles. Without
+    // this, native-chrome links (top bar / bottom nav / side nav) on a
+    // forwarded app open the system browser.
+    val session = com.nativephp.mobile.network.JumpWebViewSession
+    if (session.isActive && url.contains("${session.host}:${session.port}")) {
+        return false
+    }
     return (url.startsWith("http://") || url.startsWith("https://"))
             && !url.contains("127.0.0.1")
             && !url.contains("localhost")

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeNavRenderers.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeNavRenderers.kt
@@ -310,6 +310,15 @@ private fun parseBadgeColor(colorString: String): androidx.compose.ui.graphics.C
 }
 
 private fun isExternalUrl(url: String): Boolean {
+    // A Jump webview-forward session's host:port counts as internal: the
+    // served app generates absolute URLs with its dev-server host, and the
+    // internal path reduces them to paths the forward layer handles. Without
+    // this, native-chrome links (top bar / bottom nav / side nav) on a
+    // forwarded app open the system browser.
+    val session = com.nativephp.mobile.network.JumpWebViewSession
+    if (session.isActive && url.contains("${session.host}:${session.port}")) {
+        return false
+    }
     return (url.startsWith("http://") || url.startsWith("https://"))
             && !url.contains("127.0.0.1")
             && !url.contains("localhost")


### PR DESCRIPTION
## Summary
Android had no webview-forward mode: the Jump client always drove the native-ui flow, so v3 servers (and v4 WebView apps) connected but rendered nothing. This ports the iOS `JumpWebViewSession` design and hardens the whole path — every fix below was driven by on-device testing against a live v3 (`mobile` 3.3.6) kitchen-sink server:

- **`JumpWebViewSession`** — core-owned session seam (the interception hooks compile in every app, plugin or not; the discovery plugin just starts/stops it). Mirrors iOS, where it's also a core template file.
- **`PHPWebViewClient.forwardToRemote`** — binary-safe LAN proxy for intercepted `127.0.0.1` requests: cookie persistence through the existing stores, manual 3xx resolution rebound to the dev server (`WebResourceResponse` rejects redirect codes), and **session-origin → `127.0.0.1` rewriting in text bodies**. The served app bakes absolute URLs into its HTML (Livewire's update endpoint, assets); cross-origin XHR preflights were silently killing every `wire:click` — this is what made device APIs (flashlight etc.) work.
- **`WebViewManager`** — asset + PHP branches forward during a session; main-frame links to the session host rewrite onto `127.0.0.1` instead of opening the system browser.
- **`NativeTopBar` / `NativeSideNav` / `NativeNavRenderers`** — `isExternalUrl` treats the active session host:port as internal (native-chrome links were opening Chrome).
- **`MainActivity.jumpWebViewSwap`** — public commit-gated swap (same machinery as EXIT_WEB); Jump home stays visible through Chromium init until the forwarded page's first commit.
- Drive-by: removed an always-true instanceof check in `onDestroy` (compiler warning).

Pairs with discovery-plugin relay changes in the jump repo (`ui` parsing with v3-implying default, session lifecycle, chrome-state resets).

## Test plan
Verified on-device (Pixel, native-direct boot Jump client) against a v3 server: page + assets render via forward, body links / top bar / bottom nav / side nav navigate in-app, Livewire interactions and device bridge calls (flashlight) work, escape hatch and killed-server abandonment return to Jump home, live reload reloads the page. Native-ui v4 flow untouched (`JumpWebViewSession` inactive → identical code paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)