### PR TITLE
fix: Windows and Linux compatibility across all CLI commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,9 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "spatie/laravel-ray": "^1.26"
     },
+    "suggest": {
+        "ext-zip": "Required by native:install to validate and extract the downloaded Android PHP binary archives"
+    },
     "conflict": {
         "nativephp/mobile-device": "*",
         "nativephp/mobile-dialog": "*",

--- a/resources/jump/http-server.php
+++ b/resources/jump/http-server.php
@@ -39,9 +39,11 @@
 declare(strict_types=1);
 
 use Endroid\QrCode\Builder\Builder;
+use Workerman\Connection\AsyncTcpConnection;
 use Workerman\Connection\TcpConnection;
 use Workerman\Protocols\Http\Request;
 use Workerman\Protocols\Http\Response;
+use Workerman\Timer;
 use Workerman\Worker;
 
 // --- Argument + environment parsing -------------------------------------
@@ -119,24 +121,44 @@ $worker->name = 'JumpHttpProxy';
 
 $worker->onMessage = function (TcpConnection $connection, Request $request) {
     try {
-        $response = jumpHandleRequest($request);
+        $response = jumpHandleRequest($request, $connection);
     } catch (Throwable $e) {
         jumpRouterLog($request->method().' '.$request->uri().' [500 handler-exception] '.$e->getMessage());
         $response = new Response(500, ['Content-Type' => 'text/plain; charset=utf-8'], 'Internal proxy error: '.$e->getMessage());
     }
 
-    // Force connection teardown after every response. PHP -S can't do this
-    // (it decides keep-alive purely from the request); Workerman can, and
-    // that's the whole point of moving to it for the Windows code path.
-    // Setting the response header is for client correctness; the actual
-    // close happens via $connection->close() once send() drains.
-    $response = $response->withHeader('Connection', 'close');
-    $connection->close($response);
+    // A null response means the handler went asynchronous (the Laravel proxy)
+    // and will call jumpSendResponse() itself once the upstream replies. This
+    // is what keeps the single Windows worker free: `Route::native` requests
+    // are held open for the whole native-screen lifetime, and a blocking wait
+    // here would stall every other request behind them (see jumpProxyToLaravel).
+    if ($response === null) {
+        return;
+    }
+
+    jumpSendResponse($connection, $response);
 };
+
+/**
+ * Send a response and tear the connection down.
+ *
+ * Forcing teardown after every response is the whole point of moving the
+ * Windows path to Workerman: PHP -S decides keep-alive purely from the
+ * request, Workerman lets us close explicitly. Setting the header is for
+ * client correctness; the actual close happens via close() once send() drains.
+ */
+function jumpSendResponse(TcpConnection $connection, Response $response): void
+{
+    $connection->close($response->withHeader('Connection', 'close'));
+}
 
 // --- Dispatch -----------------------------------------------------------
 
-function jumpHandleRequest(Request $request): Response
+/**
+ * Route a request. Returns a Response to send immediately, or null when the
+ * handler has taken ownership of $connection and will respond asynchronously.
+ */
+function jumpHandleRequest(Request $request, TcpConnection $connection): ?Response
 {
     global $JUMP;
 
@@ -179,6 +201,13 @@ function jumpHandleRequest(Request $request): Response
             'app_name' => $JUMP['appName'],
             'version' => '1.0.0',
             'type' => 'nativephp-server',
+            // How the client should render this app: 'native-ui' (stream
+            // Element.* frames over the WS bridge) or 'webview' (forward HTTP
+            // responses). Set by JumpCommand via JUMP_APP_UI. Must match
+            // router.php — omitting it makes the Jump app fall back to webview
+            // and HTTP-forward a native-ui route, which blocks in the native
+            // event loop (appears to the user as a hung/500 webview).
+            'ui' => getenv('JUMP_APP_UI') ?: 'native-ui',
         ];
         if ($JUMP['wsPort']) {
             $info['ws_port'] = (string) $JUMP['wsPort'];
@@ -229,7 +258,9 @@ function jumpHandleRequest(Request $request): Response
         }
     }
 
-    return jumpProxyToLaravel($request, $method, $uri);
+    jumpProxyToLaravel($request, $method, $uri, $connection);
+
+    return null; // async — jumpProxyToLaravel owns the connection from here
 }
 
 // --- /jump/qr renderer --------------------------------------------------
