### PR TITLE
feat(edge): support <native:top-bar-title> in inline chrome

### DIFF
--- a/src/Edge/Layouts/Builders/NavBar.php
+++ b/src/Edge/Layouts/Builders/NavBar.php
@@ -7,6 +7,7 @@ use Native\Mobile\Edge\Element;
 use Native\Mobile\Edge\Elements\Image;
 use Native\Mobile\Edge\Elements\TopBar;
 use Native\Mobile\Edge\Elements\TopBarAction;
+use Native\Mobile\Edge\Elements\TopBarTitle;
 
 /**
  * Fluent builder for the top navigation bar.
@@ -136,6 +137,13 @@ class NavBar
         foreach ($element->getChildren() as $child) {
             if ($child instanceof TopBarAction) {
                 $bar->prebuiltActionElements[] = $child;
+            }
+            // An inline `<native:top-bar-title>` is the blade spelling of
+            // `titleView()`. Kept as the collected marker element (callbacks
+            // its children carry survive); NativeComponent emits it as-is
+            // rather than re-wrapping.
+            if ($child instanceof TopBarTitle) {
+                $bar->titleView = $child;
             }
         }
 

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -994,6 +994,14 @@ abstract class NativeComponent
             return null;
         }
 
+        // An inline `<native:top-bar-title>` arrives already wrapped (the
+        // collector built the marker itself) — re-wrapping would nest a
+        // `top_bar_title` inside a `top_bar_title` and the renderers, which
+        // draw the marker's direct children, would paint nothing.
+        if ($titleView instanceof TopBarTitle) {
+            return $titleView;
+        }
+
         $wrapper = TopBarTitle::make();
         $wrapper->addChild($titleView instanceof View ? $this->fromViewPartial($titleView) : $titleView);
 

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -687,6 +687,7 @@ class NativeServiceProvider extends PackageServiceProvider
             // Navigation chrome
             'top_bar' => Elements\TopBar::class,
             'top_bar_action' => Elements\TopBarAction::class,
+            'top_bar_title' => Elements\TopBarTitle::class,
             'bottom_nav' => Elements\BottomNav::class,
             'bottom_nav_item' => Elements\BottomNavItem::class,
             'side_nav' => Elements\SideNav::class,

--- a/tests/Fixtures/Edge/InlineTopBarTitleScreen.php
+++ b/tests/Fixtures/Edge/InlineTopBarTitleScreen.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Illuminate\View\View;
+use Native\Mobile\Edge\NativeComponent;
+
+/** Screen whose inline `<native:top-bar>` carries a `<native:top-bar-title>` lockup. */
+class InlineTopBarTitleScreen extends NativeComponent
+{
+    public int $brandTaps = 0;
+
+    public function brandTapped(): void
+    {
+        $this->brandTaps++;
+    }
+
+    public function render(): View
+    {
+        return view('inline-top-bar-title-screen');
+    }
+}

--- a/tests/Fixtures/views/inline-top-bar-title-screen.blade.php
+++ b/tests/Fixtures/views/inline-top-bar-title-screen.blade.php
@@ -1,0 +1,11 @@
+<native:top-bar title="Inline Title" display-mode="large">
+    <native:top-bar-title>
+        <native:pressable @tap="brandTapped">
+            <native:text>Brand Lockup</native:text>
+        </native:pressable>
+    </native:top-bar-title>
+    <native:top-bar-action id="save" icon="check" label="Save" />
+</native:top-bar>
+<native:column>
+    <native:text>Top bar body</native:text>
+</native:column>

--- a/tests/Unit/Edge/InlineChromeTest.php
+++ b/tests/Unit/Edge/InlineChromeTest.php
@@ -14,6 +14,7 @@ use Tests\Fixtures\Edge\CustomTopBarScreen;
 use Tests\Fixtures\Edge\FabScreen;
 use Tests\Fixtures\Edge\InlineBottomNavScreen;
 use Tests\Fixtures\Edge\InlineTopBarScreen;
