### PR TITLE
feat(testing): make TestableComponent macroable for element test vocabulary

### DIFF
--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -2,6 +2,7 @@
 
 namespace Native\Mobile\Testing;
 
+use Illuminate\Support\Traits\Macroable;
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\NativeComponent;
 use Native\Mobile\Edge\NativeDumpException;
@@ -46,6 +47,18 @@ use PHPUnit\Framework\TestCase;
  */
 class TestableComponent
 {
+    // Plugins register element-specific test vocabulary here (a date plugin's
+    // pickDate(), a chart plugin's assertSeries(), ...). FakeBridge macros
+    // can't serve UI elements: the bridge holds no reference back to the
+    // component, so a macro there can't read the tree or fire node events.
+    //
+    // Aliased because this class defines its own __call for FakeBridge
+    // forwarding — a class method beats a trait method, so without the alias
+    // the trait's __call would never run and macros would be invisible.
+    use Macroable {
+        __call as macroCall;
+    }
+
     // Wire event type codes — must match EventType on the native side.
     public const EVENT_PRESS = 0;
 
@@ -1254,6 +1267,13 @@ class TestableComponent
      */
     public function __call(string $method, array $arguments): mixed
     {
+        // Component-level macros win over bridge forwarding — they're the
+        // more specific registration, and a plugin naming one after a bridge
+        // method means it wants the component behaviour.
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $arguments);
+        }
+
         if (FakeBridge::hasMacro($method) || method_exists($this->bridge, $method)) {
             $result = $this->bridge->{$method}(...$arguments);
 

--- a/tests/Feature/TestableComponentMacroTest.php
+++ b/tests/Feature/TestableComponentMacroTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Testing\FakeBridge;
+use Native\Mobile\Testing\Native;
+use Native\Mobile\Testing\TestableComponent;
+use Tests\Fixtures\Edge\CounterScreen;
+
+/**
+ * Component-level test macros.
+ *
+ * Plugins register element-specific vocabulary on the harness — a date
+ * plugin's pickDate(), a chart plugin's assertSeries(). FakeBridge macros
+ * can't serve those: the bridge holds no reference back to the component,
+ * so a macro there can read what was *called on the bridge* but can't read
+ * the rendered tree or fire an event at a node.
+ *
+ * The registration is subtle enough to be worth pinning: TestableComponent
+ * defines its own __call for FakeBridge forwarding, and a class method beats
+ * a trait method, so Macroable's __call is aliased and dispatched explicitly.
+ * Drop the alias and every one of these silently stops resolving — which is
+ * exactly the kind of regression a later refactor introduces without noticing.
+ */
+beforeEach(function () {
+    NativeRouter::clearRoutes();
+    TestableComponent::flushMacros();
+    FakeBridge::flushMacros();
+});
+
+afterEach(function () {
+    NativeRouter::clearRoutes();
+    TestableComponent::flushMacros();
+    FakeBridge::flushMacros();
+});
+
+it('resolves a macro registered on the component', function () {
+    TestableComponent::macro('assertCountIs', function (int $expected) {
+        expect($this->get('count'))->toBe($expected);
+
+        return $this;
+    });
+
+    Native::test(CounterScreen::class)->assertCountIs(0);
+});
+
+it('binds $this to the component, so a macro can drive it', function () {
+    // The whole point: a component macro reaches the component's own API
+    // (interactions, state, the rendered tree) — not the bridge's.
+    TestableComponent::macro('incrementTwice', function () {
+        return $this->tap('Increment')->tap('Increment');
+    });
+
+    Native::test(CounterScreen::class)
+        ->incrementTwice()
+        ->assertSet('count', 2)
+        ->assertSee('Count: 2');
+});
+
+it('keeps the chain on the component when a macro returns $this', function () {
+    TestableComponent::macro('noop', fn () => $this);
+
+    $chained = Native::test(CounterScreen::class)->noop();
+
+    expect($chained)->toBeInstanceOf(TestableComponent::class);
+});
+
+it('still forwards unknown methods to FakeBridge macros', function () {
+    // The pre-existing extension point (how the camera plugin works) must
+    // keep working — component macros are additive, not a replacement.
+    FakeBridge::macro('assertBridgeReachable', function () {
+        return $this;
+    });
+
+    $chained = Native::test(CounterScreen::class)->assertBridgeReachable();
+
+    // Bridge macros that answer fluently hand the chain back to the component.
+    expect($chained)->toBeInstanceOf(TestableComponent::class);
+});
+
+it('prefers a component macro over a bridge macro of the same name', function () {
+    FakeBridge::macro('whoAmI', fn () => 'bridge');
+    TestableComponent::macro('whoAmI', fn () => 'component');
+
+    expect(Native::test(CounterScreen::class)->whoAmI())->toBe('component');
+});
+
+it('still throws for a method neither the component nor the bridge knows', function () {
+    Native::test(CounterScreen::class)->totallyUnknownMethod();
+})->throws(BadMethodCallException::class);


### PR DESCRIPTION
Lets plugins register **element** test vocabulary on the harness, the way they already register bridge assertions.

## Why FakeBridge macros aren't enough

Plugins can extend the harness today — that's how `mobile-camera` ships `assertPhotoRequested()`, via `FakeBridge::macro()` reached through `TestableComponent::__call`'s forwarding.

That seam only serves *bridge* assertions. Inside a `FakeBridge` macro `$this` is the bridge, and the bridge holds no reference back to the component. So a macro there can assert what the component called on the bridge, but it can't read the rendered tree or fire an event at a node.

UI-element vocabulary needs the component. A date plugin's `pickDate($target, $value)` has to resolve a callback id out of the published tree and dispatch to it; a chart plugin's `assertSeries()` has to walk the tree. Neither is reachable from the bridge.

## The change

`TestableComponent` takes `Macroable` directly:

```php
use Macroable {
    __call as macroCall;
}
```

**The alias is load-bearing.** This class defines its own `__call` for FakeBridge forwarding, and a class method beats a trait method — so without the alias the trait's `__call` never runs and every registered macro is silently invisible. Not an error: just a `BadMethodCallException` naming the bridge, which sends you looking in entirely the wrong place.

`__call` now checks component macros first, then falls through to the existing bridge forwarding unchanged.

## Compatibility

Additive by construction. No component macros exist in core today, so nothing that currently resolves can change behaviour — bridge forwarding is untouched and still handles everything it handled before.

The precedence order is deliberate: a plugin naming a macro after a bridge method wants the component behaviour, since that's the more specific registration.

## Tests

Six, pinning the parts a later refactor would quietly break:

- macros resolve at all
- `$this` binds to the component, so a macro can drive interactions
- a fluent macro keeps the chain on the component
- `FakeBridge` forwarding still works (the camera plugin's path)
- a component macro wins a name collision against a bridge macro
- genuinely unknown methods still throw

Suite: **697 passed**. Pint clean.

## What needs it

NativePHP/mobile-ui#24 — the date/time picker registers `pickDate()` / `pickTime()` / `pickDateTime()` / `clearPicker()` / `assertPicker*()`. That PR gates registration on `method_exists(TestableComponent::class, 'macro')`, so it's already fatal-free on a core without this and the macros simply don't appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)