### PR TITLE
Make native:watch interactive: sticky footer and a screen picker

### DIFF
--- a/src/Concerns/InteractsWithWatchTerminal.php
+++ b/src/Concerns/InteractsWithWatchTerminal.php
@@ -1,0 +1,355 @@
+<?php
+
+namespace Native\Mobile\Concerns;
+
+use Laravel\Prompts\Prompt;
+use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Exceptions\WatchPromptCancelled;
+use Native\Mobile\Support\Watch\WatchConsole;
+
+use function Laravel\Prompts\search;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\text;
+
+/**
+ * Drives the interactive side of `native:watch`: the sticky footer, the keys
+ * it advertises, and the screen picker behind `L`.
+ *
+ * The platform traits own the wire (adb / devicectl / file copy); this trait
+ * owns the terminal and dispatches to whichever platform is being watched.
+ */
+trait InteractsWithWatchTerminal
+{
+    protected ?WatchConsole $watchConsole = null;
+
+    protected ?string $watchPlatform = null;
+
+    protected ?string $watchDeviceLabel = null;
+
+    /**
+     * The screen the terminal last asked for. Null until the user changes
+     * it — we can't ask the device where it currently is, so we only claim
+     * to know once we've said so ourselves.
+     */
+    protected ?string $watchScreen = null;
+
+    protected int $watchChangeCount = 0;
+
+    /**
+     * Key legend, in display order.
+     */
+    protected array $watchKeys = [
+        'l' => 'change screen',
+        'r' => 'reload',
+        'c' => 'clear',
+        'q' => 'quit',
+    ];
+
+    protected function startWatchConsole(string $platform, ?string $deviceLabel = null): void
+    {
+        $this->watchPlatform = $platform;
+        $this->watchDeviceLabel = $deviceLabel;
+
+        $this->watchConsole = new WatchConsole(
+            $this->output,
+            $this->input->isInteractive(),
+        );
+
+        $this->watchConsole->keys($this->watchKeys);
+        $this->refreshWatchStatus();
+        $this->watchConsole->start();
+        $this->watchActivity('watching for changes');
+
+        // Watching ends through the watchman / polling shutdown handlers,
+        // which exit() and so cut later shutdown functions short. Register
+        // first so the terminal is always handed back.
+        register_shutdown_function(fn () => $this->stopWatchConsole());
+    }
+
+    /**
+     * Hand the terminal back. Idempotent — the quit key, signal handlers and
+     * shutdown functions all funnel through here and may overlap.
+     */
+    protected function stopWatchConsole(): void
+    {
+        $console = $this->watchConsole;
+        $this->watchConsole = null;
+
+        $console?->stop();
+    }
+
+    /**
+     * Service the terminal between watcher polls: age the activity line and
+     * run any keys the user pressed.
+     */
+    protected function pumpWatchTerminal(): void
+    {
+        if ($this->watchConsole === null) {
+            return;
+        }
+
+        $this->watchConsole->tick();
+
+        while (($key = $this->watchConsole->readKey()) !== null) {
+            $this->handleWatchKey($key);
+
+            if ($this->watchConsole === null) {
+                return;
+            }
+        }
+    }
+
+    protected function handleWatchKey(string $key): void
+    {
+        match (strtolower($key)) {
+            'l' => $this->changeWatchedScreen(),
+            'r' => $this->reloadFromTerminal(),
+            'c' => $this->watchConsole?->clearScrollback(),
+            'q' => $this->quitWatching(),
+            default => null,
+        };
+    }
+
+    /**
+     * Report a synced file. Deliberately transient — the running total is
+     * the useful signal, not a scrolling history of every save.
+     */
+    protected function watchSynced(string $relativePath): void
+    {
+        $this->watchChangeCount++;
+
+        $this->watchActivity(sprintf(
+            'synced %s · %d %s',
+            $relativePath,
+            $this->watchChangeCount,
+            $this->watchChangeCount === 1 ? 'change' : 'changes',
+        ), 'green');
+    }
+
+    /**
+     * Update the transient activity line. `$text` must be plain: the footer
+     * truncates by visible length and styles the line as a whole.
+     */
+    protected function watchActivity(string $text, ?string $style = null): void
+    {
+        if ($this->watchConsole !== null) {
+            $this->watchConsole->activity($text, $style);
+
+            return;
+        }
+
+        $this->line($style !== null ? "<fg={$style}>{$text}</>" : $text);
+    }
+
+    /**
+     * Write something worth keeping into the scrollback above the footer.
+     * May contain style tags.
+     */
+    protected function watchNote(string $text): void
+    {
+        if ($this->watchConsole !== null) {
+            $this->watchConsole->note($text);
+
+            return;
+        }
+
+        $this->line($text);
+    }
+
+    private function refreshWatchStatus(): void
+    {
+        $this->watchConsole?->status([
+            [null, $this->watchPlatform],
+            [null, $this->watchDeviceLabel],
+            ['screen', $this->watchScreen ?? 'app default'],
+        ]);
+    }
+
+    private function reloadFromTerminal(): void
+    {
+        $this->watchActivity('reloading…', 'yellow');
+
+        match ($this->watchPlatform) {
+            'ios' => $this->triggerIosReload(),
+            'android' => $this->triggerAndroidReload(),
+            default => null,
+        };
+    }
+
+    private function quitWatching(): void
+    {
+        $this->stopWatchConsole();
+
+        // Same teardown Ctrl+C takes: stop the watcher, the Vite dev server
+        // and (on iOS) iproxy, then exit.
+        if (PHP_OS_FAMILY === 'Windows' && method_exists($this, 'onPollingWatcherShutdown')) {
+            $this->onPollingWatcherShutdown();
+        }
+
+        $this->onWatchmanShutdown();
+    }
+
+    // ── Changing the active screen ──────────────────
+
+    /**
+     * The `L` key: pick a registered native route and make it the app's
+     * active screen.
+     */
+    private function changeWatchedScreen(): void
+    {
+        $options = $this->nativeScreenOptions();
+
+        if ($options === []) {
+            $this->watchNote('<fg=yellow>No native screens registered.</> <fg=gray>Add a</> <fg=cyan>Route::native()</> <fg=gray>to your route files.</>');
+
+            return;
+        }
+
+        if ($this->watchConsole === null || ! $this->watchConsole->isInteractive()) {
+            $this->watchNote('<fg=yellow>Changing screens needs an interactive terminal.</>');
+
+            return;
+        }
+
+        $this->watchConsole->suspend();
+
+        // Ctrl+C belongs to the picker while the picker is open: backing out of
+        // a screen you didn't mean to open shouldn't tear down the watcher.
+        Prompt::cancelUsing(fn () => throw new WatchPromptCancelled);
+
+        try {
+            $uri = $this->fillScreenParameters($this->promptForNativeScreen($options));
+        } catch (WatchPromptCancelled) {
+            $uri = null;
+        } finally {
+            Prompt::cancelUsing(null);
+            $this->watchConsole->resume();
+        }
+
+        if ($uri === null) {
+            return;
+        }
+
+        $this->watchScreen = $uri;
+        $this->refreshWatchStatus();
+
+        if ($this->navigateWatchTargetTo($uri)) {
+            $this->watchActivity("switching to {$uri}", 'cyan');
+        } else {
+            $this->watchNote("<fg=red>Could not switch to</> <fg=cyan>{$uri}</> <fg=gray>— is the app running on the device?</>");
+        }
+    }
+
+    /**
+     * Registered native routes as `uri pattern => label`, root first then
+     * alphabetical, with the component name aligned alongside each URI.
+     *
+     * @return array<string, string>
+     */
+    protected function nativeScreenOptions(): array
+    {
+        $routes = NativeRouter::registeredRoutes();
+
+        if ($routes === []) {
+            return [];
+        }
+
+        uksort($routes, fn (string $a, string $b) => [$a !== '/', $a] <=> [$b !== '/', $b]);
+
+        $pad = max(array_map(fn (string $uri) => mb_strlen($uri), array_keys($routes)));
+
+        $options = [];
+
+        foreach ($routes as $uri => $entry) {
+            $component = class_basename($entry['class'] ?? '');
+            $options[$uri] = trim(str_pad($uri, $pad + 3).$component);
+        }
+
+        return $options;
+    }
+
+    /**
+     * @param  array<string, string>  $options
+     */
+    private function promptForNativeScreen(array $options): ?string
+    {
+        // A handful of screens reads better as a list; a real app's worth of
+        // them is much faster to filter than to scroll.
+        if (count($options) <= 12) {
+            return select(
+                label: 'Go to native screen',
+                options: $options,
+                scroll: 12,
+                hint: 'Ctrl+C to stay put',
+            );
+        }
+
+        return search(
+            label: 'Go to native screen',
+            placeholder: 'Type to filter…',
+            options: fn (string $value) => $value === ''
+                ? $options
+                : array_filter(
+                    $options,
+                    fn (string $label) => str_contains(strtolower($label), strtolower($value)),
+                ),
+            scroll: 12,
+            hint: 'Arrow keys to pick a match, Ctrl+C to stay put',
+        );
+    }
+
+    /**
+     * Fill in any `{param}` placeholders so the URI actually resolves
+     * against the route registry.
+     */
+    private function fillScreenParameters(?string $pattern): ?string
+    {
+        if ($pattern === null) {
+            return null;
+        }
+
+        if (! preg_match_all('/\{(\w+)\??\}/', $pattern, $matches)) {
+            return $pattern;
+        }
+
+        $uri = $pattern;
+
+        foreach ($matches[1] as $index => $name) {
+            $value = text(
+                label: "Value for {{$name}}",
+                required: true,
+                hint: 'Ctrl+C to stay put',
+            );
+
+            $uri = str_replace($matches[0][$index], rawurlencode(trim($value)), $uri);
+        }
+
+        return $uri;
+    }
+
+    private function navigateWatchTargetTo(string $uri): bool
+    {
+        return match ($this->watchPlatform) {
+            'ios' => $this->navigateIosTo($uri),
+            'android' => $this->navigateAndroidTo($uri),
+            default => false,
+        };
+    }
+
+    /**
+     * Write the screen-change intent to a temp file for the platform traits
+     * to push. PHP on device consumes it on its way through the hot-reload
+     * handler — see NativeRouter::takeScreenIntent().
+     */
+    protected function writeScreenIntentFile(string $uri): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'nativephp-screen-');
+
+        file_put_contents($path, json_encode([
+            'uri' => '/'.ltrim($uri, '/'),
+            'ts' => time(),
+        ]));
+
+        return $path;
+    }
+}

