### PR TITLE
fix: keep rapid tab re-taps from reverting to a stale slow render

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootTabsRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootTabsRenderer.kt
@@ -112,10 +112,51 @@ fun NativeRootTabsRenderer(node: NativeUINode, modifier: Modifier = Modifier) {
     // Activeness flows from `BottomNavItem.active` (TabBar::highlight() set it).
     val activeTabIdx = tabs.indexOfFirst { it.props.getBool("active") }.coerceAtLeast(0)
 
+    // Stable per-tab identity for the in-flight-navigation trackers below —
+    // FlatBuffer node ids regenerate every publish, so use the PHP-side slug.
+    val tabIds = tabs.mapIndexed { idx, tab ->
+        tab.props.getString("id", "").ifEmpty { "tab_$idx" }
+    }
+    val activeTabId = tabIds.getOrElse(activeTabIdx) { "" }
+
     // Local selection mirrors PHP's active flag, but also responds to taps so
     // the bar UI updates instantly while we wait for PHP to republish.
     var selection by remember { mutableIntStateOf(activeTabIdx) }
+
+    // Rapid re-tap trackers, mirroring iOS's NativeRootTabsRenderer (see
+    // "Rapid re-taps" in its header comment). Tab navigations aren't
+    // cancellable PHP-side, so a tap sequence Home → Contacts (slow render) →
+    // Home used to settle on Contacts: the Home re-tap was swallowed
+    // (selection == active tab) and the late Contacts publish then yanked
+    // `selection` back. `pendingTabId` is the user's latest tap while its
+    // `replace` navigation is in flight; tabs it displaced go in
+    // `supersededTabIds`, whose late publishes must not move `selection`.
+    // (The content pane still keys off `activeTabIdx`, so it can show the
+    // superseded screen for the beat until the re-fired press republishes —
+    // Android keeps no per-tab tree cache to hold the selected tab's content.)
+    var pendingTabId by remember { mutableStateOf<String?>(null) }
+    val supersededTabIds = remember { mutableSetOf<String>() }
+
     LaunchedEffect(activeTabIdx) {
+        val pending = pendingTabId
+        if (pending != null && activeTabId != pending) {
+            val pendingTab = tabs.getOrNull(tabIds.indexOf(pending))
+            if (supersededTabIds.contains(activeTabId) && pendingTab != null && pendingTab.onPress != 0) {
+                // Stale publish: a navigation the user superseded by tapping
+                // again finished late. Hold `selection` where the user put it
+                // and re-fire the pending tab's press — the tap-time press
+                // carried the previous tree's callback id, which the component
+                // that just published doesn't own, so PHP dropped it. This
+                // tree's id is live.
+                NativeElementBridge.sendPressEvent(pendingTab.onPress, pendingTab.id)
+                return@LaunchedEffect
+            }
+            // Unrelated navigation won the race (programmatic replace,
+            // mount() redirect, or the pending tab left the layout) — accept
+            // the publish as authoritative.
+        }
+        pendingTabId = null
+        supersededTabIds.clear()
         if (selection != activeTabIdx) selection = activeTabIdx
     }
 
@@ -296,9 +337,22 @@ fun NativeRootTabsRenderer(node: NativeUINode, modifier: Modifier = Modifier) {
                                 // navigation fires (it's an iOS-/Android-
                                 // side overlay). For regular tabs, the
                                 // BottomNavItem-auto-wired `replace`
-                                // press handler fires here.
+                                // press handler fires here. A tap back
+                                // to the active tab normally needs no
+                                // press — except while another tab's
+                                // navigation is in flight: PHP is
+                                // already navigating away and must be
+                                // told to come back.
                                 selection = actualIdx
-                                if (!isSearchTab && actualIdx != activeTabIdx && tab.onPress != 0) {
+                                val tapNavigates = actualIdx != activeTabIdx || pendingTabId != null
+                                if (!isSearchTab && tapNavigates && tab.onPress != 0) {
+                                    if (tab.props.getString("url", "").isNotEmpty()) {
+                                        val tappedId = tabIds.getOrElse(actualIdx) { "" }
+                                        pendingTabId?.let { prev ->
+                                            if (prev != tappedId) supersededTabIds.add(prev)
+                                        }
+                                        pendingTabId = tappedId
+                                    }
                                     NativeElementBridge.sendPressEvent(tab.onPress, tab.id)
                                 }
                             },

--- a/resources/xcode/NativePHP/NativeRender/NativeRootTabsRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeRootTabsRenderer.swift
@@ -26,6 +26,25 @@ import SwiftUI
 ///     publish flow → activeTabIdx changes → set `selection` → SwiftUI
 ///     animates the swap. We don't fire press (already at activeTabIdx).
 ///
+/// **Rapid re-taps (stale publish suppression).** Tab navigations aren't
+/// cancellable PHP-side: once a tap's `replace` starts rendering, the
+/// runloop publishes that screen no matter what the user taps meanwhile.
+/// So a tap sequence Home → Contacts (slow) → Home used to end up on
+/// Contacts: the Home re-tap was swallowed (selection == owning tab),
+/// and the late Contacts publish then yanked `selection` back. Tracked
+/// intent fixes both halves:
+///   - `pendingTabId` records the user's latest tab tap while its
+///     navigation is in flight; tabs it displaced go in
+///     `supersededTabIds`.
+///   - A publish for a superseded tab is stale: don't sync `selection`
+///     to it. The user's re-tap press was sent against a tree whose
+///     component had already exited, so PHP dropped its callback id —
+///     re-fire the pending tab's press with THIS publish's fresh id and
+///     wait for the next publish instead.
+///   - A publish for the pending tab (or any unrelated URI — e.g. a
+///     mount() redirect) settles the race: clear the trackers and sync
+///     selection as before.
+///
 /// **Three-tier appearance** (matches NavigationStack):
 ///   - No `background_color` → defaults; on iOS 26+ Liquid Glass.
 ///   - `background_color` set → `.toolbarBackground(.visible, .tabBar)`
@@ -42,6 +61,16 @@ struct NativeRootTabsRenderer: View {
     // stable across publishes for the same tab.
     @State private var selection: String = ""
     @StateObject private var tabBag = TabCoordinatorBag()
+
+    /// The tab the user most recently tapped, while its `replace`
+    /// navigation is still in flight PHP-side. Cleared when a publish
+    /// settles the race (see "Rapid re-taps" in the header comment).
+    @State private var pendingTabId: String?
+
+    /// Tabs whose in-flight navigation the user superseded by tapping
+    /// another tab before the publish landed. A publish for one of these
+    /// is stale — it must not move `selection`.
+    @State private var supersededTabIds: Set<String> = []
 
     var body: some View {
         let tabs = node.children.filter { $0.type == "bottom_nav_item" }
@@ -247,6 +276,26 @@ struct NativeRootTabsRenderer: View {
         .onChange(of: owningId) { newId in
             // PHP-driven owning-tab change (publish landed under a
             // different tab's URL prefix) — sync our SwiftUI selection.
+            if let pending = pendingTabId, newId != pending {
+                if supersededTabIds.contains(newId),
+                   let tab = tabs.first(where: { $0.props.getString("id", default: "") == pending }),
+                   tab.onPress != 0 {
+                    // Stale publish: a navigation the user superseded by
+                    // tapping again finished late. Hold `selection` where
+                    // the user put it, and re-fire the pending tab's
+                    // press — the tap-time press carried the previous
+                    // tree's callback id, which the component that just
+                    // published doesn't own, so PHP dropped it. This
+                    // tree's id is live.
+                    NativeElementBridge.sendPressEvent(tab.onPress, nodeId: tab.id)
+                    return
+                }
+                // Unrelated navigation won the race (programmatic
+                // replace, mount() redirect, or the pending tab left
+                // the layout) — accept the publish as authoritative.
+            }
+            pendingTabId = nil
+            supersededTabIds.removeAll()
             if selection != newId {
                 selection = newId
             }
@@ -272,27 +321,42 @@ struct NativeRootTabsRenderer: View {
         }
         .onChange(of: selection) { newId in
             // User tapped a tab — fire its press handler so PHP runs
-            // the BottomNavItem-auto-wired `replace` navigation. We
-            // don't fire when selection already matches the owning tab
-            // (PHP-driven sync path).
-            guard newId != owningId else { return }
+            // the BottomNavItem-auto-wired `replace` navigation. Skip
+            // only the PHP-driven sync echo (we just set selection to
+            // match a publish and nothing is in flight). A tap BACK to
+            // the owning tab while a navigation IS in flight is a real
+            // user action: PHP is already navigating away, so it must
+            // be told to come back.
+            if newId == owningId && pendingTabId == nil { return }
             guard let tab = tabs.first(where: { $0.props.getString("id", default: "") == newId }) else { return }
+            let url = tab.props.getString("url", default: "")
+            let isSearch = tab.props.getBool("search")
             if tab.onPress != 0 {
+                // URL-backed tabs navigate — record the user's latest
+                // intent so the publish handler can tell the pending
+                // navigation's publish from a superseded one arriving
+                // late (see "Rapid re-taps" in the header comment).
+                if !url.isEmpty && !isSearch {
+                    if let prev = pendingTabId, prev != newId {
+                        supersededTabIds.insert(prev)
+                    }
+                    pendingTabId = newId
+                }
                 NativeElementBridge.sendPressEvent(tab.onPress, nodeId: tab.id)
             }
             // Action-only tab (no URL, no press handler) — the press
             // fires something off-screen instead of navigating, so PHP
             // won't republish to switch the owning tab. Snap selection
-            // back to the actual owning tab so the visible "selected"
-            // indicator doesn't get stuck. Search-role tabs also have
-            // `on_press == 0` (they're iOS-owned, no PHP destination)
-            // but should keep selection on themselves while the user
-            // interacts with the search UI — we skip snap-back for them.
-            let url = tab.props.getString("url", default: "")
-            let isSearch = tab.props.getBool("search")
+            // back so the visible "selected" indicator doesn't get
+            // stuck: to the pending tab when a navigation is in flight
+            // (that's where the user is headed), else to the owning
+            // tab. Search-role tabs also have `on_press == 0` (they're
+            // iOS-owned, no PHP destination) but should keep selection
+            // on themselves while the user interacts with the search
+            // UI — we skip snap-back for them.
             if url.isEmpty && !isSearch {
                 DispatchQueue.main.async {
-                    selection = owningId
+                    selection = pendingTabId ?? owningId
                 }
             }
         }


### PR DESCRIPTION
## The bug

On iOS (and Android — same logic, same race), rapidly switching bottom-nav tabs while a slow screen is still rendering ends on the wrong tab. Repro: on Home, tap Contacts (slow to render), then quickly tap Home again. The bar and screen follow the taps, but ~half a second later the app reverts to Contacts — and stays there.

## Why it happens

The second tap is lost twice over, and the late publish then wins:

1. **The renderer swallows the re-tap.** The `newId != owningId` guard (iOS) / `actualIdx != activeTabIdx` guard (Android) exists to skip the PHP-driven sync echo, but it can't tell that apart from a genuine tap back to the tab PHP still reports as active — so no press is sent while the first navigation is in flight.
2. **PHP would have dropped it anyway.** Callback IDs live in per-component registries; by tap time the Home component has already exited, so its tree's callback ID resolves to null in the Contacts component and `dispatch()` drops the event by design.
3. **The stale publish yanks selection back.** Tab navigations aren't cancellable PHP-side — the runloop publishes at the top of its iteration before it can see the queued next event — so the Contacts tree always lands, and the unconditional selection sync (`onChange(of: owningId)` / `LaunchedEffect(activeTabIdx)`) reverts the UI to it. Since PHP never learned about the Home tap, the wrong state is stable.

## The fix

Both tabs renderers now track user intent instead of trusting every publish:

- `pendingTabId` records the user's latest tab tap while its `replace` navigation is in flight; tabs it displaced go into `supersededTabIds`.
- A tap back to the still-owning tab is no longer swallowed when a navigation is pending — PHP is navigating away and must be told to come back.
- A publish for a **superseded** tab no longer moves selection. The renderer instead re-fires the pending tab's press using that fresh tree's callback ID — the one ID the just-published component actually owns — so PHP navigates on to where the user really is and the next publish settles the race.
- A publish for the pending tab, or for any unrelated URI (programmatic `replace()`, `mount()` redirect), clears the trackers and syncs exactly as before — redirects still win, and the trackers can't wedge: any settling publish resets them.

Net effect: Home → Contacts → Home stays on Home (the stale Contacts publish just warms its tab cache invisibly), and A → B → A sequences settle on A with no extra render. Multi-tab ping-pong converges to the last tap.

## Notes

- Android caveat (documented in a comment): its content pane keys off PHP's active tab and there's no per-tab tree cache, so during the brief re-fire window the bar holds the user's choice while the content can show the stale screen for a beat. iOS renders each tab from its own cached tree, so it holds both.
- The WebView + UIKit bottom-nav path is unaffected on purpose — Inertia/WKWebView cancel superseded loads themselves, which is consistent with the symptom only appearing on native EDGE screens.
- Renderer-only change; no PHP, wire-format, or event-queue changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)