### PR TITLE
feat(ios): lock the interface style via nativephp.appearance

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -82,6 +82,28 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Appearance
+    |--------------------------------------------------------------------------
+    |
+    | Pins the app to a single interface style, for apps whose identity is
+    | fixed light or fixed dark. Theme tokens only cover surfaces YOU draw —
+    | the system's own chrome (Liquid Glass bars, sheets, keyboards, the
+    | window background behind the safe areas) follows the device unless it
+    | is locked here.
+    |
+    | Options: 'system' - Follow the device (default)
+    |          'dark'   - Always dark
+    |          'light'  - Always light
+    |
+    | iOS only for now: written to the Info.plist as UIUserInterfaceStyle at
+    | build time.
+    |
+    */
+
+    'appearance' => env('NATIVEPHP_APPEARANCE', 'system'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Development Team (iOS)
     |--------------------------------------------------------------------------
     |

--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -567,6 +567,9 @@ class BuildIosAppCommand extends Command
             // Handle UIBackgroundModes
             $this->updateBackgroundModes($rootDict, $plistData, $pushNotificationsEnabled);
 
+            // Handle UIUserInterfaceStyle
+            $this->updateInterfaceStyle($dom, $rootDict, $plistData);
+
             // Handle BIFROST_APP_ID
             $bifrostAppId = env('BIFROST_APP_ID');
             if ($bifrostAppId) {
@@ -728,6 +731,47 @@ class BuildIosAppCommand extends Command
                 $rootDict->appendChild($arrayNode);
             }
         }
+    }
+
+    /**
+     * Lock the app to a single interface style via UIUserInterfaceStyle.
+     *
+     * `nativephp.appearance` of `dark` / `light` pins the whole app —
+     * system chrome (nav bars, sheets, keyboards, the window background
+     * behind safe areas) included — so an app with a fixed identity never
+     * shows the OS's opposite-appearance surfaces. `system` (the default)
+     * removes the key and follows the device.
+     *
+     * @param  array<string, array{keyNode: \DOMElement, valueNode: \DOMElement}>  $plistData
+     */
+    private function updateInterfaceStyle(\DOMDocument $dom, \DOMElement $rootDict, array &$plistData): void
+    {
+        $style = match (strtolower((string) config('nativephp.appearance', 'system'))) {
+            'dark' => 'Dark',
+            'light' => 'Light',
+            default => null,
+        };
+
+        if ($style === null) {
+            if (isset($plistData['UIUserInterfaceStyle'])) {
+                $this->removePlistKeyValue(
+                    $rootDict,
+                    $plistData['UIUserInterfaceStyle']['keyNode'],
+                    $plistData['UIUserInterfaceStyle']['valueNode']
+                );
+                unset($plistData['UIUserInterfaceStyle']);
+            }
+
+            return;
+        }
+
+        if (isset($plistData['UIUserInterfaceStyle'])) {
+            $plistData['UIUserInterfaceStyle']['valueNode']->nodeValue = $style;
+
+            return;
+        }
+
+        $this->addPlistKeyValue($dom, $rootDict, 'UIUserInterfaceStyle', 'string', $style);
     }
 
     /**

--- a/tests/Feature/IosInterfaceStyleTest.php
+++ b/tests/Feature/IosInterfaceStyleTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\File;
+use Native\Mobile\Commands\BuildIosAppCommand;
+use ReflectionClass;
+use Tests\TestCase;
+
+/**
+ * `nativephp.appearance` pins the app to a single interface style by writing
+ * UIUserInterfaceStyle into the Info.plist. Theme tokens can't reach the
+ * system's own chrome — Liquid Glass bars, sheets, keyboards, the window
+ * background behind the safe areas — so a fixed-identity app needs the plist
+ * key or those surfaces follow the device instead.
+ */
+class IosInterfaceStyleTest extends TestCase
+{
+    protected string $plistPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->plistPath = sys_get_temp_dir().'/nativephp_interface_style_test_'.uniqid().'.plist';
+    }
+
+    protected function tearDown(): void
+    {
+        File::delete($this->plistPath);
+
+        parent::tearDown();
+    }
+
+    public function test_dark_appearance_writes_the_interface_style_key(): void
+    {
+        config(['nativephp.appearance' => 'dark']);
+
+        $this->updatePlist($this->writePlist());
+
+        $this->assertStringContainsString('<key>UIUserInterfaceStyle</key>', $this->plist());
+        $this->assertStringContainsString('<string>Dark</string>', $this->plist());
+    }
+
+    public function test_light_appearance_writes_the_interface_style_key(): void
+    {
+        config(['nativephp.appearance' => 'light']);
+
+        $this->updatePlist($this->writePlist());
+
+        $this->assertStringContainsString('<string>Light</string>', $this->plist());
+    }
+
+    public function test_appearance_is_matched_case_insensitively(): void
+    {
+        config(['nativephp.appearance' => 'DARK']);
+
+        $this->updatePlist($this->writePlist());
+
+        $this->assertStringContainsString('<string>Dark</string>', $this->plist());
+    }
+
+    public function test_system_appearance_leaves_the_key_out(): void
+    {
+        config(['nativephp.appearance' => 'system']);
+
+        $this->updatePlist($this->writePlist());
+
+        $this->assertStringNotContainsString('UIUserInterfaceStyle', $this->plist());
+    }
+
+    public function test_unset_appearance_leaves_the_key_out(): void
+    {
+        config(['nativephp.appearance' => null]);
+
+        $this->updatePlist($this->writePlist());
+
+        $this->assertStringNotContainsString('UIUserInterfaceStyle', $this->plist());
+    }
+
+    /**
+     * Switching an app back to `system` has to REMOVE a key an earlier build
+     * wrote — the plist is updated in place, not regenerated from the stub.
+     */
+    public function test_switching_back_to_system_removes_a_previously_written_key(): void
+    {
+        config(['nativephp.appearance' => 'system']);
+
+        $this->updatePlist($this->writePlist(
+            "\t<key>UIUserInterfaceStyle</key>\n\t<string>Dark</string>\n"
+        ));
+
+        $this->assertStringNotContainsString('UIUserInterfaceStyle', $this->plist());
+        $this->assertStringNotContainsString('<string>Dark</string>', $this->plist());
+    }
+
+    public function test_an_existing_key_is_updated_rather_than_duplicated(): void
+    {
+        config(['nativephp.appearance' => 'dark']);
+
+        $this->updatePlist($this->writePlist(
+            "\t<key>UIUserInterfaceStyle</key>\n\t<string>Light</string>\n"
+        ));
+
+        $this->assertSame(1, substr_count($this->plist(), 'UIUserInterfaceStyle'));
+        $this->assertStringContainsString('<string>Dark</string>', $this->plist());
+        $this->assertStringNotContainsString('<string>Light</string>', $this->plist());
+    }
+
+    /** Write a minimal Info.plist, optionally with extra keys already in it. */
+    protected function writePlist(string $extraKeys = ''): string
+    {
+        File::put($this->plistPath, <<<PLIST
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+        \t<key>CFBundleURLTypes</key>
+        \t<array>
+        \t\t<dict>
+        \t\t\t<key>CFBundleTypeRole</key>
+        \t\t\t<string>Viewer</string>
+        \t\t\t<key>CFBundleURLName</key>
+        \t\t\t<string>com.nativephp.app</string>
+        \t\t\t<key>CFBundleURLSchemes</key>
+        \t\t\t<array>
+        \t\t\t\t<string>nativephp</string>
+        \t\t\t</array>
+        \t\t</dict>
+        \t</array>
+        {$extraKeys}</dict>
+        </plist>
+        PLIST);
+
+        return $this->plistPath;
+    }
+
+    protected function updatePlist(string $path): void
+    {
+        $command = new BuildIosAppCommand;
+
+        (new ReflectionClass($command))
+            ->getMethod('updateInfoPlistFile')
+            ->invoke($command, $path, 'com.nativephp.test', 'nativephp');
+    }
+
+    protected function plist(): string
+    {
+        return File::get($this->plistPath);
+    }
+}


