### PR TITLE
feat(edge): @tap alias family for @press events

### DIFF
--- a/resources/boost/skills/nativephp-mobile/SKILL.md
+++ b/resources/boost/skills/nativephp-mobile/SKILL.md
@@ -109,6 +109,9 @@ Screens are built from `native:` Blade components (the prefix is optional but pr
 </native:column>
 ```
 
+Tap handlers use `@press` (`@tap` is a permanent alias — same for `@longPress`/`@longTap` and
+`@pressDown`/`@tapDown`, `@pressUp`/`@tapUp`; both spellings compile identically).
+
 ~40 elements are available — layout (column, row, stack, scroll-view, spacer, pressable), content (text, image,
 icon, divider, badge, progress-bar, activity-indicator), forms (button, button-group, text-input, toggle,
 checkbox, radio-group, select, slider, chip), navigation (bottom-nav, top-bar, side-nav, tab-row), lists

--- a/resources/boost/skills/nativephp-webview-to-native/SKILL.md
+++ b/resources/boost/skills/nativephp-webview-to-native/SKILL.md
@@ -50,7 +50,7 @@ The web view remains available during migration, so you never need a big-bang re
 | `class Foo extends Component` | `class Foo extends NativeComponent` |
 | `Route::get()` + view / `Route::livewire()` | `Route::native('/path', Foo::class)` |
 | `wire:model` / `.blur` / `.debounce.300ms` | `native:model` / `.blur` / `.debounce.300ms` |
-| `wire:click="save"` | `@press="save"` |
+| `wire:click="save"` | `@press="save"` (or its alias `@tap="save"`) |
 | `wire:submit` | `@submit` on the input / `@press` on the button |
 | `wire:poll.5s` | `#[Poll(5000)]` on a method, or `native:poll="5s"` |
 | `#[Computed]` (Livewire) | `#[Computed]` (`Native\Mobile\Attributes\Computed`) |

--- a/src/Edge/Element.php
+++ b/src/Edge/Element.php
@@ -467,6 +467,12 @@ abstract class Element
         return $this;
     }
 
+    /** Alias of onPress() — the programmatic twin of the `@tap` directive. */
+    public function onTap(string $method): static
+    {
+        return $this->onPress($method);
+    }
+
     public function onSwipeDelete(string $method): static
     {
         $this->swipeDeleteMethod = $method;

--- a/src/Edge/NativeTagPrecompiler.php
+++ b/src/Edge/NativeTagPrecompiler.php
@@ -53,6 +53,18 @@ class NativeTagPrecompiler
         'none' => 'none',
     ];
 