--- a/src/Concerns/InteractsWithWatchTerminal.php
+++ b/src/Concerns/InteractsWithWatchTerminal.php
@@ -2,14 +2,14 @@
 
 namespace Native\Mobile\Concerns;
 
+use Laravel\Prompts\Key;
 use Laravel\Prompts\Prompt;
+use Laravel\Prompts\SearchPrompt;
+use Laravel\Prompts\SelectPrompt;
+use Laravel\Prompts\TextPrompt;
 use Native\Mobile\Edge\NativeRouter;
 use Native\Mobile\Exceptions\WatchPromptCancelled;
 use Native\Mobile\Support\Watch\WatchConsole;
-
-use function Laravel\Prompts\search;
-use function Laravel\Prompts\select;
-use function Laravel\Prompts\text;
 
 /**
  * Drives the interactive side of `native:watch`: the sticky footer, the keys
@@ -276,15 +276,15 @@ trait InteractsWithWatchTerminal
         // A handful of screens reads better as a list; a real app's worth of
         // them is much faster to filter than to scroll.
         if (count($options) <= 12) {
-            return select(
+            return $this->cancelOnEscape(new SelectPrompt(
                 label: 'Go to native screen',
                 options: $options,
                 scroll: 12,
-                hint: 'Ctrl+C to stay put',
-            );
+                hint: 'Esc or Ctrl+C to stay put',
+            ))->prompt();
         }
 
-        return search(
+        return $this->cancelOnEscape(new SearchPrompt(
             label: 'Go to native screen',
             placeholder: 'Type to filter…',
             options: fn (string $value) => $value === ''
@@ -294,8 +294,31 @@ trait InteractsWithWatchTerminal
                     fn (string $label) => str_contains(strtolower($label), strtolower($value)),
                 ),
             scroll: 12,
-            hint: 'Arrow keys to pick a match, Ctrl+C to stay put',
-        );
+            hint: 'Arrow keys to pick a match, Esc to stay put',
+        ))->prompt();
+    }
+
+    /**
+     * Make Esc back out of a prompt, the way Ctrl+C already does.
+     *
+     * Prompts has no hook for this — Esc is simply an unhandled key — so the
+     * throw comes from a `key` listener, which unwinds straight out of
+     * `prompt()`. Safe to throw through: Prompts restores the tty in its
+     * destructor, and WatchConsole re-applies the mode it captured at start()
+     * rather than re-reading whatever state the terminal was left in.
+     *
+     * Compares against a bare Esc, so arrow keys (`\e[A` and friends, which
+     * Prompts reads in one go) don't trip it.
+     */
+    private function cancelOnEscape(Prompt $prompt): Prompt
+    {
+        $prompt->on('key', function (string $key) {
+            if ($key === Key::ESCAPE) {
+                throw new WatchPromptCancelled;
+            }
+        });
+
+        return $prompt;
     }
 
     /**
@@ -315,11 +338,11 @@ trait InteractsWithWatchTerminal
         $uri = $pattern;
 
         foreach ($matches[1] as $index => $name) {
-            $value = text(
+            $value = $this->cancelOnEscape(new TextPrompt(
                 label: "Value for {{$name}}",
                 required: true,
-                hint: 'Ctrl+C to stay put',
-            );
+                hint: 'Esc or Ctrl+C to stay put',
+            ))->prompt();
 
             $uri = str_replace($matches[0][$index], rawurlencode(trim($value)), $uri);
         }

--- a/src/Concerns/ManagesPollingWatcher.php
+++ b/src/Concerns/ManagesPollingWatcher.php
@@ -21,8 +21,14 @@ trait ManagesPollingWatcher
         // Register shutdown handler
         register_shutdown_function([$this, 'onPollingWatcherShutdown']);
 
-        // Handle SIGINT (Ctrl+C) and SIGTERM gracefully
+        // Handle SIGINT (Ctrl+C) and SIGTERM gracefully. Async delivery is
+        // required: nothing in the loop below calls pcntl_signal_dispatch(),
+        // so the handlers would otherwise be installed but never run.
         if (function_exists('pcntl_signal')) {
+            if (function_exists('pcntl_async_signals')) {
+                pcntl_async_signals(true);
+            }
+
             pcntl_signal(SIGINT, [$this, 'onPollingWatcherShutdown']);
             pcntl_signal(SIGTERM, [$this, 'onPollingWatcherShutdown']);
         }
@@ -130,6 +136,12 @@ trait ManagesPollingWatcher
      */
     public function onPollingWatcherShutdown(): void
     {
+        // Hand the terminal back first — this method exits, so anything
+        // queued behind it in the shutdown sequence may never run.
+        if (method_exists($this, 'stopWatchConsole')) {
+            $this->stopWatchConsole();
+        }
+
         $this->stopPollingWatcher();
 
         // Clean up Vite dev server if the trait is available

--- a/src/Concerns/ManagesWatchman.php
+++ b/src/Concerns/ManagesWatchman.php
@@ -91,8 +91,15 @@ trait ManagesWatchman
         // Register shutdown handler to clean up
         register_shutdown_function([$this, 'onWatchmanShutdown']);
 
-        // Handle SIGINT (Ctrl+C) and SIGTERM gracefully
+        // Handle SIGINT (Ctrl+C) and SIGTERM gracefully. Async delivery is
+        // required: nothing in the loop below calls pcntl_signal_dispatch(),
+        // so without it the handlers are installed but never run and Ctrl+C
+        // is simply swallowed.
         if (function_exists('pcntl_signal')) {
+            if (function_exists('pcntl_async_signals')) {
+                pcntl_async_signals(true);
+            }
+
             pcntl_signal(SIGINT, [$this, 'onWatchmanShutdown']);
             pcntl_signal(SIGTERM, [$this, 'onWatchmanShutdown']);
         }
@@ -102,7 +109,7 @@ trait ManagesWatchman
 
         if (! $this->watchmanProcess->isRunning()) {
             $errorOutput = $this->watchmanProcess->getErrorOutput();
-            $this->error('Watchman failed to start: '.$errorOutput);
+            $this->watchmanLine('<fg=red>Watchman failed to start:</> '.$errorOutput);
 
             return;
         }
@@ -113,7 +120,7 @@ trait ManagesWatchman
             $errorOutput = $this->watchmanProcess->getIncrementalErrorOutput();
 
             if ($errorOutput) {
-                $this->line("<fg=yellow>Watchman:</fg=yellow> {$errorOutput}");
+                $this->watchmanLine("<fg=yellow>Watchman:</fg=yellow> {$errorOutput}");
             }
 
             if ($output) {
@@ -152,8 +159,23 @@ trait ManagesWatchman
         $errorOutput = $this->watchmanProcess->getErrorOutput();
 
         if ($exitCode !== 0) {
-            $this->error("Watchman exited with code {$exitCode}: {$errorOutput}");
+            $this->watchmanLine("<fg=red>Watchman exited with code {$exitCode}:</> {$errorOutput}");
         }
+    }
+
+    /**
+     * Write a line without trampling the interactive watch footer, when one
+     * is being drawn.
+     */
+    protected function watchmanLine(string $message): void
+    {
+        if (method_exists($this, 'watchNote')) {
+            $this->watchNote($message);
+
+            return;
+        }
+
+        $this->line($message);
     }
 
     /**
@@ -203,6 +225,12 @@ trait ManagesWatchman
      */
     public function onWatchmanShutdown(): void
     {
+        // Hand the terminal back first — this method exits, so anything
+        // queued behind it in the shutdown sequence may never run.
+        if (method_exists($this, 'stopWatchConsole')) {
+            $this->stopWatchConsole();
+        }
+
         $this->stopWatchman();
 
         // Clean up Vite dev server and hot file if the trait is available

--- a/src/Concerns/WatchesAndroid.php
+++ b/src/Concerns/WatchesAndroid.php
@@ -2,11 +2,12 @@
 
 namespace Native\Mobile\Concerns;
 
+use Native\Mobile\Edge\NativeRouter;
 use Symfony\Component\Process\Process;
 
 trait WatchesAndroid
 {
-    use ManagesPollingWatcher, ManagesWatchman;
+    use InteractsWithWatchTerminal, ManagesPollingWatcher, ManagesWatchman;
 
     private array $androidWatchPaths = ['app', 'resources', 'routes', 'config', 'database', 'public'];
 
@@ -182,19 +183,24 @@ trait WatchesAndroid
 
     private function startAndroidWatching(): void
     {
-        $this->info('Android hot reload active - watching for changes...');
-        $this->line('<fg=yellow>Press Ctrl+C to stop</fg=yellow>');
-
         $watchPaths = $this->getWatchPaths();
         $excludePatterns = $this->getExcludePatterns();
         $onChange = fn (string $filePath) => $this->handleAndroidFileChange($filePath);
         $onTick = fn () => $this->performAndroidPeriodicTasks();
 
-        // Use polling watcher on Windows, Watchman on macOS/Linux
-        if (PHP_OS_FAMILY === 'Windows') {
-            $this->startPollingWatcher($watchPaths, $excludePatterns, $onChange, $onTick);
-        } else {
-            $this->startWatchman($watchPaths, $excludePatterns, $onChange, $onTick);
+        $this->startWatchConsole('android', $this->androidSerial);
+
+        try {
+            // Use polling watcher on Windows, Watchman on macOS/Linux
+            if (PHP_OS_FAMILY === 'Windows') {
+                $this->startPollingWatcher($watchPaths, $excludePatterns, $onChange, $onTick);
+            } else {
+                $this->startWatchman($watchPaths, $excludePatterns, $onChange, $onTick);
+            }
+        } finally {
+            // Reached when the watcher stops on its own (watchman died); the
+            // quit key and signal paths tear the console down themselves.
+            $this->stopWatchConsole();
         }
     }
 
@@ -203,6 +209,9 @@ trait WatchesAndroid
      */
     private function performAndroidPeriodicTasks(): void
     {
+        // Service the interactive terminal (keypresses, activity line)
+        $this->pumpWatchTerminal();
+
         // Check if we should sync public/build
         $this->checkAndSyncPublicBuild();
 
@@ -213,6 +222,30 @@ trait WatchesAndroid
         if ($this->shouldRunVite()) {
             $this->checkViteProcessOutput();
         }
+    }
+
+    /**
+     * Make $uri the app's active native screen.
+     *
+     * The intent rides in on the ordinary file-sync path (so it lands under
+     * base_path() on device, where PHP can read it) and the standard reload
+     * trigger makes PHP pick it up — see NativeRouter::takeScreenIntent().
+     */
+    private function navigateAndroidTo(string $uri): bool
+    {
+        $intentFile = $this->writeScreenIntentFile($uri);
+
+        try {
+            if (! $this->syncAndroidFile($intentFile, NativeRouter::SCREEN_INTENT_PATH)) {
+                return false;
+            }
+        } finally {
+            @unlink($intentFile);
+        }
+
+        $this->triggerAndroidReload();
+
+        return true;
     }
 
     private function handleAndroidFileChange(string $filePath): void
@@ -235,7 +268,7 @@ trait WatchesAndroid
 
         // Special handling for hot file - sync but don't reload
         if (str_ends_with($relativePath, 'public/android-hot')) {
-            $this->line('<fg=cyan>Vite dev server detected, syncing hot file...</fg=cyan>');
+            $this->watchActivity('Vite dev server detected, syncing hot file…', 'cyan');
             $this->syncAndroidFile($filePath, $relativePath);
 
             return;
@@ -245,9 +278,8 @@ trait WatchesAndroid
             return;
         }
 
-        $this->line("Changed: {$relativePath}");
-
         if ($this->syncAndroidFile($filePath, $relativePath)) {
+            $this->watchSynced($relativePath);
             $this->triggerAndroidReload();
         }
     }
@@ -307,7 +339,7 @@ trait WatchesAndroid
         $pushProcess->run();
 
         if (! $pushProcess->isSuccessful()) {
-            $this->error('Hot reload: adb push failed — '.trim($pushProcess->getErrorOutput()));
+            $this->watchNote('<fg=red>Hot reload: adb push failed —</> '.trim($pushProcess->getErrorOutput()));
 
             return;
         }
@@ -437,7 +469,7 @@ trait WatchesAndroid
         $pushProcess->run();
 
         if (! $pushProcess->isSuccessful()) {
-            $this->error('Hot reload: adb push failed — '.trim($pushProcess->getErrorOutput()));
+            $this->watchNote('<fg=red>Hot reload: adb push failed —</> '.trim($pushProcess->getErrorOutput()));
 
             return false;
         }
@@ -479,7 +511,7 @@ trait WatchesAndroid
         $pushProcess->run();
 
         if (! $pushProcess->isSuccessful()) {
-            $this->error('Hot reload: adb push failed — '.$pushProcess->getErrorOutput());
+            $this->watchNote('<fg=red>Hot reload: adb push failed —</> '.trim($pushProcess->getErrorOutput()));
 
             @unlink($localTemp);
 
@@ -490,7 +522,7 @@ trait WatchesAndroid
         $copyProcess->run();
 
         if (! $copyProcess->isSuccessful()) {
-            $this->error('Hot reload: run-as cp failed — '.$copyProcess->getErrorOutput());
+            $this->watchNote('<fg=red>Hot reload: run-as cp failed —</> '.trim($copyProcess->getErrorOutput()));
         }
 
         // Touch the file to ensure mtime updates (some Android cp preserves source mtime)

--- a/src/Concerns/WatchesIos.php
+++ b/src/Concerns/WatchesIos.php
@@ -3,12 +3,25 @@
 namespace Native\Mobile\Concerns;
 
 use Illuminate\Support\Facades\Process;
+use Native\Mobile\Edge\NativeRouter;
 
 use function Laravel\Prompts\select;
 
 trait WatchesIos
 {
-    use ManagesWatchman;
+    use InteractsWithWatchTerminal, ManagesWatchman;
+
+    /**
+     * UDID of the simulator or device being watched.
+     */
+    private ?string $iosTarget = null;
+
+    /**
+     * Data container of the app on a simulator — the host can write into it
+     * directly. Null when watching a physical device, where the same writes
+     * have to go through `xcrun devicectl`.
+     */
+    private ?string $iosAppContainer = null;
 
     private array $iosWatchPaths = ['app', 'resources', 'routes', 'config'];
 
@@ -54,6 +67,7 @@ trait WatchesIos
             return;
         }
 
+        $this->iosTarget = $target;
         $isSimulator = array_key_exists($target, $this->simulators);
 
         // Start Vite dev server if the nativephpMobile plugin is installed
@@ -86,6 +100,8 @@ trait WatchesIos
                 return;
             }
 
+            $this->iosAppContainer = $derivedDataPath;
+
             $this->startIosWatching($derivedDataPath, $viteHotFile);
         } else {
             $this->startIosWatchingDevice($target, $appId);
@@ -94,19 +110,25 @@ trait WatchesIos
 
     private function startIosWatching(string $derivedDataPath, string $viteHotFile): void
     {
-        $this->info('iOS hot reload active - watching for changes...');
-        $this->line('<fg=yellow>Press Ctrl+C to stop</fg=yellow>');
-
         $basePath = base_path();
         $destinationPath = $derivedDataPath.'/Documents/app/';
 
-        $this->startWatchman(
-            $this->getIosWatchPaths(),
-            $this->getIosExcludePatterns(),
-            function (string $changedFile) use ($basePath, $destinationPath, $viteHotFile) {
-                $this->handleIosFileChange($changedFile, $basePath, $destinationPath, $viteHotFile);
-            }
-        );
+        $this->startWatchConsole('ios', $this->iosDeviceLabel());
+
+        try {
+            $this->startWatchman(
+                $this->getIosWatchPaths(),
+                $this->getIosExcludePatterns(),
+                function (string $changedFile) use ($basePath, $destinationPath, $viteHotFile) {
+                    $this->handleIosFileChange($changedFile, $basePath, $destinationPath, $viteHotFile);
+                },
+                fn () => $this->pumpWatchTerminal(),
+            );
+        } finally {
+            // Reached when the watcher stops on its own (watchman died); the
+            // quit key and signal paths tear the console down themselves.
+            $this->stopWatchConsole();
+        }
     }
 
     private function startIosWatchingDevice(string $target, string $appId): void
@@ -120,45 +142,36 @@ trait WatchesIos
             $this->line('Install it for automatic reload: <fg=cyan>brew install libimobiledevice</fg=cyan>');
         }
 
-        $this->info('iOS device hot reload active - watching for changes...');
-        $this->line('<fg=yellow>Press Ctrl+C to stop</fg=yellow>');
-
         $basePath = base_path();
 
-        $this->startWatchman(
-            $this->getIosWatchPaths(),
-            $this->getIosExcludePatterns(),
-            function (string $changedFile) use ($basePath, $target, $appId) {
-                $this->handleIosFileChangeDevice($changedFile, $basePath, $target, $appId);
-            }
-        );
+        $this->startWatchConsole('ios', $this->iosDeviceLabel());
+
+        try {
+            $this->startWatchman(
+                $this->getIosWatchPaths(),
+                $this->getIosExcludePatterns(),
+                function (string $changedFile) use ($basePath, $target, $appId) {
+                    $this->handleIosFileChangeDevice($changedFile, $basePath, $target, $appId);
+                },
+                fn () => $this->pumpWatchTerminal(),
+            );
+        } finally {
+            // Reached when the watcher stops on its own (watchman died); the
+            // quit key and signal paths tear the console down themselves.
+            $this->stopWatchConsole();
+        }
     }
 
     private function handleIosFileChangeDevice(string $changedFile, string $basePath, string $target, string $appId): void
     {
         $relativePath = str_replace($basePath.'/', '', $changedFile);
 
-        $this->line("<fg=blue>File changed:</fg=blue> {$relativePath}");
-
         if (file_exists($changedFile) && ! is_dir($changedFile)) {
-            $result = Process::timeout(30)->run([
-                'xcrun', 'devicectl', 'device', 'copy', 'to',
-                '--device', $target,
-                '--domain-type', 'appDataContainer',
-                '--domain-identifier', $appId,
-                '--source', $changedFile,
-                '--destination', 'Documents/app/'.$relativePath,
-            ]);
-
-            if ($result->successful()) {
-                $this->line("<fg=green>Synced to device:</fg=green> {$relativePath}");
-            } else {
-                $this->line("<fg=red>Failed to sync:</fg=red> {$relativePath}");
-
-                if ($errorOutput = trim($result->errorOutput())) {
-                    $this->line("<fg=gray>{$errorOutput}</fg=gray>");
-                }
+            if (! $this->copyToIosDevice($changedFile, 'Documents/app/'.$relativePath, $target, $appId)) {
+                return;
             }
+
+            $this->watchSynced($relativePath);
         }
 
         // Physical devices can't reach the Vite dev server on localhost,
@@ -172,8 +185,6 @@ trait WatchesIos
         $relativePath = str_replace($basePath.'/', '', $changedFile);
         $destinationFile = $destinationPath.$relativePath;
 
-        $this->line("<fg=blue>File changed:</fg=blue> {$relativePath}");
-
         // Create destination directory if needed
         $destinationDir = dirname($destinationFile);
         if (! is_dir($destinationDir)) {
@@ -183,7 +194,7 @@ trait WatchesIos
         // Copy the specific file
         if (file_exists($changedFile) && ! is_dir($changedFile)) {
             copy($changedFile, $destinationFile);
-            $this->line("<fg=green>Synced to iOS:</fg=green> {$relativePath}");
+            $this->watchSynced($relativePath);
         }
 
         // Skip reload for files that Vite handles via HMR
@@ -192,6 +203,77 @@ trait WatchesIos
         }
 
         $this->triggerIosReload();
+    }
+
+    /**
+     * Push a single file into the app's data container on a physical device.
+     */
+    private function copyToIosDevice(string $source, string $destination, string $target, string $appId): bool
+    {
+        $result = Process::timeout(30)->run([
+            'xcrun', 'devicectl', 'device', 'copy', 'to',
+            '--device', $target,
+            '--domain-type', 'appDataContainer',
+            '--domain-identifier', $appId,
+            '--source', $source,
+            '--destination', $destination,
+        ]);
+
+        if ($result->successful()) {
+            return true;
+        }
+
+        $this->watchNote(
+            '<fg=red>Failed to sync</> <fg=cyan>'.basename($destination).'</>'
+            .(($error = trim($result->errorOutput())) !== '' ? " <fg=gray>{$error}</>" : '')
+        );
+
+        return false;
+    }
+
+    /**
+     * Human-readable name of the watched simulator/device for the footer.
+     */
+    private function iosDeviceLabel(): ?string
+    {
+        $entry = $this->simulators[$this->iosTarget] ?? $this->devices[$this->iosTarget] ?? null;
+
+        return $entry['name'] ?? $this->iosTarget;
+    }
+
+    /**
+     * Make $uri the app's active native screen.
+     *
+     * The intent goes to the same place edited files do — base_path() inside
+     * the app's container — and the standard reload trigger makes PHP pick it
+     * up on its way through the hot-reload handler. See
+     * NativeRouter::takeScreenIntent().
+     */
+    private function navigateIosTo(string $uri): bool
+    {
+        $intentFile = $this->writeScreenIntentFile($uri);
+        $relativePath = NativeRouter::SCREEN_INTENT_PATH;
+
+        try {
+            if ($this->iosAppContainer !== null) {
+                if (! @copy($intentFile, $this->iosAppContainer.'/Documents/app/'.$relativePath)) {
+                    return false;
+                }
+            } elseif (! $this->copyToIosDevice(
+                $intentFile,
+                'Documents/app/'.$relativePath,
+                (string) $this->iosTarget,
+                (string) config('nativephp.app_id'),
+            )) {
+                return false;
+            }
+        } finally {
+            @unlink($intentFile);
+        }
+
+        $this->triggerIosReload();
+
+        return true;
     }
 
     private function triggerIosReload(): void
@@ -206,9 +288,10 @@ trait WatchesIos
             // it to the device over USB before we close
             usleep(200000);
             fclose($socket);
-            $this->line('<fg=green>Reload triggered</fg=green>');
         } else {
-            $this->line("<fg=yellow>Reload failed:</fg=yellow> Could not connect to port 9999 ({$errstr})");
+            // Transient rather than a scrollback line: the app being down is a
+            // state, not an event, so repeating it once per save is just noise.
+            $this->watchActivity("reload failed — nothing listening on port 9999 ({$errstr})", 'yellow');
         }
     }
 

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -2115,18 +2115,7 @@ abstract class NativeComponent
             // Hot reload: write restart signal and exit so Kotlin re-executes with fresh PHP
             if (($event['type'] ?? -1) === self::EVENT_HOT_RELOAD) {
                 $this->flushCompiledViews();
-                // Prefer the native router's top-of-stack URI (where the
-                // user actually IS after SPA-style internal navigation)
-                // over `request()->path()` (the original HTTP entry-
-                // point URI, typically `/`). Otherwise hot reload always
-                // lands the user back on the root screen.
-                $uri = $this->nativeRouter?->currentUri()
-                    ?? '/'.ltrim(request()->path(), '/');
-                // Serialize the full stack so back-button history
-                // survives the reboot. `Route::native`'s handler reads
-                // this on the way back in and preloads entries below
-                // the top via `NativeRouter::preloadStack`.
-                $stack = $this->nativeRouter?->getStackEntries() ?? [];
+                ['uri' => $uri, 'stack' => $stack] = $this->hotRestartPayload();
                 @file_put_contents(
                     storage_path('framework/.hot_restart'),
                     json_encode(['uri' => $uri, 'stack' => $stack, 'ts' => time()])
@@ -2312,18 +2301,7 @@ abstract class NativeComponent
             // Hot reload: write restart signal and exit so Kotlin re-executes with fresh PHP
             if (($event['type'] ?? -1) === self::EVENT_HOT_RELOAD) {
                 $this->flushCompiledViews();
-                // Prefer the native router's top-of-stack URI (where the
-                // user actually IS after SPA-style internal navigation)
-                // over `request()->path()` (the original HTTP entry-
-                // point URI, typically `/`). Otherwise hot reload always
-                // lands the user back on the root screen.
-                $uri = $this->nativeRouter?->currentUri()
-                    ?? '/'.ltrim(request()->path(), '/');
-                // Serialize the full stack so back-button history
-                // survives the reboot. `Route::native`'s handler reads
-                // this on the way back in and preloads entries below
-                // the top via `NativeRouter::preloadStack`.
-                $stack = $this->nativeRouter?->getStackEntries() ?? [];
+                ['uri' => $uri, 'stack' => $stack] = $this->hotRestartPayload();
                 @file_put_contents(
                     storage_path('framework/.hot_restart'),
                     json_encode(['uri' => $uri, 'stack' => $stack, 'ts' => time()])
@@ -2404,6 +2382,38 @@ abstract class NativeComponent
     public function resetNavigationIntent(): void
     {
         $this->nativeNavigationIntent = null;
+    }
+
+    /**
+     * Where the rebooted runtime should land after a hot reload, plus the
+     * history to restore beneath it.
+     *
+     * Normally that's wherever the user actually IS — the native router's
+     * top-of-stack URI, not `request()->path()` (the original HTTP entry
+     * point, typically `/`), otherwise every reload dumps them back at the
+     * root — with the full stack serialized so the back button survives the
+     * reboot. `Route::native`'s handler replays the entries below the top via
+     * NativeRouter::preloadStack().
+     *
+     * A screen change requested from the `native:watch` terminal wins over
+     * the live stack: it is asking to GO somewhere, so the chosen screen
+     * becomes the new root rather than being pushed onto history the user is
+     * no longer in.
+     *
+     * @return array{uri: string, stack: list<array{uri: string, params: array}>}
+     */
+    private function hotRestartPayload(): array
+    {
+        if ($requested = NativeRouter::takeScreenIntent()) {
+            NativeRouter::debugLog("HOT_RELOAD: screen change requested — $requested");
+
+            return ['uri' => $requested, 'stack' => []];
+        }
+
+        return [
+            'uri' => $this->nativeRouter?->currentUri() ?? '/'.ltrim(request()->path(), '/'),
+            'stack' => $this->nativeRouter?->getStackEntries() ?? [],
+        ];
     }
 
     /**

--- a/src/Edge/NativeRouter.php
+++ b/src/Edge/NativeRouter.php
@@ -5,6 +5,28 @@ namespace Native\Mobile\Edge;
 class NativeRouter
 {
     /**
+     * Where `native:watch` leaves a screen-change intent for the app to pick
+     * up, relative to base_path().
+     *
+     * base_path() rather than storage_path() on purpose: on device
+     * storage_path() points into a private container the host can't reach,
+     * whereas base_path() is exactly where the watcher already syncs files —
+     * so the intent rides in on the same primitives as an edited Blade file.
+     *
+     * At the root rather than under storage/framework because that directory
+     * is excluded from the bundle and so may not exist on device, and
+     * `xcrun devicectl device copy to` has no way to create it.
+     */
+    public const SCREEN_INTENT_PATH = '.native_screen';
+
+    /**
+     * How long a screen-change intent stays actionable. Bounds how far into
+     * the future an intent pushed while the app was closed can hijack a
+     * later hot reload.
+     */
+    protected const SCREEN_INTENT_TTL = 60;
+
+    /**
      * File-based debug logging — error_log() doesn't reach Android logcat,
      * so we write to a file on device instead.
      */
@@ -185,6 +207,53 @@ class NativeRouter
     public static function isNativeRoute(string $uri): bool
     {
         return static::resolve($uri) !== null;
+    }
+
+    /**
+     * Consume a screen change requested from the `native:watch` terminal UI.
+     * Returns the target URI, or null when nothing usable is waiting.
+     *
+     * The intent is always removed, even when rejected — a file we refuse to
+     * act on must not sit there and be reconsidered on every reload.
+     */
+    public static function takeScreenIntent(): ?string
+    {
+        $path = base_path(self::SCREEN_INTENT_PATH);
+
+        // The intent is written by another process (the host's watcher) into a
+        // path this long-lived runtime may already have stat'd and cached as
+        // missing, so don't trust a cached answer here.
+        clearstatcache(true, $path);
+
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $raw = @file_get_contents($path);
+        @unlink($path);
+
+        $data = $raw ? json_decode($raw, true) : null;
+        $uri = is_array($data) ? ($data['uri'] ?? null) : null;
+
+        if (! is_string($uri) || $uri === '') {
+            return null;
+        }
+
+        $uri = '/'.ltrim($uri, '/');
+
+        if (time() - (int) ($data['ts'] ?? 0) > self::SCREEN_INTENT_TTL) {
+            static::debugLog("screen intent for $uri ignored — stale");
+
+            return null;
+        }
+
+        if (! static::isNativeRoute($uri)) {
+            static::debugLog("screen intent for $uri ignored — not a native route");
+
+            return null;
+        }
+
+        return $uri;
     }
 
     public static function clearRoutes(): void

--- a/src/Exceptions/WatchPromptCancelled.php
+++ b/src/Exceptions/WatchPromptCancelled.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Native\Mobile\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when the user backs out of one of `native:watch`'s prompts with
+ * Ctrl+C. Laravel Prompts would otherwise exit the process, taking the whole
+ * watcher with it — cancelling a screen you didn't mean to open should just
+ * put you back in front of the footer.
+ *
+ * Raised via Prompt::cancelUsing() rather than returned, because the prompt
+ * helpers declare non-nullable return types.
+ */
+class WatchPromptCancelled extends RuntimeException {}

--- a/src/Http/Middleware/HonorsRequestedNativeScreen.php
+++ b/src/Http/Middleware/HonorsRequestedNativeScreen.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Native\Mobile\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Native\Mobile\Edge\NativeRouter;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Lets `native:watch`'s screen picker reach the app even when no native
+ * screen is on show.
+ *
+ * The fast path for a screen change is the runloop's hot-reload handler, which
+ * consumes the intent and re-enters at the chosen screen. But that only exists
+ * while a native component is running. Land on a web route — a 404, say, or
+ * anything reached by exiting to the WebView — and the reload trigger takes the
+ * WebView branch instead: reboot PHP, reload the current URL. No runloop, so
+ * nothing reads the intent, and the terminal loses its grip on the app exactly
+ * when you most want a way out.
+ *
+ * That WebView reload is still an ordinary request, though, so catching it here
+ * is enough: redirect to the requested screen and `Route::native` takes over,
+ * republishing a native tree and reactivating the native renderer.
+ *
+ * Only registered on device (see NativeServiceProvider), so this costs a normal
+ * web app nothing.
+ */
+class HonorsRequestedNativeScreen
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $this->isPageLoad($request)) {
+            return $next($request);
+        }
+
+        $uri = NativeRouter::takeScreenIntent();
+
+        if ($uri === null || $uri === '/'.ltrim($request->path(), '/')) {
+            return $next($request);
+        }
+
+        NativeRouter::debugLog("screen intent claimed by HTTP request — redirecting to $uri");
+
+        return redirect($uri);
+    }
+
+    /**
+     * Whether this request is the WebView navigating, rather than fetching
+     * something the page referenced.
+     *
+     * An asset request must never claim the intent: it would consume the one
+     * shot we get, redirect a stylesheet to a screen, and leave the app
+     * sitting exactly where it was. Assets ask for their own type and only
+     * tolerate `*​/*`, so requiring `text/html` outright separates them from a
+     * document load.
+     */
+    private function isPageLoad(Request $request): bool
+    {
+        return $request->isMethod('GET')
+            && ! $request->ajax()
+            && str_contains((string) $request->header('Accept'), 'text/html');
+    }
+}

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Native\Mobile;
 
+use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Foundation\Console\ServeCommand;
 use Illuminate\Support\Facades\Blade;
@@ -42,6 +43,7 @@ use Native\Mobile\Edge\NativeComponent;
 use Native\Mobile\Edge\NativeRouter;
 use Native\Mobile\Edge\NativeTagPrecompiler;
 use Native\Mobile\Events\System\AppearanceChanged;
+use Native\Mobile\Http\Middleware\HonorsRequestedNativeScreen;
 use Native\Mobile\Plugins\Compilers\AndroidPluginCompiler;
 use Native\Mobile\Plugins\Compilers\IOSPluginCompiler;
 use Native\Mobile\Plugins\PluginDiscovery;
@@ -248,6 +250,7 @@ class NativeServiceProvider extends PackageServiceProvider
         $this->registerBladeDirectives();
         $this->configureViteHotFile();
         $this->applyFpsOverlayConfig();
+        $this->registerScreenIntentMiddleware();
 
         if (config('nativephp-internal.running')) {
             $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
@@ -538,6 +541,28 @@ class NativeServiceProvider extends PackageServiceProvider
         $enabled = (bool) config('nativephp.fps_overlay', false);
 
         nativephp_call('Perf.SetFpsOverlayEnabled', json_encode(['enabled' => $enabled]));
+    }
+
+    /**
+     * Let a screen change requested from `native:watch` be picked up by an
+     * ordinary request, not just by the runloop's hot-reload handler — that's
+     * the only way back to a native screen once the app has fallen through to
+     * the WebView (a 404, say), where no runloop exists to read the intent.
+     *
+     * On device only: NATIVEPHP_PLATFORM is set by the iOS and Android hosts,
+     * so a normal web app never pays for this.
+     */
+    private function registerScreenIntentMiddleware(): void
+    {
+        if (! in_array(env('NATIVEPHP_PLATFORM'), ['ios', 'android'], true)) {
+            return;
+        }
+
+        // Deliberately not gated on runningInConsole(): that reads PHP_SAPI,
+        // which the embedded runtime does not necessarily report as a web SAPI,
+        // and getting it wrong would silently disable the middleware. Pushing
+        // it in a console context is harmless — nothing dispatches a request.
+        $this->app->make(HttpKernel::class)->pushMiddleware(HonorsRequestedNativeScreen::class);
     }
 
     private function setupComposerPostUpdateScript()

--- a/src/Support/Watch/WatchConsole.php
+++ b/src/Support/Watch/WatchConsole.php
@@ -105,7 +105,7 @@ class WatchConsole
             $this->output->write("\033[?25h");
         }
 
