### PR TITLE
Fix native chrome and flex layout bugs on iOS 26 and Android

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/NativeUIThemeProvider.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/NativeUIThemeProvider.kt
@@ -5,6 +5,9 @@ import androidx.compose.material3.Typography
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 
 /**
  * Seam that lets a UI plugin supply the app's Material3 [ColorScheme] without
@@ -18,11 +21,21 @@ import androidx.compose.runtime.Composable
  * The provider is invoked during composition, so a provider that reads Compose
  * state (PHP `Theme::merge` updates flow in as snapshot state) stays reactive
  * across recomposition.
+ *
+ * Every slot is snapshot state, because registration LOSES THE RACE against the
+ * first composition: `MainActivity` calls `setContent` from `onCreate`, while
+ * the plugin init functions run from `registerBridgeFunctions` — deferred to a
+ * background thread after the first frame to keep the boot off the TTID path.
+ * As plain `var`s these would be read as null on that first pass and never
+ * re-read (the `setContent` scope only recomposes when the system appearance
+ * flips), leaving the app on Material's baseline palette — a pinkish neutral on
+ * the top bar — for the rest of the process.
  */
 object NativeUIThemeProvider {
 
     /** Set by a UI plugin to map `isDark` → a Material3 [ColorScheme]. */
-    var colorSchemeFor: (@Composable (isDark: Boolean) -> ColorScheme)? = null
+    var colorSchemeFor: (@Composable (isDark: Boolean) -> ColorScheme)? by
+        mutableStateOf<(@Composable (isDark: Boolean) -> ColorScheme)?>(null)
 
     /**
      * Set by a UI plugin to supply the app's Material3 [Typography] — e.g.
@@ -31,7 +44,8 @@ object NativeUIThemeProvider {
      * chrome (top bars, tab labels, dropdowns) renders unchanged without a
      * UI plugin.
      */
-    var typographyFor: (@Composable () -> Typography?)? = null
+    var typographyFor: (@Composable () -> Typography?)? by
+        mutableStateOf<(@Composable () -> Typography?)?>(null)
 
     /**
      * Set by a UI plugin to resolve a font token (a bundled font file's
@@ -40,7 +54,8 @@ object NativeUIThemeProvider {
      * are stored. Null (or a null return) means "no such font" — callers
      * fall back to the ambient typography.
      */
-    var fontFamilyResolver: ((String) -> androidx.compose.ui.text.font.FontFamily?)? = null
+    var fontFamilyResolver: ((String) -> androidx.compose.ui.text.font.FontFamily?)? by
+        mutableStateOf<((String) -> androidx.compose.ui.text.font.FontFamily?)?>(null)
 
     /** Resolve a chrome font token via the plugin, or null. */
     fun resolveChromeFontFamily(name: String): androidx.compose.ui.text.font.FontFamily? =

--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -20,7 +20,7 @@ elements (`native:column`, `native:text`, `native:button`, …).** This is the w
 - Style EDGE elements with Tailwind utility classes via `class="..."` / `:class="..."` only — never inline
   CSS `style="..."` attributes or ad-hoc styling props.
 - Compose screens from **nested child components**: any `NativeComponent` under `app/NativeComponents` mounts
-  as a tag (`UserCard` → `<native:user-card :user="$u" key="user-{{ $u->id }}" @saved="onSaved" />`) with live
+  as a tag (`UserCard` → `<native:user-card :user="$u" key="user-@{{ $u->id }}" @saved="onSaved" />`) with live
   props, its own persistent state, and `emit()` events bubbling to `@event` tag bindings / `#[On('event')]`
   listeners. Prefer extracting a reusable child component over duplicating Blade across screens; give list
   children a stable domain `key` (never the loop index).

--- a/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
+++ b/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
@@ -280,6 +280,7 @@ struct FlexContainer: Layout {
         var maxCross: CGFloat = 0
         var hypotheticalMains = [Int: CGFloat]()
         var totalGrow: CGFloat = 0
+        var totalShrink: CGFloat = 0
 
         for i in cache.flowIndices {
             let info = cache.childInfos[i]
@@ -308,6 +309,7 @@ struct FlexContainer: Layout {
             hypotheticalMains[i] = childMain
             totalMain += childMain + mainMargin(info)
             totalGrow += grow
+            totalShrink += info.flexShrink
             maxCross = max(maxCross, crossSize(ideal) + crossMargin(info))
         }
 
@@ -353,6 +355,73 @@ struct FlexContainer: Layout {
                     if newCross > maxCross {
                         maxCross = newCross
                     }
+                }
+            }
+        }
+
+        // Phase B2: the mirror image — overflow with flex-shrink children.
+        // `placeSubviews` has always shrunk them; `sizeThatFits` did not, so a
+        // container reported its PRE-shrink main size to the parent. Inside a
+        // scroll view (which permits overflow) that reported width won, and
+        // e.g. a long chat bubble ran off-screen on one line instead of
+        // wrapping — Android, whose measure pass shrinks, wrapped correctly.
+        // Same ratio rule as placeSubviews so both passes agree.
+        if proposedMain.isFinite && totalShrink > 0 {
+            let remaining = proposedMain - totalMain
+            if remaining < 0 {
+                let deficit = -remaining
+                // CSS weights shrink by SCALED base size — `shrink × base` —
+                // not by shrink alone. It matters because flex-shrink defaults
+                // to 1 on every child: a row of [bubble, spacer] has
+                // totalShrink 2, so an unweighted ratio hands half the deficit
+                // to the spacer, whose base is already 0. That half evaporates
+                // (`max(0, 0 - x)`) and the bubble shrinks only halfway —
+                // measured 1113pt against a 386pt proposal. Weighting gives the
+                // zero-base spacer zero reduction and the bubble the full
+                // deficit.
+                var totalWeighted: CGFloat = 0
+                for i in cache.flowIndices {
+                    let info = cache.childInfos[i]
+                    guard info.flexShrink > 0 else { continue }
+                    totalWeighted += info.flexShrink * hypotheticalMains[i, default: 0]
+                }
+                if totalWeighted > 0 {
+                    for i in cache.flowIndices {
+                        let info = cache.childInfos[i]
+                        guard info.flexShrink > 0 else { continue }
+                        let weight = info.flexShrink * hypotheticalMains[i, default: 0]
+                        let reduction = deficit * (weight / totalWeighted)
+                        hypotheticalMains[i, default: 0] = max(0, hypotheticalMains[i, default: 0] - reduction)
+                    }
+                }
+
+                // Re-measure the shrunk children at their reduced main: text
+                // that now wraps reports a taller cross size, which is what
+                // makes the container tall enough to show every line.
+                for i in cache.flowIndices {
+                    let info = cache.childInfos[i]
+                    guard info.flexShrink > 0 else { continue }
+                    let reducedMain = hypotheticalMains[i, default: 0]
+                    let crossAvail = proposedCross.isFinite ? proposedCross - crossMargin(info) : nil
+                    let proposal: ProposedViewSize
+                    if isRow {
+                        proposal = ProposedViewSize(width: reducedMain, height: crossAvail)
+                    } else {
+                        proposal = ProposedViewSize(width: crossAvail, height: reducedMain)
+                    }
+                    let measured = subviews[i].sizeThatFits(proposal)
+                    cache.childInfos[i].idealSize = measured
+                    let newCross = crossSize(measured) + crossMargin(info)
+                    if newCross > maxCross {
+                        maxCross = newCross
+                    }
+                }
+
+                // Recompute from the shrunk values so `finalMain` below reports
+                // the fitted size rather than the original overflow.
+                totalMain = gaps
+                for i in cache.flowIndices {
+                    totalMain += hypotheticalMains[i, default: 0] + mainMargin(cache.childInfos[i])
                 }
             }
         }
@@ -452,12 +521,23 @@ struct FlexContainer: Layout {
                 }
             }
         } else if remaining < 0 && totalShrink > 0 {
-            // Shrink: reduce by flex_shrink ratio
+            // Shrink: reduce by CSS's SCALED shrink factor (`shrink × base`),
+            // matching the measure pass. Weighting matters because shrink
+            // defaults to 1 everywhere — an unweighted ratio sends part of the
+            // deficit to zero-base children (spacers), where `max(0, …)`
+            // discards it and the real content shrinks short of fitting.
             let deficit = -remaining
+            var totalWeighted: CGFloat = 0
             for i in cache.flowIndices {
                 let info = cache.childInfos[i]
-                if info.flexShrink > 0 {
-                    let reduction = deficit * (info.flexShrink / totalShrink)
+                guard info.flexShrink > 0 else { continue }
+                totalWeighted += info.flexShrink * childMains[i]
+            }
+            if totalWeighted > 0 {
+                for i in cache.flowIndices {
+                    let info = cache.childInfos[i]
+                    guard info.flexShrink > 0 else { continue }
+                    let reduction = deficit * ((info.flexShrink * childMains[i]) / totalWeighted)
                     childMains[i] = max(0, childMains[i] - reduction)
                 }
             }

--- a/resources/xcode/NativePHP/NativeRender/NativeRootStackRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeRootStackRenderer.swift
@@ -113,6 +113,22 @@ struct NativeRootStackRenderer: View {
         let textColor: Color = textArgb != 0 ? Color(argb: textArgb) : .primary
         let hasExplicitBg = bgArgb != 0
 
+        // `textColor` only reaches chrome WE draw — the back chevron, the
+        // principal-slot title, and the trailing actions. System-drawn titles
+        // (`.navigationTitle`, which is what `large` / `automatic` display
+        // modes use) take their color from the bar's color scheme instead, so
+        // an explicit `background_color` could otherwise leave a light bar with
+        // a dark-mode white title — invisible. Derive the scheme from the
+        // developer's `text_color`, matching NativeRootTabsRenderer.
+        let toolbarScheme: ColorScheme? = {
+            guard textArgb != 0 else { return nil }
+            let r = Double((textArgb >> 16) & 0xFF) / 255.0
+            let g = Double((textArgb >>  8) & 0xFF) / 255.0
+            let b = Double( textArgb        & 0xFF) / 255.0
+            let luminance = 0.299 * r + 0.587 * g + 0.114 * b
+            return luminance > 0.5 ? .dark : .light
+        }()
+
         // Map the PHP-side string to SwiftUI's NavigationBarItem.TitleDisplayMode.
         //   `large`     — iOS-native big title, left-aligned, collapses on scroll
         //   `automatic` — iOS picks (large at root, inline after a push)
@@ -211,6 +227,7 @@ struct NativeRootStackRenderer: View {
                     }
                 }
             }
+            .toolbarColorScheme(toolbarScheme, for: .navigationBar)
             .modifier(HideNavBarModifier(hidden: hideNavBar))
             .modifier(StackBarBackgroundModifier(argb: bgArgb))
             .modifier(StackBottomBarInsetModifier(bottomBar: bottomBar))
@@ -314,20 +331,51 @@ struct NativeRootStackRenderer: View {
 private struct StackBottomBarInsetModifier: ViewModifier {
     let bottomBar: NativeUINode?
 
+    @Environment(\.colorScheme) private var colorScheme
+
     func body(content: Content) -> some View {
         if let bottomBar, let inner = bottomBar.children.first {
+            // `.fixedSize(vertical:)` matters: the inset APIs propose a
+            // FINITE height to their content, and a FlexContainer fills any
+            // finite proposal (CSS block semantics). Without it a bar whose
+            // root has no explicit height inflates to the proposed height —
+            // the input floats mid-screen over a giant empty bar, and on the
+            // `.safeAreaBar` path the bar's scroll-edge effect then dims the
+            // whole content region behind it.
             if #available(iOS 26.0, *) {
                 content.safeAreaBar(edge: .bottom) {
-                    NodeView(node: inner)
+                    barContent(inner)
                 }
             } else {
                 content.safeAreaInset(edge: .bottom, spacing: 0) {
-                    NodeView(node: inner)
+                    barContent(inner)
                 }
             }
         } else {
             content
         }
+    }
+
+    /// The bar view plus a home-indicator bleed: the inset APIs place the
+    /// bar ABOVE the bottom safe area, so the strip beneath it shows the
+    /// window background (`systemBackground`) — a black band under a themed
+    /// bar in dark mode. Re-paint the bar's own background color extended
+    /// through the bottom safe area (the iMessage treatment). Bars without
+    /// an explicit background keep `.clear` and are unaffected.
+    @ViewBuilder
+    private func barContent(_ inner: NativeUINode) -> some View {
+        NodeView(node: inner)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity)
+            .background(barBackgroundColor(inner).ignoresSafeArea(edges: .bottom))
+    }
+
+    /// The bar root's resolved background color for the active appearance —
+    /// same resolution order as `NodeStyleModifier.backgroundColor`.
+    private func barBackgroundColor(_ node: NativeUINode) -> Color {
+        let darkBg = colorScheme == .dark ? node.props.getColor("dark_bg_color", default: 0) : 0
+        let argb = darkBg != 0 ? darkBg : (node.style?.bgColor ?? 0)
+        return argb != 0 ? Color(argb: argb) : .clear
     }
 }
 
