### PR TITLE
Typed platform values and a capability seam for tests

### DIFF
--- a/src/Enums/Os.php
+++ b/src/Enums/Os.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Native\Mobile\Enums;
+
+use Native\Mobile\Platform;
+
+/**
+ * The mobile operating systems NativePHP targets.
+ *
+ * Backed by the same lowercase strings {@see Platform} has
+ * always used on the wire (`'ios'` / `'android'`), so this is a typed
+ * spelling of the existing values rather than a new vocabulary — anywhere a
+ * string is accepted today, an enum case now is too.
+ *
+ * Named `Os` rather than `Platform` because `Native\Mobile\Platform` is the
+ * class that resolves it, and two `Platform` symbols in adjacent namespaces
+ * would be a permanent source of wrong imports.
+ */
+enum Os: string
+{
+    case Ios = 'ios';
+
+    case Android = 'android';
+
+    /**
+     * Resolve a case-insensitive name, or null when it isn't one of ours.
+     * Unlike `tryFrom()` this tolerates the casing people actually write
+     * (`iOS`, `Android`).
+     */
+    public static function fromLabel(string $label): ?self
+    {
+        return self::tryFrom(strtolower(trim($label)));
+    }
+
+    public function isIos(): bool
+    {
+        return $this === self::Ios;
+    }
+
+    public function isAndroid(): bool
+    {
+        return $this === self::Android;
+    }
+}

--- a/src/Platform.php
+++ b/src/Platform.php
@@ -2,6 +2,7 @@
 
 namespace Native\Mobile;
 
+use Native\Mobile\Enums\Os;
 use Native\Mobile\Facades\System;
 
 /**
@@ -20,9 +21,9 @@ use Native\Mobile\Facades\System;
  */
 class Platform
 {
-    public const IOS = 'ios';
+    public const IOS = Os::Ios->value;
 
-    public const ANDROID = 'android';
+    public const ANDROID = Os::Android->value;
 
     private static ?string $platform = null;
 
@@ -95,16 +96,42 @@ class Platform
     }
 
     /**
+     * The detected platform as an enum case, or null when it isn't known.
+     * Prefer this over {@see current()} in new code — it can't be compared
+     * against a misspelt string.
+     */
+    public static function os(): ?Os
+    {
+        $platform = self::current();
+
+        return $platform === null ? null : Os::fromLabel($platform);
+    }
+
+    /**
      * Test seam — force the cached platform value. Pass `null` to reset
      * to lazy detection on the next call.
+     *
+     * Accepts an {@see Os} case or its string spelling. An unrecognised
+     * string throws rather than being stored: silently accepting
+     * `set('androdi')` leaves isAndroid() false for the rest of the
+     * process with nothing to show for it, and the whole point of a test
+     * seam is that you can trust what it says.
      *
      * Resetting the cache is the caller's responsibility for any
      * downstream consumer that also caches keyed by platform (e.g.
      * `\Native\Mobile\Edge\TailwindParser::clearCache()`).
+     *
+     * @throws \InvalidArgumentException
      */
-    public static function set(?string $platform): void
+    public static function set(Os|string|null $platform): void
     {
-        self::$platform = $platform;
+        if (is_string($platform)) {
+            $platform = Os::fromLabel($platform) ?? throw new \InvalidArgumentException(
+                "Unknown platform [{$platform}]. Use Os::Ios, Os::Android, 'ios' or 'android'."
+            );
+        }
+
+        self::$platform = $platform?->value;
         self::$detected = $platform !== null;
         self::$lastFailedAttempt = null;
     }

--- a/src/Testing/FakeBridge.php
+++ b/src/Testing/FakeBridge.php
@@ -113,6 +113,12 @@ class FakeBridge
 
     // ── Hooks called by the nativephp_* polyfills ───
 
