### PR TITLE
feat(edge): stack z-overlay with two-point anchor/origin + attribute positioning

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/ComposeFlexLayout.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/ComposeFlexLayout.kt
@@ -52,6 +52,41 @@ object Display {
 }
 
 /**
+ * 9-point anchor for `stack` container children (matches the PHP side).
+ * Read off each child's tolerant PROPS blob via `props.getInt("anchor")`;
+ * absent → CENTER (the stack default).
+ */
+object Anchor {
+    const val CENTER        = 0
+    const val TOP_LEFT      = 1
+    const val TOP_CENTER    = 2
+    const val TOP_RIGHT     = 3
+    const val CENTER_LEFT   = 4
+    const val CENTER_RIGHT  = 5
+    const val BOTTOM_LEFT   = 6
+    const val BOTTOM_CENTER = 7
+    const val BOTTOM_RIGHT  = 8
+}
+
+/**
+ * Maps an [Anchor] int to a Compose 2-D [Alignment]. Unknown / 0 → Center.
+ * All nine constants exist on `Alignment`'s companion (TopStart/TopCenter/
+ * TopEnd, CenterStart/Center/CenterEnd, BottomStart/BottomCenter/BottomEnd),
+ * so each maps 1:1 and can be handed straight to `BoxScope.align`.
+ */
+private fun anchorToAlignment(anchor: Int): Alignment = when (anchor) {
+    Anchor.TOP_LEFT      -> Alignment.TopStart
+    Anchor.TOP_CENTER    -> Alignment.TopCenter
+    Anchor.TOP_RIGHT     -> Alignment.TopEnd
+    Anchor.CENTER_LEFT   -> Alignment.CenterStart
+    Anchor.CENTER_RIGHT  -> Alignment.CenterEnd
+    Anchor.BOTTOM_LEFT   -> Alignment.BottomStart
+    Anchor.BOTTOM_CENTER -> Alignment.BottomCenter
+    Anchor.BOTTOM_RIGHT  -> Alignment.BottomEnd
+    else                 -> Alignment.Center // 0 CENTER (stack default) or unknown
+}
+
+/**
  * Renders children in a flex container using Compose's built-in Column/Row.
  * Maps flexbox properties to Compose equivalents:
  *   - flex_direction → Column or Row
@@ -72,8 +107,51 @@ fun FlexContainer(
     wrap: Int = 0,
     childNodes: List<NativeUINode>,
     modifier: Modifier = Modifier,
+    isStack: Boolean = false,
     content: @Composable () -> Unit
 ) {
+    // `stack` container: z-overlay EVERY child in a single Box, positioned by a
+    // 9-point `anchor` prop (default center) and fine-tuned by absolute inset
+    // offsets. No flow Column/Row runs — every child is treated as overlaid.
+    //
+    // Sizing: the Box carries only the incoming `modifier` (the stack node's own
+    // width/height, resolved upstream in NodeView). We add NO fillMaxWidth/
+    // Height/Size here, so a stack with no explicit size (WRAP mode → NodeView
+    // applies no size modifier) lets Box wrap-content and measure to its LARGEST
+    // child. `.align()`/`.offset()` are placement-only (ParentDataModifier /
+    // post-measure layout) and do not change what the Box measures, so the
+    // largest child still drives the stack's size — a text + a small anchored
+    // dot sizes to the text, never collapsing to the dot nor over-expanding.
+    if (isStack) {
+        Box(modifier = modifier) {
+            // Document order = z-order: first child drawn at the back.
+            childNodes.forEachIndexed { i, node ->
+                if ((node.layout?.display ?: 0) == Display.NONE) return@forEachIndexed
+
+                val alignment = anchorToAlignment(node.props.getInt("anchor", Anchor.CENTER))
+
+                // Inset offsets nudge the anchored child. Same convention as the
+                // absolute path: a set `right`/`bottom` pulls inward from that
+                // edge, otherwise `left`/`top` push from the leading edge.
+                val left = node.layout?.positionLeft ?: 0f
+                val top = node.layout?.positionTop ?: 0f
+                val right = node.layout?.positionRight ?: 0f
+                val bottom = node.layout?.positionBottom ?: 0f
+                val offsetX = if (right > 0f) (-right).dp else left.dp
+                val offsetY = if (bottom > 0f) (-bottom).dp else top.dp
+
+                Box(
+                    modifier = Modifier
+                        .align(alignment)
+                        .offset(x = offsetX, y = offsetY)
+                ) {
+                    NodeView(node = node)
+                }
+            }
+        }
+        return
+    }
+
     // Separate absolute children from flow children
     val hasAbsolute = childNodes.any { (it.layout?.positionType ?: 0) == PositionType.ABSOLUTE }
 

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/ComposeFlexLayout.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/ComposeFlexLayout.kt
@@ -16,7 +16,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import kotlin.math.roundToInt
 
 // MARK: - Flex Enums (match PHP/binary protocol values)
 
@@ -69,21 +73,49 @@ object Anchor {
 }
 
 /**
- * Maps an [Anchor] int to a Compose 2-D [Alignment]. Unknown / 0 → Center.
- * All nine constants exist on `Alignment`'s companion (TopStart/TopCenter/
- * TopEnd, CenterStart/Center/CenterEnd, BottomStart/BottomCenter/BottomEnd),
- * so each maps 1:1 and can be handed straight to `BoxScope.align`.
+ * Maps the 0–8 anchor/origin enum to (x, y) fractions in [0, 1]:
+ * center(.5,.5), top-left(0,0), top-center(.5,0), top-right(1,0),
+ * center-left(0,.5), center-right(1,.5), bottom-left(0,1),
+ * bottom-center(.5,1), bottom-right(1,1). Unknown / 0 → center.
  */
