### PR TITLE
Support negative margins and insets in the Tailwind parser

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/ComposeFlexLayout.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/ComposeFlexLayout.kt
@@ -102,15 +102,20 @@ fun FlexContainer(
                     val right = node.layout?.positionRight ?: 0f
                     val bottom = node.layout?.positionBottom ?: 0f
 
+                    // NON-ZERO rather than positive, so NEGATIVE insets work:
+                    // `-right-8` anchors trailing and offsets OUTWARD,
+                    // deliberately overhanging the edge (Tailwind's bleed).
+                    // Zero still reads as "no anchor on that edge" — the
+                    // packed node struct has no spare byte to distinguish an
+                    // unset edge from an explicit `right-0`.
                     val anchor = when {
-                        right > 0f && bottom > 0f -> Alignment.BottomEnd
-                        right > 0f && top > 0f    -> Alignment.TopEnd
-                        right > 0f                 -> Alignment.TopEnd
-                        bottom > 0f                -> Alignment.BottomStart
-                        else                       -> Alignment.TopStart
+                        right != 0f && bottom != 0f -> Alignment.BottomEnd
+                        right != 0f                 -> Alignment.TopEnd
+                        bottom != 0f                -> Alignment.BottomStart
+                        else                        -> Alignment.TopStart
                     }
-                    val offsetX = if (right > 0f) (-right).dp else left.dp
-                    val offsetY = if (bottom > 0f) (-bottom).dp else top.dp
+                    val offsetX = if (right != 0f) (-right).dp else left.dp
+                    val offsetY = if (bottom != 0f) (-bottom).dp else top.dp
 
                     Box(
                         modifier = Modifier
@@ -242,15 +247,29 @@ private fun buildChildModifier(
     val layout = node.layout
     var mod: Modifier = Modifier
 
-    // Margins
-    if (layout != null && (layout.marginTop > 0f || layout.marginRight > 0f ||
-        layout.marginBottom > 0f || layout.marginLeft > 0f)) {
+    // Margins. Split into a positive part (padding, which reserves space and
+    // shifts siblings) and a negative part (offset, which only moves the drawn
+    // child). `Modifier.padding` THROWS on a negative dp, so the split isn't
+    // cosmetic — passing `-mt-4` straight through would crash the render.
+    //
+    // Caveat: a negative margin therefore does NOT pull siblings on Android
+    // the way it does on iOS, where FlexContainer folds margins into its own
+    // arithmetic. Use negative INSETS on an absolute child for overlap that
+    // must behave identically on both platforms.
+    if (layout != null && (layout.marginTop != 0f || layout.marginRight != 0f ||
+        layout.marginBottom != 0f || layout.marginLeft != 0f)) {
         mod = mod.padding(
-            start = layout.marginLeft.dp,
-            top = layout.marginTop.dp,
-            end = layout.marginRight.dp,
-            bottom = layout.marginBottom.dp
+            start = layout.marginLeft.coerceAtLeast(0f).dp,
+            top = layout.marginTop.coerceAtLeast(0f).dp,
+            end = layout.marginRight.coerceAtLeast(0f).dp,
+            bottom = layout.marginBottom.coerceAtLeast(0f).dp
         )
+
+        val negX = layout.marginLeft.coerceAtMost(0f) - layout.marginRight.coerceAtMost(0f)
+        val negY = layout.marginTop.coerceAtMost(0f) - layout.marginBottom.coerceAtMost(0f)
+        if (negX != 0f || negY != 0f) {
+            mod = mod.offset(x = negX.dp, y = negY.dp)
+        }
     }
 
     // Main axis: flex_grow or fill → weight

--- a/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
+++ b/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
@@ -593,15 +593,20 @@ struct FlexContainer: Layout {
     private func placeAbsolute(_ subview: LayoutSubview, info: ChildInfo, in bounds: CGRect) {
         let ideal = subview.sizeThatFits(.unspecified)
 
-        // Resolve horizontal position
+        // Resolve horizontal position. A NON-ZERO right inset (with no left)
+        // anchors to the trailing edge; `!= 0` rather than `> 0` so NEGATIVE
+        // insets work — `-right-8` resolves to maxX - width + 8, deliberately
+        // overhanging the edge (Tailwind's `-right-8` bleed). Zero still means
+        // "no right anchor", since the packed node struct has no spare byte to
+        // distinguish an unset edge from an explicit `right-0`.
         var x = bounds.minX + info.positionLeft
-        if info.positionRight > 0 && info.positionLeft == 0 {
+        if info.positionRight != 0 && info.positionLeft == 0 {
             x = bounds.maxX - ideal.width - info.positionRight
         }
 
-        // Resolve vertical position
+        // Resolve vertical position — same convention.
         var y = bounds.minY + info.positionTop
-        if info.positionBottom > 0 && info.positionTop == 0 {
+        if info.positionBottom != 0 && info.positionTop == 0 {
             y = bounds.maxY - ideal.height - info.positionBottom
         }
 

--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -342,6 +342,19 @@ class TailwindParser
             return ['dark' => $inner];
         }
 
+        // Negative utilities: `-mt-4`, `-right-8`, `-left-[12]`. Parsed by
+        // stripping the sign, running the positive form, then negating the
+        // result. Placed AFTER the variant prefixes so `ios:-right-8` works,
+        // and BEFORE arbitrary values so `-left-[12]` does too.
+        //
+        // Only inset and margin utilities may go negative — Tailwind itself
+        // has no negative padding/gap/size, and silently accepting one here
+        // would emit nonsense geometry instead of an obvious no-op. The
+        // negative form of anything else parses to null (class ignored).
+        if (str_starts_with($class, '-')) {
+            return self::negateSpacing(self::parseClassImpl(substr($class, 1)));
+        }
+
         // Arbitrary values: prefix-[value]
         if (str_contains($class, '[')) {
             if (preg_match('/^(.+?)-\[([^\]]+)\]$/', $class, $m)) {
@@ -622,6 +635,45 @@ class TailwindParser
         }
 
         return null;
+    }
+
+    /**
+     * Keys a leading `-` may legally flip. Mirrors Tailwind: margins and
+     * insets take negatives, padding / gap / sizing never do.
+     */
+    private const NEGATABLE = [
+        'margin', 'marginTop', 'marginRight', 'marginBottom', 'marginLeft',
+        'positionTop', 'positionRight', 'positionBottom', 'positionLeft',
+    ];
+
+    /**
+     * Flip the sign of a parsed spacing result, or reject it.
+     *
+     * Returns null when $parsed is null (the positive form didn't parse) or
+     * carries ANY key outside [NEGATABLE] — a negative form of a
+     * non-negatable utility is a typo, and dropping the class is safer than
+     * emitting geometry the author didn't ask for.
+     *
+     * @param  array<string, mixed>|null  $parsed
+     * @return array<string, float>|null
+     */
+    private static function negateSpacing(?array $parsed): ?array
+    {
+        if ($parsed === null || $parsed === []) {
+            return null;
+        }
+
+        $negated = [];
+
+        foreach ($parsed as $key => $value) {
+            if (! in_array($key, self::NEGATABLE, true) || ! is_numeric($value)) {
+                return null;
+            }
+
+            $negated[$key] = -(float) $value;
+        }
+
+        return $negated;
     }
 
     /**

--- a/tests/Unit/Edge/TailwindParserTest.php
+++ b/tests/Unit/Edge/TailwindParserTest.php
@@ -643,3 +643,49 @@ it('explicit attrs override class attrs', function () {
     // explicit fontSize=32 should override text-xl (20)
     expect($tree['props']['font_size'])->toBe(32.0);
 });
+
+// ── Negative utilities ──────────────────────────────
+
+it('parses negative margins', function () {
+    expect(TailwindParser::parse('-mt-4'))->toBe(['marginTop' => -16.0]);
+    expect(TailwindParser::parse('-ml-2'))->toBe(['marginLeft' => -8.0]);
+    expect(TailwindParser::parse('-m-1'))->toBe(['margin' => -4.0]);
+    expect(TailwindParser::parse('-mx-4'))->toBe(['marginLeft' => -16.0, 'marginRight' => -16.0]);
+    expect(TailwindParser::parse('-my-2'))->toBe(['marginTop' => -8.0, 'marginBottom' => -8.0]);
+});
+
+it('parses negative insets so an absolute child can overhang its container', function () {
+    expect(TailwindParser::parse('-right-8'))->toBe(['positionRight' => -32.0]);
+    expect(TailwindParser::parse('-top-2'))->toBe(['positionTop' => -8.0]);
+    expect(TailwindParser::parse('-bottom-px'))->toBe(['positionBottom' => -1.0]);
+    expect(TailwindParser::parse('-left-0.5'))->toBe(['positionLeft' => -2.0]);
+});
+
+it('parses negative arbitrary values', function () {
+    expect(TailwindParser::parse('-right-[12]'))->toBe(['positionRight' => -12.0]);
+    expect(TailwindParser::parse('-mt-[6]'))->toBe(['marginTop' => -6.0]);
+});
+
+it('composes negatives with platform and dark variants', function () {
+    TailwindParser::setPlatform('ios');
+    expect(TailwindParser::parse('ios:-right-8'))->toBe(['positionRight' => -32.0]);
+    expect(TailwindParser::parse('android:-right-8'))->toBe([]);
+    TailwindParser::setPlatform(null);
+
+    expect(TailwindParser::parse('dark:-mt-4'))->toBe(['dark' => ['marginTop' => -16.0]]);
+});
+
+it('rejects negatives on utilities that have no negative form', function () {
+    // Tailwind has no negative padding / gap / sizing; emitting geometry the
+    // author never asked for would be worse than dropping the class.
+    expect(TailwindParser::parse('-p-4'))->toBe([]);
+    expect(TailwindParser::parse('-gap-2'))->toBe([]);
+    expect(TailwindParser::parse('-w-4'))->toBe([]);
+    expect(TailwindParser::parse('-bg-red-500'))->toBe([]);
+    expect(TailwindParser::parse('-nonsense'))->toBe([]);
+});
+
+it('keeps positive spacing untouched', function () {
+    expect(TailwindParser::parse('mt-4'))->toBe(['marginTop' => 16]);
+    expect(TailwindParser::parse('right-8'))->toBe(['positionRight' => 32]);
+});


### PR DESCRIPTION
## Problem

Tailwind's negative utilities (`-mt-4`, `-right-8`) had no parse path, so they silently dropped. And the four absolute-placement sites treated a **positive** inset as the only signal for "anchored to this edge":

```swift
if info.positionRight > 0 && info.positionLeft == 0 { … }
```

which meant a negative inset could not be expressed at all — ruling out the common bleed pattern of parking an oversized decorative icon so it overhangs its container.

## Changes

**`TailwindParser`** strips a leading `-`, parses the positive form, then negates. It sits after the variant prefixes and before arbitrary values, so `ios:-right-8` and `-left-[12]` both work.

Only margin and inset keys may flip. Tailwind has no negative padding, gap or sizing, so `-p-4` / `-gap-2` / `-w-4` parse to `null` rather than emitting geometry the author never asked for.

**The four placement sites** move from `right > 0` to `right != 0` when choosing the trailing anchor:

- `resources/xcode/…/FlexContainer.swift` (`placeAbsolute`)
- `resources/androidstudio/…/ComposeFlexLayout.kt`

(the two matching sites in `nativephp/mobile-ui` — `NativeUIStackRenderer.swift` and `ContainerRenderers.kt` — need the same one-line change; happy to open that PR alongside.)

**Android margins** are split into a positive part (`padding`, which reserves space) and a negative part (`offset`, which only moves the drawn child). `Modifier.padding` **throws** on a negative dp, so passing `-mt-4` straight through would have crashed the render — the split is a correctness fix, not a nicety.

## Known limitations, both documented at the call sites

- **`right-0` still reads as "no right anchor."** The packed 160-byte node struct is full (props start at byte 154), so distinguishing an unset edge from an explicit zero needs a stride bump across the encoder and both decoders. Out of scope here; the pre-existing behavior is unchanged.
- **Negative margins don't pull siblings on Android.** `offset` doesn't affect layout, whereas iOS `FlexContainer` folds margins into its own arithmetic. Negative insets on an absolute child behave identically on both platforms and are the recommended route when that matters.

## Tests

Six new cases in `TailwindParserTest` covering negative margins, negative insets, negative arbitrary values, composition with `ios:` / `dark:` variants, rejection of non-negatable utilities, and positives left untouched.

`632 passed`, Pint clean.