### PR DESCRIPTION
## Why

Theme tokens only reach surfaces the app draws itself. The system's own chrome — Liquid Glass nav/tab bars, sheets, keyboards, and the window background behind the safe areas — resolves from `@Environment(\.colorScheme)`, so an app with a fixed light or dark identity still shows opposite-appearance surfaces on a device set the other way. Nothing in PHP can override those; they aren't our pixels.

Concretely: an app whose `native-ui` light block mirrors its dark block (a deliberately dark brand) still renders a white nav bar and a light tab bar on a device in light mode.

## What

`nativephp.appearance` of `dark` / `light` writes `UIUserInterfaceStyle` into the Info.plist at build time. UIKit applies that to the window, so both SwiftUI's `colorScheme` and the `traitCollection` behind `System::appearance()` follow it — one key pins the whole app.

- `updateInterfaceStyle()` in `BuildIosAppCommand`, called from the existing in-place Info.plist update alongside the URL types and background modes passes.
- `'appearance' => env('NATIVEPHP_APPEARANCE', 'system')` added to the config stub.

`system` is the default and **removes** the key, so switching an app back after a pinned build is a real un-pin — the plist is updated in place, not regenerated from the stub, so a stale key would otherwise survive forever.

Android has no equivalent build-time lock yet.

## Tests

`tests/Feature/IosInterfaceStyleTest.php` — 7 cases covering dark, light, case-insensitive matching, `system` and unset omitting the key, removal of a previously-written key, and update-not-duplicate when the key already exists.

Full suite: 705 passed. Pint clean.