@@ -397,11 +428,29 @@ function jumpProxyToVite(Request $request, string $method, string $uri, string $
 
 // --- Laravel proxy ------------------------------------------------------
 
-function jumpProxyToLaravel(Request $request, string $method, string $uri): Response
+/**
+ * Proxy a request to the Laravel dev server — asynchronously.
+ *
+ * WHY ASYNC (this is load-bearing on Windows, do not "simplify" back to curl):
+ * a `Route::native` route deliberately holds its HTTP response open for the
+ * entire native-screen lifetime — the request reaches Laravel, renders the
+ * component, and parks in nativephp_element_wait_event() publishing frames over
+ * the WS bridge. macOS/Linux absorb that with PHP_CLI_SERVER_WORKERS (php -S
+ * forks a pool, see JumpCommand), so router.php can afford a blocking curl with
+ * CURLOPT_TIMEOUT 0. Workerman on Windows cannot fork: $worker->count is pinned
+ * to 1, so a blocking curl here freezes the ONLY worker for the whole screen
+ * lifetime and every other request — /jump/info, assets, and the app's
+ * re-entry handshake — queues behind it. The old 90s CURLOPT_TIMEOUT turned
+ * that into a 502-then-retry loop that wedged the proxy indefinitely.
+ *
+ * Using AsyncTcpConnection keeps the event loop free while the runloop request
+ * is parked, which lets us drop the timeout entirely and match router.php.
+ * Only the transport changed: the response post-processing is untouched and
+ * still runs, verbatim, in jumpBuildLaravelResponse().
+ */
+function jumpProxyToLaravel(Request $request, string $method, string $uri, TcpConnection $connection): void
 {
     global $JUMP;
-
-    $laravelUrl = "http://127.0.0.1:{$JUMP['laravelPort']}{$uri}";
 
     $headers = jumpBuildUpstreamHeaders($request);
     if ($ct = $request->header('content-type')) {
@@ -419,50 +468,216 @@ function jumpProxyToLaravel(Request $request, string $method, string $uri): Resp
     if (in_array($method, ['POST', 'PUT', 'PATCH'], true)) {
         $body = $request->rawBody();
     }
-
-    $ch = curl_init($laravelUrl);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_HEADER, true);
-    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
-    curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
-    curl_setopt($ch, CURLOPT_TIMEOUT, 90);
-    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    // Only on methods that carry a body — curl didn't send Content-Length on
+    // GET and some handlers treat a bodyless GET with one as malformed.
     if ($body !== null) {
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+        $headers[] = 'Content-Length: '.strlen($body);
     }
+
+    // Ask for a close-delimited response: the upstream ends the body by closing
+    // the socket, so onClose is an unambiguous "response complete" signal and we
+    // never have to second-guess Content-Length.
+    $headers[] = 'Connection: close';
+
+    $wire = sprintf("%s %s HTTP/1.1\r\n", $method, $uri)
+        .implode("\r\n", $headers)
+        ."\r\n\r\n"
+        .((string) $body);
 
     $start = microtime(true);
-    $raw = curl_exec($ch);
-    $upstreamMs = (int) ((microtime(true) - $start) * 1000);
-    $error = curl_error($ch);
-    $errno = curl_errno($ch);
-    $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    $headerSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
-    curl_close($ch);
+    $raw = '';
+    $settled = false;
+    $connectTimer = null;
 
-    if ($raw === false) {
-        if ($errno === CURLE_COULDNT_CONNECT) {
-            $detail = "Laravel dev server is not listening on 127.0.0.1:{$JUMP['laravelPort']}. Is `artisan serve` running?";
-        } elseif ($errno === CURLE_OPERATION_TIMEDOUT) {
-            $detail = "Request to Laravel on port {$JUMP['laravelPort']} timed out. The handler took longer than 90s to respond.";
-        } else {
-            $detail = "Could not reach Laravel on port {$JUMP['laravelPort']}. cURL error ({$errno}): {$error}";
-        }
+    try {
+        $upstream = new AsyncTcpConnection("tcp://127.0.0.1:{$JUMP['laravelPort']}");
+    } catch (Throwable $e) {
+        jumpSendResponse($connection, jumpLaravelError(
+            $method, $uri,
+            "Could not open a connection to Laravel on port {$JUMP['laravelPort']}: ".$e->getMessage()
+        ));
 
-        jumpRouterLog("{$method} {$uri} [502] {$detail}");
-
-        return new Response(502, ['Content-Type' => 'text/plain; charset=utf-8'], "Bad Gateway: {$detail}");
+        return;
     }
 
-    $rawHeaders = substr((string) $raw, 0, $headerSize);
-    $body = substr((string) $raw, $headerSize);
+    // Settle exactly once, whichever of the four paths gets there first
+    // (response complete / upstream error / connect timeout / client hang-up).
+    $finish = function (?Response $response) use (&$settled, &$connectTimer, $connection, $upstream) {
+        if ($settled) {
+            return;
+        }
+        $settled = true;
+        if ($connectTimer !== null) {
+            Timer::del($connectTimer);
+            $connectTimer = null;
+        }
+        $upstream->onClose = null; // our own close() must not re-enter
+        $upstream->close();
+        if ($response !== null) {
+            jumpSendResponse($connection, $response);
+        }
+    };
+
+    $upstream->onConnect = function (AsyncTcpConnection $c) use ($wire, &$connectTimer) {
+        if ($connectTimer !== null) {
+            Timer::del($connectTimer);
+            $connectTimer = null;
+        }
+        $c->send($wire);
+    };
+
+    $upstream->onMessage = function (AsyncTcpConnection $c, $chunk) use (&$raw) {
+        $raw .= $chunk;
+    };
+
+    // Upstream closed — with `Connection: close` that means the response is
+    // complete. NOTE: there is deliberately no read timeout here; a parked
+    // native runloop request is expected to stay open indefinitely.
+    $upstream->onClose = function () use (&$raw, $method, $uri, $start, $finish) {
+        if ($raw === '') {
+            $ms = (int) ((microtime(true) - $start) * 1000);
+            $finish(jumpLaravelError(
+                $method, $uri,
+                "Laravel closed the connection after {$ms}ms without sending a response."
+            ));
+
+            return;
+        }
+
+        $finish(jumpBuildLaravelResponse($raw, $method, $uri));
+    };
+
+    $upstream->onError = function (AsyncTcpConnection $c, $code, $msg) use ($method, $uri, $finish) {
+        global $JUMP;
+        $finish(jumpLaravelError(
+            $method, $uri,
+            "Laravel dev server is not listening on 127.0.0.1:{$JUMP['laravelPort']}. Is `artisan serve` running? (error {$code}: {$msg})"
+        ));
+    };
+
+    // Client hung up — app exited, re-entered, or dismissed the screen. Drop
+    // the upstream with it, otherwise every exit/re-enter strands another
+    // Laravel worker parked in the native runloop until the server restarts.
+    $connection->onClose = function () use (&$settled, &$connectTimer, $upstream) {
+        if ($settled) {
+            return;
+        }
+        $settled = true;
+        if ($connectTimer !== null) {
+            Timer::del($connectTimer);
+            $connectTimer = null;
+        }
+        $upstream->onClose = null;
+        $upstream->close();
+    };
+
+    // AsyncTcpConnection has no built-in connect timeout; reproduce the 5s
+    // CONNECTTIMEOUT the curl implementation used. Cancelled on connect.
+    $connectTimer = Timer::add(5, function () use ($method, $uri, $finish) {
+        global $JUMP;
+        $finish(jumpLaravelError(
+            $method, $uri,
+            "Timed out connecting to Laravel on 127.0.0.1:{$JUMP['laravelPort']} after 5s. Is `artisan serve` running?"
+        ));
+    }, [], false);
+
+    $upstream->connect();
+}
+
+/**
+ * Log and build the 502 the client sees when the upstream is unreachable.
+ * Kept as a real status + human-readable detail so the native error screens
+ * planned for v4 have something meaningful to render.
+ */
+function jumpLaravelError(string $method, string $uri, string $detail): Response
+{
+    jumpRouterLog("{$method} {$uri} [502] {$detail}");
+
+    return new Response(502, ['Content-Type' => 'text/plain; charset=utf-8'], "Bad Gateway: {$detail}");
+}
+
+/**
+ * Decode a chunked transfer-encoded body. curl did this for us; over a raw
+ * socket we have to do it ourselves.
+ */
+function jumpDechunk(string $body): string
+{
+    $out = '';
+    $offset = 0;
+    $len = strlen($body);
+
+    while ($offset < $len) {
+        $lineEnd = strpos($body, "\r\n", $offset);
+        if ($lineEnd === false) {
+            break;
+        }
+        $sizeHex = substr($body, $offset, $lineEnd - $offset);
+        if (($semi = strpos($sizeHex, ';')) !== false) { // chunk extensions
+            $sizeHex = substr($sizeHex, 0, $semi);
+        }
+        $sizeHex = trim($sizeHex);
+        if ($sizeHex === '' || ! ctype_xdigit($sizeHex)) {
+            break;
+        }
+        $size = (int) hexdec($sizeHex);
+        if ($size <= 0) {
+            break; // terminal chunk
+        }
+        $out .= substr($body, $lineEnd + 2, $size);
+        $offset = $lineEnd + 2 + $size + 2; // chunk data + trailing CRLF
+    }
+
+    // If it didn't parse as chunked at all, hand back what we got rather than
+    // silently serving an empty body.
+    if ($out === '' && ! str_starts_with(ltrim($body), '0')) {
+        return $body;
+    }
+
+    return $out;
+}
+
+/**
+ * Turn a raw upstream HTTP response into a Workerman Response.
+ *
+ * Everything below the header/body split is carried over verbatim from the
+ * previous curl implementation — Set-Cookie batching and Vite origin rewriting
+ * are unchanged on purpose, so the async switch is a transport-only change.
+ */
+function jumpBuildLaravelResponse(string $raw, string $method, string $uri): Response
+{
+    global $JUMP;
+
+    // Split status line + headers from the body, stepping over any 1xx
+    // informational block (e.g. "100 Continue") that precedes the real one.
+    $rawHeaders = $raw;
+    $body = '';
+    while (true) {
+        $split = strpos($raw, "\r\n\r\n");
+        if ($split === false) {
+            $rawHeaders = $raw;
+            $body = '';
+            break;
+        }
+        $rawHeaders = substr($raw, 0, $split);
+        $body = substr($raw, $split + 4);
+        if (preg_match('#^HTTP/\d\.\d\s+1\d\d#', $rawHeaders)) {
+            $raw = $body; // informational — the real response follows
+            continue;
+        }
+        break;
+    }
+
+    $httpCode = 200;
+    if (preg_match('#^HTTP/\d\.\d\s+(\d{3})#', $rawHeaders, $m)) {
+        $httpCode = (int) $m[1];
+    }
 
     $laravelOrigin = "http://127.0.0.1:{$JUMP['laravelPort']}";
     $jumpOrigin = "http://{$JUMP['displayHost']}:{$JUMP['httpPort']}";
 
     $response = new Response($httpCode);
     $setCookies = [];
+    $isChunked = false;
 
     foreach (explode("\r\n", $rawHeaders) as $line) {
         if ($line === '' || str_starts_with($line, 'HTTP/')) {
@@ -477,6 +692,11 @@ function jumpProxyToLaravel(Request $request, string $method, string $uri): Resp
         $lower = strtolower($name);
 
         if (in_array($lower, ['transfer-encoding', 'connection', 'keep-alive'], true)) {
+            // curl de-chunked for us; over a raw socket we have to notice.
+            if ($lower === 'transfer-encoding' && stripos($value, 'chunked') !== false) {
+                $isChunked = true;
+            }
+
             continue;
         }
 
@@ -500,6 +720,10 @@ function jumpProxyToLaravel(Request $request, string $method, string $uri): Resp
 
     if (! empty($setCookies)) {
         $response = $response->withHeader('Set-Cookie', $setCookies);
+    }
+
+    if ($isChunked) {
+        $body = jumpDechunk($body);
     }
 
     // Rewrite any Vite dev-server origins the Inertia template emitted,

--- a/resources/jump/http-server.php
+++ b/resources/jump/http-server.php
@@ -662,6 +662,7 @@ function jumpBuildLaravelResponse(string $raw, string $method, string $uri): Res
         $body = substr($raw, $split + 4);
         if (preg_match('#^HTTP/\d\.\d\s+1\d\d#', $rawHeaders)) {
             $raw = $body; // informational — the real response follows
+
             continue;
         }
         break;

--- a/resources/jump/mdns-server.php
+++ b/resources/jump/mdns-server.php
@@ -35,7 +35,6 @@
  * Output (banner + errors) goes to STDERR so the caller can route it to
  * storage/logs/jump-mdns.log, mirroring the other Windows Jump subprocesses.
  */
-
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_WARNING);
 
 $basePath = $argv[1] ?? getcwd();

--- a/resources/jump/mdns-server.php
+++ b/resources/jump/mdns-server.php
@@ -1,0 +1,438 @@
+<?php
+
+/**
+ * Pure-PHP DNS-SD (mDNS / Bonjour) responder for the Jump dev server.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * On macOS the Jump command advertises `_jump._tcp` by shelling out to
+ * `dns-sd -R` (Bonjour is built in); on Linux it uses `avahi-publish-service`.
+ * Windows ships neither, so LAN auto-discovery was simply skipped there and the
+ * phone could only connect by scanning the QR. This script is the Windows
+ * (and generic no-Bonjour) fallback: a self-contained multicast responder that
+ * answers `_jump._tcp.local` browse/resolve queries with the SAME host + port
+ * the QR encodes, using nothing but PHP's `sockets` extension.
+ *
+ * It advertises exactly the records `dns-sd -R <name> _jump._tcp local <port>
+ * host=<ip> port=<port> name=<label>` would, so the app's discovery flow is
+ * identical across platforms.
+ *
+ * USAGE
+ *   php mdns-server.php <basePath> <instanceLabel> <port> <ip> [parentPid]
+ *
+ * SHUTDOWN — WHY THE STOP-FILE + PARENT WATCH
+ * On Windows there is no pcntl and proc_terminate() is a hard TerminateProcess,
+ * so we can't rely on a signal handler to multicast the DNS-SD "goodbye" (TTL-0)
+ * packet that tells the Jump app to drop the entry immediately. Without it the
+ * app shows a phantom "server nearby" for the full record TTL after Jump quits.
+ * Two cooperative exits cover that:
+ *   1. Stop-file (graceful): JumpCommand::stopAdvertiser() creates
+ *      storage/framework/jump-mdns.stop; we see it, send goodbye, and exit.
+ *   2. Parent-PID watch (crash/orphan): if the Jump process dies without a
+ *      clean stop (Ctrl+C hard-kill, crash, or a leftover from testing), we
+ *      notice the parent is gone within ~2s, send goodbye, and exit ourselves.
+ *
+ * Output (banner + errors) goes to STDERR so the caller can route it to
+ * storage/logs/jump-mdns.log, mirroring the other Windows Jump subprocesses.
+ */
+
+error_reporting(E_ALL & ~E_DEPRECATED & ~E_WARNING);
+
+$basePath = $argv[1] ?? getcwd();
+$instance = $argv[2] ?? 'NativePHP';
+$port = (int) ($argv[3] ?? 0);
+$ip = $argv[4] ?? '127.0.0.1';
+$parentPid = (int) ($argv[5] ?? 0);
+
+// Graceful-stop sentinel. JumpCommand drops this file to ask us to deregister
+// (send goodbye) and exit. Clear any stale copy from a previous run first.
+$stopFile = rtrim($basePath, '\\/').DIRECTORY_SEPARATOR.'storage'.DIRECTORY_SEPARATOR.'framework'.DIRECTORY_SEPARATOR.'jump-mdns.stop';
+@unlink($stopFile);
+
+function logline(string $msg): void
+{
+    $ts = date('H:i:s');
+    fwrite(STDERR, "[$ts] [Jump mDNS] $msg\n");
+}
+
+if (! extension_loaded('sockets')) {
+    logline('FATAL: the PHP `sockets` extension is not loaded — cannot advertise on the LAN. Enable ext-sockets in php.ini. (QR still works.)');
+    exit(1);
+}
+
+if ($port <= 0) {
+    logline('FATAL: no port supplied — nothing to advertise.');
+    exit(1);
+}
+
+const MDNS_GROUP = '224.0.0.251';
+const MDNS_PORT = 5353;
+
+// RFC 6762 defaults are PTR 4500 / others 120, tuned for stable services. This
+// is an ephemeral dev server that starts and stops constantly, so we cap the
+// PTR at 120 too: if a goodbye ever fails to land (both stop-file and
+// parent-watch missed), a phantom "server nearby" ages out in ~2min instead of
+// 75. Goodbye (TTL 0) still clears it instantly in the normal case.
+const TTL_PTR = 120;
+const TTL_SRV = 120;
+const TTL_TXT = 120;
+const TTL_A = 120;
+
+// ---------------------------------------------------------------------------
+// Names. Instance labels in DNS-SD are a SINGLE label that may legally contain
+// dots and spaces, so we carry every name as an explicit array of labels and
+// never split on '.' — otherwise an app dir like "my.app" would corrupt the
+// wire name.
+// ---------------------------------------------------------------------------
+$serviceType = ['_jump', '_tcp', 'local'];
+$instanceName = array_merge([$instance], $serviceType); // <label>._jump._tcp.local
+
+// SRV target host. A real .local hostname keeps the record standards-compliant
+// even though the app reads host+port straight out of the TXT metadata.
+$rawHost = gethostname() ?: 'jump-host';
+$hostLabel = preg_replace('/[^A-Za-z0-9-]/', '-', explode('.', $rawHost)[0]);
+if ($hostLabel === '' || $hostLabel === null) {
+    $hostLabel = 'jump-host';
+}
+$hostName = [$hostLabel, 'local']; // <host>.local
+
+$label = $instance;
+$txtRecords = [
+    'host='.$ip,
+    'port='.$port,
+    'name='.$label,
+];
+
+// ---------------------------------------------------------------------------
+// Wire encoders
+// ---------------------------------------------------------------------------
+function encodeName(array $labels): string
+{
+    $out = '';
+    foreach ($labels as $label) {
+        $label = (string) $label;
+        // A single label is capped at 63 octets on the wire.
+        if (strlen($label) > 63) {
+            $label = substr($label, 0, 63);
+        }
+        $out .= chr(strlen($label)).$label;
+    }
+
+    return $out."\x00";
+}
+
+function encodeTxt(array $records): string
+{
+    if (empty($records)) {
+        return "\x00"; // one empty string
+    }
+    $out = '';
+    foreach ($records as $r) {
+        $r = (string) $r;
+        if (strlen($r) > 255) {
+            $r = substr($r, 0, 255);
+        }
+        $out .= chr(strlen($r)).$r;
+    }
+
+    return $out;
+}
+
+function rr(string $name, int $type, int $class, int $ttl, string $rdata): string
+{
+    return $name.pack('n', $type).pack('n', $class).pack('N', $ttl).pack('n', strlen($rdata)).$rdata;
+}
+
+// DNS record types / classes
+const TYPE_A = 1;
+const TYPE_PTR = 12;
+const TYPE_TXT = 16;
+const TYPE_SRV = 33;
+const TYPE_ANY = 255;
+const CLASS_IN = 1;
+const FLUSH = 0x8000; // cache-flush bit OR'd onto CLASS for unique records
+
+/**
+ * Build a full DNS-SD announcement/response: PTR in the answer section,
+ * SRV+TXT+A in additional — the layout Bonjour and Android NsdManager expect.
+ * $ttlScale lets us reuse the same builder for goodbye packets (TTL 0).
+ */
+function buildResponse(array $ctx, int $ttlScale = 1): string
+{
+    $ptr = rr(encodeName($ctx['serviceType']), TYPE_PTR, CLASS_IN, TTL_PTR * $ttlScale, encodeName($ctx['instanceName']));
+
+    $srvData = pack('n', 0).pack('n', 0).pack('n', $ctx['port']).encodeName($ctx['hostName']);
+    $srv = rr(encodeName($ctx['instanceName']), TYPE_SRV, CLASS_IN | FLUSH, TTL_SRV * $ttlScale, $srvData);
+
+    $txt = rr(encodeName($ctx['instanceName']), TYPE_TXT, CLASS_IN | FLUSH, TTL_TXT * $ttlScale, encodeTxt($ctx['txtRecords']));
+
+    $aData = inet_pton($ctx['ip']);
+    $a = ($aData !== false && strlen($aData) === 4)
+        ? rr(encodeName($ctx['hostName']), TYPE_A, CLASS_IN | FLUSH, TTL_A * $ttlScale, $aData)
+        : '';
+
+    $ancount = 1;                       // PTR
+    $arcount = 2 + ($a !== '' ? 1 : 0); // SRV, TXT, [A]
+
+    $header = pack('n', 0)          // ID
+        .pack('n', 0x8400)          // flags: QR=1, AA=1
+        .pack('n', 0)               // QDCOUNT
+        .pack('n', $ancount)        // ANCOUNT
+        .pack('n', 0)               // NSCOUNT
+        .pack('n', $arcount);       // ARCOUNT
+
+    return $header.$ptr.$srv.$txt.$a;
+}
+
+// ---------------------------------------------------------------------------
+// Incoming-query parsing — just enough to decide whether a packet is asking
+// for something we own. Handles compression pointers defensively (queries
+// rarely use them, but a malformed one shouldn't wedge the loop).
+// ---------------------------------------------------------------------------
+function readName(string $pkt, int &$offset): string
+{
+    $labels = [];
+    $len = strlen($pkt);
+    $jumped = false;
+    $guard = 0;
+    while ($offset < $len && $guard++ < 128) {
+        $b = ord($pkt[$offset]);
+        if ($b === 0) {
+            $offset++;
+            break;
+        }
+        if (($b & 0xC0) === 0xC0) { // compression pointer
+            if ($offset + 1 >= $len) {
+                break;
+            }
+            $ptr = (($b & 0x3F) << 8) | ord($pkt[$offset + 1]);
+            if (! $jumped) {
+                $offset += 2;
+            }
+            $offset = $ptr;
+            $jumped = true;
+            // continue from pointer target using a local cursor
+            $sub = $offset;
+            $subLabels = [];
+            $subGuard = 0;
+            while ($sub < $len && $subGuard++ < 128) {
+                $sb = ord($pkt[$sub]);
+                if ($sb === 0) {
+                    break;
+                }
+                if (($sb & 0xC0) === 0xC0) {
+                    if ($sub + 1 >= $len) {
+                        break 2;
+                    }
+                    $sub = (($sb & 0x3F) << 8) | ord($pkt[$sub + 1]);
+
+                    continue;
+                }
+                $subLabels[] = substr($pkt, $sub + 1, $sb);
+                $sub += 1 + $sb;
+            }
+
+            return strtolower(implode('.', array_merge($labels, $subLabels)));
+        }
+        $labels[] = substr($pkt, $offset + 1, $b);
+        $offset += 1 + $b;
+    }
+
+    return strtolower(implode('.', $labels));
+}
+
+function queryTargets(string $pkt): array
+{
+    if (strlen($pkt) < 12) {
+        return [];
+    }
+    $header = unpack('nid/nflags/nqd/nan/nns/nar', substr($pkt, 0, 12));
+    if ($header['flags'] & 0x8000) {
+        return []; // a response, not a query
+    }
+    $offset = 12;
+    $names = [];
+    for ($i = 0; $i < $header['qd']; $i++) {
+        $name = readName($pkt, $offset);
+        $offset += 4; // skip QTYPE + QCLASS
+        if ($name !== '') {
+            $names[] = $name;
+        }
+    }
+
+    return $names;
+}
+
+// ---------------------------------------------------------------------------
+// Socket setup
+// ---------------------------------------------------------------------------
+$sock = @socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+if ($sock === false) {
+    logline('FATAL: socket_create failed: '.socket_strerror(socket_last_error()));
+    exit(1);
+}
+
+@socket_set_option($sock, SOL_SOCKET, SO_REUSEADDR, 1);
+if (defined('SO_REUSEPORT') && PHP_OS_FAMILY !== 'Windows') {
+    @socket_set_option($sock, SOL_SOCKET, SO_REUSEPORT, 1);
+}
+
+if (! @socket_bind($sock, '0.0.0.0', MDNS_PORT)) {
+    logline('FATAL: could not bind UDP '.MDNS_PORT.' ('.socket_strerror(socket_last_error($sock)).'). Another mDNS responder (e.g. Bonjour) may own it.');
+    exit(1);
+}
+
+// Join the multicast group so we actually receive browse/resolve queries.
+$joined = false;
+if (defined('MCAST_JOIN_GROUP')) {
+    $joined = @socket_set_option($sock, IPPROTO_IP, MCAST_JOIN_GROUP, ['group' => MDNS_GROUP, 'interface' => 0]);
+}
+if (! $joined && defined('IP_ADD_MEMBERSHIP')) {
+    $joined = @socket_set_option($sock, IPPROTO_IP, IP_ADD_MEMBERSHIP, ['group' => MDNS_GROUP, 'interface' => '0.0.0.0']);
+}
+if (! $joined) {
+    logline('WARN: could not join multicast group '.MDNS_GROUP.' — passive announcements will still be sent, but query responses may not reach the app.');
+}
+
+// mDNS wants TTL 255 on the wire. Leave multicast loopback at its default
+// (on): it lets same-host consumers and the OS resolver cache see our records,
+// and our own announcements are harmless here since queryTargets() ignores any
+// packet with the response (QR) bit set.
+if (defined('IP_MULTICAST_TTL')) {
+    @socket_set_option($sock, IPPROTO_IP, IP_MULTICAST_TTL, 255);
+}
+
+$ctx = [
+    'serviceType' => $serviceType,
+    'instanceName' => $instanceName,
+    'hostName' => $hostName,
+    'port' => $port,
+    'ip' => $ip,
+    'txtRecords' => $txtRecords,
+];
+
+$responsePkt = buildResponse($ctx);
+
+$targets = [
+    '_jump._tcp.local',
+    strtolower(implode('.', $instanceName)),
+    strtolower(implode('.', $hostName)),
+];
+
+function announce($sock, string $pkt): void
+{
+    @socket_sendto($sock, $pkt, strlen($pkt), 0, MDNS_GROUP, MDNS_PORT);
+}
+
+function parentAlive(int $pid): bool
+{
+    if ($pid <= 0) {
+        return true; // not tracking a parent
+    }
+    if (PHP_OS_FAMILY === 'Windows') {
+        $out = (string) @shell_exec('tasklist /FI "PID eq '.$pid.'" /NH /FO CSV 2>NUL');
+
+        return str_contains($out, '"'.$pid.'"');
+    }
+    if (function_exists('posix_kill')) {
+        return @posix_kill($pid, 0);
+    }
+
+    return is_dir('/proc/'.$pid);
+}
+
+// Deregister: multicast the goodbye (TTL-0) records twice so browsing devices
+// drop the entry immediately instead of caching it for the record TTL.
+$shuttingDown = false;
+$goodbye = function (string $why) use ($sock, $ctx, $stopFile, &$shuttingDown) {
+    if ($shuttingDown) {
+        return;
+    }
+    $shuttingDown = true;
+    $bye = buildResponse($ctx, 0);
+    announce($sock, $bye);
+    announce($sock, $bye);
+    @unlink($stopFile);
+    logline("sent goodbye packets ($why), exiting.");
+    exit(0);
+};
+// pcntl only exists on unix; on Windows the stop-file + parent watch drive the
+// goodbye instead (see the loop below).
+if (function_exists('pcntl_signal') && function_exists('pcntl_async_signals')) {
+    pcntl_async_signals(true);
+    pcntl_signal(SIGTERM, fn () => $goodbye('SIGTERM'));
+    pcntl_signal(SIGINT, fn () => $goodbye('SIGINT'));
+}
+
+logline("advertising \"$label\" as _jump._tcp.local -> $ip:$port (SRV target ".implode('.', $hostName).')');
+
+// Initial burst: RFC 6762 §8.3 recommends 2-3 announcements ~1s apart so a
+// device that just started browsing catches us without waiting for a query.
+announce($sock, $responsePkt);
+$nextBurst = microtime(true) + 1.0;
+$burstsLeft = 2;
+$nextPeriodic = microtime(true) + 30.0;
+$lastResponse = 0.0;
+$nextParentCheck = microtime(true) + 2.0;
+
+while (true) {
+    $read = [$sock];
+    $write = null;
+    $except = null;
+    // 1s tick drives the startup burst + 30s keep-alive between packets.
+    $ready = @socket_select($read, $write, $except, 1);
+
+    $now = microtime(true);
+
+    // Cooperative shutdown (Windows has no pcntl): a stop-file means Jump asked
+    // us to deregister; a dead parent means Jump crashed or was hard-killed. In
+    // both cases send the goodbye so the app drops the entry now, not in ~TTL.
+    if (is_file($stopFile)) {
+        $goodbye('stop-file');
+    }
+    if ($now >= $nextParentCheck) {
+        $nextParentCheck = $now + 2.0;
+        if (! parentAlive($parentPid)) {
+            $goodbye('parent gone');
+        }
+    }
+
+    if ($ready === false) {
+        // Interrupted by a signal (e.g. SIGTERM) — loop; the handler exits.
+        continue;
+    }
+
+    if ($ready > 0) {
+        $buf = '';
+        $from = '';
+        $fromPort = 0;
+        $n = @socket_recvfrom($sock, $buf, 4096, 0, $from, $fromPort);
+        if ($n > 0 && $buf !== '') {
+            $names = queryTargets($buf);
+            $wantsUs = false;
+            foreach ($names as $qn) {
+                if (in_array($qn, $targets, true)) {
+                    $wantsUs = true;
+                    break;
+                }
+            }
+            // Throttle: at most one response per 250ms to avoid packet storms
+            // when several devices browse at once.
+            if ($wantsUs && ($now - $lastResponse) > 0.25) {
+                announce($sock, $responsePkt);
+                $lastResponse = $now;
+            }
+        }
+    }
+
+    if ($burstsLeft > 0 && $now >= $nextBurst) {
+        announce($sock, $responsePkt);
+        $burstsLeft--;
+        $nextBurst = $now + 1.0;
+    }
+
+    if ($now >= $nextPeriodic) {
+        announce($sock, $responsePkt);
+        $nextPeriodic = $now + 30.0;
+    }
+}

--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -48,6 +48,14 @@ class BuildIosAppCommand extends Command
 
     public function handle(): int|string
     {
+        // Building iOS apps needs Xcode and its command-line tools, so bail out
+        // early before we touch the build log or copy any files.
+        if (PHP_OS_FAMILY !== 'Darwin') {
+            $this->error('native:build requires macOS — building iOS apps needs Xcode and its command-line tools.');
+
+            return Command::FAILURE;
+        }
+
         $this->basePath = base_path('nativephp/ios');
         $this->logPath = base_path('nativephp/ios-build.log');
 

--- a/src/Commands/DebugCommand.php
+++ b/src/Commands/DebugCommand.php
@@ -155,11 +155,20 @@ class DebugCommand extends Command
                 '/Applications/Android Studio.app/Contents/Resources/product-info.json',
             ],
             'Linux' => [
-                $home.'/.local/share/Google/AndroidStudio*/product-info.json',
-                $home.'/.config/Google/AndroidStudio*/product-info.json',
+                '/opt/android-studio/product-info.json',
+                '/usr/local/android-studio/product-info.json',
+                $home.'/android-studio/product-info.json',
+                // JetBrains Toolbox 2.x layout
+                $home.'/.local/share/JetBrains/Toolbox/apps/android-studio*/product-info.json',
+                // JetBrains Toolbox 1.x channel layout (glob * does not cross /, so spell out the nesting)
+                $home.'/.local/share/JetBrains/Toolbox/apps/AndroidStudio/ch-*/*/product-info.json',
+                // Snap
+                '/snap/android-studio/current/android-studio/product-info.json',
             ],
             'Windows' => [
-                ($_SERVER['APPDATA'] ?? '').'/Google/AndroidStudio*/product-info.json',
+                'C:/Program Files/Android/Android Studio*/product-info.json',
+                // JetBrains Toolbox 2.x default install location
+                ($_SERVER['LOCALAPPDATA'] ?? '').'/Programs/Android Studio*/product-info.json',
             ],
             default => [],
         };
@@ -167,19 +176,23 @@ class DebugCommand extends Command
 
     protected function getGradleVersion(): string
     {
-        // Check for the Gradle wrapper in the NativePHP android project first
-        $gradlew = base_path('nativephp/android/gradlew');
+        // Check for the Gradle wrapper in the NativePHP android project first;
+        // cmd.exe can't execute the unix shell script, so use the batch wrapper on Windows
+        $wrapper = PHP_OS_FAMILY === 'Windows' ? 'gradlew.bat' : 'gradlew';
+        $gradlew = base_path('nativephp/android/'.$wrapper);
 
         if (file_exists($gradlew)) {
+            // 2>&1 works on both sh and cmd.exe (2>/dev/null does not);
+            // extractGradleVersion() only matches 'Gradle ' lines so stderr noise is harmless
             return $this->getCommandVersion(
-                escapeshellarg($gradlew).' --version 2>/dev/null',
+                escapeshellarg($gradlew).' --version 2>&1',
                 fn ($output) => $this->extractGradleVersion($output)
             );
         }
 
         // Fall back to a globally installed gradle
         return $this->getCommandVersion(
-            'gradle --version 2>/dev/null',
+            'gradle --version 2>&1',
             fn ($output) => $this->extractGradleVersion($output)
         );
     }

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -178,11 +178,19 @@ class InstallCommand extends Command
         )) {
             $url = 'https://github.com/NativePHP/mobile-air';
 
-            match (PHP_OS_FAMILY) {
-                'Darwin' => exec("open {$url}"),
-                'Windows' => exec("start {$url}"),
-                default => exec("xdg-open {$url}"),
-            };
+            // xdg-open may be absent on headless/minimal Linux and WSL —
+            // probe first and fall back to printing the URL. Quote the URL
+            // everywhere; `start` needs a leading "" title arg when quoting.
+            if (PHP_OS_FAMILY === 'Darwin') {
+                exec('open '.escapeshellarg($url));
+            } elseif (PHP_OS_FAMILY === 'Windows') {
+                exec('start "" "'.$url.'"');
+            } else {
+                exec('command -v xdg-open >/dev/null 2>&1', $probe, $missing);
+                $missing === 0
+                    ? exec('xdg-open '.escapeshellarg($url).' >/dev/null 2>&1')
+                    : $this->line("  Open in your browser: {$url}");
+            }
         }
 
         $this->showSuperNativeBanner();
@@ -257,14 +265,17 @@ class InstallCommand extends Command
         $envPath = base_path('.env');
         $envContents = file_exists($envPath) ? file_get_contents($envPath) : '';
 
-        $pattern = "/^{$key}=.*$/m";
+        // [^\r\n]* instead of .*$ so a CRLF file's trailing \r isn't consumed
+        // by the replacement (which would leave mixed line endings on Windows)
+        $pattern = "/^{$key}=[^\\r\\n]*/m";
 
         if (preg_match($pattern, $envContents)) {
             // Update existing value
             $envContents = preg_replace($pattern, "{$key}={$value}", $envContents);
         } else {
-            // Append new value
-            $envContents = rtrim($envContents)."\n\n{$key}={$value}\n";
+            // Append new value, matching the file's existing line endings
+            $eol = str_contains($envContents, "\r\n") ? "\r\n" : "\n";
+            $envContents = rtrim($envContents).$eol.$eol."{$key}={$value}".$eol;
         }
 
         file_put_contents($envPath, $envContents);

--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -343,7 +343,7 @@ class JumpCommand extends Command
         if (PHP_OS_FAMILY !== 'Windows') {
             $command = trim((string) @shell_exec('ps -p '.$leaderPid.' -o command= 2>/dev/null'));
             $ppid = (int) trim((string) @shell_exec('ps -p '.$leaderPid.' -o ppid= 2>/dev/null'));
-            if ($command === '' || ! $this->isJumpOwnedProcess($command, $ppid)) {
+            if ($command === '' || ! $this->isJumpOwnedProcess($command, $ppid, $leaderPid)) {
                 return; // recycled or not ours — never group-kill a stranger
             }
         }
@@ -926,8 +926,23 @@ class JumpCommand extends Command
             return;
         }
 
+        // Which path to warm on. For a native-UI app, `GET /` runs the element
+        // runloop, which BLOCKS for the whole lifetime of the screen — the same
+        // property that makes PHP_CLI_SERVER_WORKERS necessary. Warming it means
+        // the request never returns and every single start burns the full 120s
+        // timeout before continuing:
+        //
+        //   Laravel warmup  failed after 120s: Operation timed out … 0 bytes received
+        //
+        // Any request boots the framework (autoload, providers, config, opcache),
+        // which is what warming is actually for, so native-UI apps are warmed on
+        // a deliberately unrouted path: full bootstrap, 404, no runloop. WebView
+        // apps keep warming `/`, where compiling the actual page is the point.
+        $startUrl = config('nativephp.start_url') ?: '/';
+        $warmPath = NativeRouter::isNativeRoute($startUrl) ? '/__nativephp_warmup' : '/';
+
         $start = microtime(true);
-        $ch = curl_init("http://127.0.0.1:{$port}/");
+        $ch = curl_init("http://127.0.0.1:{$port}{$warmPath}");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_NOBODY, false);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
@@ -952,6 +967,7 @@ class JumpCommand extends Command
             return;
         }
 