+use Tests\Fixtures\Edge\InlineTopBarTitleScreen;
 use Tests\Fixtures\Edge\ScrollFabScreen;
 use Tests\Fixtures\Edge\ScrollNoFabScreen;
 use Tests\Fixtures\Edge\ScrollRootFabScreen;
@@ -160,6 +161,35 @@ it('hoists an inline top-bar into a NativeRootStack with no layout at all', func
         // The bar was hoisted — it must not also render as a drawn element.
         ->assertMissingElement('top_bar')
         ->assertSee('Top bar body');
+});
+
+it('hoists an inline top-bar-title into the chrome root as the principal slot content', function () {
+    $screen = Native::test(InlineTopBarTitleScreen::class)
+        ->assertMissingElement('top_bar')
+        // The marker rides on the chrome root, NOT nested in another marker —
+        // the renderers draw its direct children in the principal slot.
+        ->assertElement('top_bar_title', function (array $n) {
+            $children = $n['children'] ?? [];
+
+            return count($children) === 1
+                && ($children[0]['type'] ?? null) === 'pressable';
+        })
+        ->assertMissingElement('top_bar_title', function (array $n) {
+            foreach ($n['children'] ?? [] as $child) {
+                if (($child['type'] ?? null) === 'top_bar_title') {
+                    return true;
+                }
+            }
+
+            return false;
+        })
+        // A string title still rides along (iOS labels the back-history menu
+        // from it) and actions are unaffected.
+        ->assertNavTitle('Inline Title')
+        ->assertElement('top_bar_action', fn (array $n) => ($n['props']['id'] ?? null) === 'save');
+
+    // Callbacks wired by the collector inside the title view survive.
+    $screen->tap('Brand Lockup')->assertSet('brandTaps', 1);
 });
 
 it('keeps inline top-bar actions (and their callbacks) on the chrome root', function () {


### PR DESCRIPTION
## Why

Both renderers already know how to draw a `top_bar_title` node in the bar's principal slot — iOS as `ToolbarItem(placement: .principal)`, Android in the `TopAppBar` title slot. But it was only reachable from the builder path (`NavBar::titleView()` / `->logo()`): `NavBar::fromElement()` adopted only `top_bar_action` children, so a title view declared inside an inline `<native:top-bar>` in a screen's blade was silently dropped.

That left composable blade chrome unable to express a logo/wordmark bar without falling back to a layout builder.

## What

- Register `'top_bar_title' => Elements\TopBarTitle::class` so `<native:top-bar-title>` is a real tag.
- `NavBar::fromElement()` adopts a `TopBarTitle` child as the bar's `titleView`, keeping the collected instance so callbacks the collector wired inside the lockup (e.g. a `@tap` on a pressable brand) survive.
- `NativeComponent::topBarTitleElement()` returns an already-wrapped marker as-is. Re-wrapping would nest a `top_bar_title` inside a `top_bar_title`, and since the renderers draw the marker's *direct* children, the bar would paint nothing.

PHP-only — no Swift/Kotlin changes, so no rebuild is required.

## Usage

```blade
<native:top-bar title="WhipRate" display-mode="inline">
    <native:top-bar-title>
        <native:image src="{{ public_path('img/logo-text.png') }}" alt="WhipRate" class="h-6 object-contain" />
    </native:top-bar-title>
    <native:top-bar-action id="menu" icon="ellipsis" label="More" />
</native:top-bar>
```

Keep `title` set even though the image owns the slot — iOS labels the back-chevron long-press history and VoiceOver from it. A title view forces `.inline` on iOS regardless of `display-mode`, and the slot renders all children in an HStack, so image + text can be mixed without a wrapper.

## Tests

New case in `tests/Unit/Edge/InlineChromeTest.php` (plus an `InlineTopBarTitleScreen` fixture) asserting the marker lands on the chrome root un-nested, the string title and actions are unaffected, and a `@tap` inside the title view still fires. `tests/Unit/Edge` — 211 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)