### PR TITLE
docs: design-system guidance (theme tokens, font aliases, layouts) + parser regression tests

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -26,6 +26,36 @@ elements (`native:column`, `native:text`, `native:button`, …).** This is the w
   Blade's use directive first. The enums are generated, not shipped — if `app/Icons/` doesn't exist yet, run
   `php artisan native-ui:generate-icons` first (safe to run yourself).
 
+### Theme Tokens, Font Aliases, and Layouts — the Design System Trio
+
+Every app's visual identity belongs in `config/native-ui.php` (publish with
+`php artisan vendor:publish --tag=native-ui-config`), not scattered through the markup. When building or
+reviewing screens, enforce all three:
+
+1. **Theme tokens over hardcoded colors.** Define the palette once in the config's `theme` block, then style
+   with `bg-theme-*` / `text-theme-*` / `border-theme-*` classes (`bg-theme-surface`, `text-theme-on-surface`,
+   `border-theme-outline`). Never sprinkle `bg-[#1E2021]`-style arbitrary values for what is really a theme
+   role — they can't be re-skinned and don't get automatic dark-mode pairs. Arbitrary color values are for
+   genuine data-driven color (per-category identity colors, map imagery, chart series), and those belong in
+   one PHP home (an enum or model method), never inline per view. Two capabilities that prevent hex fallbacks:
+   - **The token map is open-ended.** When a design needs a role the shipped set lacks (a success green, an
+     `outline-variant`), add it to both `light` and `dark` blocks — `bg-theme-success` works immediately; no
+     package change required.
+   - **Theme classes take opacity modifiers** just like palette classes: `bg-theme-primary/15` is the correct
+     tonal-fill idiom (applies to the dark companion too) — never approximate with a hardcoded alpha hex.
+2. **Font aliases over file tokens.** Register semantic aliases in the config's `fonts` array
+   (`'headline' => 'ArchivoNarrow-Bold'`, `'mono' => 'JetBrainsMono-Regular'`, `'default' => …` for the
+   app-wide font) and write `font="headline"` in views — never `font="ArchivoNarrow-Bold"`. Swapping a
+   typeface must be a one-line config change.
+3. **Every screen belongs to a `NativeLayout`.** Attach one via `Route::native(...)->layout(...)` or
+   `Route::nativeGroup(...)` — tab roots share a tabs layout (`navBar()` + `tabBar()`), pushed screens get a
+   stack layout with auto-back. Prefer `usesNativeChrome(): true` for real NavigationStack/TabView chrome.
+   Never hand-roll top bars or bottom navs out of rows and pressables inside screen views — that forfeits
+   native back gestures, safe-area handling, and Liquid Glass/Material You. Chrome builder colors take raw
+   strings — feed them with the appearance-aware `theme()` helper (`->activeColor(theme('primary'))`), which
+   reads the same config tokens and follows light/dark switches; never paste hex into a layout. Bar fonts take
+   config aliases (`->font('mono')`). Only screens rendered without any layout may use `safe-area` classes.
+
 ### When a Capability Is Missing
 
 If the app needs native functionality or a UI component that core and `native-ui` don't provide:

--- a/resources/boost/skills/nativephp-mobile/SKILL.md
+++ b/resources/boost/skills/nativephp-mobile/SKILL.md
@@ -22,6 +22,14 @@ rendering **EDGE** Blade elements. There is no web server and — for native UI 
   `nativephp-webview-to-native` skill walks through the conversion.
 - Style exclusively with Tailwind utility classes via `class="..."` / `:class="..."`. Never inline CSS
   `style="..."` or ad-hoc styling props.