+    /**
+     * Alias directive → canonical press-family directive. Both spellings are
+     * permanent; the alias is normalized away at compile time so the rest of
+     * the pipeline only ever sees the canonical name.
+     */
+    private const TAP_ALIASES = [
+        'tap' => 'press',
+        'longTap' => 'longPress',
+        'tapDown' => 'pressDown',
+        'tapUp' => 'pressUp',
+    ];
+
     private const C = '\\Native\\Mobile\\Edge\\NativeElementCollector';
 
     /**
@@ -239,6 +251,21 @@ class NativeTagPrecompiler
                 $m[1] ?? '',
                 ! empty($m[4]) ? substr($m[4], 1, -1) : (($m[2] ?? '') !== '' ? "'{$m[2]}'" : ($m[3] ?? '')),
             ),
+            $value
+        );
+
+        // Tap spellings are aliases of the press family — `@tap` is the
+        // mobile-native way to say `@press`, and both are supported for
+        // good. They rewrite straight to the *canonical* underscored attr,
+        // so nothing downstream (collector, Element, wire format, testing
+        // suite) ever learns a second name, and every existing app written
+        // against `@press` compiles byte-identically.
+        // Longer spellings precede their prefix, as in the canonical pass
+        // below. `@doubleTap` is untouched: the alternation is anchored at
+        // `@`, so `tap` can't match mid-word.
+        $value = preg_replace_callback(
+            '/@(longTap|tapDown|tapUp|tap)=/',
+            fn ($m) => '_'.self::TAP_ALIASES[$m[1]].'=',
             $value
         );
 

--- a/src/Validation/BladeTemplateAnalyzer.php
+++ b/src/Validation/BladeTemplateAnalyzer.php
@@ -142,8 +142,13 @@ class BladeTemplateAnalyzer
         $stripped = preg_replace('/<!--.*?-->/s', '', $stripped);
 
         // Match @press="method", @longPress="method", @doubleTap="method", @change="method", @submit="method"
-        // Also match the precompiled _press="method" form
-        $pattern = '/[_@](press|longPress|doubleTap|change|submit)\s*=\s*["\']([^"\']+)["\']/';
+        // Also match the precompiled _press="method" form, and the @tap family
+        // aliases (see NativeTagPrecompiler::TAP_ALIASES) — templates are
+        // analyzed before precompilation, so the alias spellings must be
+        // recognized here or their handlers go unvalidated.
+        // Longer spellings precede their prefix (`pressDown`/`pressUp` before
+        // `press`, `tapDown`/`tapUp` before `tap`) so they win the longer match.
+        $pattern = '/[_@](pressDown|pressUp|press|longPress|doubleTap|change|submit|tapDown|tapUp|tap|longTap)\s*=\s*["\']([^"\']+)["\']/';
 
         if (preg_match_all($pattern, $stripped, $matches, PREG_OFFSET_CAPTURE)) {
             foreach ($matches[0] as $i => $match) {

--- a/tests/Unit/Edge/NativeTagPrecompilerTest.php
+++ b/tests/Unit/Edge/NativeTagPrecompilerTest.php
@@ -128,6 +128,41 @@ it('keeps @press and @pressDown distinct on the same tag', function () {
     expect($result)->toContain("'_pressDown' => 'charge'");
 });
 
+it('rewrites @tap to _press', function () {
+    $result = ($this->precompiler)('<native:button label="+" @tap="increment" />');
+
+    expect($result)->toContain("'_press' => 'increment'");
+    expect($result)->not->toContain('@tap');
+});
+
+it('rewrites the rest of the tap aliases onto the press family', function () {
+    $result = ($this->precompiler)(
+        '<native:pressable @longTap="hold" @tapDown="charge" @tapUp="release">x</native:pressable>'
+    );
+
+    expect($result)->toContain("'_longPress' => 'hold'");
+    expect($result)->toContain("'_pressDown' => 'charge'");
+    expect($result)->toContain("'_pressUp' => 'release'");
+});
+
+it('leaves @doubleTap alone when aliasing @tap', function () {
+    // The alias alternation is anchored at `@`, so `tap` can never match the
+    // tail of `doubleTap`.
+    $result = ($this->precompiler)('<native:column @doubleTap="two" @tap="one">x</native:column>');
+
+    expect($result)->toContain("'_doubleTap' => 'two'");
+    expect($result)->toContain("'_press' => 'one'");
+});
+
+it('accepts @press and @tap side by side on the same screen', function () {
+    $result = ($this->precompiler)(
+        '<native:column><native:button label="a" @press="old" /><native:button label="b" @tap="new" /></native:column>'
+    );
+
+    expect($result)->toContain("'_press' => 'old'");
+    expect($result)->toContain("'_press' => 'new'");
+});
+
 it('rewrites @change and @submit', function () {
     $result = ($this->precompiler)('<native:text-input @change="onTextChange" @submit="onTextSubmit" />');
 

--- a/tests/Unit/Validation/BladeTemplateAnalyzerTest.php
+++ b/tests/Unit/Validation/BladeTemplateAnalyzerTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use Native\Mobile\Validation\BladeTemplateAnalyzer;
+
+beforeEach(function () {
+    $this->analyzer = new BladeTemplateAnalyzer;
+});
+
+/** @return array<string, string> method => type */
+function callbackMap(array $callbacks): array
+{
+    return collect($callbacks)->mapWithKeys(
+        fn ($c) => [$c['method'] => $c['type']]
+    )->all();
+}
+
+it('extracts the canonical press-family callbacks', function () {
+    $callbacks = $this->analyzer->extractCallbacks(<<<'BLADE'
+        <native:button @press="save" />
+        <native:pressable @longPress="hold" @doubleTap="zoom">x</native:pressable>
+        <native:pressable @pressDown="charge" @pressUp="release">y</native:pressable>
+        <native:text-input @change="onChange" @submit="onSubmit" />
+        BLADE);
+
+    expect(callbackMap($callbacks))->toBe([
+        'save' => 'press',
+        'hold' => 'longPress',
+        'zoom' => 'doubleTap',
+        'charge' => 'pressDown',
+        'release' => 'pressUp',
+        'onChange' => 'change',
+        'onSubmit' => 'submit',
+    ]);
+});
+
+it('extracts the @tap alias family', function () {
+    $callbacks = $this->analyzer->extractCallbacks(<<<'BLADE'
+        <native:button @tap="save" />
+        <native:pressable @longTap="hold" @tapDown="charge" @tapUp="release">x</native:pressable>
+        BLADE);
+
+    expect(callbackMap($callbacks))->toBe([
+        'save' => 'tap',
+        'hold' => 'longTap',
+        'charge' => 'tapDown',
+        'release' => 'tapUp',
+    ]);
+});
+
+it('extracts the precompiled underscored form', function () {
+    $callbacks = $this->analyzer->extractCallbacks('<native:button _press="save" />');
+
+    expect(callbackMap($callbacks))->toBe(['save' => 'press']);
+});
+
+it('skips dynamic callback values', function () {
+    $callbacks = $this->analyzer->extractCallbacks(
+        '<native:button @press="{{ $method }}" /><native:button @tap="do($id)" /><native:button @tap="live" />'
+    );
+
+    expect(callbackMap($callbacks))->toBe(['live' => 'tap']);
+});
+
+it('ignores callbacks inside comments', function () {
+    $callbacks = $this->analyzer->extractCallbacks(<<<'BLADE'
+        {{-- <native:button @press="old" /> --}}
+        <!-- <native:button @tap="older" /> -->
+        <native:button @press="live" />
+        BLADE);
+
+    expect(callbackMap($callbacks))->toBe(['live' => 'press']);
+});


