### PR TITLE
Fix Pint 1.29 code style failures in CI

### DIFF
--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
+use Native\Mobile\Edge\NativeRouter;
 use Native\Mobile\Plugins\Compilers\IOSPluginCompiler;
 use Native\Mobile\Plugins\PluginHookRunner;
 use Native\Mobile\Plugins\PluginRegistry;
@@ -952,7 +953,7 @@ class BuildIosAppCommand extends Command
         // to decide whether the first screen dispatches directly into the
         // persistent runtime (no WKWebView) or through the legacy WebView
         // path. NATIVEPHP_BOOT_MODE=web forces the legacy path.
-        $nativeRoutes = array_keys(\Native\Mobile\Edge\NativeRouter::registeredRoutes());
+        $nativeRoutes = array_keys(NativeRouter::registeredRoutes());
         $entryMode = env('NATIVEPHP_BOOT_MODE') === 'web' ? 'web' : 'auto';
 
         $bundleMeta = json_encode([

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -222,7 +222,7 @@ class NativeServiceProvider extends PackageServiceProvider
                 return;
             }
             try {
-                $routes = array_keys(\Native\Mobile\Edge\NativeRouter::registeredRoutes());
+                $routes = array_keys(NativeRouter::registeredRoutes());
                 file_put_contents(
                     storage_path('framework/native_routes.json'),
                     json_encode([

--- a/src/Traits/PreparesBuild.php
+++ b/src/Traits/PreparesBuild.php
@@ -5,6 +5,7 @@ namespace Native\Mobile\Traits;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
+use Native\Mobile\Edge\NativeRouter;
 use Symfony\Component\Process\Process as SymfonyProcess;
 
 trait PreparesBuild
@@ -324,7 +325,7 @@ trait PreparesBuild
             // WebView path. Routes are registered by the app's route files, which
             // this artisan process has already loaded. NATIVEPHP_BOOT_MODE=web
             // forces the legacy path regardless.
-            $nativeRoutes = array_keys(\Native\Mobile\Edge\NativeRouter::registeredRoutes());
+            $nativeRoutes = array_keys(NativeRouter::registeredRoutes());
             $entryMode = env('NATIVEPHP_BOOT_MODE') === 'web' ? 'web' : 'auto';
 
             $bundleMeta = json_encode([


### PR DESCRIPTION
## What

Fixes the failing **Code Style** check in CI (seen on #208 and any other open PR) by resolving three `fully_qualified_strict_types` violations — inline `\Native\Mobile\Edge\NativeRouter` FQCNs replaced with proper imports:

- `src/Commands/BuildIosAppCommand.php`
- `src/NativeServiceProvider.php` (import already existed)
- `src/Traits/PreparesBuild.php`

## Why

These violations are pre-existing on `main`, not introduced by any open PR. `composer.lock` is gitignored, so CI resolves fresh dependencies on every run — it recently started pulling **Pint 1.29.3**, which flags these usages that the older Pint 1.27.x did not. Any PR touching anything now fails the Code Style check.

## Verification

With Pint 1.29.3 (matching CI):
- `vendor/bin/pint --test` — passes
- `vendor/bin/phpstan analyse` — no errors
- `vendor/bin/pest` — 590 passed (4 risky, 3 skipped, pre-existing)

## Note

Since `composer.lock` is gitignored, CI can break again whenever a dep releases a new version. Consider pinning Pint (e.g. `~1.29.0`) or committing the lock file for deterministic CI — happy to follow up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)