+- **Prefer theme tokens and font aliases over raw values.** Publish `config/native-ui.php`
+  (`vendor:publish --tag=native-ui-config`), define the palette in its `theme` block and semantic font
+  aliases in `fonts` (`'headline' => 'ArchivoNarrow-Bold'`), then style with `bg-theme-*` / `text-theme-*` /
+  `border-theme-*` classes and `font="headline"`. The token map is open-ended (add `success`,
+  `outline-variant`, … to both blocks and `bg-theme-success` just works) and theme classes accept opacity
+  modifiers (`bg-theme-primary/15` — the tonal-fill idiom). Arbitrary `bg-[#…]` values are only for genuine
+  data-driven color (category identity colors, imagery) and belong in one PHP home (enum/model), never inline
+  per view.
 - Use `native:icon` for iconography (SF Symbols on iOS, Material Icons on Android — cross-platform names like
   `home` resolve on both). Never use emoji characters in UI text, labels, or buttons unless the user explicitly
   asks for them. Prefer the **typed icon enums** (`App\Icons\Ios`, `App\Icons\Android`, `App\Icons\AndroidOutlined`,
@@ -158,6 +166,13 @@ A `NativeLayout` class declares nav bars, tab bars, and drawers once; attach wit
 / `tabBar()` using the `NavBar`, `NavAction`, `TabBar`, and `Tab` fluent builders. Layouts handle safe areas
 automatically — never add `safe-area` classes to screens under a layout (reserve them for chrome-less screens).
 
+**Every screen should have a layout.** Tab roots share a tabs layout, pushed details get a stack layout with
+auto-back; prefer `usesNativeChrome(): true` for real NavigationStack/TabView chrome (edge-swipe back,
+predictive back, large titles, Liquid Glass/Material You for free). Never hand-roll top bars or bottom navs
+out of rows and pressables inside screen views. Chrome builder colors (`backgroundColor()`, `activeColor()`,
+`textColor()`) take raw color strings — feed them with the appearance-aware `theme()` helper
+(`->activeColor(theme('primary'))`) instead of hardcoding hex; bar fonts take aliases (`->font('mono')`).
+
 ## Device APIs
 
 **Core built-ins** (`Native\Mobile\Facades`): `Device`, `Dialog`, `File`, `System` — these ship inside
@@ -252,6 +267,9 @@ rest with the `nativephp-webview-to-native` skill.
 - Missing `NATIVEPHP_APP_ID` in `.env` before `native:install`
 - Suggesting iOS commands on Windows/Linux
 - Adding `safe-area` classes to screens already wrapped by a NativeLayout
+- Hardcoding hex colors or font file tokens in views instead of theme tokens (`bg-theme-surface`) and font
+  aliases (`font="headline"`) from `config/native-ui.php`
+- Hand-rolling top bars / bottom navs inside screens instead of attaching a `NativeLayout`
 - Expecting Vite HMR without passing `--vite` (opt-in since v4)
 - Installing a plugin with Composer but never running `native:plugin:register` — the plugin silently does
   nothing and `native:run` warns "installed but not registered"; always register and verify with

--- a/tests/Unit/Edge/ThemeClassTokensTest.php
+++ b/tests/Unit/Edge/ThemeClassTokensTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Native\Mobile\Edge\TailwindParser;
+
+/**
+ * Theme-aware color classes (`bg-theme-*` / `text-theme-*` / `border-theme-*`):
+ *  - tokens are open-ended — whatever key the registered resolver answers for
+ *    works, including app-defined tokens like `success` or `outline-variant`;
+ *  - the standard trailing `/N` opacity modifier applies to the RESOLVED
+ *    token color (light AND the dark companion), same as palette/hex classes.
+ */
+beforeEach(function () {
+    TailwindParser::setThemeResolver(fn (string $token): ?string => match ($token) {
+        'primary' => '#FF6B00',
+        'success' => '#00E475',
+        'outline-variant' => '#3E4246',
+        default => null,
+    });
+    TailwindParser::setThemeDarkResolver(fn (string $token): ?string => match ($token) {
+        'primary' => '#FFA85C',
+        default => null,
+    });
+});
+
+afterEach(function () {
+    TailwindParser::setThemeResolver(null);
+    TailwindParser::setThemeDarkResolver(null);
+});
+
+it('resolves app-defined theme tokens, not just the shipped set', function () {
+    expect(TailwindParser::parse('bg-theme-success'))->toBe(['bg' => '#00E475'])
+        ->and(TailwindParser::parse('border-theme-outline-variant'))
+        ->toBe(['borderColor' => '#3E4246', 'borderWidth' => 1]);
+});
+
+it('applies opacity modifiers to resolved theme colors', function () {
+    // 15% → 0x26 alpha byte, prepended in wire order.
+    expect(TailwindParser::parse('bg-theme-success/15'))->toBe(['bg' => '#2600E475'])
+        ->and(TailwindParser::parse('text-theme-success/50'))->toBe(['color' => '#8000E475']);
+});
+
+it('applies the opacity modifier to the dark companion too', function () {
+    $parsed = TailwindParser::parse('bg-theme-primary/50');
+
+    expect($parsed['bg'])->toBe('#80FF6B00')
+        ->and($parsed['dark']['bg'])->toBe('#80FFA85C');
+});
+
+it('leaves unknown theme tokens unresolved rather than guessing', function () {
+    expect(TailwindParser::parse('bg-theme-nonexistent'))->toBe([]);
+});


### PR DESCRIPTION
## What

AI agents (and humans) building NativePHP apps keep reaching for hardcoded hex, raw font file tokens, and hand-rolled top/bottom bars — because nothing in the Boost guidelines told them otherwise. This adds the missing design-system guidance and pins the parser behavior it relies on.

### Boost guidelines + skill

New "Theme Tokens, Font Aliases, and Layouts — the Design System Trio" section (guidelines) with matching skill updates and Common Pitfalls entries:

1. **Theme tokens over hardcoded colors** — style with `bg-theme-*` / `text-theme-*` / `border-theme-*` from `config/native-ui.php`. Documents two capabilities that prevent hex fallbacks: the token map is **open-ended** (app-defined roles like `success` resolve immediately), and theme classes accept **opacity modifiers** (`bg-theme-primary/15` — the tonal-fill idiom, dark companion included).
2. **Font aliases over file tokens** — `font="headline"` from the config `fonts` map, never `font="ArchivoNarrow-Bold"` inline.
3. **Every screen belongs to a NativeLayout** — tabs/stack chrome via builders, prefer `usesNativeChrome(): true`, feed chrome colors through the appearance-aware `theme()` helper, never hand-roll bars from rows and pressables.

### Tests

`tests/Unit/Edge/ThemeClassTokensTest.php` — regression coverage for the previously-untested theme-class behavior the guidance depends on: app-defined token resolution, opacity applied to the resolved color (light + dark), and unknown tokens staying unresolved. 4 tests, passing.

Pairs with NativePHP/mobile-ui#15 (first-class success/outline-variant tokens + `variant="success"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)