+        // A 404 is the expected, healthy result on the native-UI warm path.
         $this->components->twoColumnDetail(
             'Laravel warmup',
             "<fg=green>ready in {$elapsed}s (HTTP {$httpCode})</>"
@@ -1499,7 +1515,7 @@ APPLESCRIPT;
             $ppid = (int) $m[1];
             $command = trim($m[2]);
 
-            if (! $this->isJumpOwnedProcess($command, $ppid)) {
+            if (! $this->isJumpOwnedProcess($command, $ppid, (int) $pid)) {
                 $this->warn("Port {$port} is held by an unrelated process (pid {$pid}) — leaving it alone.");
 
                 continue;
@@ -1517,7 +1533,7 @@ APPLESCRIPT;
      * ORPHANED `php -S … server.php` workers (PPID 1 — a live user server's
      * workers still have their artisan parent).
      */
-    private function isJumpOwnedProcess(string $command, int $ppid): bool
+    private function isJumpOwnedProcess(string $command, int $ppid, int $pid = 0): bool
     {
         if (str_contains($command, 'resources/jump/router.php')
             || str_contains($command, 'resources/jump/websocket-server.php')
@@ -1538,6 +1554,29 @@ APPLESCRIPT;
             return true;
         }
 
+        // The managed Laravel dev server. `artisan serve` execs
+        // `php -S <host>:<port> …/Foundation/resources/server.php`, and with
+        // PHP_CLI_SERVER_WORKERS that master forks a worker per slot. NONE of
+        // them carry "artisan serve" in their command line, and their ppid is
+        // the master (or the serve process) — not 1 — so the ppid===1 test below
+        // rejected all ~11 of them and left port 8000 held forever:
+        //
+        //   Port 8000 is held by an unrelated process (pid 2000) — leaving it alone.
+        //   … once per worker, every shutdown
+        //
+        // startLaravelServer() exports JUMP_BRIDGE_PORT into that server's
+        // environment and the forked workers inherit it, so it is a definitive
+        // marker: it distinguishes our server from a plain `php artisan serve`
+        // the user started themselves, which must never be killed.
+        if ($pid > 0
+            && preg_match('/php[^ ]* -S \S+:\d+/', $command)
+            && str_contains($command, 'server.php')
+            && str_contains($this->processEnvironment($pid), 'JUMP_BRIDGE_PORT=')) {
+            return true;
+        }
+
+        // Fallback for when the environment isn't readable (Windows, or a
+        // process we can't inspect): an orphaned `php -S` on loopback.
         if ($ppid === 1
             && preg_match('/php[^ ]* -S 127\.0\.0\.1:\d+/', $command)
             && str_contains($command, 'server.php')) {
@@ -1545,6 +1584,30 @@ APPLESCRIPT;
         }
 
         return false;
+    }
+
+    /**
+     * A process's environment as a flat string, for identity checks. Empty when
+     * it can't be read — callers must treat that as "unknown", never as "ours".
+     */
+    private function processEnvironment(int $pid): string
+    {
+        if ($pid <= 0) {
+            return '';
+        }
+
+        // Linux: /proc is authoritative and NUL-separated.
+        if (PHP_OS_FAMILY === 'Linux' && @is_readable("/proc/{$pid}/environ")) {
+            return str_replace("\0", ' ', (string) @file_get_contents("/proc/{$pid}/environ"));
+        }
+
+        // macOS: `ps -E` appends the environment after the command line. Only
+        // works for our own processes, which is exactly the case we care about.
+        if (PHP_OS_FAMILY === 'Darwin') {
+            return (string) @shell_exec('ps -Ewww -p '.$pid.' 2>/dev/null');
+        }
+
+        return '';
     }
 
     /**
@@ -1649,7 +1712,7 @@ APPLESCRIPT;
             if ($pid === getmypid() || $ppid !== 1) {
                 continue; // only reap processes orphaned to init
             }
-            if ($this->isJumpOwnedProcess($command, $ppid)) {
+            if ($this->isJumpOwnedProcess($command, $ppid, $pid)) {
                 @exec('kill -9 '.$pid.' 2>/dev/null');
             }
         }

--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -6,12 +6,16 @@ use Endroid\QrCode\Builder\Builder;
 use Endroid\QrCode\ErrorCorrectionLevel;
 use Illuminate\Console\Command;
 use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Traits\PlatformFileOperations;
 
 use function Laravel\Prompts\intro;
+use function Laravel\Prompts\note;
 use function Laravel\Prompts\select;
 
 class JumpCommand extends Command
 {
+    use PlatformFileOperations;
+
     protected $signature = 'native:jump
                             {--host=0.0.0.0 : The host address to serve the application on}
                             {--ip= : The IP address to display in the QR code (overrides auto-detection)}
@@ -75,6 +79,27 @@ class JumpCommand extends Command
 
         intro('NativePHP Jump Server');
 
+        // WSL2's default NAT networking gives eth0 a virtual-switch address
+        // (172.x) that a phone on the LAN cannot reach — the QR code would
+        // encode an IP that silently hangs on scan. Mirrored networking mode
+        // puts the real LAN IP on eth0, so only warn when NOT mirrored.
+        if ($this->isRunningInWSL()) {
+            $mode = trim((string) @shell_exec('wslinfo --networking-mode 2>/dev/null'));
+            if ($mode !== 'mirrored') {
+                $this->warn('WSL2 NAT networking detected — the auto-detected IP (172.x) is NOT reachable from your phone.');
+                note(<<<'NOTE'
+                    Scanning the QR code will hang unless you do one of the following:
+
+                      - Enable mirrored networking: set networkingMode=mirrored under [wsl2]
+                        in %UserProfile%\.wslconfig, then run `wsl --shutdown` (Windows 11).
+                        Jump then works with no further setup.
+                      - Set up `netsh interface portproxy` on Windows for the HTTP, WebSocket
+                        and Vite-proxy ports, and pass your Windows LAN IP via --ip.
+                      - Run `php artisan native:jump` from Windows directly instead of WSL.
+                    NOTE);
+            }
+        }
+
         // Arm teardown BEFORE any spawn so a Cmd+C during the blocking startup
         // (port waits, the 120s Laravel warmup, the interactive IP prompt) is
         // honoured and tears the whole fleet down deterministically.
@@ -129,9 +154,15 @@ class JumpCommand extends Command
 
         // Start or detect the Laravel dev server
         if ($this->option('no-serve')) {
-            // User is running their own artisan serve — tell them what to export
+            // User is running their own artisan serve — tell them what to export.
+            // The VAR=value command prefix is POSIX-shell-only, so Windows gets
+            // the PowerShell form (cmd.exe's `set X=v && …` embeds a trailing
+            // space in the value).
             if (! $this->isPortInUse($this->laravelPort)) {
-                $this->warn("No server detected on port {$this->laravelPort}. Start one with: JUMP_BRIDGE_PORT={$bridgePort} php artisan serve --port={$this->laravelPort}");
+                $hint = PHP_OS_FAMILY === 'Windows'
+                    ? "\$env:JUMP_BRIDGE_PORT={$bridgePort}; php artisan serve --port={$this->laravelPort}"
+                    : "JUMP_BRIDGE_PORT={$bridgePort} php artisan serve --port={$this->laravelPort}";
+                $this->warn("No server detected on port {$this->laravelPort}. Start one with: {$hint}");
             }
         } else {
             $this->startLaravelServer($this->laravelPort, $bridgePort, $wsPort);
@@ -480,11 +511,29 @@ class JumpCommand extends Command
         $phpBinary = PHP_BINARY;
         $serverHost = $host === '0.0.0.0' ? '0.0.0.0' : $host;
 
-        $descriptorSpec = [
-            0 => ['pipe', 'r'],  // stdin
-            1 => ['pipe', 'w'],  // stdout
-            2 => ['pipe', 'w'],  // stderr
-        ];
+        if ($useWorkerman) {
+            // Windows: stream_set_blocking() has no effect on proc_open pipes
+            // (PHP bugs #51800/#65650), so the main loop's fgets() would block
+            // forever once the Workerman proxy goes quiet — freezing log relay,
+            // the liveness check AND the artisan-serve pipe drain. Log to a
+            // file instead (same pattern as startBridgeServer).
+            $logDir = base_path('storage/logs');
+            if (! is_dir($logDir)) {
+                @mkdir($logDir, 0755, true);
+            }
+            $httpLogFile = $logDir.'/jump-http.log';
+            $descriptorSpec = [
+                0 => ['pipe', 'r'],  // stdin
+                1 => ['file', $httpLogFile, 'a'],
+                2 => ['file', $httpLogFile, 'a'],
+            ];
+        } else {
+            $descriptorSpec = [
+                0 => ['pipe', 'r'],  // stdin
+                1 => ['pipe', 'w'],  // stdout
+                2 => ['pipe', 'w'],  // stderr
+            ];
+        }
 
         if ($useWorkerman) {
             // Workerman script takes positional args: base_path, host, port,
@@ -500,6 +549,7 @@ class JumpCommand extends Command
             );
 
             $this->components->twoColumnDetail('HTTP proxy', '<fg=cyan>workerman</> (windows: avoids `php -S` dead-socket wedge)');
+            $this->components->twoColumnDetail('HTTP proxy log', "powershell -Command Get-Content -Path '{$httpLogFile}' -Tail 20 -Wait");
         } else {
             $cmd = sprintf(
                 '%s -S %s:%d %s',
@@ -529,9 +579,13 @@ class JumpCommand extends Command
         // the parent is still recoverable by group next run.
         $this->writeInstanceRegistry();
 
-        // Set pipes to non-blocking
-        stream_set_blocking($pipes[1], false);
-        stream_set_blocking($pipes[2], false);
+        // Set pipes to non-blocking. Windows has no stdout/stderr pipes here
+        // (file descriptors above) — and stream_set_blocking wouldn't work on
+        // them anyway (PHP bugs #51800/#65650).
+        if (! $useWorkerman) {
+            stream_set_blocking($pipes[1], false);
+            stream_set_blocking($pipes[2], false);
+        }
 
         // Close stdin - we don't need to write to the server
         fclose($pipes[0]);
@@ -580,25 +634,30 @@ class JumpCommand extends Command
                 break;
             }
 
-            // Read stdout (PHP server access log)
-            $stdout = fgets($pipes[1]);
-            if ($stdout) {
-                // Filter out noisy requests (unless verbose)
-                if ($this->verbose || (! str_contains($stdout, 'favicon.ico') && ! str_contains($stdout, '.map'))) {
-                    // Parse and format the output
-                    $this->formatServerOutput($stdout);
+            // Relay server output. Windows skips this: its stdout/stderr go to
+            // jump-http.log (non-blocking pipes are impossible there and a
+            // blocking fgets() would wedge the whole loop — see descriptor spec).
+            if (! $useWorkerman) {
+                // Read stdout (PHP server access log)
+                $stdout = fgets($pipes[1]);
+                if ($stdout) {
+                    // Filter out noisy requests (unless verbose)
+                    if ($this->verbose || (! str_contains($stdout, 'favicon.ico') && ! str_contains($stdout, '.map'))) {
+                        // Parse and format the output
+                        $this->formatServerOutput($stdout);
+                    }
                 }
-            }
 
-            // Read stderr (our custom log messages from router)
-            $stderr = fgets($pipes[2]);
-            if ($stderr) {
-                // Our router logs to stderr with [Jump] prefix
-                if (str_contains($stderr, '[Jump]')) {
-                    $message = trim(str_replace('[Jump]', '', $stderr));
-                    $this->components->twoColumnDetail('Device', $message);
-                } elseif ($this->verbose) {
-                    $this->line('  <fg=gray>[php] '.trim($stderr).'</>');
+                // Read stderr (our custom log messages from router)
+                $stderr = fgets($pipes[2]);
+                if ($stderr) {
+                    // Our router logs to stderr with [Jump] prefix
+                    if (str_contains($stderr, '[Jump]')) {
+                        $message = trim(str_replace('[Jump]', '', $stderr));
+                        $this->components->twoColumnDetail('Device', $message);
+                    } elseif ($this->verbose) {
+                        $this->line('  <fg=gray>[php] '.trim($stderr).'</>');
+                    }
                 }
             }
 
@@ -633,8 +692,9 @@ class JumpCommand extends Command
                 pcntl_signal_dispatch();
             }
 
-            // Small sleep to prevent CPU spinning
-            usleep(10000); // 10ms
+            // Small sleep to prevent CPU spinning. Windows sleeps longer — the
+            // loop is only a proc_get_status liveness check there (no log relay).
+            usleep($useWorkerman ? 200000 : 10000); // 200ms / 10ms
         }
 
         // Router died on its own (crash / external kill) — same idempotent teardown.
@@ -763,7 +823,12 @@ class JumpCommand extends Command
         // Give it a moment to start
         usleep(500000);
 
-        $this->components->twoColumnDetail('Bridge log', "tail -f {$logFile}");
+        // `tail` doesn't exist on stock Windows — show a paste-able PowerShell
+        // equivalent there (works from cmd.exe or an existing PS session).
+        $tailHint = PHP_OS_FAMILY === 'Windows'
+            ? "powershell -Command Get-Content -Path '{$logFile}' -Tail 20 -Wait"
+            : "tail -f {$logFile}";
+        $this->components->twoColumnDetail('Bridge log', $tailHint);
 
         // On Windows, Workerman cannot start multiple Worker instances from
         // one PHP file (no fork() — the second Worker is silently dropped
@@ -835,11 +900,29 @@ class JumpCommand extends Command
         $phpBinary = PHP_BINARY;
         $artisan = base_path('artisan');
 
-        $descriptorSpec = [
-            0 => ['pipe', 'r'],
-            1 => ['pipe', 'w'],
-            2 => ['pipe', 'w'],
-        ];
+        if (PHP_OS_FAMILY === 'Windows') {
+            // Windows: pipes can't be made non-blocking (PHP bugs #51800/#65650)
+            // and nothing drains them once the main loop stalls — artisan serve
+            // logs a line per request, so a full 4KB anonymous pipe would block
+            // the Laravel server mid-session. Log to a file instead; the main
+            // loop's drain self-disables via its is_resource() guards.
+            $logDir = base_path('storage/logs');
+            if (! is_dir($logDir)) {
+                @mkdir($logDir, 0755, true);
+            }
+            $laravelLogFile = $logDir.'/jump-laravel.log';
+            $descriptorSpec = [
+                0 => ['pipe', 'r'],
+                1 => ['file', $laravelLogFile, 'a'],
+                2 => ['file', $laravelLogFile, 'a'],
+            ];
+        } else {
+            $descriptorSpec = [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ];
+        }
 
         // --no-reload is REQUIRED for two reasons:
         //  1. It lets artisan serve honour PHP_CLI_SERVER_WORKERS — Laravel only
@@ -885,9 +968,12 @@ class JumpCommand extends Command
             return;
         }
 
-        // Set pipes to non-blocking so we don't hang
-        stream_set_blocking($this->laravelPipes[1], false);
-        stream_set_blocking($this->laravelPipes[2], false);
+        // Set pipes to non-blocking so we don't hang. On Windows stdout/stderr
+        // are file descriptors (see above) — only stdin exists as a pipe.
+        if (PHP_OS_FAMILY !== 'Windows') {
+            stream_set_blocking($this->laravelPipes[1], false);
+            stream_set_blocking($this->laravelPipes[2], false);
+        }
         fclose($this->laravelPipes[0]);
 
         // Wait for Laravel to actually start listening
@@ -1194,8 +1280,19 @@ class JumpCommand extends Command
         $txtPort = 'port='.$httpPort;
         $txtName = 'name='.$label;
 
-        $dnssd = trim((string) @shell_exec('command -v dns-sd 2>/dev/null'));
-        $avahi = $dnssd === '' ? trim((string) @shell_exec('command -v avahi-publish-service 2>/dev/null')) : '';
+        // `command -v` is a POSIX-shell builtin — on Windows shell_exec runs via
+        // cmd.exe, where it fails (and /dev/null is a bad redirect target), so
+        // resolution always came up empty even with Bonjour's dns-sd.exe
+        // installed. Use `where` there (first line of output); avahi is
+        // unix-only so skip that probe. dns-sd.exe accepts the identical
+        // `-R <name> _jump._tcp local <port> <txt…>` syntax.
+        if (PHP_OS_FAMILY === 'Windows') {
+            $dnssd = trim((string) strtok((string) @shell_exec('where dns-sd 2>NUL'), "\r\n"));
+            $avahi = '';
+        } else {
+            $dnssd = trim((string) @shell_exec('command -v dns-sd 2>/dev/null'));
+            $avahi = $dnssd === '' ? trim((string) @shell_exec('command -v avahi-publish-service 2>/dev/null')) : '';
+        }
 
         if ($dnssd !== '') {
             // macOS / Bonjour: dns-sd -R <name> <type> <domain> <port> [k=v ...]
@@ -1223,12 +1320,18 @@ class JumpCommand extends Command
             return; // no advertiser on this platform — QR-only, no harm
         }
 
+        $null = PHP_OS_FAMILY === 'Windows' ? 'NUL' : '/dev/null';
         $spec = [
             0 => ['pipe', 'r'],
-            1 => ['file', '/dev/null', 'w'],
-            2 => ['file', '/dev/null', 'w'],
+            1 => ['file', $null, 'w'],
+            2 => ['file', $null, 'w'],
         ];
-        $proc = @proc_open($cmd, $spec, $pipes);
+        // bypass_shell on Windows (same pattern as startBridgeServer) so
+        // stopAdvertiser()'s proc_terminate() signals dns-sd.exe itself — not a
+        // wrapping cmd.exe — preserving the goodbye-packet deregistration.
+        $proc = PHP_OS_FAMILY === 'Windows'
+            ? @proc_open($cmd, $spec, $pipes, base_path(), null, ['bypass_shell' => true])
+            : @proc_open($cmd, $spec, $pipes);
         if (is_resource($proc)) {
             $this->mdnsProcess = $proc;
             $this->components->info("Discoverable on this network as \"{$label}\" — open the app to connect without scanning.");
@@ -1243,17 +1346,19 @@ class JumpCommand extends Command
         if (PHP_OS_FAMILY === 'Darwin') {
             $this->openOrRefreshMacOS($url);
         } elseif (PHP_OS_FAMILY === 'Linux') {
-            $commands = [
-                'xdg-open '.escapeshellarg($url).' > /dev/null 2>&1 &',
-                'sensible-browser '.escapeshellarg($url).' > /dev/null 2>&1 &',
-                'x-www-browser '.escapeshellarg($url).' > /dev/null 2>&1 &',
-            ];
-            foreach ($commands as $command) {
-                exec($command, $output, $returnCode);
-                if ($returnCode === 0) {
-                    break;
+            // Backgrounding with `&` makes the shell exit 0 whether or not the
+            // opener exists, so probe availability first instead of trusting
+            // the exit code. The redirect + & stay: they keep a slow opener
+            // from blocking the serve loop.
+            foreach (['xdg-open', 'sensible-browser', 'x-www-browser'] as $bin) {
+                $path = trim((string) @shell_exec('command -v '.escapeshellarg($bin).' 2>/dev/null'));
+                if ($path !== '') {
+                    exec(escapeshellarg($path).' '.escapeshellarg($url).' > /dev/null 2>&1 &');
+
+                    return;
                 }
             }
+            $this->components->warn("No browser opener found (xdg-open/sensible-browser/x-www-browser). Open {$url} manually.");
         } elseif (PHP_OS_FAMILY === 'Windows') {
             exec('start "" '.escapeshellarg($url));
         }
@@ -1331,11 +1436,28 @@ APPLESCRIPT;
             // (router + Workerman bridge + Windows vite-hmr proxy), not just the
             // router, and tree-kill (/T) so php -S workers and Workerman worker
             // processes are reaped too — otherwise ws/bridge/vite ports escalate.
+            // Match by the package path fragment WITH FORWARD SLASHES — the
+            // spawned command lines embed __DIR__.'/../../resources/jump/…'
+            // verbatim (no realpath), so the tail keeps '/'. Bare filenames
+            // ('router.php') would tree-kill unrelated `php -S … router.php`
+            // dev servers. Also scope to THIS project — base_path() is an
+            // argument of every jump child — so live siblings serving other
+            // projects survive, matching the Unix branch's multi-project
+            // behaviour. http-server.php is the Windows HTTP proxy (was
+            // never reaped before).
             $pids = [];
-            foreach (['router.php', 'websocket-server.php', 'vite-hmr-server.php'] as $needle) {
-                $output = shell_exec('wmic process where "commandline like \'%'.$needle.'%\'" get processid 2>NUL');
+            $base = base_path();
+            $wqlBase = str_replace('\\', '\\\\', $base); // backslashes must be doubled in WQL
+            $needles = [
+                'resources/jump/router.php',
+                'resources/jump/http-server.php',
+                'resources/jump/websocket-server.php',
+                'resources/jump/vite-hmr-server.php',
+            ];
+            foreach ($needles as $needle) {
+                $output = shell_exec('wmic process where "commandline like \'%'.$needle.'%\' and commandline like \'%'.$wqlBase.'%\'" get processid 2>NUL');
                 if (! $output) {
-                    $output = shell_exec('powershell -Command "Get-WmiObject Win32_Process | Where-Object { $_.CommandLine -like \'*'.$needle.'*\' } | Select-Object -ExpandProperty ProcessId" 2>NUL');
+                    $output = shell_exec('powershell -Command "Get-WmiObject Win32_Process | Where-Object { $_.CommandLine -like \'*'.$needle.'*\' -and $_.CommandLine -like \'*'.$base.'*\' } | Select-Object -ExpandProperty ProcessId" 2>NUL');
                 }
                 if ($output) {
                     foreach (preg_split('/\s+/', trim($output)) as $pid) {
@@ -1500,10 +1622,25 @@ APPLESCRIPT;
             return;
         }
         $out = trim((string) @shell_exec('lsof -nP -iTCP:'.$port.' -sTCP:LISTEN -t 2>/dev/null'));
-        if ($out === '') {
+        $pids = $out === '' ? [] : preg_split('/\s+/', $out);
+
+        // lsof isn't installed on minimal Debian/Ubuntu, many Docker images and
+        // some WSL distros — without a fallback the reap silently no-ops and
+        // every restart escalates to higher ports. Fall back to ss on Linux
+        // only (macOS always ships lsof and has no ss). `ss -p` only emits
+        // pid= for same-user sockets — exactly the jump-owned set — and every
+        // PID found still passes through the identity gate below.
+        if (empty($pids) && PHP_OS_FAMILY === 'Linux') {
+            $ssOut = (string) @shell_exec('ss -ltnpH "sport = :'.$port.'" 2>/dev/null');
+            if (preg_match_all('/pid=(\d+)/', $ssOut, $m)) {
+                $pids = $m[1];
+            }
+        }
+
+        if (empty($pids)) {
             return;
         }
-        foreach (array_unique(preg_split('/\s+/', $out)) as $pid) {
+        foreach (array_unique($pids) as $pid) {
             if (! is_numeric($pid) || (int) $pid === getmypid()) {
                 continue;
             }

--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -52,6 +52,9 @@ class JumpCommand extends Command
     /** Handle to the mDNS/Bonjour advertiser subprocess (LAN discovery). */
     private $mdnsProcess = null;
 
+    /** True when $mdnsProcess is our pure-PHP responder (needs stop-file teardown, not a hard kill). */
+    private bool $mdnsIsPhpResponder = false;
+
     /** @var resource|null Router (php -S) proc_open handle. */
     private $routerProcess = null;
 
@@ -601,9 +604,13 @@ class JumpCommand extends Command
             usleep(100000);
         }
         if (! is_resource($this->mdnsProcess)) {
-            $this->warn($this->isPortInUse($httpPort)
-                ? 'LAN discovery unavailable (no dns-sd/avahi) — use the QR code.'
-                : "Server did not start on port {$httpPort} — not advertising on the network.");
+            if (! $this->isPortInUse($httpPort)) {
+                $this->warn("Server did not start on port {$httpPort} — not advertising on the network.");
+            } elseif (PHP_OS_FAMILY !== 'Windows') {
+                // Windows falls back to the pure-PHP responder, which warns for
+                // itself if it can't bind — so only warn here on macOS/Linux.
+                $this->warn('LAN discovery unavailable (no dns-sd/avahi) — use the QR code.');
+            }
         }
 
         // Signal handlers and the advertiser/registry shutdown functions are
@@ -702,6 +709,69 @@ class JumpCommand extends Command
     }
 
     /**
+     * Windows fallback advertiser: spawn the pure-PHP DNS-SD responder
+     * (resources/jump/mdns-server.php) when no Bonjour dns-sd.exe is present.
+     * Stored on $this->mdnsProcess so the existing stopAdvertiser() teardown
+     * reaps it unchanged. Best-effort — if it can't bind UDP 5353 the QR still
+     * works, so we only warn.
+     */
+    private function startPhpMdnsResponder(int $httpPort, string $ip, string $label): void
+    {
+        $serverPath = __DIR__.'/../../resources/jump/mdns-server.php';
+        if (! file_exists($serverPath)) {
+            return;
+        }
+
+        $logDir = base_path('storage/logs');
+        if (! is_dir($logDir)) {
+            @mkdir($logDir, 0755, true);
+        }
+        $logFile = $logDir.'/jump-mdns.log';
+
+        // Pass our own PID so the responder can watch it: if Jump is hard-killed
+        // or crashes (no graceful stopAdvertiser), the responder notices the
+        // parent is gone and multicasts its own goodbye instead of lingering.
+        $cmd = sprintf(
+            '%s %s %s %s %d %s %d',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg($serverPath),
+            escapeshellarg(base_path()),
+            escapeshellarg($label),
+            $httpPort,
+            escapeshellarg($ip),
+            getmypid() ?: 0,
+        );
+        $desc = [
+            0 => ['file', 'NUL', 'r'],
+            1 => ['file', $logFile, 'a'],
+            2 => ['file', $logFile, 'a'],
+        ];
+
+        // bypass_shell so stopAdvertiser()'s proc_terminate() signals php.exe
+        // itself (not a wrapping cmd.exe), matching the bridge/vite spawns.
+        $proc = @proc_open($cmd, $desc, $pipes, base_path(), null, ['bypass_shell' => true]);
+        if (! is_resource($proc)) {
+            return;
+        }
+
+        // Give it a beat to bind (or fail on a missing ext-sockets / busy port).
+        usleep(400000);
+        if (! (@proc_get_status($proc)['running'] ?? false)) {
+            proc_close($proc);
+            $this->warn('LAN discovery unavailable — the pure-PHP mDNS responder exited (see storage/logs/jump-mdns.log). Use the QR code.');
+
+            return;
+        }
+
+        $this->mdnsProcess = $proc;
+        $this->mdnsIsPhpResponder = true;
+        if (($pid = (int) (@proc_get_status($proc)['pid'] ?? 0)) > 0) {
+            $this->childPids[] = $pid;
+        }
+        $this->components->info("Discoverable on this network as \"{$label}\" — open the app to connect without scanning.");
+    }
+
+    /**
      * Terminate the mDNS/Bonjour advertiser subprocess. When `dns-sd -R`
      * exits, mDNSResponder deregisters the service and multicasts goodbye
      * packets, so browsing devices drop the entry within seconds instead of
@@ -709,11 +779,39 @@ class JumpCommand extends Command
      */
     public function stopAdvertiser(): void
     {
-        if (is_resource($this->mdnsProcess)) {
-            proc_terminate($this->mdnsProcess);
-            proc_close($this->mdnsProcess);
-            $this->mdnsProcess = null;
+        if (! is_resource($this->mdnsProcess)) {
+            return;
         }
+
+        if ($this->mdnsIsPhpResponder) {
+            // The pure-PHP responder can't catch proc_terminate() (a hard
+            // TerminateProcess on Windows), so a plain kill would skip the
+            // DNS-SD goodbye and leave a phantom "server nearby" in the app for
+            // the record TTL. Instead drop the stop-file it polls: it multicasts
+            // the goodbye (TTL-0) and exits on its own. proc_terminate stays as a
+            // backstop only if it doesn't exit within the grace window.
+            $stopFile = base_path('storage/framework/jump-mdns.stop');
+            @touch($stopFile);
+            for ($i = 0; $i < 15; $i++) { // up to ~1.5s
+                if (! (@proc_get_status($this->mdnsProcess)['running'] ?? false)) {
+                    break;
+                }
+                usleep(100000);
+            }
+            @unlink($stopFile);
+            if (@proc_get_status($this->mdnsProcess)['running'] ?? false) {
+                @proc_terminate($this->mdnsProcess);
+            }
+            @proc_close($this->mdnsProcess);
+            $this->mdnsProcess = null;
+            $this->mdnsIsPhpResponder = false;
+
+            return;
+        }
+
+        proc_terminate($this->mdnsProcess);
+        proc_close($this->mdnsProcess);
+        $this->mdnsProcess = null;
     }
 
     /**
@@ -1316,6 +1414,14 @@ class JumpCommand extends Command
                 escapeshellarg($txtPort),
                 escapeshellarg($txtName),
             );
+        } elseif (PHP_OS_FAMILY === 'Windows') {
+            // No Bonjour dns-sd.exe on this Windows box — fall back to our
+            // self-contained pure-PHP DNS-SD responder so LAN discovery still
+            // works without asking the user to install Bonjour. It advertises
+            // the identical _jump._tcp record (host/port/name) the QR encodes.
+            $this->startPhpMdnsResponder($httpPort, $ip, $label);
+
+            return;
         } else {
             return; // no advertiser on this platform — QR-only, no harm
         }

--- a/src/Commands/LaunchEmulatorCommand.php
+++ b/src/Commands/LaunchEmulatorCommand.php
@@ -21,6 +21,14 @@ class LaunchEmulatorCommand extends Command
             default => throw new \Exception('Invalid OS type.')
         };
 
+        // iOS simulators are macOS-only tooling — fail fast on Windows/Linux
+        // instead of silently falling through to the Android flow.
+        if ($os === 'ios' && PHP_OS_FAMILY !== 'Darwin') {
+            $this->error('iOS simulators require macOS with Xcode installed. Use `php artisan native:emulator android` on this platform.');
+
+            return;
+        }
+
         match ($os) {
             'android' => $this->startAndroid(),
             'ios' => $this->startAndroid(),

--- a/src/Commands/MakeNativeComponentCommand.php
+++ b/src/Commands/MakeNativeComponentCommand.php
@@ -105,8 +105,12 @@ class MakeNativeComponentCommand extends Command
 
         // ── Output ──────────────────────────────────────
 
-        $relativeClassPath = str_replace(base_path().'/', '', $classPath);
-        $relativeViewPath = str_replace(base_path().'/', '', $viewPath);
+        // Strip the base path by length and normalize separators so the
+        // relative path displays cleanly on Windows (where app_path() and
+        // resource_path() join with backslashes) as well as macOS/Linux.
+        $relative = fn (string $path): string => ltrim(str_replace('\\', '/', substr($path, strlen(base_path()))), '/');
+        $relativeClassPath = $relative($classPath);
+        $relativeViewPath = $relative($viewPath);
 
         outro("Created {$className}");
 

--- a/src/Commands/PackageCommand.php
+++ b/src/Commands/PackageCommand.php
@@ -471,6 +471,17 @@ class PackageCommand extends Command
         } elseif (PHP_OS_FAMILY === 'Darwin') {
             exec("open \"$directory\"");
         } elseif (PHP_OS_FAMILY === 'Linux') {
+            // In WSL there's usually no desktop session (so no xdg-open), but
+            // Windows Explorer is reachable via interop — open it there instead
+            if ($this->isRunningInWSL()) {
+                $windowsPath = trim((string) shell_exec('wslpath -w '.escapeshellarg($directory).' 2>/dev/null'));
+                if ($windowsPath !== '') {
+                    exec('explorer.exe '.escapeshellarg($windowsPath).' >/dev/null 2>&1');
+
+                    return;
+                }
+            }
+
             if (shell_exec('which xdg-open')) {
                 exec("xdg-open \"$directory\"");
             }

--- a/src/Commands/PluginCreateCommand.php
+++ b/src/Commands/PluginCreateCommand.php
@@ -1604,7 +1604,13 @@ PHP;
         $this->components->twoColumnDetail('To install in your app', '');
         $this->line('  Add to composer.json <comment>"repositories"</comment> section:');
         $this->newLine();
-        $this->line('  <info>{"type": "path", "url": "'.$this->pluginData['path'].'"}</info>');
+        // Forward slashes keep the snippet valid JSON on Windows (backslashes
+        // would need escaping) and Composer path repositories accept them there.
+        $repoJson = json_encode([
+            'type' => 'path',
+            'url' => str_replace('\\', '/', $this->pluginData['path']),
+        ], JSON_UNESCAPED_SLASHES);
+        $this->line('  <info>'.$repoJson.'</info>');
         $this->newLine();
         $this->line('  Then run:');
         $this->line('  <comment>composer require '.$this->pluginData['name'].'</comment>');

--- a/src/Commands/PluginMakeHookCommand.php
+++ b/src/Commands/PluginMakeHookCommand.php
@@ -61,7 +61,7 @@ class PluginMakeHookCommand extends Command
         }
 
         // Resolve relative paths
-        if (! str_starts_with($pluginPath, '/')) {
+        if (! $this->isAbsolutePath($pluginPath)) {
             $pluginPath = base_path($pluginPath);
         }
 
@@ -163,6 +163,18 @@ class PluginMakeHookCommand extends Command
         }
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Detect absolute paths on all platforms — Windows drive (C:\ or C:/) and
+     * UNC (\\server\share) paths would otherwise be treated as relative and
+     * wrongly prefixed with base_path().
+     */
+    protected function isAbsolutePath(string $path): bool
+    {
+        return str_starts_with($path, '/')          // unix
+            || str_starts_with($path, '\\\\')       // UNC \\server\share
+            || preg_match('/^[A-Za-z]:[\\\\\\/]/', $path) === 1; // C:\ or C:/
     }
 
     protected function selectPlugin(): ?string

--- a/src/Commands/PluginRegisterCommand.php
+++ b/src/Commands/PluginRegisterCommand.php
@@ -192,7 +192,11 @@ class PluginRegisterCommand extends Command
             return self::FAILURE;
         }
 
-        $content = preg_replace_callback($pattern, function ($matches) use ($serviceProvider) {
+        // Preserve the provider file's existing line endings (CRLF on typical
+        // Windows checkouts) so we don't splice in mixed EOLs
+        $eol = str_contains($content, "\r\n") ? "\r\n" : "\n";
+
+        $content = preg_replace_callback($pattern, function ($matches) use ($serviceProvider, $eol) {
             $before = $matches[1];
             $existing = $matches[2];
             $after = $matches[3];
@@ -207,10 +211,10 @@ class PluginRegisterCommand extends Command
 
             if ($isPlaceholder) {
                 // Empty or only has placeholder comment - replace with plugin
-                $newContent = "\n            \\{$serviceProvider}::class,\n        ";
+                $newContent = "{$eol}            \\{$serviceProvider}::class,{$eol}        ";
             } else {
                 // Has existing plugins - append
-                $newContent = rtrim($existing, " \t\n")."\n            \\{$serviceProvider}::class,\n        ";
+                $newContent = rtrim($existing, " \t\r\n").$eol."            \\{$serviceProvider}::class,{$eol}        ";
             }
 
             return $before.$newContent.$after;
@@ -233,13 +237,17 @@ class PluginRegisterCommand extends Command
         }
 
         // Remove the plugin line (handles both ::class format)
+        // \r?\n? keeps the tail EOL-agnostic for CRLF files on Windows checkouts
         $escapedProvider = preg_quote($serviceProvider, '/');
-        $pattern = "/\s*\\\\?{$escapedProvider}::class,?\n?/";
+        $pattern = "/\s*\\\\?{$escapedProvider}::class,?\r?\n?/";
 
-        $content = preg_replace($pattern, "\n", $content);
+        // Preserve the provider file's existing line endings (see addPlugin)
+        $eol = str_contains($content, "\r\n") ? "\r\n" : "\n";
 
-        // Clean up any double newlines in the array
-        $content = preg_replace('/(\[\s*)\n\n+/', "$1\n", $content);
+        $content = preg_replace($pattern, $eol, $content);
+
+        // Clean up any double newlines in the array (CRLF-aware)
+        $content = preg_replace('/(\[\s*)(?:\r?\n){2,}/', '$1'.$eol, $content);
 
         $this->files->put($providerPath, $content);
 

--- a/src/Commands/PluginUninstallCommand.php
+++ b/src/Commands/PluginUninstallCommand.php
@@ -297,7 +297,8 @@ class PluginUninstallCommand extends Command
      */
     protected function resolveRepositoryPath(string $url): string
     {
-        if (str_starts_with($url, '/')) {
+        // Absolute: unix (/...), Windows drive-letter (C:\ or C:/), or UNC (\\server\share)
+        if (str_starts_with($url, '/') || preg_match('#^(?:[A-Za-z]:[\\\\/]|\\\\{2})#', $url)) {
             return $url;
         }
 
@@ -323,7 +324,7 @@ class PluginUninstallCommand extends Command
 
         // Drop the `use Vendor\Plugin\ServiceProvider;` import line entirely.
         $newContent = preg_replace(
-            '/^use\s+\\\\?'.preg_quote($serviceProvider, '/').';[ \t]*\n/m',
+            '/^use\s+\\\\?'.preg_quote($serviceProvider, '/').';[ \t]*\r?\n/m',
             '',
             $content
         );

--- a/src/Commands/ReleaseCommand.php
+++ b/src/Commands/ReleaseCommand.php
@@ -68,7 +68,8 @@ class ReleaseCommand extends Command
         if (str_contains($envContent, 'NATIVEPHP_APP_VERSION=')) {
             // Update existing version
             $updatedContent = preg_replace(
-                '/^NATIVEPHP_APP_VERSION=.+$/m',
+                // [^\r\n] (without '$') keeps the \r intact on CRLF .env files (Windows)
+                '/^NATIVEPHP_APP_VERSION=[^\r\n]+/m',
                 "NATIVEPHP_APP_VERSION={$newVersion}",
                 $envContent
             );

--- a/src/Commands/RemoveNativeComponentCommand.php
+++ b/src/Commands/RemoveNativeComponentCommand.php
@@ -68,7 +68,9 @@ class RemoveNativeComponentCommand extends Command
 
         $viewPath = $viewDirectory.'/'.$viewName.'.blade.php';
         $viewExists = $this->files->exists($viewPath);
-        $relativeViewPath = str_replace(base_path().'/', '', $viewPath);
+        // Normalize separators before stripping base_path() — on Windows base_path()
+        // is backslashed while $viewPath is mixed, so a naive replace never matches
+        $relativeViewPath = ltrim(str_replace(str_replace('\\', '/', base_path()), '', str_replace('\\', '/', $viewPath)), '/');
 
         $targets = $relativePath.($viewExists ? " and {$relativeViewPath}" : '');
         if (! confirm("Delete {$targets}?", default: false)) {
@@ -95,9 +97,16 @@ class RemoveNativeComponentCommand extends Command
 
     protected function cleanupEmptyDirs(string $directory, string $baseDir): void
     {
+        // Normalize separators so the strict comparison against $baseDir holds on
+        // Windows, where dirname() preserves mixed slashes and would otherwise let
+        // the loop delete the base directory itself
+        $normalize = fn (string $p): string => rtrim(str_replace('\\', '/', $p), '/');
+        $directory = $normalize($directory);
+        $baseDir = $normalize($baseDir);
+
         while ($directory !== $baseDir && $this->files->isDirectory($directory) && empty($this->files->files($directory)) && empty($this->files->directories($directory))) {
             $this->files->deleteDirectory($directory);
-            $directory = dirname($directory);
+            $directory = $normalize(dirname($directory));
         }
     }
 
@@ -113,8 +122,10 @@ class RemoveNativeComponentCommand extends Command
 
         $files = collect($this->files->allFiles($baseDir))
             ->filter(fn ($file) => $file->getExtension() === 'php')
-            ->mapWithKeys(function ($file) use ($baseDir) {
-                $relative = str_replace($baseDir.'/', '', $file->getPathname());
+            ->mapWithKeys(function ($file) {
+                // getRelativePathname() avoids separator-mismatch issues on Windows;
+                // normalize to forward slashes so handle()'s path building works
+                $relative = str_replace('\\', '/', $file->getRelativePathname());
                 $name = substr($relative, 0, -4); // strip .php
 
                 return [$name => $name];

--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -69,6 +69,15 @@ class RunCommand extends Command
             };
         }
 
+        // iOS builds depend on the Xcode toolchain (xcrun, xcodebuild), which only
+        // exists on macOS — fail fast before touching logs, Vite, or devices
+        if ($os === 'ios' && PHP_OS_FAMILY !== 'Darwin') {
+            error('iOS builds require macOS (Xcode toolchain).');
+            note('You can build and run the Android app on this machine with `php artisan native:run android`.');
+
+            return self::FAILURE;
+        }
+
         // Check for WSL environment - Android is not supported in WSL
         if ($this->isRunningInWSL()) {
             error('Android is not supported in WSL (Windows Subsystem for Linux).');

--- a/src/Commands/ValidateCommand.php
+++ b/src/Commands/ValidateCommand.php
@@ -70,9 +70,10 @@ class ValidateCommand extends Command
                 continue;
             }
 
-            $relative = str_replace($componentPath.'/', '', $file->getPathname());
-            $relative = substr($relative, 0, -4);
-            $relative = str_replace('/', '\\', $relative);
+            // Use the Finder-relative path so the mapping works regardless of
+            // platform directory separators (Windows returns backslashes).
+            $relative = substr($file->getRelativePathname(), 0, -4);
+            $relative = str_replace(['/', DIRECTORY_SEPARATOR], '\\', $relative);
             $className = 'App\\NativeComponents\\'.$relative;
 
             if ($componentFilter !== null) {

--- a/src/Commands/WatchCommand.php
+++ b/src/Commands/WatchCommand.php
@@ -27,10 +27,6 @@ class WatchCommand extends Command
 
     public function handle(): int
     {
-        if (! $this->checkWatchmanDependencies()) {
-            return self::FAILURE;
-        }
-
         // Get platform (flags take priority over argument)
         if ($this->option('ios')) {
             $platform = 'ios';
@@ -40,13 +36,18 @@ class WatchCommand extends Command
             $platform = $this->argument('platform');
 
             if (! $platform) {
-                $platform = select(
-                    label: 'Select platform to watch',
-                    options: [
-                        'ios' => 'iOS',
-                        'android' => 'Android',
-                    ]
-                );
+                // iOS watching needs the Xcode toolchain, so only offer it on macOS
+                if (PHP_OS_FAMILY !== 'Darwin') {
+                    $platform = 'android';
+                } else {
+                    $platform = select(
+                        label: 'Select platform to watch',
+                        options: [
+                            'ios' => 'iOS',
+                            'android' => 'Android',
+                        ]
+                    );
+                }
             } else {
                 // Support shorthands: 'a' for android, 'i' for ios
                 $platform = match (strtolower($platform)) {
@@ -55,6 +56,14 @@ class WatchCommand extends Command
                     default => $platform,
                 };
             }
+        }
+
+        // iOS watching depends on the Xcode toolchain (xcrun), which only exists
+        // on macOS — fail fast with a clear error for explicit --ios / ios / i
+        if ($platform === 'ios' && PHP_OS_FAMILY !== 'Darwin') {
+            $this->error('Watching iOS apps requires macOS (Xcode toolchain).');
+
+            return self::FAILURE;
         }
 
         $targetUdid = $this->argument('target');

--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -1102,7 +1102,8 @@ class AndroidPluginCompiler
         }
 
         // First, remove any existing plugin permission comments to avoid duplicates
-        $manifest = preg_replace('/\s*<!-- NativePHP Plugin Permissions -->\n/s', '', $manifest);
+        // (\r?\n tolerates CRLF manifests generated/committed on Windows)
+        $manifest = preg_replace('/\s*<!-- NativePHP Plugin Permissions -->\r?\n/s', '', $manifest);
 
         $permissionBlock = "\n    <!-- NativePHP Plugin Permissions -->\n";
         $hasNewPermissions = false;
@@ -1141,7 +1142,8 @@ class AndroidPluginCompiler
         }
 
         // First, remove any existing plugin feature comments to avoid duplicates
-        $manifest = preg_replace('/\s*<!-- NativePHP Plugin Features -->\n/s', '', $manifest);
+        // (\r?\n tolerates CRLF manifests generated/committed on Windows)
+        $manifest = preg_replace('/\s*<!-- NativePHP Plugin Features -->\r?\n/s', '', $manifest);
 
         $featureBlock = "\n    <!-- NativePHP Plugin Features -->\n";
         $hasNewFeatures = false;

--- a/src/Traits/ChecksLatestBuildNumber.php
+++ b/src/Traits/ChecksLatestBuildNumber.php
@@ -464,13 +464,16 @@ trait ChecksLatestBuildNumber
         $envContent = file_get_contents($envFilePath);
         $newLine = "{$key}={$value}";
 
-        // Check if the key already exists
-        if (preg_match("/^{$key}=.*$/m", $envContent)) {
+        // Match up to (but not including) the line terminator so a CRLF .env
+        // keeps its \r intact instead of ending up with mixed line endings
+        if (preg_match("/^{$key}=[^\r\n]*/m", $envContent)) {
             // Update existing line
-            $envContent = preg_replace("/^{$key}=.*$/m", $newLine, $envContent);
+            $envContent = preg_replace("/^{$key}=[^\r\n]*/m", $newLine, $envContent);
         } else {
-            // Add new line
-            $envContent = PHP_EOL.rtrim($envContent).PHP_EOL.$newLine.PHP_EOL;
+            // Add new line using the file's dominant line ending, not PHP_EOL,
+            // so we don't inject CRLF into an LF .env on Windows (or vice versa)
+            $eol = str_contains($envContent, "\r\n") ? "\r\n" : "\n";
+            $envContent = $eol.rtrim($envContent, "\r\n").$eol.$newLine.$eol;
         }
 
         file_put_contents($envFilePath, $envContent);

--- a/src/Traits/CreatesAndroidCredentials.php
+++ b/src/Traits/CreatesAndroidCredentials.php
@@ -364,14 +364,21 @@ trait CreatesAndroidCredentials
     {
         // Try different potential keytool commands based on platform
         $commands = ['keytool'];
+        $javaHome = getenv('JAVA_HOME');
 
         // On Windows, keytool might be in different locations
         if (PHP_OS_FAMILY === 'Windows') {
             $commands[] = 'keytool.exe';
             // Try common Java installation paths
-            $javaHome = getenv('JAVA_HOME');
             if ($javaHome) {
                 $commands[] = $javaHome.'\bin\keytool.exe';
+            }
+        } elseif ($javaHome) {
+            // On Linux/macOS, JAVA_HOME (e.g. Android Studio's bundled JBR) is
+            // often set without its bin/ directory on PATH
+            $candidate = rtrim($javaHome, '/').'/bin/keytool';
+            if (is_file($candidate)) {
+                $commands[] = $candidate;
             }
         }
 

--- a/src/Traits/InstallsAndroid.php
+++ b/src/Traits/InstallsAndroid.php
@@ -113,6 +113,18 @@ trait InstallsAndroid
 
     private function installPHPAndroid(): void
     {
+        // Fail early: ZipArchive validates (and on Linux/macOS extracts) the
+        // downloaded archive, but ext-zip is not guaranteed on stock Linux or
+        // Windows PHP installs — better to error now than after a multi-MB download.
+        if (! class_exists(ZipArchive::class)) {
+            error('The PHP zip extension (ext-zip) is required to install Android PHP binaries.');
+            note(PHP_OS_FAMILY === 'Windows'
+                ? 'Enable extension=zip in your php.ini and retry.'
+                : 'Install it (e.g. sudo apt install php'.PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'-zip) and retry.');
+
+            return;
+        }
+
         $includeIcu = $this->includeIcu ?? false;
         $phpVersion = $this->phpVersion;
         $versions = $this->versionsManifest;

--- a/src/Traits/LaunchesAndroidEmulator.php
+++ b/src/Traits/LaunchesAndroidEmulator.php
@@ -29,7 +29,9 @@ trait LaunchesAndroidEmulator
             return;
         }
 
-        $avds = array_filter(explode("\n", trim($listProcess->getOutput())));
+        // Split on \r?\n and trim each entry: emulator.exe emits CRLF on Windows,
+        // and a stray "\r" in an AVD name breaks the -avd launch argument.
+        $avds = array_values(array_filter(array_map('trim', preg_split('/\r?\n/', trim($listProcess->getOutput())))));
 
         if (empty($avds)) {
             $this->error('❌ No emulators (AVDs) found.');
@@ -55,18 +57,33 @@ trait LaunchesAndroidEmulator
             $escapedAvd = escapeshellarg($selected);
             $launchCommand = "nohup $escapedPath -avd $escapedAvd > /tmp/emulator.log 2>&1 &";
         }
-        Process::fromShellCommandline($launchCommand)->start();
+        // Hold the Process reference until this method returns: a discarded temporary
+        // is destructed immediately, and on Windows Process::__destruct() tree-kills
+        // the cmd.exe wrapper (taskkill /F /T), taking the emulator down with it.
+        $launchProcess = Process::fromShellCommandline($launchCommand);
+
+        if (PHP_OS_FAMILY === 'Windows') {
+            // Detach the wrapper into its own console so the destructor closes
+            // pipes instead of tree-killing the spawned emulator.
+            $launchProcess->setOptions(['create_new_console' => true]);
+        }
+
+        $launchProcess->start();
 
         $this->info('⏳ Waiting for emulator to boot...');
+
+        // Resolve adb from the SDK: platform-tools is frequently not on PATH,
+        // especially on stock Android Studio installs (Windows/Linux).
+        $adb = $this->resolveAdbPath($emulatorPath);
 
         $booted = false;
 
         for ($i = 0; $i < 200; $i++) { // ~24s
-            $bootProcess = Process::fromShellCommandline('adb shell getprop sys.boot_completed');
+            $bootProcess = Process::fromShellCommandline(sprintf('"%s" shell getprop sys.boot_completed', $adb));
             $bootProcess->run();
             $bootCompleted = trim($bootProcess->getOutput());
 
-            $readyProcess = Process::fromShellCommandline('adb shell getprop init.svc.bootanim');
+            $readyProcess = Process::fromShellCommandline(sprintf('"%s" shell getprop init.svc.bootanim', $adb));
             $readyProcess->run();
             $bootAnimStatus = trim($readyProcess->getOutput());
 
@@ -83,6 +100,29 @@ trait LaunchesAndroidEmulator
         } else {
             $this->warn('⚠️ Emulator did not finish booting in time.');
         }
+    }
+
+    protected function resolveAdbPath(string $emulatorPath): string
+    {
+        $adbName = PHP_OS_FAMILY === 'Windows' ? 'adb.exe' : 'adb';
+
+        $candidates = [];
+
+        // Every emulator candidate lives at <sdk>/emulator/<bin>, so the SDK root
+        // is two levels up — this covers stock installs where ANDROID_HOME is unset.
+        $candidates[] = dirname($emulatorPath, 2).DIRECTORY_SEPARATOR.'platform-tools'.DIRECTORY_SEPARATOR.$adbName;
+
+        if ($sdk = env('ANDROID_HOME') ?: env('ANDROID_SDK_ROOT')) {
+            $candidates[] = $sdk.DIRECTORY_SEPARATOR.'platform-tools'.DIRECTORY_SEPARATOR.$adbName;
+        }
+
+        foreach ($candidates as $candidate) {
+            if (file_exists($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return $adbName; // fall back to PATH
     }
 
     protected function resolveAndroidEmulatorPath(): ?string

--- a/src/Traits/ManagesIosSigning.php
+++ b/src/Traits/ManagesIosSigning.php
@@ -850,9 +850,15 @@ trait ManagesIosSigning
      */
     protected function readAndEncodeFile(string $filePath): ?string
     {
-        // Expand tilde to home directory
-        if (str_starts_with($filePath, '~/')) {
-            $filePath = $_SERVER['HOME'].substr($filePath, 1);
+        // Expand tilde to home directory. $_SERVER['HOME'] is unset on Windows
+        // (which uses USERPROFILE) and in some Linux CI containers, so fall back
+        // before mangling the path; if no home dir is resolvable, leave the path
+        // untouched so it falls through to the base_path() resolution below.
+        if (str_starts_with($filePath, '~/') || str_starts_with($filePath, '~\\')) {
+            $home = $_SERVER['HOME'] ?? getenv('HOME') ?: getenv('USERPROFILE');
+            if ($home) {
+                $filePath = rtrim($home, '/\\').substr($filePath, 1);
+            }
         }
 
         // Resolve relative paths relative to Laravel's base path

--- a/src/Traits/ManagesWatchman.php
+++ b/src/Traits/ManagesWatchman.php
@@ -15,10 +15,22 @@ trait ManagesWatchman
 
     /**
      * Check if Watchman is installed and available
+     *
+     * Probes both `watchman` and `watchman-wait`: startWatchman() executes
+     * watchman-wait, which is a separate pywatchman helper that some package
+     * managers (e.g. apt's watchman package) do not ship alongside watchman.
      */
     protected function isWatchmanAvailable(): bool
     {
-        $command = PHP_OS_FAMILY === 'Windows' ? 'where watchman' : 'which watchman';
+        return $this->isBinaryAvailable('watchman') && $this->isBinaryAvailable('watchman-wait');
+    }
+
+    /**
+     * Check if a binary is resolvable on the PATH
+     */
+    private function isBinaryAvailable(string $binary): bool
+    {
+        $command = PHP_OS_FAMILY === 'Windows' ? "where {$binary}" : "which {$binary}";
         $process = Process::fromShellCommandline($command);
         $process->run();
 
@@ -35,7 +47,8 @@ trait ManagesWatchman
                 'brew install watchman',
             ],
             'Linux' => [
-                'sudo apt-get install watchman',
+                'sudo apt-get install watchman python3-pywatchman',
+                '# watchman-wait is provided by python3-pywatchman (or: pip install pywatchman)',
                 '# Or build from source: https://facebook.github.io/watchman/docs/install.html',
             ],
             'Windows' => [
@@ -205,8 +218,18 @@ trait ManagesWatchman
      */
     protected function checkWatchmanDependencies(): bool
     {
+        // Windows flows use ManagesPollingWatcher; watchman is never spawned
+        if (PHP_OS_FAMILY === 'Windows') {
+            return true;
+        }
+
         if (! $this->isWatchmanAvailable()) {
-            error('Watchman is not installed.');
+            $missing = array_filter(
+                ['watchman', 'watchman-wait'],
+                fn (string $binary) => ! $this->isBinaryAvailable($binary)
+            );
+
+            error(implode(' and ', $missing).' not found. Watchman is not fully installed.');
             info('Please install Watchman to use the watch command:');
 
             foreach ($this->getWatchmanInstallInstructions() as $instruction) {

--- a/src/Traits/OpensAndroidProject.php
+++ b/src/Traits/OpensAndroidProject.php
@@ -22,11 +22,24 @@ trait OpensAndroidProject
                 $command = 'exec open -a "Android Studio" "'.$projectPath.'"';
                 Process::fromShellCommandline($command)->run();
             } elseif (PHP_OS_FAMILY === 'Windows') {
-                $command = ['cmd', '/c', 'start', '', $projectPath];
-                (new Process($command))->start();
+                // 'start' on a bare directory opens Explorer, not the IDE — resolve Studio first
+                $studio = $this->findWindowsStudioBinary();
+
+                if ($studio !== null) {
+                    $command = ['cmd', '/c', 'start', '', $studio, $projectPath];
+                } else {
+                    $this->warn('Android Studio not found; opening the project folder instead.');
+                    $command = ['cmd', '/c', 'start', '', $projectPath];
+                }
+
+                // 'start' detaches and returns immediately, so run() won't block —
+                // and Process::__destruct won't kill a still-running start()ed child
+                (new Process($command))->run();
             } else {
-                $command = [$this->findStudioBinary(), $projectPath];
-                (new Process($command))->start();
+                // Background via the shell so the IDE survives Process::__destruct's stop();
+                // studio.sh runs in the foreground, so a plain run() would block until it closes
+                $command = escapeshellarg($this->findStudioBinary()).' '.escapeshellarg($projectPath).' > /dev/null 2>&1 &';
+                Process::fromShellCommandline($command)->run();
             }
 
             $this->info('Opening Android project...');
@@ -40,5 +53,36 @@ trait OpensAndroidProject
         $whichStudio = exec('which studio');
 
         return ! empty($whichStudio) ? 'studio' : '/opt/android-studio/bin/studio.sh';
+    }
+
+    protected function findWindowsStudioBinary(): ?string
+    {
+        // Default installer locations (guard against getenv returning false)
+        $candidates = [];
+
+        if (($localAppData = getenv('LOCALAPPDATA')) !== false) {
+            $candidates[] = $localAppData.'\\Programs\\Android Studio\\bin\\studio64.exe';
+        }
+
+        $candidates[] = (getenv('ProgramFiles') ?: 'C:\\Program Files').'\\Android\\Android Studio\\bin\\studio64.exe';
+
+        foreach ($candidates as $candidate) {
+            if (is_file($candidate)) {
+                return $candidate;
+            }
+        }
+
+        // JetBrains Toolbox drops studio.cmd shims on PATH
+        foreach (['where studio 2>nul', 'where studio64 2>nul'] as $probe) {
+            $output = [];
+            exec($probe, $output);
+
+            // 'where' may list multiple matches; the first has PATH precedence
+            if (! empty($output[0])) {
+                return trim($output[0]);
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Traits/PackagesIos.php
+++ b/src/Traits/PackagesIos.php
@@ -17,6 +17,14 @@ trait PackagesIos
 
     protected function buildIos(?array $iosSigningConfig = null): void
     {
+        // Guard first: every iOS packaging path (test-upload, validate-only, full build)
+        // relies on macOS-only tooling (xcrun, xcodebuild, codesign), so fail fast off-macOS
+        if (PHP_OS_FAMILY !== 'Darwin') {
+            \Laravel\Prompts\error('iOS packaging (including App Store uploads) is only supported on macOS.');
+
+            return;
+        }
+
         // If test-upload flag is set, just test upload without building
         if ($this->option('test-upload')) {
             $this->testAppStoreUpload();
@@ -29,12 +37,6 @@ trait PackagesIos
         if (! is_dir($iosPath)) {
             \Laravel\Prompts\error('No iOS project found at [nativephp/ios].');
             \Laravel\Prompts\note('Run `php artisan native:install` first.');
-
-            return;
-        }
-
-        if (PHP_OS_FAMILY !== 'Darwin') {
-            \Laravel\Prompts\error('iOS builds are only supported on macOS.');
 
             return;
         }

--- a/src/Traits/PlatformFileOperations.php
+++ b/src/Traits/PlatformFileOperations.php
@@ -12,12 +12,33 @@ trait PlatformFileOperations
     protected function platformOptimizedCopy(string $source, string $destination, array $excludedDirs = []): void
     {
         if (PHP_OS_FAMILY === 'Windows') {
+            // Normalize separators: robocopy/xcopy path matching requires backslashes,
+            // but callers build paths with forward slashes (base_path('foo/bar'))
+            $source = str_replace('/', '\\', $source);
+            $destination = str_replace('/', '\\', $destination);
+
             // Use robocopy on Windows
             if (! empty($excludedDirs)) {
                 $excludeArgs = '';
                 foreach ($excludedDirs as $dir) {
-                    $excludeArgs .= " /XD \"{$source}\\{$dir}\"";
+                    $dir = str_replace('/', '\\', $dir);
+                    $full = "{$source}\\{$dir}";
+                    // /XD only excludes directories; files need /XF (e.g. storage/logs/laravel.log)
+                    $excludeArgs .= is_file($full) ? " /XF \"{$full}\"" : " /XD \"{$full}\"";
                 }
+
+                // Mirror the Unix branch's nested-vendor exclusions: robocopy follows
+                // directory junctions (composer path-repos), and /XD can't express
+                // multi-level wildcards, so expand 'vendor/*/vendor' at PHP level
+                $excludeArgs .= " /XD \"{$source}\\vendor\\nativephp\\mobile\\vendor\"";
+                foreach (glob($source.'/vendor/*/vendor', GLOB_ONLYDIR) ?: [] as $nested) {
+                    $excludeArgs .= ' /XD "'.str_replace('/', '\\', $nested).'"';
+                }
+
+                // Bare names match at any depth (parity with rsync's anywhere-matching
+                // patterns) — keeps a path-repo junction's .git/node_modules out too
+                $excludeArgs .= ' /XD .git /XD node_modules';
+
                 $cmd = "robocopy \"{$source}\" \"{$destination}\" /MIR /NFL /NDL /NJH /NJS /NP /R:0 /W:0{$excludeArgs}";
             } else {
                 $cmd = "xcopy \"{$source}\\*\" \"{$destination}\\\" /E /I /Y /Q";
@@ -28,6 +49,8 @@ trait PlatformFileOperations
             // Robocopy returns 0-7 as success codes
             if ($result >= 8 && strpos($cmd, 'robocopy') !== false) {
                 $this->components->warn("robocopy failed with exit code $result");
+            } elseif ($result !== 0 && strpos($cmd, 'xcopy') !== false) {
+                throw new \RuntimeException("File copy failed (exit code {$result}): {$cmd}");
             }
         } else {
             // Use rsync on Unix-like systems
@@ -40,7 +63,14 @@ trait PlatformFileOperations
             } else {
                 $cmd = "cp -a \"{$source}/.\" \"{$destination}/\"";
             }
-            exec($cmd);
+            exec($cmd, $output, $result);
+
+            if ($result !== 0) {
+                throw new \RuntimeException(
+                    "File copy failed (exit code {$result}): {$cmd}\n".
+                    'On Linux, ensure rsync is installed (e.g. `apt-get install rsync` or `apk add rsync`).'
+                );
+            }
         }
     }
 

--- a/src/Traits/PreparesBuild.php
+++ b/src/Traits/PreparesBuild.php
@@ -208,9 +208,21 @@ trait PreparesBuild
         $this->logToFile("  Source: $source");
         $this->logToFile("  Destination: $destinationZip");
 
-        $tempDir = PHP_OS_FAMILY === 'Windows'
-            ? 'C:\\temp\\'.time()
-            : base_path('nativephp/android/laravel');
+        if (PHP_OS_FAMILY === 'Windows') {
+            // Derive the drive from the environment rather than assuming C:, and
+            // probe writability up front — File::ensureDirectoryExists() below
+            // throws (rather than returning false) when the drive root's ACL is
+            // locked down, so a fallback after the fact would never fire.
+            $tempBase = (getenv('SystemDrive') ?: 'C:').'\\temp';
+            if (! is_dir($tempBase) && ! @mkdir($tempBase, 0755, true)) {
+                // Root ACL locked down or drive missing — use the user's temp dir
+                // instead (still short enough to avoid MAX_PATH in practice)
+                $tempBase = rtrim(sys_get_temp_dir(), '\\/').DIRECTORY_SEPARATOR.'nativephp';
+            }
+            $tempDir = $tempBase.DIRECTORY_SEPARATOR.time();
+        } else {
+            $tempDir = base_path('nativephp/android/laravel');
+        }
 
         $this->logToFile("  Temp directory: $tempDir");
 
@@ -361,7 +373,56 @@ trait PreparesBuild
                 exit(1);
             }
 
-            $cmd = "\"$sevenZip\" a -tzip \"$destination\" \"$source\\*\" -xr!node_modules";
+            // Pre-create the runtime dirs Laravel needs at boot so they land in
+            // the archive — 7-Zip stores empty dirs matched by "$source\*",
+            // mirroring the addEmptyDir() guarantee of the ZipArchive branch
+            $requiredDirs = [
+                'bootstrap/cache',
+                'storage/framework/cache',
+                'storage/framework/sessions',
+                'storage/framework/views',
+            ];
+
+            foreach ($requiredDirs as $dir) {
+                File::ensureDirectoryExists($source.DIRECTORY_SEPARATOR.str_replace('/', '\\', $dir));
+            }
+
+            // Mirror the exclusions applied by addDirectoryToZip() on macOS/Linux.
+            // The robocopy /XD exclusions in platformOptimizedCopy remain the first
+            // line of defense, but /XD is directory-only — the zip-level *.jks and
+            // laravel.log patterns here are what keep keystores and logs out of
+            // the publicly distributed bundle.
+            $patterns = [
+                // Recursive name/extension matches (any depth)
+                '-xr!node_modules',
+                '-xr!*.jks',
+                '-xr!*.zip',
+                '-xr!.idea',
+                // Root-anchored paths (-x! matches relative to the scan root,
+                // preserving the Str::startsWith semantics of the unix branch)
+                '-x!output',
+                '-x!public\\storage',
+                '-x!storage\\app\\native-build',
+                '-x!storage\\logs\\laravel.log',
+                '-x!vendor\\endroid',
+                '-x!vendor\\nativephp\\mobile\\resources',
+                '-x!vendor\\nativephp\\mobile\\vendor',
+                // Keep the runtime dirs themselves but drop their cached contents
+                '-x!bootstrap\\cache\\*',
+                '-x!storage\\framework\\cache\\*',
+                '-x!storage\\framework\\sessions\\*',
+                '-x!storage\\framework\\views\\*',
+            ];
+
+            // Honor the configured exclusions for parity with the unix branch
+            // (entries containing * pass through as 7-Zip wildcards)
+            foreach ($excludedDirs as $dir) {
+                $patterns[] = '-x!'.str_replace('/', '\\', rtrim($dir, '/'));
+            }
+
+            $excludeFlags = implode(' ', array_map(fn ($p) => '"'.$p.'"', $patterns));
+
+            $cmd = "\"$sevenZip\" a -tzip \"$destination\" \"$source\\*\" $excludeFlags";
             exec($cmd, $output, $code);
 
             if ($code !== 0) {
@@ -504,22 +565,15 @@ trait PreparesBuild
 
         $this->components->twoColumnDetail('Running Gradle', $gradleTask);
 
-        // Also pass signing properties as system properties for extra reliability
-        $extraArgs = '';
-        if ($signingConfig) {
-            $extraArgs = sprintf(
-                ' -PMYAPP_UPLOAD_STORE_FILE="%s" -PMYAPP_UPLOAD_KEY_ALIAS="%s" -PMYAPP_UPLOAD_STORE_PASSWORD="%s" -PMYAPP_UPLOAD_KEY_PASSWORD="%s"',
-                str_replace('\\', '/', $signingConfig['keystore']),
-                $signingConfig['keyAlias'],
-                $signingConfig['keystorePassword'],
-                $signingConfig['keyPassword']
-            );
-        }
+        // Signing properties are read by Gradle from gradle.properties (written by
+        // applySigningConfiguration above) with no shell involvement. Passing them
+        // as -P args on the command line would run passwords through sh/cmd, where
+        // $, backticks, " and %VAR% sequences get expanded or mangled.
 
         $buildSuccessful = false;
 
         if (PHP_OS_FAMILY === 'Windows') {
-            $cmd = "cd /d \"$androidPath\" && $gradleWrapper $gradleTask$extraArgs";
+            $cmd = "cd /d \"$androidPath\" && $gradleWrapper $gradleTask";
             $exitCode = 0;
             passthru($cmd, $exitCode);
             $buildSuccessful = ($exitCode === 0);
@@ -531,7 +585,7 @@ trait PreparesBuild
                 $process->tty();
             }
 
-            $result = $process->run("$gradleWrapper $gradleTask$extraArgs");
+            $result = $process->run("$gradleWrapper $gradleTask");
 
             if (! $result->successful()) {
                 \Laravel\Prompts\error('Gradle build failed');
@@ -580,9 +634,11 @@ trait PreparesBuild
             return;
         }
 
-        // Use jarsigner to verify the signature
+        // Use jarsigner to verify the signature. shell_exec() returns null
+        // when jarsigner isn't on PATH (common on Windows) — treat that as
+        // "couldn't verify" rather than feeding null to str_contains().
         $verifyCmd = sprintf('jarsigner -verify -verbose %s 2>&1', escapeshellarg($outputPath));
-        $verifyOutput = shell_exec($verifyCmd);
+        $verifyOutput = shell_exec($verifyCmd) ?? '';
 
         if (str_contains($verifyOutput, 'jar is unsigned')) {
             \Laravel\Prompts\warning('Build output is unsigned - this will be rejected by Google Play Console');

--- a/src/Traits/RunsAndroid.php
+++ b/src/Traits/RunsAndroid.php
@@ -490,7 +490,8 @@ XML;
             $process = Process::path($androidPath)
                 ->timeout(600);
 
-            if (! $this->option('no-tty')) {
+            // TTY needs a real terminal; Symfony throws on Docker/CI/piped output
+            if (! $this->option('no-tty') && SymfonyProcess::isTtySupported()) {
                 $process->tty();
             }
 
@@ -668,7 +669,10 @@ XML;
             exit(1);
         }
 
-        $avds = array_filter(explode("\n", trim($listProcess->getOutput())));
+        // Trim each line: emulator.exe emits CRLF on Windows, and a stray \r in
+        // an AVD name breaks the launch command. array_values keeps a list so
+        // select() returns the name, not an integer key.
+        $avds = array_values(array_filter(array_map('trim', explode("\n", $listProcess->getOutput()))));
 
         if (empty($avds)) {
             error('No AVDs found.');

--- a/src/Traits/RunsIos.php
+++ b/src/Traits/RunsIos.php
@@ -92,6 +92,16 @@ trait RunsIos
 
     public function runIos(): void
     {
+        // iOS builds require the Xcode toolchain (xcrun, simctl, devicectl),
+        // so bail out early with a clear message on Windows/Linux instead of
+        // failing cryptically once xcrun is invoked.
+        if (PHP_OS_FAMILY !== 'Darwin') {
+            error('iOS apps can only be built and run on macOS.');
+            note('Use `php artisan native:run android` on this machine.');
+
+            return;
+        }
+
         $this->watching = $this->option('watch');
 
         $this->iosLogPath = base_path($this->iosLogPath);

--- a/src/Traits/WatchesAndroid.php
+++ b/src/Traits/WatchesAndroid.php
@@ -385,11 +385,12 @@ trait WatchesAndroid
 
         // Convert relative paths to absolute paths
         return array_map(function ($path) {
-            if (! str_starts_with($path, '/')) {
-                return base_path($path);
-            }
+            // Recognize Unix, Windows drive-letter (C:\ or C:/), and UNC (\\server) absolute paths
+            $isAbsolute = str_starts_with($path, '/')
+                || preg_match('/^[A-Za-z]:[\\\\\\/]/', $path) === 1
+                || str_starts_with($path, '\\\\');
 
-            return $path;
+            return $isAbsolute ? $path : base_path($path);
         }, $paths);
     }
 

--- a/src/Traits/WatchesIos.php
+++ b/src/Traits/WatchesIos.php
@@ -25,6 +25,15 @@ trait WatchesIos
 
     protected function startIosHotReload(?string $target = null): void
     {
+        // Everything here depends on macOS-only tooling (xcrun simctl/devicectl,
+        // iproxy, lsof), so bail out early with a clear message on Windows/Linux
+        // instead of failing cryptically once device discovery runs xcrun.
+        if (PHP_OS_FAMILY !== 'Darwin') {
+            $this->error('iOS hot reload requires macOS with Xcode command line tools. Use `php artisan native:watch android` on this platform.');
+
+            return;
+        }
+
         $this->line('');
         $this->info('Starting iOS hot reload...');
 

--- a/src/Validation/RouteAnalyzer.php
+++ b/src/Validation/RouteAnalyzer.php
@@ -131,7 +131,10 @@ class RouteAnalyzer
 
     protected function relativePath(string $path): string
     {
-        $base = base_path().'/';
+        // Normalize to forward slashes so the base-path prefix strips on
+        // Windows too (base_path() returns backslashes there).
+        $path = str_replace('\\', '/', $path);
+        $base = str_replace('\\', '/', base_path()).'/';
 
         return str_starts_with($path, $base) ? substr($path, strlen($base)) : $path;
     }

--- a/src/jump_bridge_functions.php
+++ b/src/jump_bridge_functions.php
@@ -92,6 +92,7 @@ if (! function_exists('nativephp_element_wait_event')) {
         }
 
         static $consecutiveErrors = 0;
+        static $firstErrorAt = 0.0;
 
         $result = JumpBridge::instance()->call('Element.WaitEvent', json_encode(['timeout' => $timeoutMs]));
 
@@ -102,7 +103,24 @@ if (! function_exists('nativephp_element_wait_event')) {
 
         $decoded = json_decode($result, true);
 
-        if (! is_array($decoded) || (isset($decoded['status']) && $decoded['status'] === 'error')) {
+        // Two DIFFERENT rejection shapes reach us and both must count as errors:
+        //   JumpBridge::call() itself  → {"status":"error","code":"NO_DEVICE",…}
+        //   websocket-server.php       → {"id":…,"error":"No device connected"}
+        // Only the first was ever matched here, so a device that vanished mid
+        // session fell through to the success path below, reset the counter, and
+        // got returned to the runloop as a bogus type-less "event". The give-up
+        // branch could therefore never fire: the orphaned runloop spun forever,
+        // pinning its artisan-serve worker. On macOS php -S forks a pool so that
+        // just leaked one worker at a time; on Windows `forking is not supported`
+        // means there is exactly ONE worker, so the first orphan deadlocked the
+        // whole dev server — no later scan could ever be served. A real event
+        // always carries `type`, so require its absence before treating an
+        // `error` key as a failure.
+        $isBridgeError = ! is_array($decoded)
+            || (isset($decoded['status']) && $decoded['status'] === 'error')
+            || (isset($decoded['error']) && ! isset($decoded['type']));
+
+        if ($isBridgeError) {
             // Bridge error — almost always the device WebSocket briefly
             // dropped (app backgrounded, Wi-Fi blip, dev-server reconnect).
             // The iOS / Android client auto-reconnects within ~2s, so this
@@ -117,19 +135,25 @@ if (! function_exists('nativephp_element_wait_event')) {
             // a long *continuous* outage so a genuinely-gone device doesn't
             // pin an artisan-serve worker forever.
             $consecutiveErrors++;
+            $firstErrorAt = $firstErrorAt ?: microtime(true);
             usleep(200_000); // 200ms — throttle the spin while disconnected
-            // The client auto-reconnects within ~2s (≈10 ticks), so ride
-            // out short outages. But the runloop is holding the GET /
-            // request open on the single-threaded `php -S` server the whole
-            // time it spins here — so if the device is genuinely gone we
-            // must give up fairly quickly and let the runloop return,
-            // freeing the worker. Otherwise a dropped session pins the
-            // server and every later scan / re-scan just hangs (which is
-            // exactly the "restart jump, same thing again" loop). ~8s is a
-            // comfortable margin over the 2s reconnect without locking the
-            // server up for long.
-            if ($consecutiveErrors >= 40) { // ~8s of unbroken failure
+            // The client auto-reconnects within ~2s, so ride out short outages.
+            // But the runloop holds the GET / request open on a single-threaded
+            // `php -S` worker the whole time it spins here — so if the device is
+            // genuinely gone we must give up and let the runloop return, freeing
+            // the worker. Otherwise a dropped session pins the server and every
+            // later scan / re-scan hangs (the "restart jump, same thing again"
+            // loop). 8s is a comfortable margin over the 2s reconnect.
+            //
+            // Measured in WALL TIME, not tick count: websocket-server.php
+            // deliberately delays each rejection ~1s to stop an orphaned runloop
+            // saturating its event loop, so a 40-tick budget was really ~48s on
+            // that path while the immediate NO_DEVICE path (no server round trip)
+            // hit it in ~8s. Timing the outage makes the budget mean the same
+            // thing regardless of which rejection path we're on.
+            if (microtime(true) - $firstErrorAt >= 8.0) {
                 $consecutiveErrors = 0;
+                $firstErrorAt = 0.0;
 
                 return ['type' => 8, 'callback_id' => 0, 'node_id' => 0];
             }
@@ -139,6 +163,7 @@ if (! function_exists('nativephp_element_wait_event')) {
 
         // Reset on success
         $consecutiveErrors = 0;
+        $firstErrorAt = 0.0;
 
         // Hot reload (EVENT_HOT_RELOAD = 15): PASS IT THROUGH to the runloop
         // instead of handling in-place. A long-running runloop can't re-render

--- a/tests/Unit/JumpOwnershipTest.php
+++ b/tests/Unit/JumpOwnershipTest.php
@@ -34,7 +34,7 @@ it('owns Workerman workers carrying the Jump prefix despite the rewritten proces
 });
 
 it('owns our artisan serve (spawned with --no-reload) but not a plain one', function () {
-    expect(isJumpOwned("php artisan serve --port=8000 --host=127.0.0.1 --no-interaction --no-reload", 42))->toBeTrue()
+    expect(isJumpOwned('php artisan serve --port=8000 --host=127.0.0.1 --no-interaction --no-reload', 42))->toBeTrue()
         ->and(isJumpOwned('php artisan serve --port=8000', 42))->toBeFalse();
 });
 

--- a/tests/Unit/JumpOwnershipTest.php
+++ b/tests/Unit/JumpOwnershipTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Native\Mobile\Commands\JumpCommand;
+
+/**
+ * isJumpOwnedProcess() is the identity gate for every kill in teardown — a
+ * wrong `true` executes an innocent process, a wrong `false` strands ports
+ * (the ppid===1 regression left the whole PHP_CLI_SERVER_WORKERS pool holding
+ * 8000 on every shutdown). Pin the command-line classification here.
+ *
+ * The JUMP_BRIDGE_PORT environment branch needs a live process to read the
+ * env of (ps -Ewww / /proc), so it is exercised by the end-to-end flow, not
+ * here; pid=0 skips it, which is also the safe default the method must keep.
+ */
+function isJumpOwned(string $command, int $ppid, int $pid = 0): bool
+{
+    $method = new ReflectionMethod(JumpCommand::class, 'isJumpOwnedProcess');
+
+    return $method->invoke(new JumpCommand, $command, $ppid, $pid);
+}
+
+it('owns the jump router and bridge scripts', function (string $command) {
+    expect(isJumpOwned($command, 42))->toBeTrue();
+})->with([
+    'router' => 'php -S 0.0.0.0:3000 /app/vendor/nativephp/mobile/resources/jump/router.php',
+    'bridge' => 'php /app/vendor/nativephp/mobile/resources/jump/websocket-server.php /app 3001 3002 3003 start',
+    'mdns advertiser' => '/usr/bin/dns-sd -R native _jump._tcp local 3000 host=192.168.1.10',
+]);
+
+it('owns Workerman workers carrying the Jump prefix despite the rewritten process title', function () {
+    expect(isJumpOwned('WorkerMan: worker process JumpBridge websocket://0.0.0.0:3001', 1))->toBeTrue()
+        ->and(isJumpOwned('WorkerMan: worker process JumpViteProxy websocket://0.0.0.0:3003', 1))->toBeTrue()
+        ->and(isJumpOwned('WorkerMan: worker process SomeoneElses websocket://0.0.0.0:9000', 1))->toBeFalse();
+});
+
+it('owns our artisan serve (spawned with --no-reload) but not a plain one', function () {
+    expect(isJumpOwned("php artisan serve --port=8000 --host=127.0.0.1 --no-interaction --no-reload", 42))->toBeTrue()
+        ->and(isJumpOwned('php artisan serve --port=8000', 42))->toBeFalse();
+});
+
+it('owns an orphaned loopback php -S server.php as the no-env fallback only', function () {
+    $worker = '/usr/bin/php84 -S 127.0.0.1:8000 /app/vendor/laravel/framework/src/Illuminate/Foundation/resources/server.php';
+
+    // Orphaned to init: recognisable even without reading its environment.
+    expect(isJumpOwned($worker, 1))->toBeTrue();
+
+    // Parented (the PHP_CLI_SERVER_WORKERS pool shape) with NO pid to read the
+    // environment from: must stay false — never kill on the command line alone,
+    // it is identical for a user's own artisan serve.
+    expect(isJumpOwned($worker, 4419))->toBeFalse();
+});
+
+it('never owns unrelated processes', function (string $command) {
+    expect(isJumpOwned($command, 1))->toBeFalse();
+})->with([
+    'random server' => 'node /usr/local/bin/vite --port 3000',
+    'docker proxy' => '/usr/bin/docker-proxy -proto tcp -host-port 8000',
+    'boost mcp' => 'php artisan boost:mcp',
+]);


### PR DESCRIPTION
## Summary

Full compatibility sweep of every artisan command (27), trait (25), and supporting class (plugin compilers, `FileWatcher`, `BundleFileManager`) for Windows and Linux. Platform policy applied throughout:

- **iOS-toolchain code paths** (xcodebuild, simctl, CocoaPods…) fail fast with a clear *requires macOS* error instead of running halfway and dying cryptically
- **Everything Android-side and generic** (install, run, watch, emulator, credentials, plugin:*, make:*, validate, jump…) now genuinely works on Windows and Linux (incl. WSL)

Produced by a 154-agent audit→adversarial-verify→fix pipeline: 64 raw findings, 55 confirmed (9 refuted as false positives), plus 4 gaps caught by a completeness critic.

## By category

| Category | Fixes |
|---|---|
| Missing macOS guards | `build:ios` early guard; `emulator --os=ios` clean error; iOS packaging guard moved before test-upload/validate paths; iOS omitted from `watch` select off-mac |
| cmd.exe compatibility | `gradlew.bat` resolution; `2>/dev/null` → portable redirection; `start "" "url"` quoting; platform-branched env-var hints (`$env:X=…` vs `X=… cmd`) |
| `jump` on Windows | file-descriptor logging instead of wedging proc_open pipes; project-scoped process reaping via WQL (can't kill unrelated `php -S` servers); `dns-sd` resolved via `where`; WSL2 NAT reachability warning |
| Linux | `xdg-open` availability probe with URL fallback; `lsof` → `ss -ltnpH` fallback; real Android Studio paths (/opt, JetBrains Toolbox, Snap); WSL opens output dirs via `wslpath` + `explorer.exe` |
| Environment/paths | USERPROFILE-aware home resolution; CRLF-safe `.env` editing; backslash-safe relative-path display |
| Robustness | `native:install` errors early with instructions when ext-zip missing (before the multi-MB download); absent `jarsigner` no longer feeds `null` to `str_contains`; removed broken `-P` signing args (gradle.properties already carries them — also fixed a latent macOS bug) |

## Deliberate behavior changes

1. `platformOptimizedCopy` (Unix) now **throws on nonzero rsync exit** — partial transfers used to pass silently into broken builds
2. robocopy branch always excludes `.git`/`node_modules` (Windows junction safety); Unix still excludes only caller-supplied dirs

## Test plan

- [x] Full suite green: 616 passed (2056 assertions)
- [x] Pint + PHPStan clean, `composer validate` OK
- [x] Every changed file passes `php -l`
- [ ] Manual smoke test on Windows/Linux (@shane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)