@@ -335,14 +383,30 @@ private struct StackBottomBarInsetModifier: ViewModifier {
 /// `.toolbarBackground` entirely when the layout didn't supply an
 /// explicit color, so iOS 26 keeps its adaptive Liquid Glass material
 /// on the navigation bar instead of having `.clear` forcibly applied.
+///
+/// The visibility request is dropped on iOS 26. Under Liquid Glass, forcing
+/// the navigation bar background visible doesn't just recolor the bar — it
+/// drops the large-title row entirely, leaving the toolbar items behind on
+/// an empty bar. Verified on a device: both spellings do it, the deprecated
+/// `.toolbarBackground(.visible, for:)` and the renamed
+/// `.toolbarBackgroundVisibility(_:for:)`, so this is the request itself and
+/// not the API name. The style overload alone already makes the bar opaque
+/// there, so the explicit visibility call buys nothing. Pre-26 still needs
+/// the pair — without it the color is applied to a hidden bar and never
+/// shows.
 private struct StackBarBackgroundModifier: ViewModifier {
     let argb: Int
 
     func body(content: Content) -> some View {
         if argb != 0 {
-            content
-                .toolbarBackground(Color(argb: argb), for: .navigationBar)
-                .toolbarBackground(.visible, for: .navigationBar)
+            if #available(iOS 26.0, *) {
+                content
+                    .toolbarBackground(Color(argb: argb), for: .navigationBar)
+            } else {
+                content
+                    .toolbarBackground(Color(argb: argb), for: .navigationBar)
+                    .toolbarBackground(.visible, for: .navigationBar)
+            }
         } else {
             content
         }

--- a/resources/xcode/NativePHP/NativeRender/NativeRootTabsRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeRootTabsRenderer.swift
@@ -695,24 +695,41 @@ private struct TabsActionView: View {
 private struct BottomBarInsetModifier: ViewModifier {
     let bottomBar: NativeUINode?
 
+    @Environment(\.colorScheme) private var colorScheme
+
     func body(content: Content) -> some View {
-        // Always use `.safeAreaInset(.bottom)` — the battle-tested
-        // primitive for pinning content above the safe-area bottom.
+        // `.safeAreaInset(.bottom)` — the battle-tested primitive for
+        // pinning content above the safe-area bottom.
         //
         // Earlier this path branched to `.safeAreaBar(.bottom)` on iOS 26+
-        // for the floating-glass treatment iMessage uses. That implementation
-        // mis-pins on the iOS 26 simulator (bar latches mid-screen) and adds
-        // a wide glass plate behind the bar that visually washes content
-        // above it. Both symptoms cleared by reverting to `.safeAreaInset`.
-        // Re-enable `.safeAreaBar` later if Apple's implementation
-        // stabilises on real hardware AND we want the floating treatment.
+        // and was reverted when the bar latched mid-screen with a glass
+        // plate washing out the content above it. Root cause found since
+        // (see the stack renderer's twin): the inset APIs propose a FINITE
+        // height, and a FlexContainer fills any finite proposal, so a bar
+        // whose root has no explicit height inflated to the proposal —
+        // `.safeAreaBar` was never at fault. `.fixedSize(vertical:)` pins
+        // the bar to its intrinsic height either way; re-enabling
+        // `.safeAreaBar` for the floating-glass treatment is now viable
+        // but a separate, visual decision.
         if let bottomBar, let inner = bottomBar.children.first {
             content.safeAreaInset(edge: .bottom, spacing: 0) {
                 NodeView(node: inner)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity)
+                    .background(barBackgroundColor(inner).ignoresSafeArea(edges: .bottom))
             }
         } else {
             content
         }
+    }
+
+    /// The bar root's resolved background color for the active appearance,
+    /// extended through the bottom safe area so the strip beneath the bar
+    /// doesn't show the window background — see the stack renderer's twin.
+    private func barBackgroundColor(_ node: NativeUINode) -> Color {
+        let darkBg = colorScheme == .dark ? node.props.getColor("dark_bg_color", default: 0) : 0
+        let argb = darkBg != 0 ? darkBg : (node.style?.bgColor ?? 0)
+        return argb != 0 ? Color(argb: argb) : .clear
     }
 }
 


### PR DESCRIPTION
Four fixes found while building a chat screen with a themed top bar and a pinned `<native:bottom-bar>` input. Each was reproduced on a device/emulator, fixed, and re-verified — iOS on the iPhone 17 simulator (iOS 26.5), Android on an emulator.

## Android: chrome stuck on Material's baseline palette

`NativeUIThemeProvider`'s slots were plain `var`s, so registration lost a race it could never win: `MainActivity` calls `setContent` from `onCreate`, while the plugin init functions that populate the seam run via `registerBridgeFunctions` — deliberately deferred to a background thread after the first frame to keep the boot off the TTID path.

First composition read `colorSchemeFor` as null and fell back to `lightColorScheme()`. Because a plain `var` isn't snapshot state, setting it later invalidated nothing, and that `setContent` scope only recomposes when the system appearance flips — so an app with native-ui installed ran on the baseline palette for the whole process. Most visibly: a pinkish neutral top bar instead of the configured `surface`.

All three slots are now `mutableStateOf`. `typographyFor` and `fontFamilyResolver` lose the same race — the first is silent only while the app's default font is `"System"`, the second leaves per-bar `font_name` tokens unresolvable on the first pass.

## iOS: large title vanished on an explicitly-colored nav bar

Forcing the nav-bar background visible doesn't merely recolor the bar under Liquid Glass — it drops the large-title row entirely, leaving the toolbar items on an empty bar. Confirmed on device that **both** spellings do it, the deprecated `.toolbarBackground(.visible, for:)` and the renamed `.toolbarBackgroundVisibility(_:for:)`, so the visibility *request* is the problem rather than the API name. The style overload alone already makes the bar opaque on iOS 26; pre-26 still needs the pair or the color lands on a hidden bar.

## iOS: `text_color` never reached system-drawn titles

It only styles chrome we draw — back chevron, principal-slot title, trailing actions — while `.navigationTitle` (used by `large` / `automatic`) takes its color from the bar's color scheme. An explicit background could then pair a light bar with a dark-mode white title. Now derived from `text_color` luminance, matching what `NativeRootTabsRenderer` already did.

## iOS: bottom bars inflated, and left a black band beneath

The inset APIs propose a **finite** height, and a `FlexContainer` fills any finite proposal, so a bar whose root has no explicit height grew to the proposal — the input floated mid-screen and `.safeAreaBar`'s scroll-edge effect dimmed the content behind it.

That is the symptom the tabs renderer blamed on `.safeAreaBar` when it reverted to `.safeAreaInset`; an A/B run showed the revert never fixed it, so that comment is corrected. `.fixedSize(vertical:)` pins the bar to its intrinsic height on both paths.

Separately, the inset APIs place the bar *above* the bottom safe area, so the home-indicator strip showed the window background — a black band under a themed bar in dark mode. The bar's own background now bleeds through it; bars without one resolve to `.clear` and are unchanged.

## iOS FlexContainer: shrink during measurement, weighted by base size

Two bugs that together let a long chat bubble run off-screen on one line where Android wrapped it.

**`sizeThatFits` had no shrink pass.** It distributes space to flex-grow children when the proposal leaves room, but had no mirror for overflow — only `placeSubviews` shrank. A container reported its *pre-shrink* main size to its parent, and inside a scroll view (which permits overflow) that reported width won.

**Shrink ignored base size.** CSS distributes by the scaled factor `shrink × base`, not `shrink` alone, and it bites because flex-shrink defaults to 1 on every child: a row of `[bubble, spacer]` has `totalShrink 2`, so an unweighted ratio hands half the deficit to a spacer whose base is already 0. That half evaporates in `max(0, 0 - x)` and the content shrinks only halfway. Instrumented on device:

```
propMain=386.0  totalMain=1113.7  totalShrink=2.0  final={1113.67, 59}
```

Weighting gives the zero-base spacer zero reduction and the bubble the whole deficit.

The second bug was latent in `placeSubviews` all along — any row mixing a shrinkable child with a zero-base sibling under-shrinks — and was masked by the first reporting an even larger size. Both passes now use the same rule, so measurement and placement agree.

## Also

Escapes the Blade interpolation in the Boost guidelines' child-component example, which was evaluating `{{ $u->id }}` while rendering the template and publishing an empty `key`.

## Risk

`FlexContainer` governs every row and column, not just chrome, and the PHP suite doesn't reach Swift. The `placeSubviews` half also changes behavior for existing layouts that mix a shrinkable child with a zero-base sibling — they under-shrank before and shrink correctly now. Strictly more CSS-correct, but it is a behavior change and the piece most worth a second pair of eyes.

## Test plan

- `vendor/bin/pest` — 691 passed, 0 failures (4 risky / 3 skipped, all pre-existing)
- iOS: themed top bar with `display-mode="large"` renders its title in light and dark; pinned bottom bar sits at intrinsic height with its background continuous to the screen edge; long chat bubble wraps within the viewport while short bubbles hug
- Android: top bar renders on the configured `surface` from the first frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)