+    /** @var array<int, string> Bridge functions a test has marked unavailable. */
+    protected array $unavailable = [];
+
+    /** @var array<int, string> Every capability probe made, in order. */
+    protected array $capabilityChecks = [];
+
     public function call(string $method, string $params = '{}'): ?string
     {
         $decoded = json_decode($params, true);
@@ -133,6 +139,50 @@ class FakeBridge
         }
 
         return $response;
+    }
+
+    /**
+     * Answer a capability probe. Everything is available unless a test has
+     * said otherwise via {@see cannot()}.
+     *
+     * Without this, capability-gated branches are untestable: the polyfill's
+     * nativephp_can() hardcodes `true`, so the fallback arm of every
+     * `nativephp_can(...)` check is dead code as far as the suite is
+     * concerned. That is how an iOS-only bridge function reached main
+     * swallowing Android toasts (#237).
+     */
+    public function can(string $method): bool
+    {
+        $this->capabilityChecks[] = $method;
+
+        return ! in_array($method, $this->unavailable, true);
+    }
+
+    /**
+     * Mark bridge functions as absent, so `nativephp_can()` reports false for
+     * them and the caller's fallback path runs.
+     */
+    public function cannot(string ...$methods): static
+    {
+        foreach ($methods as $method) {
+            if (! in_array($method, $this->unavailable, true)) {
+                $this->unavailable[] = $method;
+            }
+        }
+
+        return $this;
+    }
+
+    /** Assert the code asked whether a bridge function was available. */
+    public function assertCapabilityChecked(string $method): static
+    {
+        Assert::assertContains(
+            $method,
+            $this->capabilityChecks,
+            "Expected a capability check for [{$method}], but none was made."
+        );
+
+        return $this;
     }
 
     public function elementInit(): void

--- a/src/jump_bridge_functions.php
+++ b/src/jump_bridge_functions.php
@@ -47,6 +47,10 @@ if (! function_exists('nativephp_can')) {
      */
     function nativephp_can(string $method): bool
     {
+        if ($fake = FakeBridge::current()) {
+            return $fake->can($method);
+        }
+
         return true;
     }
 }