-        $this->disableRawInput();
+        $this->restoreTtyMode(forget: true);
         $this->started = false;
     }
 
@@ -122,7 +122,7 @@ class WatchConsole
             $this->output->write("\033[?25h");
         }
 
-        $this->disableRawInput();
+        $this->restoreTtyMode(forget: false);
     }
 
     public function resume(): void
@@ -445,6 +445,13 @@ class WatchConsole
      * Switch the tty to character-at-a-time, no-echo, fully non-blocking
      * reads. `isig` is deliberately left on so Ctrl+C keeps working
      * alongside the quit key.
+     *
+     * The mode to hand back later is captured once, on the first call, and
+     * reused by every subsequent resume() — never re-read. Between suspend()
+     * and resume() something else owns the terminal, and a prompt that throws
+     * (Esc or Ctrl+C out of the picker) can be mid-restore when we come back;
+     * re-reading here would capture that transient state as the mode to leave
+     * the user's terminal in at exit.
      */
     private function enableRawInput(): bool
     {
@@ -452,14 +459,16 @@ class WatchConsole
             return false;
         }
 
-        $mode = @shell_exec('stty -g 2>/dev/null');
-        $mode = is_string($mode) ? trim($mode) : '';
+        if ($this->originalTtyMode === null) {
+            $mode = @shell_exec('stty -g 2>/dev/null');
+            $mode = is_string($mode) ? trim($mode) : '';
 
-        if ($mode === '') {
-            return false;
+            if ($mode === '') {
+                return false;
+            }
+
+            $this->originalTtyMode = $mode;
         }
-
-        $this->originalTtyMode = $mode;
 
         @shell_exec('stty -icanon -echo min 0 time 0 2>/dev/null');
         @stream_set_blocking(STDIN, false);
@@ -467,7 +476,12 @@ class WatchConsole
         return true;
     }
 
