### PR TITLE
fix: iOS hot reload dropped in native-direct boots

### DIFF
--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -358,7 +358,6 @@ struct WebView: UIViewRepresentable {
         let logger = ConsoleLogger()
         var webView: WKWebView?
         var hasCompletedInitialLoad = false
-        private var reloadInProgress = false
 
         func webView(_ webView: WKWebView,
                      decidePolicyFor navigationAction: WKNavigationAction,
@@ -546,137 +545,6 @@ struct WebView: UIViewRepresentable {
             }
         }
 
-        @objc func reloadWebView() {
-            // Guard against rapid-fire file change events (file + directory)
-            // triggering concurrent reboots that race on php_embed_shutdown.
-            guard !reloadInProgress else { return }
-            reloadInProgress = true
-
-            let isNativeUI = NativeUIBridge.shared.isActive
-            // Capture current route for native UI re-execution
-            let currentPath = self.webView?.url?.path ?? NativePHPApp.getStartURL()
-
-            if isNativeUI {
-                // Show the "Reloading…" overlay (ContentView watches this).
-                // Cleared in `NativeElementBridge.postTreeUpdateFromRegion`
-                // when the first new tree from the rebooted PHP arrives.
-                DispatchQueue.main.async {
-                    NativeUIBridge.shared.isReloading = true
-                }
-
-                // CRITICAL: Send the hot reload event BEFORE queuing on the serial
-                // dispatch queue. For native UI routes the serial queue is blocked by
-                // the component's event-loop dispatch (PHPSchemeHandler also uses
-                // executeOnPHPThreadAsync). Writing the event to the mmap region here
-                // wakes nativephp_element_wait_event(), causing PHP to exit the event
-                // loop and return from dispatch() — which frees the serial queue so
-                // the block below can execute.
-                NativeUIBridge.sendHotReloadEvent()
-            }
-
-            // All reboot work runs off the main thread — persistent_php_shutdown
-            // blocks on a semaphore and must not run on the main queue.
-            PersistentPHPRuntime.shared.executeOnPHPThreadAsync { [weak self] in
-                // By the time this block runs, the native route dispatch has already
-                // returned (the hot reload event caused PHP to exit its event loop).
-                if isNativeUI {
-                    // `preserveTree: true` keeps the last published tree
-                    // on screen while PHP reboots (~500ms). The next
-                    // publish from the dispatch below replaces it
-                    // atomically — no white flash through the WebView
-                    // root.
-                    NativeElementBridge.stopWatching(preserveTree: true)
-                    NativeElementBridge.unregisterRegion()
-                }
-
-                // Reboot persistent runtime to pick up changed code.
-                // The queue worker MUST be stopped first — php_embed_shutdown()
-                // destroys global Zend module state, and the worker's live TSRM
-                // context would reference freed memory, causing a heap-corruption crash.
-                if PersistentPHPRuntime.shared.isBooted {
-                    PHPQueueWorker.shared.stopAndWait()
-                    _ = PersistentPHPRuntime.shared.reboot()
-                    // Clear compiled Blade views so templates are recompiled from
-                    // the updated source files copied by the watcher.
-                    _ = PersistentPHPRuntime.shared.artisan(command: "view:clear")
-                    PHPQueueWorker.shared.start()
-                } else {
-                    _ = NativePHPApp.shared?.artisan(additionalArgs: ["view:clear"])
-                }
-
-                DispatchQueue.main.async {
-                    NativeUIState.shared.clearAll()
-                }
-
-                if isNativeUI {
-                    // Allow future hot reloads BEFORE re-entering the event loop.
-                    // The serial queue will be blocked by the new dispatch, but the
-                    // next reloadWebView() can still send a hot reload event (above)
-                    // to break out of it.
-                    self?.reloadInProgress = false
-
-                    // Prefer the URI PHP wrote into .hot_restart over the WebView's
-                    // URL — for native-chrome routes the WebView URL isn't kept in
-                    // sync with the active component, so otherwise we'd lose the
-                    // screen on every reload and land on `/`. Android already does
-                    // the same (MainActivity.kt::startHotReloadWatcher).
-                    //
-                    // The file is written by `NativeComponent::runLoop` after the
-                    // EVENT_HOT_RELOAD event fires (PHP-side), and by this point
-                    // PHP has already exited the event loop and the file is on
-                    // disk. Read once, delete, then use.
-                    // Peek at the URI PHP wrote into `.hot_restart`
-                    // (full stack + top URI). We don't delete the
-                    // file here — the PHP-side `Route::native` macro
-                    // handler is the sole consumer; it reads the full
-                    // stack and removes the file. Otherwise we'd lose
-                    // the back-history payload.
-                    let hotRestartUri: String? = {
-                        let storageDir = FileManager.default
-                            .urls(for: .applicationSupportDirectory, in: .userDomainMask)
-                            .first
-                        guard let path = storageDir?
-                            .appendingPathComponent("storage/framework/.hot_restart")
-                            .path,
-                            let data = FileManager.default.contents(atPath: path),
-                            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                            let uri = json["uri"] as? String,
-                            !uri.isEmpty
-                        else { return nil }
-                        return uri
-                    }()
-
-                    // Native element mode: re-execute the route directly through
-                    // the persistent runtime (same as Android's executeNativeRoute).
-                    // PHP re-registers the mmap region and publishes a new tree.
-                    let request = RequestData(
-                        method: "GET",
-                        uri: hotRestartUri ?? currentPath,
-                        data: nil,
-                        query: nil,
-                        headers: [:]
-                    )
-                    _ = PersistentPHPRuntime.shared.dispatch(request: request)
-                } else {
-                    // WebView mode: reload with cache-bust
-                    DispatchQueue.main.async {
-                        guard let webView = self?.webView else {
-                            self?.reloadInProgress = false
-                            return
-                        }
-                        webView.stopLoading()
-                        let currentUrl = webView.url?.absoluteString ?? "php://127.0.0.1/"
-                        let separator = currentUrl.contains("?") ? "&" : "?"
-                        let cacheBustUrl = "\(currentUrl)\(separator)_cb=\(Int(Date().timeIntervalSince1970 * 1000))"
-                        if let url = URL(string: cacheBustUrl) {
-                            webView.load(URLRequest(url: url))
-                        }
-                        self?.reloadInProgress = false
-                    }
-                }
-            }
-        }
-
         // Swipe gestures disabled for back/forward navigation
         // @objc func handleSwipeLeft(_ gesture: UISwipeGestureRecognizer) {
         //     if let webView = gesture.view as? WKWebView, webView.canGoForward {
@@ -843,13 +711,9 @@ struct WebView: UIViewRepresentable {
         }
 
         // Register NotificationCenter observers
-        NotificationCenter.default.addObserver(
-            context.coordinator,
-            selector: #selector(Coordinator.reloadWebView),
-            name: .reloadWebViewNotification,
-            object: nil
-        )
-
+        // (reloadWebViewNotification is handled app-wide by HotReloadCoordinator,
+        // registered at launch — a native-direct boot never runs makeUIView, so
+        // reload handling must not live here.)
         NotificationCenter.default.addObserver(
             context.coordinator,
             selector: #selector(Coordinator.redirectToURL),

--- a/resources/xcode/NativePHP/HotReloadServer.swift
+++ b/resources/xcode/NativePHP/HotReloadServer.swift
@@ -1,5 +1,171 @@
 import Foundation
 import Network
+import WebKit
+
+/// Owns the actual reload work triggered by `reloadWebViewNotification`
+/// (hot reload connections in DEBUG, OTA updates via `AppUpdateManager`).
+///
+/// This observer used to live on the WebView's Coordinator, registered inside
+/// `WebView.makeUIView` — but a native-direct boot withholds the WebView
+/// entirely (and ContentView unmounts it whenever native UI is active), so
+/// fully-native apps never registered an observer and reload triggers were
+/// silently dropped. Registering here at app launch decouples reload handling
+/// from the WebView lifecycle; the WebView, when one exists, is resolved
+/// lazily through `SharedWebView.shared`.
+class HotReloadCoordinator {
+    static let shared = HotReloadCoordinator()
+
+    private var reloadInProgress = false
+    private var activated = false
+
+    private init() {}
+
+    /// Register for reload notifications. Called once at app launch —
+    /// unconditionally, not only in DEBUG, because `AppUpdateManager`
+    /// posts the same notification after applying an OTA update.
+    func activate() {
+        guard !activated else { return }
+        activated = true
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(reload),
+            name: .reloadWebViewNotification,
+            object: nil
+        )
+    }
+
+    @objc func reload() {
+        // Guard against rapid-fire file change events (file + directory)
+        // triggering concurrent reboots that race on php_embed_shutdown.
+        guard !reloadInProgress else { return }
+        reloadInProgress = true
+
+        let isNativeUI = NativeUIBridge.shared.isActive
+        // Capture current route for native UI re-execution
+        let currentPath = SharedWebView.shared.webView?.url?.path ?? NativePHPApp.getStartURL()
+
+        if isNativeUI {
+            // Show the "Reloading…" overlay (ContentView watches this).
+            // Cleared in `NativeElementBridge.postTreeUpdateFromRegion`
+            // when the first new tree from the rebooted PHP arrives.
+            DispatchQueue.main.async {
+                NativeUIBridge.shared.isReloading = true
+            }
+
+            // CRITICAL: Send the hot reload event BEFORE queuing on the serial
+            // dispatch queue. For native UI routes the serial queue is blocked by
+            // the component's event-loop dispatch (PHPSchemeHandler also uses
+            // executeOnPHPThreadAsync). Writing the event to the mmap region here
+            // wakes nativephp_element_wait_event(), causing PHP to exit the event
+            // loop and return from dispatch() — which frees the serial queue so
+            // the block below can execute.
+            NativeUIBridge.sendHotReloadEvent()
+        }
+
+        // All reboot work runs off the main thread — persistent_php_shutdown
+        // blocks on a semaphore and must not run on the main queue.
+        PersistentPHPRuntime.shared.executeOnPHPThreadAsync { [weak self] in
+            // By the time this block runs, the native route dispatch has already
+            // returned (the hot reload event caused PHP to exit its event loop).
+            if isNativeUI {
+                // `preserveTree: true` keeps the last published tree
+                // on screen while PHP reboots (~500ms). The next
+                // publish from the dispatch below replaces it
+                // atomically — no white flash through the WebView
+                // root.
+                NativeElementBridge.stopWatching(preserveTree: true)
+                NativeElementBridge.unregisterRegion()
+            }
+
+            // Reboot persistent runtime to pick up changed code.
+            // The queue worker MUST be stopped first — php_embed_shutdown()
+            // destroys global Zend module state, and the worker's live TSRM
+            // context would reference freed memory, causing a heap-corruption crash.
+            if PersistentPHPRuntime.shared.isBooted {
+                PHPQueueWorker.shared.stopAndWait()
+                _ = PersistentPHPRuntime.shared.reboot()
+                // Clear compiled Blade views so templates are recompiled from
+                // the updated source files copied by the watcher.
+                _ = PersistentPHPRuntime.shared.artisan(command: "view:clear")
+                PHPQueueWorker.shared.start()
+            } else {
+                _ = NativePHPApp.shared?.artisan(additionalArgs: ["view:clear"])
+            }
+
+            DispatchQueue.main.async {
+                NativeUIState.shared.clearAll()
+            }
+
+            if isNativeUI {
+                // Allow future hot reloads BEFORE re-entering the event loop.
+                // The serial queue will be blocked by the new dispatch, but the
+                // next reload() can still send a hot reload event (above)
+                // to break out of it.
+                self?.reloadInProgress = false
+
+                // Prefer the URI PHP wrote into .hot_restart over the WebView's
+                // URL — for native-chrome routes the WebView URL isn't kept in
+                // sync with the active component, so otherwise we'd lose the
+                // screen on every reload and land on `/`. Android already does
+                // the same (MainActivity.kt::startHotReloadWatcher).
+                //
+                // The file is written by `NativeComponent::runLoop` after the
+                // EVENT_HOT_RELOAD event fires (PHP-side), and by this point
+                // PHP has already exited the event loop and the file is on
+                // disk. Read once, delete, then use.
+                // Peek at the URI PHP wrote into `.hot_restart`
+                // (full stack + top URI). We don't delete the
+                // file here — the PHP-side `Route::native` macro
+                // handler is the sole consumer; it reads the full
+                // stack and removes the file. Otherwise we'd lose
+                // the back-history payload.
+                let hotRestartUri: String? = {
+                    let storageDir = FileManager.default
+                        .urls(for: .applicationSupportDirectory, in: .userDomainMask)
+                        .first
+                    guard let path = storageDir?
+                        .appendingPathComponent("storage/framework/.hot_restart")
+                        .path,
+                        let data = FileManager.default.contents(atPath: path),
+                        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                        let uri = json["uri"] as? String,
+                        !uri.isEmpty
+                    else { return nil }
+                    return uri
+                }()
+
+                // Native element mode: re-execute the route directly through
+                // the persistent runtime (same as Android's executeNativeRoute).
+                // PHP re-registers the mmap region and publishes a new tree.
+                let request = RequestData(
+                    method: "GET",
+                    uri: hotRestartUri ?? currentPath,
+                    data: nil,
+                    query: nil,
+                    headers: [:]
+                )
+                _ = PersistentPHPRuntime.shared.dispatch(request: request)
+            } else {
+                // WebView mode: reload with cache-bust
+                DispatchQueue.main.async {
+                    guard let webView = SharedWebView.shared.webView else {
+                        self?.reloadInProgress = false
+                        return
+                    }
+                    webView.stopLoading()
+                    let currentUrl = webView.url?.absoluteString ?? "php://127.0.0.1/"
+                    let separator = currentUrl.contains("?") ? "&" : "?"
+                    let cacheBustUrl = "\(currentUrl)\(separator)_cb=\(Int(Date().timeIntervalSince1970 * 1000))"
+                    if let url = URL(string: cacheBustUrl) {
+                        webView.load(URLRequest(url: url))
+                    }
+                    self?.reloadInProgress = false
+                }
+            }
+        }
+    }
+}
 
 class HotReloadServer {
     private var listener: NWListener?

--- a/resources/xcode/NativePHP/NativePHPApp.swift
+++ b/resources/xcode/NativePHP/NativePHPApp.swift
@@ -122,7 +122,12 @@ struct NativePHPApp: App {
             NativePHPPluginRegistry.shared.executeOnAppLaunch()
         }
 
-        // 6. Start hot reload server for development
+        // 6. Reload handling + hot reload server. The coordinator must be
+        // registered before anything can post reloadWebViewNotification —
+        // HotReloadServer triggers (DEBUG) or AppUpdateManager after an OTA
+        // update (production) — and independently of the WebView, which a
+        // native-direct boot never mounts.
+        HotReloadCoordinator.shared.activate()
         #if DEBUG
         HotReloadServer.shared.start()
         #endif

--- a/resources/xcode/NativePHP/NativeRender/NativeElementBridge.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeElementBridge.swift
@@ -505,7 +505,7 @@ final class NativeElementBridge {
                 if isFreshStackMount { NavigationCoordinator.shared.reset() }
                 bridge.currentTree = finalTree
                 // First publish after a hot-reload dismisses the
-                // "Reloading…" pill. Set by `ContentView.reloadWebView`
+                // "Reloading…" pill. Set by `HotReloadCoordinator.reload`
                 // at the start of the reboot; cleared here when the
                 // fresh tree from the rebooted PHP runtime lands.
                 if bridge.isReloading { bridge.isReloading = false }


### PR DESCRIPTION
## Problem

On fully-native (SuperNative) apps, `native:watch` / `native:run --watch` appears to work — files sync into the app container and the reload trigger connects to port 9999 — but the running app never reloads.

Root cause: `HotReloadServer.handleConnection` delivers reload triggers by posting `reloadWebViewNotification`, and the **only** observer for that notification was registered inside `WebView.makeUIView`. A native-direct boot withholds the WebView entirely (`NativePHPApp`: "native-direct boot — WebView withheld"), and `ContentView` unmounts it whenever native UI is active — so the observer never registers and every trigger is posted into the void. Verified live: the app accepts the 9999 connection, cancels it in ~1ms, and no PHP reboot follows.

`AppUpdateManager` posts the same notification after applying an OTA update, so production OTA reloads had the identical dead-observer bug.

## Fix

- New `HotReloadCoordinator` singleton (in `HotReloadServer.swift`) owns the reload logic, moved verbatim from `Coordinator.reloadWebView` — including the native-UI reboot path, `.hot_restart` route restore, and web-mode cache-bust reload.
- Registered once at app launch in `NativePHPApp` — unconditionally, not `#if DEBUG`, to cover OTA-triggered reloads in production.
- Resolves the WebView lazily through `SharedWebView.shared`, so it works whether or not a WebView was ever mounted.
- Old observer registration and `Coordinator.reloadWebView` removed from `ContentView.swift`.

Android is unaffected — its watcher thread starts in `MainActivity.onCreate` independent of the WebView and already branches on `NativeUIBridge.isActive`.

## Testing

- Full simulator build succeeds with zero warnings (`NativePHP-simulator` scheme).
- Verified end-to-end on device simulator: file edit → watcher sync → reload trigger → "Reloading…" pill → updated screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)