--- a/tests/Unit/PlatformEnumTest.php
+++ b/tests/Unit/PlatformEnumTest.php
@@ -1,0 +1,89 @@
+<?php
+
+use Native\Mobile\Enums\Os;
+use Native\Mobile\Platform;
+use Native\Mobile\Testing\FakeBridge;
+
+afterEach(function () {
+    Platform::set(null);
+    FakeBridge::disable();
+});
+
+// ── Platform::set() ─────────────────────────────────
+
+it('accepts an enum case', function () {
+    Platform::set(Os::Android);
+
+    expect(Platform::isAndroid())->toBeTrue()
+        ->and(Platform::isIos())->toBeFalse()
+        ->and(Platform::current())->toBe('android')
+        ->and(Platform::os())->toBe(Os::Android);
+});
+
+it('still accepts the string spellings it always has', function () {
+    Platform::set('ios');
+
+    expect(Platform::isIos())->toBeTrue()
+        ->and(Platform::current())->toBe('ios')
+        ->and(Platform::os())->toBe(Os::Ios);
+});
+
+it('tolerates the casing people actually write', function () {
+    Platform::set('iOS');
+
+    expect(Platform::os())->toBe(Os::Ios);
+});
+
+it('rejects an unknown platform instead of storing it', function () {
+    // The bug this closes: set('androdi') used to be accepted silently and
+    // left isAndroid() false for the rest of the process.
+    expect(fn () => Platform::set('androdi'))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('resets to lazy detection on null', function () {
+    Platform::set(Os::Ios);
+    expect(Platform::os())->toBe(Os::Ios);
+
+    Platform::set(null);
+
+    expect(Platform::current())->toBeNull()
+        ->and(Platform::os())->toBeNull();
+});
+
+it('keeps the long-standing constants in step with the enum', function () {
+    expect(Platform::IOS)->toBe(Os::Ios->value)
+        ->and(Platform::ANDROID)->toBe(Os::Android->value);
+});
+
+it('exposes the platform check on the enum itself', function () {
+    expect(Os::Ios->isIos())->toBeTrue()
+        ->and(Os::Ios->isAndroid())->toBeFalse()
+        ->and(Os::fromLabel('nope'))->toBeNull();
+});
+
+// ── Capability seam ─────────────────────────────────
+
+it('reports every bridge function as available by default', function () {
+    $bridge = FakeBridge::enable();
+
+    expect(nativephp_can('Toast.Show'))->toBeTrue();
+
+    $bridge->assertCapabilityChecked('Toast.Show');
+});
+
+it('lets a test deny a bridge function so the fallback path runs', function () {
+    // Before this seam the fallback arm of every nativephp_can() check was
+    // unreachable from the suite, because the polyfill hardcoded `true`.
+    $bridge = FakeBridge::enable()->cannot('Toast.Show');
+
+    expect(nativephp_can('Toast.Show'))->toBeFalse()
+        ->and(nativephp_can('Dialog.Toast'))->toBeTrue();
+});
+
+it('can deny several bridge functions at once', function () {
+    FakeBridge::enable()->cannot('Toast.Show', 'Toast.Dismiss');
+
+    expect(nativephp_can('Toast.Show'))->toBeFalse()
+        ->and(nativephp_can('Toast.Dismiss'))->toBeFalse();
+});


### PR DESCRIPTION
Two testability gaps that let a real regression through in #237.

## `Platform::set()` accepted any string

```php
Platform::set('androdi');   // accepted silently
Platform::isAndroid();      // false, for the rest of the process
```

A test seam you can't trust is worse than not having one. It now takes an `Os` enum case or its string spelling, and throws on anything else:

```php
Platform::set(Os::Android);   // typed
Platform::set('ios');         // still works
Platform::set('iOS');         // casing tolerated
Platform::set('androdi');     // InvalidArgumentException
```

`Os` is backed by the same `'ios'` / `'android'` values `Platform` has always used, so **nothing changes on the wire and no existing call site changes**. `current()` still returns `?string`; `Platform::IOS` / `ANDROID` are now expressed in terms of the enum so they can't drift. New code can use `Platform::os()` for a value that can't be compared against a typo.

Named `Os` rather than `Platform` because `Native\Mobile\Platform` is the class that resolves it, and two `Platform` symbols in adjacent namespaces would be a permanent source of wrong imports.

## `nativephp_can()` had no seam at all

`FakeBridge` intercepts `call()` and the element functions but never `nativephp_can()`, and the polyfill hardcodes `return true`. So **the fallback arm of every capability-gated branch was unreachable from the suite** — it could only be reached indirectly, if at all.

That is how an iOS-only `Toast.Show` reached review silently swallowing every Android toast, including existing `Dialog::toast()` calls (#237). The guard was there; nothing could test what happened when it said no.

```php
$bridge = FakeBridge::enable()->cannot('Toast.Show');

Toast::message('Saved')->show();

$bridge->assertCalled('Dialog.Toast')
       ->assertNotCalled('Toast.Show')
       ->assertCapabilityChecked('Toast.Show');
```

Everything stays available by default, so existing tests are unaffected.

## Deliberately out of scope

The Jump polyfill still answers `true` to every capability probe regardless of the connected device:

```php
// In Jump hybrid mode, we assume all functions are available
// on the connected device.
function nativephp_can(string $method): bool
{
    return true;
}
```

That's the behavioural half of the same problem and it's being picked up on #237, so I've left it alone rather than have two PRs edit the same function. This PR is the testing half — it gives that work something to assert against.

## Tests

10 new, covering enum and string input, casing, the rejection, the null reset, constant/enum agreement, and the capability seam in both directions. Full suite **748 passing**, Pint clean, PHPStan clean on all three changed files.