-    private function disableRawInput(): void
+    /**
+     * Put the tty back the way start() found it. `$forget` also releases the
+     * captured mode, so only stop() ends the console's ownership of it —
+     * suspend() keeps it for the resume() that follows.
+     */
+    private function restoreTtyMode(bool $forget): void
     {
         if ($this->originalTtyMode === null) {
             return;
@@ -481,8 +495,11 @@ class WatchConsole
         // instead of keys.
         @stream_set_blocking(STDIN, true);
 
-        $this->originalTtyMode = null;
         $this->rawInput = false;
+
+        if ($forget) {
+            $this->originalTtyMode = null;
+        }
     }
 
     private function supportsRawInput(): bool

--- a/src/Support/Watch/WatchConsole.php
+++ b/src/Support/Watch/WatchConsole.php
@@ -1,0 +1,497 @@
+<?php
+
+namespace Native\Mobile\Support\Watch;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
+
+/**
+ * The terminal surface for `native:watch`.
+ *
+ * Two things live here: a sticky footer pinned below the scrollback (status
+ * line, one transient activity line, key legend) and non-blocking single-key
+ * input. The footer means file changes can update in place instead of
+ * scrolling a history nobody reads, and the legend stays visible so the
+ * available keys never have to be remembered.
+ *
+ * Everything degrades: without an interactive TTY (CI, piped output,
+ * `--no-interaction`, Windows) the footer is not drawn and activity lines
+ * print normally, one per change.
+ */
+class WatchConsole
+{
+    /**
+     * Seconds of quiet before the activity line dims to "idle". Purely
+     * cosmetic — the text stays, only its marker changes — so nothing is
+     * lost if the user looks away.
+     */
+    private const IDLE_AFTER = 2.5;
+
+    /**
+     * Terminal mode as `stty -g` reported it before we switched to
+     * character-at-a-time input; restored verbatim on stop().
+     */
+    private ?string $originalTtyMode = null;
+
+    private bool $rawInput = false;
+
+    /**
+     * How many lines the footer currently occupies on screen. Drives the
+     * relative cursor-up used to redraw it, so it must match reality
+     * exactly — hence the hard truncation in line().
+     */
+    private int $drawn = 0;
+
+    private bool $started = false;
+
+    /** @var list<array{0: ?string, 1: string}> */
+    private array $status = [];
+
+    /** @var array<string, string> */
+    private array $keys = [];
+
+    private string $activity = '';
+
+    private ?string $activityStyle = null;
+
+    private float $activityAt = 0.0;
+
+    private bool $idle = true;
+
+    public function __construct(
+        private OutputInterface $output,
+        private bool $interactive = true,
+    ) {}
+
+    /**
+     * True when the footer is live and keys are being read — i.e. when the
+     * caller can rely on activity() replacing output rather than appending.
+     */
+    public function isInteractive(): bool
+    {
+        return $this->rawInput;
+    }
+
+    /**
+     * Take over the terminal: switch to character-at-a-time input, hide the
+     * cursor and draw the footer for the first time.
+     */
+    public function start(): void
+    {
+        $this->started = true;
+        $this->rawInput = $this->enableRawInput();
+
+        if ($this->decorated()) {
+            $this->output->write("\033[?25l");
+        }
+
+        $this->draw();
+    }
+
+    /**
+     * Give the terminal back — cooked input, visible cursor, no footer.
+     * Idempotent: shutdown handlers, the quit key and signal paths all
+     * funnel through here and may overlap.
+     */
+    public function stop(): void
+    {
+        if (! $this->started) {
+            return;
+        }
+
+        $this->erase();
+
+        if ($this->decorated()) {
+            $this->output->write("\033[?25h");
+        }
+
+        $this->disableRawInput();
+        $this->started = false;
+    }
+
+    /**
+     * Step out of the way so something else can own the terminal (a
+     * Laravel Prompts selector, say). Whatever it prints becomes ordinary
+     * scrollback once resume() redraws the footer beneath it.
+     */
+    public function suspend(): void
+    {
+        $this->erase();
+
+        if ($this->decorated()) {
+            $this->output->write("\033[?25h");
+        }
+
+        $this->disableRawInput();
+    }
+
+    public function resume(): void
+    {
+        if (! $this->started) {
+            return;
+        }
+
+        $this->rawInput = $this->enableRawInput();
+
+        if ($this->decorated()) {
+            $this->output->write("\033[?25l");
+        }
+
+        $this->draw();
+    }
+
+    /**
+     * Set the footer's status segments. Each entry is a `[label, value]`
+     * pair (a null label renders the value on its own); entries with an
+     * empty value are dropped.
+     *
+     * @param  list<array{0: ?string, 1: ?string}>  $segments
+     */
+    public function status(array $segments): void
+    {
+        $this->status = array_values(array_filter(
+            $segments,
+            fn (array $segment) => ($segment[1] ?? '') !== '',
+        ));
+
+        $this->draw();
+    }
+
+    /**
+     * Set the key legend, in display order: key => description.
+     *
+     * @param  array<string, string>  $keys
+     */
+    public function keys(array $keys): void
+    {
+        $this->keys = $keys;
+
+        $this->draw();
+    }
+
+    /**
+     * Replace the single activity line. `$text` must be plain — the footer
+     * truncates by visible length, so it styles the whole line itself
+     * rather than trying to measure embedded markup.
+     */
+    public function activity(string $text, ?string $style = null): void
+    {
+        $this->activity = $text;
+        $this->activityStyle = $style;
+        $this->activityAt = microtime(true);
+        $this->idle = false;
+
+        if (! $this->decorated()) {
+            // No footer to update in place, so fall back to a plain line —
+            // still one per change, which is what a log wants anyway.
+            $this->output->writeln($style !== null ? "<fg={$style}>{$text}</>" : $text);
+
+            return;
+        }
+
+        $this->draw();
+    }
+
+    /**
+     * Write a line into the scrollback above the footer. For things worth
+     * keeping — errors, screen changes — not for per-file churn.
+     */
+    public function note(string $text): void
+    {
+        $this->erase();
+        $this->output->writeln($text);
+        $this->draw();
+    }
+
+    /**
+     * Wipe the scrollback above the footer.
+     */
+    public function clearScrollback(): void
+    {
+        if (! $this->decorated()) {
+            return;
+        }
+
+        $this->erase();
+        $this->output->write("\033[2J\033[H");
+        $this->draw();
+    }
+
+    /**
+     * Housekeeping for the caller's watch loop: ages the activity line out
+     * to "idle". Cheap enough to call on every poll.
+     */
+    public function tick(): void
+    {
+        if ($this->idle || ! $this->decorated()) {
+            return;
+        }
+
+        if ((microtime(true) - $this->activityAt) < self::IDLE_AFTER) {
+            return;
+        }
+
+        $this->idle = true;
+        $this->draw();
+    }
+
+    /**
+     * The next buffered keypress, or null if nothing is waiting. Escape
+     * sequences (arrow keys, function keys) are swallowed rather than
+     * surfaced as the stray letters they end in.
+     */
+    public function readKey(): ?string
+    {
+        if (! $this->rawInput) {
+            return null;
+        }
+
+        $read = [STDIN];
+        $write = $except = [];
+
+        if (@stream_select($read, $write, $except, 0, 0) < 1) {
+            return null;
+        }
+
+        $char = @fread(STDIN, 1);
+
+        if ($char === false || $char === '') {
+            return null;
+        }
+
+        if ($char === "\033") {
+            $this->drainEscapeSequence();
+
+            return null;
+        }
+
+        return $char;
+    }
+
+    /**
+     * Discard the rest of a CSI/SS3 sequence so its trailing letter (the
+     * `A` of an up-arrow, say) is not mistaken for a command key.
+     */
+    private function drainEscapeSequence(): void
+    {
+        for ($i = 0; $i < 8; $i++) {
+            $read = [STDIN];
+            $write = $except = [];
+
+            if (@stream_select($read, $write, $except, 0, 1000) < 1) {
+                return;
+            }
+
+            if (@fread(STDIN, 1) === '') {
+                return;
+            }
+        }
+    }
+
+    // ── Footer rendering ────────────────────────────
+
+    /**
+     * Redraw the footer in place: back up over the previous draw, then
+     * rewrite each line. Relative cursor movement (rather than absolute
+     * positioning) is what makes this survive the terminal scrolling.
+     */
+    private function draw(): void
+    {
+        if (! $this->started || ! $this->decorated()) {
+            return;
+        }
+
+        $lines = $this->footer();
+
+        $buffer = $this->drawn > 0 ? "\033[{$this->drawn}A" : '';
+
+        foreach ($lines as $line) {
+            $buffer .= "\033[2K".$line."\n";
+        }
+
+        // A footer that just got shorter would otherwise leave its old
+        // tail on screen.
+        if ($this->drawn > count($lines)) {
+            $buffer .= "\033[0J";
+        }
+
+        $this->output->write($buffer);
+        $this->drawn = count($lines);
+    }
+
+    private function erase(): void
+    {
+        if ($this->drawn === 0 || ! $this->decorated()) {
+            return;
+        }
+
+        $this->output->write("\033[{$this->drawn}A\033[0J");
+        $this->drawn = 0;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function footer(): array
+    {
+        return [
+            $this->line([[str_repeat('─', $this->width()), 'gray']]),
+            $this->line($this->statusSegments()),
+            $this->line($this->activitySegments()),
+            $this->line($this->legendSegments()),
+        ];
+    }
+
+    /**
+     * @return list<array{0: string, 1: ?string}>
+     */
+    private function statusSegments(): array
+    {
+        $segments = [[' ', null]];
+
+        foreach ($this->status as $index => [$label, $value]) {
+            if ($index > 0) {
+                $segments[] = [' · ', 'gray'];
+            }
+
+            if ($label !== null) {
+                $segments[] = [$label.' ', 'gray'];
+            }
+
+            $segments[] = [$value, 'default'];
+        }
+
+        return $segments;
+    }
+
+    /**
+     * @return list<array{0: string, 1: ?string}>
+     */
+    private function activitySegments(): array
+    {
+        if ($this->activity === '') {
+            return [[' ', null]];
+        }
+
+        return [
+            [' ', null],
+            [$this->idle ? '○ ' : '● ', $this->idle ? 'gray' : ($this->activityStyle ?? 'default')],
+            [$this->activity, $this->idle ? 'gray' : ($this->activityStyle ?? 'default')],
+        ];
+    }
+
+    /**
+     * @return list<array{0: string, 1: ?string}>
+     */
+    private function legendSegments(): array
+    {
+        $segments = [[' ', null]];
+
+        foreach ($this->keys as $key => $description) {
+            if (count($segments) > 1) {
+                $segments[] = ['  ', null];
+            }
+
+            $segments[] = [strtoupper($key), 'cyan'];
+            $segments[] = [' '.$description, 'gray'];
+        }
+
+        return $segments;
+    }
+
+    /**
+     * Compose one footer line from styled segments, truncated to the
+     * terminal width. Truncation is not cosmetic: a wrapped line would
+     * occupy two rows and throw off the cursor-up count on the next draw.
+     *
+     * @param  list<array{0: string, 1: ?string}>  $segments
+     */
+    private function line(array $segments): string
+    {
+        $budget = $this->width();
+        $rendered = '';
+
+        foreach ($segments as [$text, $style]) {
+            if ($budget <= 0) {
+                break;
+            }
+
+            if (mb_strlen($text) > $budget) {
+                $text = $budget > 1 ? mb_substr($text, 0, $budget - 1).'…' : '…';
+            }
+
+            $budget -= mb_strlen($text);
+            $text = $this->output->getFormatter()->escape($text);
+
+            $rendered .= $style !== null ? "<fg={$style}>{$text}</>" : $text;
+        }
+
+        return $rendered;
+    }
+
+    private function width(): int
+    {
+        return max(20, (new Terminal)->getWidth() - 1);
+    }
+
+    private function decorated(): bool
+    {
+        return $this->output->isDecorated();
+    }
+
+    // ── Terminal input mode ─────────────────────────
+
+    /**
+     * Switch the tty to character-at-a-time, no-echo, fully non-blocking
+     * reads. `isig` is deliberately left on so Ctrl+C keeps working
+     * alongside the quit key.
+     */
+    private function enableRawInput(): bool
+    {
+        if (! $this->supportsRawInput()) {
+            return false;
+        }
+
+        $mode = @shell_exec('stty -g 2>/dev/null');
+        $mode = is_string($mode) ? trim($mode) : '';
+
+        if ($mode === '') {
+            return false;
+        }
+
+        $this->originalTtyMode = $mode;
+
+        @shell_exec('stty -icanon -echo min 0 time 0 2>/dev/null');
+        @stream_set_blocking(STDIN, false);
+
+        return true;
+    }
+
+    private function disableRawInput(): void
+    {
+        if ($this->originalTtyMode === null) {
+            return;
+        }
+
+        @shell_exec('stty '.escapeshellarg($this->originalTtyMode).' 2>/dev/null');
+
+        // Restoring the tty mode is not enough — PHP's own non-blocking flag
+        // on the stream outlives it, and anything that then reads STDIN
+        // (a Laravel Prompts selector, say) gets a torrent of empty strings
+        // instead of keys.
+        @stream_set_blocking(STDIN, true);
+
+        $this->originalTtyMode = null;
+        $this->rawInput = false;
+    }
+
+    private function supportsRawInput(): bool
+    {
+        return $this->interactive
+            && PHP_OS_FAMILY !== 'Windows'
+            && $this->decorated()
+            && function_exists('shell_exec')
+            && defined('STDIN')
+            && @stream_isatty(STDIN);
+    }
+}

--- a/tests/Feature/WatchScreenIntentTest.php
+++ b/tests/Feature/WatchScreenIntentTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Edge\NativeRouter;
+use Tests\Fixtures\Edge\CounterScreen;
+use Tests\Fixtures\Edge\DetailScreen;
+
+/**
+ * `native:watch`'s `L` key pushes a screen-change intent into the app's
+ * base_path() and triggers an ordinary hot reload; PHP consumes the intent on
+ * its way through the reload handler. These cover the consuming end.
+ */
+function intentPath(): string
+{
+    return base_path(NativeRouter::SCREEN_INTENT_PATH);
+}
+
+function writeScreenIntent(array $payload): void
+{
+    file_put_contents(intentPath(), json_encode($payload));
+}
+
+beforeEach(function () {
+    NativeRouter::clearRoutes();
+    @unlink(intentPath());
+});
+
+afterEach(function () {
+    NativeRouter::clearRoutes();
+    @unlink(intentPath());
+});
+
+it('returns nothing when no screen change has been requested', function () {
+    expect(NativeRouter::takeScreenIntent())->toBeNull();
+});
+
+it('takes a requested screen and consumes the intent', function () {
+    Route::native('/settings', CounterScreen::class);
+
+    writeScreenIntent(['uri' => '/settings', 'ts' => time()]);
+
+    expect(NativeRouter::takeScreenIntent())->toBe('/settings');
+    expect(intentPath())->not->toBeFile();
+});
+
+it('normalises a requested screen to a leading slash', function () {
+    Route::native('/settings', CounterScreen::class);
+
+    writeScreenIntent(['uri' => 'settings', 'ts' => time()]);
+
+    expect(NativeRouter::takeScreenIntent())->toBe('/settings');
+});
+
+it('takes a parameterised screen that matches a registered pattern', function () {
+    Route::native('/detail/{id}', DetailScreen::class);
+
+    writeScreenIntent(['uri' => '/detail/42', 'ts' => time()]);
+
+    expect(NativeRouter::takeScreenIntent())->toBe('/detail/42');
+});
+
+// A stale intent must not hijack a hot reload that happens minutes later.
+it('ignores an intent pushed while the app was closed', function () {
+    Route::native('/settings', CounterScreen::class);
+
+    writeScreenIntent(['uri' => '/settings', 'ts' => time() - 3600]);
+
+    expect(NativeRouter::takeScreenIntent())->toBeNull();
+});
+
+it('ignores a screen that is not a native route', function () {
+    Route::native('/settings', CounterScreen::class);
+
+    writeScreenIntent(['uri' => '/some-web-page', 'ts' => time()]);
+
+    expect(NativeRouter::takeScreenIntent())->toBeNull();
+});
+
+it('consumes an intent it refuses to act on, so it is not reconsidered', function () {
+    writeScreenIntent(['uri' => '/gone-away', 'ts' => time()]);
+
+    expect(NativeRouter::takeScreenIntent())->toBeNull();
+    expect(intentPath())->not->toBeFile();
+});
+
+it('survives a corrupt intent file', function () {
+    file_put_contents(intentPath(), 'not json at all');
+
+    expect(NativeRouter::takeScreenIntent())->toBeNull();
+    expect(intentPath())->not->toBeFile();
+});
+
+it('lands a hot reload on the requested screen, as the new root', function () {
+    Route::native('/settings', CounterScreen::class);
+
+    writeScreenIntent(['uri' => '/settings', 'ts' => time()]);
+
+    expect(hotRestartPayload(new CounterScreen))->toBe([
+        'uri' => '/settings',
+        'stack' => [],
+    ]);
+});
+
+it('lands a hot reload where the user already was when no screen was requested', function () {
+    expect(hotRestartPayload(new CounterScreen))->toBe([
+        'uri' => '/',
+        'stack' => [],
+    ]);
+});
+
+function hotRestartPayload(NativeComponent $component): array
+{
+    $method = new ReflectionMethod($component, 'hotRestartPayload');
+
+    return $method->invoke($component);
+}

--- a/tests/Unit/Watch/HonorsRequestedNativeScreenTest.php
+++ b/tests/Unit/Watch/HonorsRequestedNativeScreenTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Http\Middleware\HonorsRequestedNativeScreen;
+use Tests\Fixtures\Edge\CounterScreen;
+
+/**
+ * The recovery path for a screen change: when the app has fallen through to the
+ * WebView there is no runloop to read the intent, so an ordinary page load has
+ * to claim it instead.
+ */
+function screenIntentPath(): string
+{
+    return base_path(NativeRouter::SCREEN_INTENT_PATH);
+}
+
+function pendingIntent(string $uri, ?int $ts = null): void
+{
+    file_put_contents(screenIntentPath(), json_encode([
+        'uri' => $uri,
+        'ts' => $ts ?? time(),
+    ]));
+}
+
+/**
+ * @param  array<string, string>  $headers
+ */
+function runMiddleware(string $uri = '/whatever', string $method = 'GET', array $headers = ['Accept' => 'text/html,application/xhtml+xml']): mixed
+{
+    $request = Request::create($uri, $method);
+
+    foreach ($headers as $name => $value) {
+        $request->headers->set($name, $value);
+    }
+
+    return (new HonorsRequestedNativeScreen)->handle(
+        $request,
+        fn () => response('passed through'),
+    );
+}
+
+beforeEach(function () {
+    NativeRouter::clearRoutes();
+    @unlink(screenIntentPath());
+    Route::native('/counter', CounterScreen::class);
+});
+
+afterEach(function () {
+    NativeRouter::clearRoutes();
+    @unlink(screenIntentPath());
+});
+
+it('passes the request through when no screen was requested', function () {
+    expect(runMiddleware()->getContent())->toBe('passed through');
+});
+
+it('redirects a page load to the requested screen', function () {
+    pendingIntent('/counter');
+
+    $response = runMiddleware('/a-404-page');
+
+    // Same shape of redirect `Route::native` already uses to land the app on a
+    // native screen, so it travels the path the platforms already handle.
+    expect($response->isRedirection())->toBeTrue();
+    expect(parse_url($response->headers->get('Location'), PHP_URL_PATH))->toBe('/counter');
+    expect(screenIntentPath())->not->toBeFile();
+});
+
+it('leaves the request alone when it is already the requested screen', function () {
+    pendingIntent('/counter');
+
+    // The native path's own re-entry lands here; redirecting would loop.
+    expect(runMiddleware('/counter')->getContent())->toBe('passed through');
+});
+
+// An asset request must not burn the one shot we get and redirect a stylesheet
+// to a screen, leaving the app exactly where it was.
+it('does not let asset requests claim the intent', function () {
+    pendingIntent('/counter');
+
+    $response = runMiddleware('/build/app.css', headers: ['Accept' => 'text/css,*/*;q=0.1']);
+
+    expect($response->getContent())->toBe('passed through');
+    expect(screenIntentPath())->toBeFile();
+});
+
+it('does not let XHR claim the intent', function () {
+    pendingIntent('/counter');
+
+    $response = runMiddleware(headers: [
+        'Accept' => 'text/html',
+        'X-Requested-With' => 'XMLHttpRequest',
+    ]);
+
+    expect($response->getContent())->toBe('passed through');
+    expect(screenIntentPath())->toBeFile();
+});
+
+it('does not let a form post claim the intent', function () {
+    pendingIntent('/counter');
+
+    $response = runMiddleware('/submit', 'POST');
+
+    expect($response->getContent())->toBe('passed through');
+    expect(screenIntentPath())->toBeFile();
+});
+
+it('ignores a stale intent and still serves the request', function () {
+    pendingIntent('/counter', time() - 3600);
+
+    expect(runMiddleware()->getContent())->toBe('passed through');
+});
+
+it('ignores an intent for a screen that is not a native route', function () {
+    pendingIntent('/not-a-native-route');
+
+    expect(runMiddleware()->getContent())->toBe('passed through');
+});

--- a/tests/Unit/Watch/NativeScreenOptionsTest.php
+++ b/tests/Unit/Watch/NativeScreenOptionsTest.php
@@ -1,8 +1,11 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Laravel\Prompts\Key;
+use Laravel\Prompts\Prompt;
 use Native\Mobile\Concerns\InteractsWithWatchTerminal;
 use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Exceptions\WatchPromptCancelled;
 use Tests\Fixtures\Edge\CounterScreen;
 use Tests\Fixtures\Edge\DetailScreen;
 
@@ -28,6 +31,11 @@ function screenPicker(): object
         public function intentFor(string $uri): string
         {
             return $this->writeScreenIntentFile($uri);
+        }
+
+        public function bindEscape(Prompt $prompt): Prompt
+        {
+            return $this->cancelOnEscape($prompt);
         }
     };
 }