-private fun anchorToAlignment(anchor: Int): Alignment = when (anchor) {
-    Anchor.TOP_LEFT      -> Alignment.TopStart
-    Anchor.TOP_CENTER    -> Alignment.TopCenter
-    Anchor.TOP_RIGHT     -> Alignment.TopEnd
-    Anchor.CENTER_LEFT   -> Alignment.CenterStart
-    Anchor.CENTER_RIGHT  -> Alignment.CenterEnd
-    Anchor.BOTTOM_LEFT   -> Alignment.BottomStart
-    Anchor.BOTTOM_CENTER -> Alignment.BottomCenter
-    Anchor.BOTTOM_RIGHT  -> Alignment.BottomEnd
-    else                 -> Alignment.Center // 0 CENTER (stack default) or unknown
+private fun anchorFraction(point: Int): Pair<Float, Float> = when (point) {
+    Anchor.TOP_LEFT      -> 0f to 0f
+    Anchor.TOP_CENTER    -> 0.5f to 0f
+    Anchor.TOP_RIGHT     -> 1f to 0f
+    Anchor.CENTER_LEFT   -> 0f to 0.5f
+    Anchor.CENTER_RIGHT  -> 1f to 0.5f
+    Anchor.BOTTOM_LEFT   -> 0f to 1f
+    Anchor.BOTTOM_CENTER -> 0.5f to 1f
+    Anchor.BOTTOM_RIGHT  -> 1f to 1f
+    else                 -> 0.5f to 0.5f // CENTER (0) or unknown
+}
+
+/**
+ * A custom two-point [Alignment]: [anchor] is the point on the PARENT the child
+ * hooks onto; [origin] is the point ON THE CHILD that lands on that parent point.
+ * Both use the 0–8 enum (default center). The built-in `Alignment` constants
+ * only express a single point, so a decoupled anchor/origin needs this.
+ *
+ * Intentionally LTR-absolute — it IGNORES [layoutDirection] — to stay consistent
+ * with the absolute top/right/bottom/left inset system and with iOS. That's a
+ * deliberate improvement over the built-in RTL-aware Alignments.
+ *
+ * Implemented as a `data class` so instances are value-equal on (anchor, origin);
+ * that keeps `BoxScope.align` skip-friendly across recompositions instead of
+ * re-laying-out on every fresh lambda.
+ */
+private data class TwoPointAlignment(
+    val anchor: Int,
+    val origin: Int
+) : Alignment {
+    override fun align(size: IntSize, space: IntSize, layoutDirection: LayoutDirection): IntOffset {
+        val (aax, aay) = anchorFraction(anchor) // parent point
+        val (oax, oay) = anchorFraction(origin) // child point
+        return IntOffset(
+            (space.width * aax - size.width * oax).roundToInt(),
+            (space.height * aay - size.height * oay).roundToInt(),
+        )
+    }
 }
 
 /**
@@ -128,7 +160,12 @@ fun FlexContainer(
             childNodes.forEachIndexed { i, node ->
                 if ((node.layout?.display ?: 0) == Display.NONE) return@forEachIndexed
 
-                val alignment = anchorToAlignment(node.props.getInt("anchor", Anchor.CENTER))
+                // Two-point model: `anchor` = point on this parent, `origin` =
+                // point on the child that lands on it. Both default to center.
+                val alignment = TwoPointAlignment(
+                    anchor = node.props.getInt("anchor", Anchor.CENTER),
+                    origin = node.props.getInt("origin", Anchor.CENTER)
+                )
 
                 // Inset offsets nudge the anchored child. Same convention as the
                 // absolute path: a set `right`/`bottom` pulls inward from that
@@ -180,12 +217,23 @@ fun FlexContainer(
                     val right = node.layout?.positionRight ?: 0f
                     val bottom = node.layout?.positionBottom ?: 0f
 
-                    val anchor = when {
-                        right > 0f && bottom > 0f -> Alignment.BottomEnd
-                        right > 0f && top > 0f    -> Alignment.TopEnd
-                        right > 0f                 -> Alignment.TopEnd
-                        bottom > 0f                -> Alignment.BottomStart
-                        else                       -> Alignment.TopStart
+                    // Opt-in: if this absolute child carries an `anchor`/`origin`
+                    // prop, use the two-point model. With NEITHER prop it keeps
+                    // the legacy inset-derived corner logic byte-for-byte, so
+                    // existing `absolute top-0 right-0` layouts are untouched.
+                    val anchor: Alignment = if (node.props.has("anchor") || node.props.has("origin")) {
+                        TwoPointAlignment(
+                            anchor = node.props.getInt("anchor", Anchor.CENTER),
+                            origin = node.props.getInt("origin", Anchor.CENTER)
+                        )
+                    } else {
+                        when {
+                            right > 0f && bottom > 0f -> Alignment.BottomEnd
+                            right > 0f && top > 0f    -> Alignment.TopEnd
+                            right > 0f                 -> Alignment.TopEnd
+                            bottom > 0f                -> Alignment.BottomStart
+                            else                       -> Alignment.TopStart
+                        }
                     }
                     val offsetX = if (right > 0f) (-right).dp else left.dp
                     val offsetY = if (bottom > 0f) (-bottom).dp else top.dp

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeView.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeView.kt
@@ -331,7 +331,8 @@ fun DefaultContainerNode(node: NativeUINode, modifier: Modifier = Modifier) {
             gap = node.layout?.gap ?: 0f,
             wrap = node.layout?.flexWrap ?: 0,
             childNodes = node.children,
-            modifier = modifier
+            modifier = modifier,
+            isStack = node.type == "stack"
         ) {
             // Content is rendered by FlexContainer itself via NodeView calls
         }

--- a/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
+++ b/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
@@ -141,11 +141,16 @@ struct FlexContainer: Layout {
         let display: Int
         let flexBasis: CGFloat
         /// 9-point anchor (0=center … 8=bottom-right) read from the child's
-        /// tolerant PROPS blob. `nil` when the child has no `anchor` prop —
-        /// which keeps legacy non-stack absolute children on the inset-based
-        /// top-left placement. Stack children default to center (see
-        /// `placeAbsolute`).
+        /// tolerant PROPS blob. This is the point ON THE PARENT that the child
+        /// hooks onto. `nil` when the child has no `anchor` prop — which, with
+        /// no `origin` prop and outside a stack, keeps legacy non-stack absolute
+        /// children on the inset-based top-left placement. Stack children
+        /// default to center (see `placeAbsolute`).
         let anchor: Int?
+        /// 9-point origin (same 0–8 enum) read from the child's PROPS blob. This
+        /// is the point ON THE CHILD that lands on the parent's `anchor` point.
+        /// `nil` when absent; defaults to center inside the two-point path.
+        let origin: Int?
         var idealSize: CGSize = .zero
     }
 
@@ -157,14 +162,20 @@ struct FlexContainer: Layout {
 
         for (i, _) in subviews.enumerated() {
             let layout = i < childNodes.count ? childNodes[i].layout : nil
-            // The `anchor` value rides the tolerant PROPS blob, not the fixed
-            // binary layout struct. Read it directly off the node's props;
-            // `has` distinguishes an explicit `center` (0) from an absent prop.
+            // The `anchor` / `origin` values ride the tolerant PROPS blob, not
+            // the fixed binary layout struct. Read them directly off the node's
+            // props; `has` distinguishes an explicit `center` (0) from absence.
+            // `anchor` = point on the PARENT the child hooks onto; `origin` =
+            // point on the CHILD that lands on it.
             let anchor: Int?
-            if i < childNodes.count, childNodes[i].props.has("anchor") {
-                anchor = childNodes[i].props.getInt("anchor")
+            let origin: Int?
+            if i < childNodes.count {
+                let props = childNodes[i].props
+                anchor = props.has("anchor") ? props.getInt("anchor") : nil
+                origin = props.has("origin") ? props.getInt("origin") : nil
             } else {
                 anchor = nil
+                origin = nil
             }
             let info = ChildInfo(
                 flexGrow: CGFloat(layout?.flexGrow ?? 0),
@@ -187,7 +198,8 @@ struct FlexContainer: Layout {
                 // flex-1 children inflate to their natural width (e.g. a long
                 // single-line <native:text> ⇒ 600+pt column overflow).
                 flexBasis: (layout?.flexBasisMode ?? 0) == 1 ? CGFloat(layout?.flexBasis ?? 0) : -1,
-                anchor: anchor
+                anchor: anchor,
+                origin: origin
             )
             cache.childInfos.append(info)
 
@@ -665,28 +677,31 @@ struct FlexContainer: Layout {
     /// Place an absolute-positioned child.
     ///
     /// Two placement modes:
-    ///   • Anchored — used for stack children (default anchor = center) and any
-    ///     child carrying an explicit `anchor` prop. The child's frame is
-    ///     positioned within the container by the anchor fraction, then the
+    ///   • Two-point anchor/origin — used for stack children and any child
+    ///     carrying an explicit `anchor` and/or `origin` prop. The child's
+    ///     `origin` point (a fraction of its own frame) is pinned to the
+    ///     parent's `anchor` point (a fraction of the container), then the
     ///     position insets nudge it (left/top push right/down, right/bottom
-    ///     push left/up).
-    ///   • Legacy inset — used for non-stack absolute children with no anchor.
-    ///     Byte-identical to the historical top-left/inset behavior.
+    ///     push left/up). Both default to center (0). This can intentionally
+    ///     draw partly outside the container — a plain container doesn't clip.
+    ///   • Legacy inset — used for non-stack absolute children with neither
+    ///     an `anchor` nor an `origin`. Byte-identical to the historical
+    ///     top-left/inset behavior.
     private func placeAbsolute(_ subview: LayoutSubview, info: ChildInfo, in bounds: CGRect) {
         let ideal = subview.sizeThatFits(.unspecified)
 
-        // Explicit per-child anchor wins; otherwise stack children default to
-        // center (0). A nil result (non-stack absolute child, no anchor) falls
-        // through to the unchanged legacy inset placement.
-        let effectiveAnchor: Int? = info.anchor ?? (isStack ? 0 : nil)
+        // Use the two-point model for stacks, or whenever the child opts in with
+        // either prop. Otherwise fall through to the unchanged legacy inset path.
+        let useAnchorModel = isStack || info.anchor != nil || info.origin != nil
 
         let x: CGFloat
         let y: CGFloat
-        if let anchor = effectiveAnchor {
-            let (ax, ay) = anchorFractions(anchor)
-            x = bounds.minX + (bounds.width - ideal.width) * ax
+        if useAnchorModel {
+            let (aax, aay) = anchorFractions(info.anchor ?? 0)   // point on the parent
+            let (oax, oay) = anchorFractions(info.origin ?? 0)   // point on the child
+            x = bounds.minX + bounds.width * aax - ideal.width * oax
                 + info.positionLeft - info.positionRight
-            y = bounds.minY + (bounds.height - ideal.height) * ay
+            y = bounds.minY + bounds.height * aay - ideal.height * oay
                 + info.positionTop - info.positionBottom
         } else {
             // Legacy inset-based placement (unchanged).

--- a/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
+++ b/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
@@ -62,6 +62,11 @@ struct FlexContainer: Layout {
     let align: Int       // AlignItems
     let gap: CGFloat
     let wrap: Int        // 0 = nowrap, 1 = wrap
+    /// When true this container behaves like a SwiftUI ZStack: EVERY visible
+    /// child is z-overlaid via absolute placement (ignoring its own
+    /// positionType) using a 9-point anchor, and the container sizes to the
+    /// union of its children (its largest child on each axis).
+    let isStack: Bool
     /// Direct access to child nodes — LayoutValueKeys don't propagate through ViewModifiers,
     /// so we pass the node array and index into flex properties directly.
     let childNodes: [NativeUINode]
@@ -72,6 +77,7 @@ struct FlexContainer: Layout {
         align: Int = AlignItems.stretch,
         gap: CGFloat = 0,
         wrap: Int = 0,
+        isStack: Bool = false,
         childNodes: [NativeUINode] = []
     ) {
         self.direction = direction
@@ -79,6 +85,7 @@ struct FlexContainer: Layout {
         self.align = align
         self.gap = gap
         self.wrap = wrap
+        self.isStack = isStack
         self.childNodes = childNodes
     }
 
@@ -133,6 +140,12 @@ struct FlexContainer: Layout {
         let positionLeft: CGFloat
         let display: Int
         let flexBasis: CGFloat
+        /// 9-point anchor (0=center … 8=bottom-right) read from the child's
+        /// tolerant PROPS blob. `nil` when the child has no `anchor` prop —
+        /// which keeps legacy non-stack absolute children on the inset-based
+        /// top-left placement. Stack children default to center (see
+        /// `placeAbsolute`).
+        let anchor: Int?
         var idealSize: CGSize = .zero
     }
 
@@ -144,6 +157,15 @@ struct FlexContainer: Layout {
 
         for (i, _) in subviews.enumerated() {
             let layout = i < childNodes.count ? childNodes[i].layout : nil
+            // The `anchor` value rides the tolerant PROPS blob, not the fixed
+            // binary layout struct. Read it directly off the node's props;
+            // `has` distinguishes an explicit `center` (0) from an absent prop.
+            let anchor: Int?
+            if i < childNodes.count, childNodes[i].props.has("anchor") {
+                anchor = childNodes[i].props.getInt("anchor")
+            } else {
+                anchor = nil
+            }
             let info = ChildInfo(
                 flexGrow: CGFloat(layout?.flexGrow ?? 0),
                 flexShrink: CGFloat(layout?.flexShrink ?? 0),
@@ -164,12 +186,17 @@ struct FlexContainer: Layout {
                 // basis of 0 was treated as "use content size", which made
                 // flex-1 children inflate to their natural width (e.g. a long
                 // single-line <native:text> ⇒ 600+pt column overflow).
-                flexBasis: (layout?.flexBasisMode ?? 0) == 1 ? CGFloat(layout?.flexBasis ?? 0) : -1
+                flexBasis: (layout?.flexBasisMode ?? 0) == 1 ? CGFloat(layout?.flexBasis ?? 0) : -1,
+                anchor: anchor
             )
             cache.childInfos.append(info)
 
             if info.display == Display.none { continue }
-            if info.positionType == PositionType.absolute {
+            // In a stack, EVERY visible child overlays regardless of its own
+            // positionType — they're all placed absolutely with the anchor.
+            // Enumeration is in ascending index order, so absoluteIndices keeps
+            // document order → z-order = document order (first child at back).
+            if isStack || info.positionType == PositionType.absolute {
                 cache.absoluteIndices.append(i)
             } else {
                 cache.flowIndices.append(i)
@@ -221,6 +248,35 @@ struct FlexContainer: Layout {
         subviews: Subviews,
         cache: inout CacheData
     ) -> CGSize {
+        // Stack containers overlay every child (all routed to absoluteIndices),
+        // so `flowIndices` is empty and absolute children don't feed the flex
+        // sizing below. Size like a SwiftUI ZStack instead: the union of the
+        // children's intrinsic sizes (largest child on each axis). This makes a
+        // stack with no explicit width/height wrap its largest child rather than
+        // collapsing to zero (e.g. a wordmark <text> gives the stack its size,
+        // and a small anchored dot rides on top). A finite proposal on an axis
+        // still wins, so an explicitly filled/sized stack fills as before.
+        if isStack {
+            let key = ProposalKey(proposal)
+            if let cached = cache.sizeCache[key] { return cached }
+
+            var maxWidth: CGFloat = 0
+            var maxHeight: CGFloat = 0
+            for i in cache.absoluteIndices {
+                let ideal = subviews[i].sizeThatFits(.unspecified)
+                cache.childInfos[i].idealSize = ideal
+                maxWidth = max(maxWidth, ideal.width)
+                maxHeight = max(maxHeight, ideal.height)
+            }
+
+            let result = CGSize(
+                width: proposal.width ?? maxWidth,
+                height: proposal.height ?? maxHeight
+            )
+            cache.sizeCache[key] = result
+            return result
+        }
+
         guard !cache.flowIndices.isEmpty else {
             // Even with no children, fill the proposed space if finite
             return CGSize(
@@ -589,20 +645,63 @@ struct FlexContainer: Layout {
         }
     }
 
-    /// Place an absolute-positioned child using position insets.
+    /// Map a 9-point anchor id to its horizontal/vertical placement fractions.
+    ///   0=center, 1=top-left, 2=top-center, 3=top-right, 4=center-left,
+    ///   5=center-right, 6=bottom-left, 7=bottom-center, 8=bottom-right.
+    private func anchorFractions(_ anchor: Int) -> (ax: CGFloat, ay: CGFloat) {
+        switch anchor {
+        case 1: return (0, 0)       // top-left
+        case 2: return (0.5, 0)     // top-center
+        case 3: return (1, 0)       // top-right
+        case 4: return (0, 0.5)     // center-left
+        case 5: return (1, 0.5)     // center-right
+        case 6: return (0, 1)       // bottom-left
+        case 7: return (0.5, 1)     // bottom-center
+        case 8: return (1, 1)       // bottom-right
+        default: return (0.5, 0.5)  // 0 = center (also the stack default)
+        }
+    }
+
+    /// Place an absolute-positioned child.
+    ///
+    /// Two placement modes:
+    ///   • Anchored — used for stack children (default anchor = center) and any
+    ///     child carrying an explicit `anchor` prop. The child's frame is
+    ///     positioned within the container by the anchor fraction, then the
+    ///     position insets nudge it (left/top push right/down, right/bottom
+    ///     push left/up).
+    ///   • Legacy inset — used for non-stack absolute children with no anchor.
+    ///     Byte-identical to the historical top-left/inset behavior.
     private func placeAbsolute(_ subview: LayoutSubview, info: ChildInfo, in bounds: CGRect) {
         let ideal = subview.sizeThatFits(.unspecified)
 
-        // Resolve horizontal position
-        var x = bounds.minX + info.positionLeft
-        if info.positionRight > 0 && info.positionLeft == 0 {
-            x = bounds.maxX - ideal.width - info.positionRight
-        }
+        // Explicit per-child anchor wins; otherwise stack children default to
+        // center (0). A nil result (non-stack absolute child, no anchor) falls
+        // through to the unchanged legacy inset placement.
+        let effectiveAnchor: Int? = info.anchor ?? (isStack ? 0 : nil)
 
-        // Resolve vertical position
-        var y = bounds.minY + info.positionTop
-        if info.positionBottom > 0 && info.positionTop == 0 {
-            y = bounds.maxY - ideal.height - info.positionBottom
+        let x: CGFloat
+        let y: CGFloat
+        if let anchor = effectiveAnchor {
+            let (ax, ay) = anchorFractions(anchor)
+            x = bounds.minX + (bounds.width - ideal.width) * ax
+                + info.positionLeft - info.positionRight
+            y = bounds.minY + (bounds.height - ideal.height) * ay
+                + info.positionTop - info.positionBottom
+        } else {
+            // Legacy inset-based placement (unchanged).
+            var lx = bounds.minX + info.positionLeft
+            if info.positionRight > 0 && info.positionLeft == 0 {
+                lx = bounds.maxX - ideal.width - info.positionRight
+            }
+
+            var ly = bounds.minY + info.positionTop
+            if info.positionBottom > 0 && info.positionTop == 0 {
+                ly = bounds.maxY - ideal.height - info.positionBottom
+            }
+
+            x = lx
+            y = ly
         }
 
         subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(ideal))

--- a/resources/xcode/NativePHP/NativeRender/SwiftUINodeRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/SwiftUINodeRenderer.swift
@@ -190,6 +190,9 @@ struct NodeView: View, Equatable {
                 align: node.layout?.alignItems ?? AlignItems.stretch,
                 gap: CGFloat(node.layout?.gap ?? 0),
                 wrap: node.layout?.flexWrap ?? 0,
+                // A `stack` overlays all its children (z-stack) with 9-point
+                // anchored absolute positioning, sizing to its largest child.
+                isStack: node.type == "stack",
                 childNodes: node.children
             ) {
                 ForEach(node.children) { child in

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -134,7 +134,7 @@ class NativeElementCollector
         if (in_array($type, $builtinTypes, true)) {
             $layout = static::buildLayoutArray($attrs);
             $style = static::buildStyleArray($attrs);
-            $props = static::buildDarkProps($attrs) + static::buildAnimationProps($attrs) + static::anchorProp($attrs);
+            $props = static::buildDarkProps($attrs) + static::buildAnimationProps($attrs) + static::anchorProps($attrs);
             $onPress = static::resolveOnPress($attrs);
             $onLongPress = static::resolveOnLongPress($attrs);
 
@@ -224,7 +224,7 @@ class NativeElementCollector
         if (in_array($type, $builtinTypes, true)) {
             $layout = static::buildLayoutArray($attrs);
             $style = static::buildStyleArray($attrs);
-            $props = static::buildDarkProps($attrs) + static::buildAnimationProps($attrs) + static::anchorProp($attrs);
+            $props = static::buildDarkProps($attrs) + static::buildAnimationProps($attrs) + static::anchorProps($attrs);
             $onPress = static::resolveOnPress($attrs);
             $onLongPress = static::resolveOnLongPress($attrs);
 
@@ -425,25 +425,32 @@ class NativeElementCollector
     }
 
     /**
-     * The stack `anchor` as a prop entry (the anchor rides the tolerant props
-     * blob, not the fixed layout struct, so the native decoders pick it up
-     * without a wire-format change). `[]` when absent or unrecognized.
+     * The `anchor` (point on the parent) and `origin` (point on the child)
+     * as prop entries. An absolutely-positioned child aligns its `origin`
+     * point to the parent's `anchor` point; both default to `center` on the
+     * native side. They ride the tolerant props blob (not the fixed layout
+     * struct), so the native decoders pick them up without a wire-format
+     * change. Unrecognized names are dropped.
      *
-     * @return array{anchor?: int}
+     * @return array{anchor?: int, origin?: int}
      */
-    protected static function anchorProp(array $attrs): array
+    protected static function anchorProps(array $attrs): array
     {
-        if (! isset($attrs['anchor'])) {
-            return [];
+        $props = [];
+
+        if (isset($attrs['anchor']) && ($anchor = self::resolveAnchor((string) $attrs['anchor'])) !== null) {
+            $props['anchor'] = $anchor;
         }
 
-        $anchor = self::resolveAnchor((string) $attrs['anchor']);
+        if (isset($attrs['origin']) && ($origin = self::resolveAnchor((string) $attrs['origin'])) !== null) {
+            $props['origin'] = $origin;
+        }
 
-        return $anchor === null ? [] : ['anchor' => $anchor];
+        return $props;
     }
 
     /**
-     * Anchor names → wire enum, shared with the native stack renderers.
+     * Anchor/origin names → wire enum, shared with the native renderers.
      * `center` (0) is the default; the eight compass points follow. Aliases
      * collapse to their canonical point (`top` == `top-center`, etc.).
      */
@@ -1192,10 +1199,10 @@ class NativeElementCollector
 
     public static function applyElementProps(Element $element, array $attrs): void
     {
-        // Stack anchor — where this element sits when it's a child of a
-        // `stack` (whose children are z-stacked and absolutely positioned).
-        // Rides props so it applies to every element type uniformly.
-        foreach (static::anchorProp($attrs) as $key => $value) {
+        // Anchor/origin — where this element sits when it's absolutely
+        // positioned (always, for a `stack` child). Rides props so it applies
+        // to every element type uniformly.
+        foreach (static::anchorProps($attrs) as $key => $value) {
             $element->setProp($key, $value);
         }
 

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -134,7 +134,7 @@ class NativeElementCollector
         if (in_array($type, $builtinTypes, true)) {
             $layout = static::buildLayoutArray($attrs);
             $style = static::buildStyleArray($attrs);
-            $props = static::buildDarkProps($attrs) + static::buildAnimationProps($attrs);
+            $props = static::buildDarkProps($attrs) + static::buildAnimationProps($attrs) + static::anchorProp($attrs);
             $onPress = static::resolveOnPress($attrs);
             $onLongPress = static::resolveOnLongPress($attrs);
 
@@ -224,7 +224,7 @@ class NativeElementCollector
         if (in_array($type, $builtinTypes, true)) {
             $layout = static::buildLayoutArray($attrs);
             $style = static::buildStyleArray($attrs);
-            $props = static::buildDarkProps($attrs) + static::buildAnimationProps($attrs);
+            $props = static::buildDarkProps($attrs) + static::buildAnimationProps($attrs) + static::anchorProp($attrs);
             $onPress = static::resolveOnPress($attrs);
             $onLongPress = static::resolveOnLongPress($attrs);
 
@@ -390,21 +390,77 @@ class NativeElementCollector
         if (isset($attrs['justifyContent'])) {
             $layout['justify_content'] = (int) $attrs['justifyContent'];
         }
-        if (isset($attrs['positionType'])) {
-            $layout['position_type'] = (int) $attrs['positionType'];
+        // Position type. Accept the short attribute spellings alongside the
+        // class-derived `positionType`, so `<native:column absolute>` and
+        // `position="absolute"` work like `class="absolute"`.
+        $positionType = match (true) {
+            isset($attrs['positionType']) => (int) $attrs['positionType'],
+            ! empty($attrs['absolute']) || ($attrs['position'] ?? null) === 'absolute' => 1,
+            ! empty($attrs['relative']) || ($attrs['position'] ?? null) === 'relative' => 0,
+            default => null,
+        };
+        if ($positionType !== null) {
+            $layout['position_type'] = $positionType;
         }
-        if (isset($attrs['positionTop']) || isset($attrs['positionRight'])
-            || isset($attrs['positionBottom']) || isset($attrs['positionLeft'])) {
+
+        // Position offsets. `positionTop` (from `top-0`) and the bare `top`
+        // attribute are equivalent — the explicit camelCase wins when both
+        // are present. Same for right/bottom/left.
+        $positionTop = $attrs['positionTop'] ?? $attrs['top'] ?? null;
+        $positionRight = $attrs['positionRight'] ?? $attrs['right'] ?? null;
+        $positionBottom = $attrs['positionBottom'] ?? $attrs['bottom'] ?? null;
+        $positionLeft = $attrs['positionLeft'] ?? $attrs['left'] ?? null;
+        if ($positionTop !== null || $positionRight !== null
+            || $positionBottom !== null || $positionLeft !== null) {
             // [top, right, bottom, left] — same order as Element::insets()
             $layout['position'] = [
-                (float) ($attrs['positionTop'] ?? 0),
-                (float) ($attrs['positionRight'] ?? 0),
-                (float) ($attrs['positionBottom'] ?? 0),
-                (float) ($attrs['positionLeft'] ?? 0),
+                (float) ($positionTop ?? 0),
+                (float) ($positionRight ?? 0),
+                (float) ($positionBottom ?? 0),
+                (float) ($positionLeft ?? 0),
             ];
         }
 
         return $layout;
+    }
+
+    /**
+     * The stack `anchor` as a prop entry (the anchor rides the tolerant props
+     * blob, not the fixed layout struct, so the native decoders pick it up
+     * without a wire-format change). `[]` when absent or unrecognized.
+     *
+     * @return array{anchor?: int}
+     */
+    protected static function anchorProp(array $attrs): array
+    {
+        if (! isset($attrs['anchor'])) {
+            return [];
+        }
+
+        $anchor = self::resolveAnchor((string) $attrs['anchor']);
+
+        return $anchor === null ? [] : ['anchor' => $anchor];
+    }
+
+    /**
+     * Anchor names → wire enum, shared with the native stack renderers.
+     * `center` (0) is the default; the eight compass points follow. Aliases
+     * collapse to their canonical point (`top` == `top-center`, etc.).
+     */
+    private static function resolveAnchor(string $anchor): ?int
+    {
+        return match (strtolower(trim($anchor))) {
+            'center', 'center-center', 'middle' => 0,
+            'top-left', 'top-start' => 1,
+            'top', 'top-center' => 2,
+            'top-right', 'top-end' => 3,
+            'left', 'center-left' => 4,
+            'right', 'center-right' => 5,
+            'bottom-left', 'bottom-start' => 6,
+            'bottom', 'bottom-center' => 7,
+            'bottom-right', 'bottom-end' => 8,
+            default => null,
+        };
     }
 
     public static function buildStyleArray(array $attrs): array
@@ -1136,6 +1192,13 @@ class NativeElementCollector
 
     public static function applyElementProps(Element $element, array $attrs): void
     {
+        // Stack anchor — where this element sits when it's a child of a
+        // `stack` (whose children are z-stacked and absolutely positioned).
+        // Rides props so it applies to every element type uniformly.
+        foreach (static::anchorProp($attrs) as $key => $value) {
+            $element->setProp($key, $value);
+        }
+
         if ($element instanceof ScrollView) {
             // `axis="both"` enables 2D scrolling. Falls back to the legacy
             // `horizontal` boolean when axis isn't set.

--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -401,6 +401,11 @@ class TailwindParser
             $class === 'absolute' => ['positionType' => 1],
             $class === 'relative' => ['positionType' => 0],
 
+            // Stack anchor — `anchor-top-right`, `anchor-center`, etc. The
+            // name is resolved to the wire enum in buildLayoutArray, the same
+            // place the `anchor="…"` attribute is resolved.
+            str_starts_with($class, 'anchor-') => ['anchor' => substr($class, 7)],
+
             // Padding
             str_starts_with($class, 'px-') => self::parseSpacingAxis('padding', 'x', substr($class, 3)),
             str_starts_with($class, 'py-') => self::parseSpacingAxis('padding', 'y', substr($class, 3)),

--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -401,10 +401,12 @@ class TailwindParser
             $class === 'absolute' => ['positionType' => 1],
             $class === 'relative' => ['positionType' => 0],
 
-            // Stack anchor — `anchor-top-right`, `anchor-center`, etc. The
-            // name is resolved to the wire enum in buildLayoutArray, the same
-            // place the `anchor="…"` attribute is resolved.
+            // Anchor (point on the parent) / origin (point on the child) for
+            // absolutely-positioned / stacked children — `anchor-top-right`,
+            // `origin-center`, etc. Resolved to the wire enum in anchorProps,
+            // the same place the `anchor="…"` / `origin="…"` attributes are.
             str_starts_with($class, 'anchor-') => ['anchor' => substr($class, 7)],
+            str_starts_with($class, 'origin-') => ['origin' => substr($class, 7)],
 
             // Padding
             str_starts_with($class, 'px-') => self::parseSpacingAxis('padding', 'x', substr($class, 3)),

--- a/tests/Unit/Edge/LayoutPositioningTest.php
+++ b/tests/Unit/Edge/LayoutPositioningTest.php
@@ -9,13 +9,19 @@ beforeEach(function () {
     TailwindParser::clearCache();
 });
 
-/** Resolve the `anchor` prop an element ends up with for the given attrs. */
-function anchorPropFor(array $attrs): ?int
+/** The props an element ends up with after the collector applies the attrs. */
+function positionPropsFor(array $attrs): array
 {
     $element = Column::make();
     NativeElementCollector::applyElementProps($element, $attrs);
 
-    return $element->toArray(new CallbackRegistry)['props']['anchor'] ?? null;
+    return $element->toArray(new CallbackRegistry)['props'] ?? [];
+}
+
+/** Just the `anchor` prop, or null. */
+function anchorPropFor(array $attrs): ?int
+{
+    return positionPropsFor($attrs)['anchor'] ?? null;
 }
 
 // ── Attribute-based position (parity with the utility classes) ──────────
@@ -102,4 +108,29 @@ it('parses the anchor-* utility class to the anchor name', function () {
 
 it('resolves the anchor class end to end into the prop enum', function () {
     expect(anchorPropFor(TailwindParser::parse('anchor-bottom-right')))->toBe(8);
+});
+
+// ── Origin (the point ON the child that aligns to the parent's anchor) ───
+
+it('resolves the origin attribute to its own prop', function () {
+    expect(positionPropsFor(['origin' => 'top-left'])['origin'] ?? null)->toBe(1);
+    expect(positionPropsFor(['origin' => 'center'])['origin'] ?? null)->toBe(0);
+});
+
+it('parses the origin-* utility class', function () {
+    expect(TailwindParser::parse('origin-bottom-right'))->toBe(['origin' => 'bottom-right']);
+});
+
+it('carries anchor and origin independently on the same element', function () {
+    // A badge whose top-left (origin) hooks onto the parent's top-right (anchor).
+    expect(positionPropsFor(['anchor' => 'top-right', 'origin' => 'top-left']))
+        ->toMatchArray(['anchor' => 3, 'origin' => 1]);
+
+    // Mix attribute + class.
+    $attrs = array_merge(TailwindParser::parse('origin-center'), ['anchor' => 'bottom-left']);
+    expect(positionPropsFor($attrs))->toMatchArray(['anchor' => 6, 'origin' => 0]);
+});
+
+it('emits no origin prop for an unknown name', function () {
+    expect(positionPropsFor(['origin' => 'nowhere']))->not->toHaveKey('origin');
 });

--- a/tests/Unit/Edge/LayoutPositioningTest.php
+++ b/tests/Unit/Edge/LayoutPositioningTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\NativeElementCollector;
+use Native\Mobile\Edge\TailwindParser;
+
+beforeEach(function () {
+    TailwindParser::clearCache();
+});
+
+/** Resolve the `anchor` prop an element ends up with for the given attrs. */
+function anchorPropFor(array $attrs): ?int
+{
+    $element = Column::make();
+    NativeElementCollector::applyElementProps($element, $attrs);
+
+    return $element->toArray(new CallbackRegistry)['props']['anchor'] ?? null;
+}
+
+// ── Attribute-based position (parity with the utility classes) ──────────
+
+it('reads the bare absolute attribute like the class', function () {
+    expect(NativeElementCollector::buildLayoutArray(['absolute' => true]))
+        ->toBe(['position_type' => 1]);
+
+    expect(NativeElementCollector::buildLayoutArray(['relative' => true]))
+        ->toBe(['position_type' => 0]);
+});
+
+it('reads position="absolute" / position="relative"', function () {
+    expect(NativeElementCollector::buildLayoutArray(['position' => 'absolute']))
+        ->toBe(['position_type' => 1]);
+
+    expect(NativeElementCollector::buildLayoutArray(['position' => 'relative']))
+        ->toBe(['position_type' => 0]);
+});
+
+it('reads bare top/right/bottom/left offset attributes', function () {
+    expect(NativeElementCollector::buildLayoutArray(['top' => 0, 'right' => 0]))
+        ->toBe(['position' => [0.0, 0.0, 0.0, 0.0]]);
+
+    expect(NativeElementCollector::buildLayoutArray(['top' => 8, 'left' => 12]))
+        ->toBe(['position' => [8.0, 0.0, 0.0, 12.0]]);
+});
+
+it('lets the explicit positionType/positionTop win over the short spelling', function () {
+    // positionTop (from `top-4`) takes precedence over a bare `top`.
+    expect(NativeElementCollector::buildLayoutArray(['positionTop' => 4, 'top' => 99]))
+        ->toBe(['position' => [4.0, 0.0, 0.0, 0.0]]);
+
+    expect(NativeElementCollector::buildLayoutArray(['positionType' => 1, 'absolute' => true]))
+        ->toBe(['position_type' => 1]);
+});
+
+it('composes absolute + offsets from attributes exactly like the classes', function () {
+    $fromAttrs = NativeElementCollector::buildLayoutArray(['absolute' => true, 'top' => 0, 'right' => 0]);
+
+    $fromClasses = NativeElementCollector::buildLayoutArray(
+        array_merge(TailwindParser::parse('absolute top-0 right-0'), [])
+    );
+
+    expect($fromAttrs)->toBe($fromClasses)
+        ->and($fromAttrs)->toBe(['position_type' => 1, 'position' => [0.0, 0.0, 0.0, 0.0]]);
+});
+
+// ── Stack anchor ────────────────────────────────────────────────────────
+// The anchor rides the props blob (not the fixed layout struct), so it
+// surfaces on the element's serialized `props`, not its `layout`.
+
+it('never lands in the layout struct', function () {
+    // The C packer would drop an unknown layout key, so anchor must not be there.
+    expect(NativeElementCollector::buildLayoutArray(['anchor' => 'top-right']))->toBe([]);
+});
+
+it('resolves every anchor name to its wire enum as a prop', function (string $name, int $value) {
+    expect(anchorPropFor(['anchor' => $name]))->toBe($value);
+})->with([
+    ['center', 0],
+    ['top-left', 1],
+    ['top', 2],
+    ['top-center', 2],
+    ['top-right', 3],
+    ['left', 4],
+    ['center-left', 4],
+    ['right', 5],
+    ['center-right', 5],
+    ['bottom-left', 6],
+    ['bottom', 7],
+    ['bottom-center', 7],
+    ['bottom-right', 8],
+]);
+
+it('emits no anchor prop for an unknown name', function () {
+    expect(anchorPropFor(['anchor' => 'nowhere']))->toBeNull();
+});
+
+it('parses the anchor-* utility class to the anchor name', function () {
+    expect(TailwindParser::parse('anchor-top-right'))->toBe(['anchor' => 'top-right']);
+    expect(TailwindParser::parse('anchor-center'))->toBe(['anchor' => 'center']);
+});
+
+it('resolves the anchor class end to end into the prop enum', function () {
+    expect(anchorPropFor(TailwindParser::parse('anchor-bottom-right')))->toBe(8);
+});


### PR DESCRIPTION
## What

Two related positioning improvements to the Edge layout system.

### 1. Position via attributes (not just utility classes)

`buildLayoutArray` now accepts the short attribute spellings alongside the Tailwind classes:

```blade
{{-- these are equivalent --}}
<native:column class="absolute top-0 right-0" />
<native:column absolute top="0" right="0" />
<native:column position="absolute" :top="0" :right="0" />
```

- `absolute` / `relative` (bare boolean) and `position="absolute|relative"` → `position_type`
- bare `top` / `right` / `bottom` / `left` → the position offsets

The explicit camelCase form (`positionTop` from `top-4`) still wins on conflict. **No native change** — these produce byte-identical layout to the class forms.

### 2. `<native:stack>` is a real z-stack, with two-point anchoring

Previously `stack` fell through to a column-direction `FlexContainer` (aspirational per the docs, not implemented). Now its children are z-overlaid and absolutely positioned by default, and each child places itself with **two independent points**:

- **`anchor`** — the point on the **parent** the child hooks onto.
- **`origin`** — the point **on the child** that lands on that parent point.

Both default to `center`, and both are child attributes (or `anchor-*` / `origin-*` classes). Values: `center`, the four edges (`top`/`right`/`bottom`/`left`), and the four corners (`top-left`…`bottom-right`).

```blade
{{-- centered dot (default) --}}
<native:stack>
    <native:text class="text-[40] font-bold" font="pinkary">Pinkary</native:text>
    <native:column anchor="top-right" class="w-[14] h-[14] rounded-full bg-theme-primary" />
</native:stack>
{{-- ^ anchor=top-right, origin defaults to center → the dot's CENTER sits on the
     wordmark's top-right corner (drawing half outside — a plain stack doesn't clip). --}}

{{-- a badge whose bottom-left corner hooks the parent's top-right corner --}}
<native:column origin="bottom-left" anchor="top-right" ... />
```

Placement is `child.topLeft = parent.min + parentSize·anchor − childSize·origin` (+ insets as a nudge). The single-anchor case is just `origin == anchor`. The stack **sizes to its largest child** (ZStack/wrap-content), so no explicit size is needed. This lets a child draw **outside** its container — supported on both platforms as long as no clipping ancestor (rounded corners / scroll viewport) intervenes.

## How it's wired

`anchor` and `origin` ride the **tolerant props blob** (like `scroll_anchor`, `glass`) rather than the fixed binary layout struct (which is packed by an out-of-repo C extension and has no spare field) — so **no wire-format or C-extension change**. Shared enum: `center=0`, then the eight compass points `1..8`.

- **PHP** (`NativeElementCollector`, `TailwindParser`): resolves `anchor`/`origin`/`position`/short-offset attrs and `anchor-*`/`origin-*` classes; anchor/origin emitted through props on both the streaming and Element paths.
- **iOS** (`FlexContainer.swift`, `SwiftUINodeRenderer.swift`): a `stack` gets `isStack` — all children absolute, `sizeThatFits` = union of children, and `placeAbsolute` uses `W·anchor − w·origin` (+ insets).
- **Android** (`ComposeFlexLayout.kt`, `NodeView.kt`): a `stack` overlays children in a wrap-content `Box`, positioning each via a value-equal `TwoPointAlignment` built on Compose's `Alignment.align(size, space)`.

**Non-stack containers and non-anchored absolute children are byte-identical** — the new behavior is gated behind `isStack` / an explicit `anchor`|`origin`; plain `absolute top-0 right-0` keeps the legacy inset-corner behavior.

## Tests

26 PHP tests (`tests/Unit/Edge/LayoutPositioningTest.php`) — attribute↔class parity & precedence, the 9 anchor/origin names + aliases, independent anchor+origin on one element, anchor/origin ride props (never the layout struct). Full suite green (652), Pint clean.

## Needs on-device verification

Swift/Kotlin can't compile in the authoring environment. Please verify: a bare `<native:stack>` sizes to its child (not zero, not full-width); anchor+origin combinations land as expected (esp. a child drawing outside the container, and that hit-testing on the overflow behaves acceptably for interactive children); and the inset-as-nudge convention reads consistently across iOS/Android. Non-blocking: `app/src/main/baseline-prof.txt` pins the old `FlexContainer` signature — a stale generated-profile entry that just skips PGO for that method until regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)