### PR DESCRIPTION
## Summary

Adds `@tap`, `@longTap`, `@tapDown`, and `@tapUp` as permanent aliases of `@press`, `@longPress`, `@pressDown`, and `@pressUp` in EDGE Blade views.

| you write | compiles to |
|---|---|
| `@tap` | `_press` |
| `@longTap` | `_longPress` |
| `@tapDown` / `@tapUp` | `_pressDown` / `_pressUp` |

The aliases are normalized to the canonical underscored attrs in a dedicated precompiler pass, so nothing downstream (collector, `Element`, binary wire format, testing suite) ever learns a second name — existing `@press` templates compile byte-identically. `@doubleTap` is unaffected: the alias alternation is anchored at `@`, so `tap` can never match mid-word.

## Also in this PR

- `Element::onTap()` as the programmatic twin of the directive (alias of `onPress()`)
- `BladeTemplateAnalyzer` now validates the alias spellings **plus the previously-unvalidated `@pressDown`/`@pressUp`** — closing a gap where a handler pointing at a missing component method passed `native:validate` and only failed at tap time
- First test coverage for `BladeTemplateAnalyzer::extractCallbacks()` (5 tests)
- Boost skill docs mention the alias

## Test plan

- [x] 4 new precompiler tests: `@tap` → `_press`, the rest of the family, `@doubleTap` non-interference, `@press` + `@tap` side by side
- [x] 5 new analyzer tests: canonical spellings, alias family, precompiled `_press` form, dynamic-value skipping, comment stripping
- [x] Full suite green: 607 passed (2043 assertions)
- [x] Pint + PHPStan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)