### PR TITLE
fix: suspend embedded webview PHP contexts across a runtime reboot

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
@@ -154,6 +154,7 @@ class PHPBridge(private val context: Context) {
         // exactly what SEGVs/hangs.
         if (persistentBooted) {
             Log.i(TAG, "Persistent runtime already booted — reusing (process outlived its activity)")
+            WebviewPHPRuntime.resumeAfterRuntimeReboot()
             return true
         }
 
@@ -176,7 +177,14 @@ class PHPBridge(private val context: Context) {
                 false
             }
         }
-        return future.get()
+        val booted = future.get()
+
+        // Re-open the window shutdownPersistentRuntime() closed, so webview
+        // contexts suspended for this reboot can boot again. No-op on a cold
+        // launch.
+        WebviewPHPRuntime.resumeAfterRuntimeReboot()
+
+        return booted
     }
 
     /**
@@ -220,6 +228,15 @@ class PHPBridge(private val context: Context) {
      */
     fun shutdownPersistentRuntime() {
         if (!persistentBooted) return
+
+        // Embedded php-mode webviews each own a PHP context on their own
+        // thread, built on the process-wide Zend module state that
+        // php_embed_shutdown() is about to destroy. Take them down first or
+        // they are left dereferencing freed memory — same hazard as the
+        // queue worker, and why a hot reload with a php webview on screen
+        // crashed. They re-boot on their next request once
+        // bootPersistentRuntime() reopens the window.
+        WebviewPHPRuntime.suspendAllForRuntimeReboot()
 
         try {
             com.nativephp.mobile.ui.nativerender.NativeElementBridge.sendShutdownEvent()

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/WebviewPHPRuntime.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/WebviewPHPRuntime.kt
@@ -3,7 +3,14 @@ package com.nativephp.mobile.bridge
 import android.util.Log
 import com.nativephp.mobile.network.PHPRequest
 import com.nativephp.mobile.security.LaravelCookieStore
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
 
 /**
  * A dedicated PHP context for one embedded php-mode webview.
@@ -15,10 +22,120 @@ import java.util.concurrent.Executors
  * its own TSRM context in the C bridge (thread == context): boot happens on
  * first use, requests serialize behind it, and [release] tears the context
  * down when the webview leaves the view hierarchy.
+ *
+ * A hot reload is the one event that reaches across those private lanes:
+ * [PHPBridge.shutdownPersistentRuntime] calls php_embed_shutdown(), which
+ * destroys process-wide Zend module state every webview context is built on.
+ * See [suspendAllForRuntimeReboot].
  */
 class WebviewPHPRuntime(private val bridge: PHPBridge) {
     companion object {
         private const val TAG = "WebviewPHPRuntime"
+
+        /** How long a reboot waits for live contexts to come down. */
+        private const val SUSPEND_TIMEOUT_MS = 5_000L
+
+        /** How long a request parks waiting for a reboot to finish. */
+        private const val REBOOT_WAIT_TIMEOUT_MS = 15_000L
+
+        /**
+         * Every un-released runtime in the process. Strong refs: [release]
+         * is the sole exit, and a runtime we lost track of would keep a live
+         * PHP context we can no longer suspend — exactly what breaks the
+         * reboot.
+         */
+        private val live: MutableSet<WebviewPHPRuntime> =
+            Collections.newSetFromMap(ConcurrentHashMap<WebviewPHPRuntime, Boolean>())
+
+        private val rebootLock = ReentrantLock()
+        private val rebootFinished = rebootLock.newCondition()
+
+        @Volatile
+        private var rebootInFlight = false
+
+        /**
+         * Close the reboot window and tear down every live webview context,
+         * blocking until they are all gone.
+         *
+         * This MUST run before php_embed_shutdown() — i.e. before
+         * [PHPBridge.shutdownPersistentRuntime], which is what a hot reload
+         * does. That shutdown destroys the shared Zend module state every
+         * webview context is built on, so a context still live across it
+         * dereferences freed memory: the same hazard the queue worker is
+         * stopped for, and the reason a hot reload with an embedded php
+         * webview on screen took the whole app down.
+         *
+         * The contexts are suspended, not retired. [resumeAfterRuntimeReboot]
+         * re-opens the window and each runtime boots a fresh context on its
+         * next request, so a webview that survives the reload (the tree is
+         * preserved across it) keeps serving — on the reloaded code.
+         */
+        @JvmStatic
+        fun suspendAllForRuntimeReboot() {
+            rebootLock.withLock { rebootInFlight = true }
+
+            val runtimes = live.toList()
+            if (runtimes.isEmpty()) {
+                return
+            }
+
+            Log.i(TAG, "suspending ${runtimes.size} context(s) for runtime reboot")
+
+            // Bounded — a wedged context must not deadlock the reload.
+            // Timing out means we are about to reboot with a live context
+            // attached, so say so loudly: that is the crash this prevents.
+            val deadline = System.currentTimeMillis() + SUSPEND_TIMEOUT_MS
+            runtimes.mapNotNull { it.suspendForReboot() }.forEach { pending ->
+                val remaining = (deadline - System.currentTimeMillis()).coerceAtLeast(0)
+                try {
+                    pending.get(remaining, TimeUnit.MILLISECONDS)
+                } catch (e: Exception) {
+                    Log.e(
+                        TAG,
+                        "⚠️ suspend did not complete (${e.javaClass.simpleName}) — " +
+                            "rebooting with a live context still attached"
+                    )
+                }
+            }
+        }
+
+        /**
+         * Re-open the reboot window once the persistent runtime is back up.
+         * Requests parked in [request] wake and boot themselves a fresh
+         * context. No-op when no reboot was in flight.
+         */
+        @JvmStatic
+        fun resumeAfterRuntimeReboot() {
+            rebootLock.withLock {
+                if (!rebootInFlight) {
+                    return
+                }
+                rebootInFlight = false
+                rebootFinished.signalAll()
+            }
+            Log.i(TAG, "reboot window closed — contexts re-boot on next request")
+        }
+
+        /** Park the calling lane while a persistent-runtime reboot is in flight. */
+        private fun awaitRuntimeReboot() {
+            if (!rebootInFlight) {
+                return
+            }
+
+            rebootLock.withLock {
+                // Bounded so a reload that never completes degrades to a 503
+                // rather than a webview that hangs forever.
+                var remaining = TimeUnit.MILLISECONDS.toNanos(REBOOT_WAIT_TIMEOUT_MS)
+                while (rebootInFlight && remaining > 0) {
+                    remaining = try {
+                        rebootFinished.awaitNanos(remaining)
+                    } catch (e: InterruptedException) {
+                        Thread.currentThread().interrupt()
+                        return
+                    }
+                }
+            }
+        }
     }
 
     private val executor = Executors.newSingleThreadExecutor { r ->
@@ -30,13 +147,11 @@ class WebviewPHPRuntime(private val bridge: PHPBridge) {
 
     // Executor-confined — only ever touched on the runtime's own thread.
     private var booted = false
+    private var needsBoot = true
 
     init {
-        executor.execute {
-            val rc = bridge.nativeWebviewPhpBoot(bridge.webviewBootstrapScript)
-            booted = rc == 0
-            Log.i(TAG, if (booted) "boot OK" else "boot FAILED ($rc)")
-        }
+        live.add(this)
+        executor.execute { boot() }
     }
 
     /**
@@ -51,6 +166,19 @@ class WebviewPHPRuntime(private val bridge: PHPBridge) {
 
         return try {
             executor.submit<String> {
+                if (needsBoot) {
+                    // No context right now — most likely a hot reload just
+                    // suspended it. Hold the request until the persistent
+                    // runtime is back rather than answering 503, so the
+                    // webview renders the reloaded code instead of an error
+                    // page. Only requests that actually need a context wait,
+                    // so a request already queued ahead of the suspend still
+                    // completes on the old context (and can't deadlock the
+                    // suspend behind it).
+                    awaitRuntimeReboot()
+                    boot()
+                }
+
                 if (!booted) {
                     return@submit unavailable()
                 }
@@ -91,6 +219,7 @@ class WebviewPHPRuntime(private val bridge: PHPBridge) {
             return
         }
         released = true
+        live.remove(this)
 
         executor.execute {
             if (booted) {
@@ -98,8 +227,60 @@ class WebviewPHPRuntime(private val bridge: PHPBridge) {
                 booted = false
                 Log.i(TAG, "context released")
             }
+            needsBoot = false
         }
         executor.shutdown()
+    }
+
+    /** Boot this runtime's PHP context. Executor-confined. */
+    private fun boot() {
+        if (released) {
+            return
+        }
+
+        // Never boot across a persistent-runtime reboot. With the persistent
+        // runtime down, ephemeral_embed_init takes its COLD path and calls
+        // php_embed_init() beside the runtime that is about to re-boot,
+        // corrupting TSRM/SAPI globals. Defer to the next request.
+        if (rebootInFlight) {
+            needsBoot = true
+            return
+        }
+
+        val rc = bridge.nativeWebviewPhpBoot(bridge.webviewBootstrapScript)
+        booted = rc == 0
+        // Leave the door open on failure — the next request retries rather
+        // than leaving the webview permanently dead.
+        needsBoot = !booted
+        Log.i(TAG, if (booted) "boot OK" else "boot FAILED ($rc)")
+    }
+
+    /**
+     * Stop this runtime's context while keeping the runtime usable — the next
+     * request boots a fresh one. Queued behind any in-flight request, so a
+     * response already being generated still completes on the old context
+     * before it goes away.
+     */
+    private fun suspendForReboot(): Future<*>? {
+        if (released) {
+            return null
+        }
+
+        return try {
+            // Explicit Runnable: submit(Runnable) vs submit(Callable) is
+            // ambiguous for a Unit-returning lambda.
+            executor.submit(Runnable {
+                if (booted) {
+                    bridge.nativeWebviewPhpShutdown()
+                    booted = false
+                    Log.i(TAG, "context suspended for runtime reboot")
+                }
+                needsBoot = true
+            })
+        } catch (e: RejectedExecutionException) {
+            // Released between the check above and the submit.
+            null
+        }
     }
 
     private fun unavailable(): String =

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
@@ -920,7 +920,10 @@ class MainActivity : FragmentActivity(), WebViewProvider {
                                 Log.d("HotReload", "HMR#$gen rebooting persistent runtime...")
 
                                 // Stop queue worker before shutdown — its TSRM context
-                                // will be destroyed by php_module_shutdown
+                                // will be destroyed by php_module_shutdown.
+                                // Embedded php-mode webviews own contexts with the
+                                // same hazard; shutdownPersistentRuntime() suspends
+                                // those itself.
                                 queueWorker?.stop()
 
                                 phpBridge.shutdownPersistentRuntime()

--- a/resources/xcode/NativePHP/Bridge/PersistentPHPRuntime.swift
+++ b/resources/xcode/NativePHP/Bridge/PersistentPHPRuntime.swift
@@ -96,6 +96,10 @@ final class PersistentPHPRuntime {
             print("PersistentPHPRuntime: boot FAILED (\(result)) error: \(bootError)")
         }
 
+        // Re-open the window shutdown() closed, so webview contexts
+        // suspended for this reboot can boot again. No-op on a cold launch.
+        WebviewPHPRuntime.resumeAfterRuntimeReboot()
+
         return isBooted
     }
 
@@ -186,6 +190,15 @@ final class PersistentPHPRuntime {
 
     /// Shutdown the persistent runtime.
     func shutdown() {
+        // Embedded php-mode webviews each own a PHP context on their own
+        // thread, built on the process-wide Zend module state that
+        // php_embed_shutdown() is about to destroy. Take them down first or
+        // they are left dereferencing freed memory — same hazard as the
+        // queue worker, and why a hot reload with a php webview on screen
+        // crashed. They re-boot on their next request once boot() reopens
+        // the window.
+        WebviewPHPRuntime.suspendAllForRuntimeReboot()
+
         _persistent_php_shutdown()
         isBooted = false
     }

--- a/resources/xcode/NativePHP/Bridge/WebviewPHPRuntime.swift
+++ b/resources/xcode/NativePHP/Bridge/WebviewPHPRuntime.swift
@@ -30,6 +30,11 @@ private func _webview_php_stop(_ handle: Int32)
 /// All work is serialized on a private queue: requests naturally queue
 /// behind the (asynchronous) boot, and `release()` behind in-flight
 /// requests — no explicit state machine needed.
+///
+/// A hot reload is the one event that reaches across those private queues:
+/// `PersistentPHPRuntime.shutdown()` calls `php_embed_shutdown()`, which
+/// destroys process-wide Zend module state every webview context is built
+/// on. See `suspendAllForRuntimeReboot()`.
 final class WebviewPHPRuntime {
     /// Queue-confined runtime state, boxed separately from the runtime
     /// object so queued blocks — including the deinit backstop — capture
@@ -39,19 +44,23 @@ final class WebviewPHPRuntime {
     private final class State {
         var handle: Int32 = -1
         var released = false
+        /// Context is gone but the runtime is still usable: the next
+        /// request boots a fresh one. Set when a boot failed or when the
+        /// context was suspended for a persistent-runtime reboot. Unlike
+        /// `released`, which is terminal, this is recoverable.
+        var needsBoot = false
     }
+
+    private static let unavailableResponse =
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/plain\r\n\r\nWebview PHP runtime unavailable."
 
     private let queue = DispatchQueue(label: "com.nativephp.webview-php", qos: .userInitiated)
     private let state = State()
 
     init() {
+        Self.register(self)
         let state = self.state
-        queue.async {
-            let appPath = AppUpdateManager.shared.getAppPath()
-            let bootstrap = appPath + "/vendor/nativephp/mobile/bootstrap/ios/persistent.php"
-            state.handle = _webview_php_start(bootstrap)
-            print("[NativePHP] webview runtime: boot \(state.handle >= 0 ? "OK (slot \(state.handle))" : "FAILED (\(state.handle))")")
-        }
+        queue.async { Self.boot(state) }
     }
 
     /// Dispatch a request on this webview's own PHP context. The completion
@@ -60,8 +69,20 @@ final class WebviewPHPRuntime {
     func dispatch(request: RequestData, completion: @escaping (String) -> Void) {
         let state = self.state
         queue.async {
+            if !state.released, state.needsBoot {
+                // No context right now — most likely a hot reload just
+                // suspended it. Hold the request until the persistent
+                // runtime is back rather than answering 503, so the webview
+                // renders the reloaded code instead of an error page. Only
+                // requests that actually need a context wait, so a request
+                // already queued ahead of the suspend still completes on the
+                // old context (and can't deadlock the suspend behind it).
+                Self.waitForRuntimeReboot()
+                Self.boot(state)
+            }
+
             guard !state.released, state.handle >= 0 else {
-                completion("HTTP/1.1 503 Service Unavailable\r\nContent-Type: text/plain\r\n\r\nWebview PHP runtime unavailable.")
+                completion(Self.unavailableResponse)
                 return
             }
 
@@ -100,24 +121,171 @@ final class WebviewPHPRuntime {
     /// Stop this webview's PHP thread and free its slot. Queued after any
     /// in-flight request; further dispatches answer 503. Idempotent.
     func release() {
+        Self.deregister(self)
         Self.releaseAsync(state: state, queue: queue)
     }
 
     deinit {
         // Backstop for paths where dismantleUIView never ran. Captures only
-        // the state box and queue — never `self`.
+        // the state box and queue — never `self`. No deregister call here:
+        // the registry is weak (it has to be, or this backstop could never
+        // fire) and drops the entry on dealloc.
         Self.releaseAsync(state: state, queue: queue)
+    }
+
+    /// Boot a PHP context for this runtime. Runs on the runtime's own queue.
+    private static func boot(_ state: State) {
+        guard !state.released else { return }
+
+        // Never boot across a persistent-runtime reboot. `webview_php_start`
+        // gates on the persistent boot state, which is reset to
+        // NEVER_STARTED while the runtime is down, so the boot would fail —
+        // and a context created just before the reboot would be torn down
+        // again moments later anyway. Defer to the next request.
+        if isRebootingRuntime {
+            state.needsBoot = true
+            return
+        }
+
+        let appPath = AppUpdateManager.shared.getAppPath()
+        let bootstrap = appPath + "/vendor/nativephp/mobile/bootstrap/ios/persistent.php"
+        state.handle = _webview_php_start(bootstrap)
+        // Leave the door open on failure — the next request retries rather
+        // than leaving the webview permanently dead.
+        state.needsBoot = state.handle < 0
+        print("[NativePHP] webview runtime: boot \(state.handle >= 0 ? "OK (slot \(state.handle))" : "FAILED (\(state.handle))")")
     }
 
     private static func releaseAsync(state: State, queue: DispatchQueue) {
         queue.async {
             guard !state.released else { return }
             state.released = true
+            state.needsBoot = false
             if state.handle >= 0 {
                 _webview_php_stop(state.handle)
                 print("[NativePHP] webview runtime: slot \(state.handle) released")
                 state.handle = -1
             }
+        }
+    }
+
+    // MARK: - Live registry & runtime-reboot barrier
+
+    /// Every un-released runtime in the process. Weak on purpose: `deinit`
+    /// is the backstop for renderers that never call `release()`, and a
+    /// strong registry would keep those objects alive forever. Pointer
+    /// personality so membership never sends `hash`/`isEqual:` to an entry
+    /// that is mid-dealloc.
+    private static let registry = NSHashTable<WebviewPHPRuntime>(
+        options: [.weakMemory, .objectPointerPersonality],
+        capacity: 0
+    )
+    private static let registryLock = NSLock()
+
+    /// Guards the reboot window. Broadcast when the window closes.
+    private static let rebootCondition = NSCondition()
+    private static var rebootInFlight = false
+
+    private static var isRebootingRuntime: Bool {
+        rebootCondition.lock()
+        defer { rebootCondition.unlock() }
+        return rebootInFlight
+    }
+
+    private static func register(_ runtime: WebviewPHPRuntime) {
+        registryLock.lock()
+        registry.add(runtime)
+        registryLock.unlock()
+    }
+
+    private static func deregister(_ runtime: WebviewPHPRuntime) {
+        registryLock.lock()
+        registry.remove(runtime)
+        registryLock.unlock()
+    }
+
+    /// Close the reboot window and tear down every live webview context,
+    /// blocking until they are all gone.
+    ///
+    /// This MUST run before `php_embed_shutdown()` — i.e. before
+    /// `PersistentPHPRuntime.shutdown()`, which is what a hot reload does.
+    /// That shutdown destroys the shared Zend module state every webview
+    /// context is built on, so a context still live across it dereferences
+    /// freed memory: the same heap corruption `PHPQueueWorker.stopAndWait()`
+    /// exists to prevent, and the reason a hot reload with an embedded php
+    /// webview on screen took the whole app down.
+    ///
+    /// The contexts are suspended, not retired. `resumeAfterRuntimeReboot()`
+    /// re-opens the window and each runtime boots a fresh context on its
+    /// next request, so a webview that survives the reload (the tree is
+    /// preserved across it) keeps serving — on the reloaded code.
+    static func suspendAllForRuntimeReboot() {
+        rebootCondition.lock()
+        rebootInFlight = true
+        rebootCondition.unlock()
+
+        registryLock.lock()
+        let runtimes = registry.allObjects
+        registryLock.unlock()
+
+        guard !runtimes.isEmpty else { return }
+
+        NSLog("%@", "[NativePHP] webview runtime: suspending \(runtimes.count) context(s) for runtime reboot")
+
+        let group = DispatchGroup()
+        for runtime in runtimes {
+            group.enter()
+            runtime.suspendForReboot { group.leave() }
+        }
+
+        // Bounded — a wedged context must not deadlock the reload. Timing
+        // out means we are about to reboot with a live context attached, so
+        // say so loudly: that is the crash this whole path prevents.
+        if group.wait(timeout: .now() + 5) == .timedOut {
+            NSLog("%@", "[NativePHP] ⚠️ webview runtime: suspend timed out — rebooting with a live context still attached")
+        }
+    }
+
+    /// Re-open the reboot window once the persistent runtime is back up.
+    /// Requests parked in `dispatch` wake and boot themselves a fresh
+    /// context. No-op when no reboot was in flight.
+    static func resumeAfterRuntimeReboot() {
+        rebootCondition.lock()
+        defer { rebootCondition.unlock() }
+        guard rebootInFlight else { return }
+        rebootInFlight = false
+        rebootCondition.broadcast()
+        NSLog("%@", "[NativePHP] webview runtime: reboot window closed — contexts re-boot on next request")
+    }
+
+    /// Park the calling lane while a persistent-runtime reboot is in flight.
+    private static func waitForRuntimeReboot() {
+        rebootCondition.lock()
+        defer { rebootCondition.unlock() }
+
+        // Bounded so a reload that never completes degrades to a 503 rather
+        // than a webview that hangs forever.
+        let deadline = Date().addingTimeInterval(15)
+        while rebootInFlight {
+            if !rebootCondition.wait(until: deadline) { return }
+        }
+    }
+
+    /// Stop this runtime's context while keeping the runtime usable — the
+    /// next request boots a fresh one. Queued behind any in-flight request,
+    /// so a response already being generated still completes on the old
+    /// context before it goes away.
+    private func suspendForReboot(completion: @escaping () -> Void) {
+        let state = self.state
+        queue.async {
+            defer { completion() }
+            guard !state.released else { return }
+            if state.handle >= 0 {
+                _webview_php_stop(state.handle)
+                print("[NativePHP] webview runtime: slot \(state.handle) suspended for runtime reboot")
+                state.handle = -1
+            }
+            state.needsBoot = true
         }
     }
 }

--- a/resources/xcode/NativePHP/HotReloadServer.swift
+++ b/resources/xcode/NativePHP/HotReloadServer.swift
@@ -82,6 +82,9 @@ class HotReloadCoordinator {
             // The queue worker MUST be stopped first — php_embed_shutdown()
             // destroys global Zend module state, and the worker's live TSRM
             // context would reference freed memory, causing a heap-corruption crash.
+            // Embedded php-mode webviews own TSRM contexts with the same
+            // hazard; `PersistentPHPRuntime.shutdown()` suspends those itself
+            // (see `WebviewPHPRuntime.suspendAllForRuntimeReboot`).
             if PersistentPHPRuntime.shared.isBooted {
                 PHPQueueWorker.shared.stopAndWait()
                 _ = PersistentPHPRuntime.shared.reboot()


### PR DESCRIPTION
## The crash

Hot reload with an embedded `<native:webview php>` on screen takes the whole app down.

Those webviews each get a **dedicated PHP context on their own thread** (`WebviewPHPRuntime` → `webview_php_start` / `nativeWebviewPhpBoot`), because the persistent runtime's single lane is parked inside the native screen's event loop and can never answer their `php://` requests.

Hot reload reboots the persistent runtime, and `php_embed_shutdown()` destroys **process-wide Zend module state** — the state every webview context is built on. Nothing tore those contexts down first, so they were left dereferencing freed memory.

It's the exact hazard the code already guards for the queue worker:

```swift
// The queue worker MUST be stopped first — php_embed_shutdown()
// destroys global Zend module state, and the worker's live TSRM
// context would reference freed memory, causing a heap-corruption crash.
PHPQueueWorker.shared.stopAndWait()
```

Webview contexts were simply never added to that list. It only surfaces with a php webview on screen because that's the only thing that creates one.

## The fix

Both platforms, same shape — `WebviewPHPRuntime` now knows about the reload boundary.

- **Live registry** — runtimes self-register at init, deregister on `release()`. iOS uses a weak `NSHashTable` (the `deinit` backstop for renderers that skip `release()` has to keep working); Android uses strong refs removed in `release()`. **No change needed in `nativephp/mobile-ui`.**
- **`suspendAllForRuntimeReboot()`** — closes a reboot window and tears every live context down, blocking until they're gone (bounded at 5s, logs loudly if it ever times out). Called from `PersistentPHPRuntime.shutdown()` / `PHPBridge.shutdownPersistentRuntime()`, so *every* reboot path is covered rather than just today's call sites.
- **`resumeAfterRuntimeReboot()`** — reopens the window from `boot()` / `bootPersistentRuntime()`.
- **Suspended, not retired** — a request landing mid-reload parks on the closed window (bounded, degrades to 503) and then boots a fresh context, so the webview comes back rendering the *reloaded* code instead of an error page.
- **Boots inside the window are deferred**, not attempted: on iOS `webview_php_start` would fail its boot gate, and on Android `ephemeral_embed_init` would take its **cold** path and call `php_embed_init()` beside the rebooting runtime.
- A **failed boot now retries** on the next request instead of leaving the webview permanently dead.

### Why it can't deadlock

Two invariants:

1. Only requests that actually need a context wait — one queued ahead of the suspend still completes on the old context, so it can never park the suspend behind it.
2. `needsBoot == true` always implies there is no live context. So a suspend stuck behind a parked request can't be the crash case; the timeout backstop is only reachable for a genuinely wedged live context.

## Verification

- `swiftc -typecheck` across the whole iOS source tree: clean (only third-party module imports fail outside Xcode).
- Pest suite: 626 passed, no PHP touched.
- ⚠️ No Kotlin compiler in this environment — the Android side is reviewed but **not compiled**. Worth a build before merge.
- ⚠️ Not yet run on a device against a real hot reload. That's the confirmation still outstanding, and the main reason this is a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)