@@ -64,6 +72,36 @@ it('passes a parameterless screen straight through', function () {
 it('has nothing to fill in when the picker was cancelled', function () {
     expect(screenPicker()->fill(null))->toBeNull();
 });
+
+/**
+ * A prompt with no key handlers of its own, so emitting a key exercises only
+ * the listener under test rather than a real prompt's internals.
+ */
+function promptWithEscapeBinding(): Prompt
+{
+    return screenPicker()->bindEscape(new class extends Prompt
+    {
+        public function value(): mixed
+        {
+            return null;
+        }
+    });
+}
+
+it('backs out of a prompt on Esc', function () {
+    expect(fn () => promptWithEscapeBinding()->emit('key', Key::ESCAPE))
+        ->toThrow(WatchPromptCancelled::class);
+});
+
+// Arrow keys arrive as `\e[A` and friends in a single read, so only a bare Esc
+// may cancel — otherwise navigating the list would close the picker.
+it('leaves every other key to the prompt', function () {
+    $prompt = promptWithEscapeBinding();
+
+    foreach ([Key::UP_ARROW, Key::DOWN_ARROW, Key::ENTER, Key::TAB, Key::CTRL_C, 'c', ' '] as $key) {
+        $prompt->emit('key', $key);
+    }
+})->throwsNoExceptions();
 
 // The two ends of the wire: what the watcher pushes has to be exactly what the
 // app is prepared to read back out.

--- a/tests/Unit/Watch/NativeScreenOptionsTest.php
+++ b/tests/Unit/Watch/NativeScreenOptionsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Native\Mobile\Concerns\InteractsWithWatchTerminal;
+use Native\Mobile\Edge\NativeRouter;
+use Tests\Fixtures\Edge\CounterScreen;
+use Tests\Fixtures\Edge\DetailScreen;
+
+/**
+ * What the `L` key offers the user, and what a chosen pattern turns into.
+ */
+function screenPicker(): object
+{
+    return new class
+    {
+        use InteractsWithWatchTerminal;
+
+        public function options(): array
+        {
+            return $this->nativeScreenOptions();
+        }
+
+        public function fill(?string $pattern): ?string
+        {
+            return $this->fillScreenParameters($pattern);
+        }
+
+        public function intentFor(string $uri): string
+        {
+            return $this->writeScreenIntentFile($uri);
+        }
+    };
+}
+
+beforeEach(fn () => NativeRouter::clearRoutes());
+afterEach(fn () => NativeRouter::clearRoutes());
+
+it('offers nothing when the app has no native screens', function () {
+    expect(screenPicker()->options())->toBe([]);
+});
+
+it('lists every registered native screen with its component', function () {
+    Route::native('/settings', CounterScreen::class);
+    Route::native('/detail/{id}', DetailScreen::class);
+
+    expect(screenPicker()->options())->toBe([
+        '/detail/{id}' => '/detail/{id}   DetailScreen',
+        '/settings' => '/settings      CounterScreen',
+    ]);
+});
+
+it('offers the root screen first, then the rest alphabetically', function () {
+    Route::native('/zebra', CounterScreen::class);
+    Route::native('/apple', CounterScreen::class);
+    Route::native('/', CounterScreen::class);
+
+    expect(array_keys(screenPicker()->options()))->toBe(['/', '/apple', '/zebra']);
+});
+
+it('passes a parameterless screen straight through', function () {
+    expect(screenPicker()->fill('/settings'))->toBe('/settings');
+});
+
+it('has nothing to fill in when the picker was cancelled', function () {
+    expect(screenPicker()->fill(null))->toBeNull();
+});
+
+// The two ends of the wire: what the watcher pushes has to be exactly what the
+// app is prepared to read back out.
+it('writes an intent file the app will accept', function () {
+    Route::native('/settings', CounterScreen::class);
+
+    $intentFile = screenPicker()->intentFor('/settings');
+
+    copy($intentFile, base_path(NativeRouter::SCREEN_INTENT_PATH));
+    @unlink($intentFile);
+
+    expect(NativeRouter::takeScreenIntent())->toBe('/settings');
+});

--- a/tests/Unit/Watch/WatchConsoleTest.php
+++ b/tests/Unit/Watch/WatchConsoleTest.php
@@ -1,0 +1,143 @@
+<?php
+
+use Native\Mobile\Support\Watch\WatchConsole;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
+
+/**
+ * Strip SGR colour codes but keep the cursor/erase sequences — those are what
+ * has to be right for the sticky footer to stay in one place.
+ */
+function layout(BufferedOutput $output): string
+{
+    return preg_replace('/\e\[\d*(?:;\d+)*m/', '', $output->fetch());
+}
+
+function console(BufferedOutput $output, bool $decorated = true): WatchConsole
+{
+    $output->setDecorated($decorated);
+
+    $console = new WatchConsole($output, interactive: false);
+    $console->keys(['l' => 'change screen', 'q' => 'quit']);
+    $console->status([[null, 'android'], ['screen', '/']]);
+
+    return $console;
+}
+
+it('draws the status, activity and legend as a four line footer', function () {
+    $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+
+    console($output)->start();
+
+    $rendered = layout($output);
+
+    expect($rendered)->toContain('android')
+        ->toContain('screen /')
+        ->toContain('L change screen')
+        ->toContain('Q quit');
+
+    // Hidden cursor, four freshly-cleared lines, no cursor movement on the
+    // very first draw (there is nothing above to back up over).
+    expect($rendered)->toStartWith("\e[?25l")
+        ->and(substr_count($rendered, "\e[2K"))->toBe(4)
+        ->and($rendered)->not->toContain("\e[4A");
+});
+
+it('redraws the footer in place rather than scrolling it', function () {
+    $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+    $console = console($output);
+    $console->start();
+    $output->fetch();
+
+    $console->activity('synced routes/web.php · 1 change', 'green');
+
+    // Back up over exactly the four lines drawn last time, then rewrite them.
+    expect(layout($output))
+        ->toStartWith("\e[4A")
+        ->toContain('synced routes/web.php · 1 change');
+});
+
+it('keeps notes in the scrollback above the footer', function () {
+    $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+    $console = console($output);
+    $console->start();
+    $output->fetch();
+
+    $console->note('adb push failed');
+
+    // Erase the footer, write the note, redraw the footer underneath it.
+    expect(layout($output))->toStartWith("\e[4A\e[0J".'adb push failed');
+});
+
+it('truncates footer lines so they cannot wrap and desync the redraw', function () {
+    $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+    $console = console($output);
+    $console->start();
+    $output->fetch();
+
+    $console->activity(str_repeat('deeply/nested/', 40).'file.blade.php');
+
+    $width = (new Terminal)->getWidth();
+
+    foreach (explode("\n", trim(layout($output))) as $line) {
+        expect(mb_strlen(str_replace(["\e[4A", "\e[2K"], '', $line)))
+            ->toBeLessThan($width);
+    }
+});
+
+it('escapes activity text instead of parsing it as markup', function () {
+    $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+    $console = console($output);
+    $console->start();
+    $output->fetch();
+
+    $console->activity('resources/views/<x-thing>.blade.php');
+
+    expect(layout($output))->toContain('resources/views/<x-thing>.blade.php');
+});
+
+it('leaves no footer behind when it hands the terminal back', function () {
+    $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+    $console = console($output);
+    $console->start();
+    $output->fetch();
+
+    $console->stop();
+
+    expect(layout($output))->toBe("\e[4A\e[0J\e[?25h");
+});
+
+it('can be stopped more than once', function () {
+    $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+    $console = console($output);
+    $console->start();
+    $console->stop();
+    $output->fetch();
+
+    $console->stop();
+
+    expect(layout($output))->toBe('');
+});
+
+it('reports no keypresses when the terminal cannot be put into raw mode', function () {
+    $output = new BufferedOutput(OutputInterface::VERBOSITY_NORMAL, true);
+    $console = console($output);
+    $console->start();
+
+    expect($console->isInteractive())->toBeFalse();
+    expect($console->readKey())->toBeNull();
+});
+
+it('falls back to plain lines when the output is not decorated', function () {
+    $output = new BufferedOutput;
+    $console = console($output, decorated: false);
+    $console->start();
+    $output->fetch();
+
+    $console->activity('synced routes/web.php');
+    $console->note('adb push failed');
+
+    // No footer, no cursor games — just readable log lines.
+    expect($output->fetch())->toBe("synced routes/web.php\nadb push failed\n");
+});


### PR DESCRIPTION
`native:watch` scrolled a line per changed file and told you to press Ctrl+C. This replaces that with a footer pinned below the scrollback, and adds a way to change the app's active native screen from the terminal.

```
────────────────────────────────────────────────────────────
 ios · iPhone 17 Pro Simulator · screen /counter
 ● synced app/NativeComponents/Counter.php · 3 changes
 L change screen  R reload  C clear  Q quit
```

One transient activity line updates in place (dimming to `○` after a couple of seconds of quiet) instead of accumulating a history nobody reads. Errors worth keeping — adb push failures, watchman dying — still scroll above the footer.

## Changing the active screen

`L` offers the app's registered `Route::native()` screens with their component names: a plain list under 12 screens, a filterable search above that. Parameterised routes prompt for each `{param}`. Ctrl+C inside the picker cancels the picker rather than tearing down the watcher.

The chosen URI travels as a small intent file pushed to `base_path()` on device by the same primitives that sync an edited Blade file, followed by the ordinary reload trigger. PHP consumes it in its hot-reload handler and the existing `.hot_restart` plumbing lands the app there — so Android's `executeNativeRoute` and iOS's `HotReloadCoordinator` need no changes. The chosen screen becomes the new root; intents go stale after 60s and are dropped if they don't resolve to a native route.

It sits at the app root rather than under `storage/framework` because that directory is excluded from the bundle and so may not exist on device, and `xcrun devicectl device copy to` can't create it.

## Recovering from a non-native screen

That hot-reload handler only exists while a native component is running. Once the app falls through to the WebView — a 404, say — the reload trigger takes its other branch (reboot PHP, reload the current URL), nothing reads the intent, and the terminal loses its grip on the app exactly when you most want a way out.

`HonorsRequestedNativeScreen` catches that reload's request and redirects to the requested screen; `Route::native` then republishes a native tree and the native renderer reactivates. It's the same shape of redirect `Route::native` already uses for hot-restart, so it travels a path both platforms handle. Registered on device only (gated on `NATIVEPHP_PLATFORM`), and only for html `GET`s — an asset request must not burn the one shot and redirect a stylesheet to a screen.

Deliberately not gated on `runningInConsole()`: that reads `PHP_SAPI`, which the embedded runtime doesn't necessarily report as a web SAPI, and getting it wrong would silently disable the middleware.

## Incidental fix

Both watch loops installed SIGINT handlers but never enabled `pcntl_async_signals` and never called `pcntl_signal_dispatch()`, so the handlers were installed and never ran — Ctrl+C was swallowed on the Android and simulator paths. Now enabled alongside the existing handler registration.

## Verification

33 new tests (724 total passing); formatting and PHPStan clean on the new files.

Beyond the tests, the real command was driven against a live iOS simulator through a pty: the footer's cursor math, key reading including swallowing arrow-key escape sequences, the full `L` → picker → param → navigate flow, and the tty restored to canonical+echo on every exit path. Screenshots confirmed the app actually landing on the chosen screens. The 404 case was reproduced faithfully — a saved nav target pointing at a URI that resolves to neither a native nor a web route — and the middleware recovered it, taking the app from a dead WebView 404 to a live native screen.

Two bugs were caught by that pty work rather than by unit tests: `suspend()` restored the tty mode but left PHP's STDIN stream non-blocking, so Laravel Prompts read a flood of empty strings instead of keys; and footer lines had to be hard-truncated, because a wrapped line occupies two rows and desyncs the cursor-up count on the next redraw.

Everything degrades without an interactive TTY (CI, piped output, `--no-interaction`, Windows): no footer, one concise line per change.

Android was exercised only through the shared code paths — no device was attached, so the adb push and reload triggers are untested on real hardware.

Also includes one unrelated one-character commit, kept separate: the Boost core guidelines wrote `key="user-{{ $u->id }}"` unescaped, so the template rendered the id instead of showing the syntax. It was already uncommitted on this branch.