### PR TITLE
Remove duplicate runtime blocks from nativephp config

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -147,24 +147,14 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Environment Keys to Clean Up
-    |--------------------------------------------------------------------------
-    |
-    | These are keys that will be removed from the .env file during app
-    | bundling to prevent secrets or development credentials from being
-    | leaked. Wildcards are supported (e.g. AWS_* or *_SECRET).
-    |
-    */
-
-    /*
-    |--------------------------------------------------------------------------
     | Runtime Configuration
     |--------------------------------------------------------------------------
     |
     | Controls how the PHP interpreter runs on device. In 'persistent' mode,
     | PHP boots once and stays alive — subsequent requests dispatch through
     | the running interpreter (~5-30ms instead of ~200-300ms). In 'classic'
-    | mode, each request does a full php_embed_init/shutdown cycle.
+    | mode, each request does a full php_embed_init/shutdown cycle. Falls
+    | back to 'classic' mode if persistent boot fails.
     |
     | reset_instances:        Clear resolved facade instances between dispatches
     | gc_between_dispatches:  Run gc_collect_cycles() between dispatches
@@ -176,6 +166,17 @@ return [
         'reset_instances' => true,
         'gc_between_dispatches' => false,
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Environment Keys to Clean Up
+    |--------------------------------------------------------------------------
+    |
+    | These are keys that will be removed from the .env file during app
+    | bundling to prevent secrets or development credentials from being
+    | leaked. Wildcards are supported (e.g. AWS_* or *_SECRET).
+    |
+    */
 
     'cleanup_env_keys' => [
         'AWS_*',
@@ -202,42 +203,6 @@ return [
         'storage/framework/cache',
         'storage/framework/testing',
         'storage/logs/laravel.log',
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Runtime Configuration
-    |--------------------------------------------------------------------------
-    |
-    | Controls the persistent PHP runtime behavior. In 'persistent' mode,
-    | Laravel boots once and the kernel is reused across requests (~5-30ms
-    | per dispatch instead of ~200-300ms). Falls back to 'classic' mode
-    | (full init/shutdown per request) if persistent boot fails.
-    |
-    */
-
-    'runtime' => [
-        'mode' => 'persistent', // 'classic' or 'persistent'
-        'reset_instances' => true,
-        'gc_between_dispatches' => false,
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Runtime Configuration
-    |--------------------------------------------------------------------------
-    |
-    | Controls the persistent PHP runtime behavior. In 'persistent' mode,
-    | Laravel boots once and the kernel is reused across requests (~5-30ms
-    | per dispatch instead of ~200-300ms). Falls back to 'classic' mode
-    | (full init/shutdown per request) if persistent boot fails.
-    |
-    */
-
-    'runtime' => [
-        'mode' => env('NATIVEPHP_RUNTIME_MODE', 'persistent'),
-        'reset_instances' => true,
-        'gc_between_dispatches' => false,
     ],
 
     /*


### PR DESCRIPTION
The 'runtime' key was defined three times (last one silently won). Collapsed into one block and moved the orphaned cleanup_env_keys doc comment back above its array. No effective config changes.