### PR TITLE
Simplify the install command's closing moment

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -10,7 +10,6 @@ use Native\Mobile\Concerns\InstallsAndroid;
 use Native\Mobile\Concerns\InstallsIos;
 use Native\Mobile\Concerns\PlatformFileOperations;
 
-use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;
 use function Laravel\Prompts\note;
@@ -169,29 +168,6 @@ class InstallCommand extends Command
         }
 
         outro('NativePHP for Mobile installed successfully!');
-
-        if (confirm(
-            label: 'Would you mind starring us on GitHub? It really helps!',
-            yes: 'Hell Yeah! 🔥',
-            no: 'Already Did',
-            default: true,
-        )) {
-            $url = 'https://github.com/NativePHP/mobile-air';
-
-            // xdg-open may be absent on headless/minimal Linux and WSL —
-            // probe first and fall back to printing the URL. Quote the URL
-            // everywhere; `start` needs a leading "" title arg when quoting.
-            if (PHP_OS_FAMILY === 'Darwin') {
-                exec('open '.escapeshellarg($url));
-            } elseif (PHP_OS_FAMILY === 'Windows') {
-                exec('start "" "'.$url.'"');
-            } else {
-                exec('command -v xdg-open >/dev/null 2>&1', $probe, $missing);
-                $missing === 0
-                    ? exec('xdg-open '.escapeshellarg($url).' >/dev/null 2>&1')
-                    : $this->line("  Open in your browser: {$url}");
-            }
-        }
 
         $this->showSuperNativeBanner();
     }

--- a/src/Concerns/DisplaysMarketingBanners.php
+++ b/src/Concerns/DisplaysMarketingBanners.php
@@ -40,26 +40,13 @@ trait DisplaysMarketingBanners
 
         $this->newLine();
 
-        // Charge bar "powers up" left → right, then the SUPERNATIVE label sparks in.
-        $segments = 10;
-        $label = ' <fg=#FFE600;options=bold>⚡</> <fg=#5EEAD4;options=bold>S U P E R N A T I V E</>'
-            .'   <fg=gray>//</>  <fg=white;options=bold>supercharged</>';
+        // SUPERNATIVE sits centred under the wordmark, flanked by matching charge
+        // cells and bolts. 11 spaces of indent centres its 49 columns under the
+        // 72-column logo above.
+        $cells = '<fg=#34D399>'.str_repeat('▰', 10).'</>';
+        $bolt = '<fg=#FFE600;options=bold>⚡</>';
 
-        if ($animate) {
-            for ($i = 0; $i <= $segments; $i++) {
-                $filled = str_repeat('▰', $i);
-                $empty = str_repeat('▱', $segments - $i);
-                $bar = "   <fg=#34D399>{$filled}</><fg=#0E3B33>{$empty}</>";
-                // Reveal the label only once the bar is fully charged.
-                $suffix = $i === $segments ? '  '.$label : '';
-                $this->output->write("\r".$bar.$suffix);
-                usleep(60_000);
-            }
-            $this->newLine();
-        } else {
-            $bar = '   <fg=#34D399>'.str_repeat('▰', $segments).'</>';
-            $this->line($bar.'  '.$label);
-        }
+        $this->line("           {$cells} {$bolt} <fg=#5EEAD4;options=bold>S U P E R N A T I V E</> {$bolt} {$cells}");
 
         $this->newLine();
         $this->line('  <fg=white;options=bold>From</> <fg=green>laravel new</> <fg=white;options=bold>to App Store.</> <fg=#34D399;options=bold>Now supercharged.</>');
@@ -68,6 +55,10 @@ trait DisplaysMarketingBanners
         $this->line('  <fg=yellow;options=bold>⚡ Bifrost</> <fg=gray>—</> <fg=white>Ship to stores</> <fg=cyan>→</> <fg=cyan;options=underscore>bifrost.nativephp.com</>');
         $this->line('  <fg=magenta;options=bold>🔌 Plugins</> <fg=gray>—</> <fg=white>Native features</> <fg=magenta>→</> <fg=magenta;options=underscore>nativephp.com/plugins</>');
         $this->line('  <fg=white;options=bold>📚 Docs</>    <fg=gray>—</> <fg=white>Get started</> <fg=gray>→</> <fg=gray;options=underscore>nativephp.com/docs/mobile</>');
+        $this->newLine();
+
+        $this->line('  <fg=#FFD700;options=bold>★ Help keep NativePHP free: Star the project on GitHub</>');
+        $this->line('  <fg=#FFD700;options=underscore>https://github.com/NativePHP/mobile-air</>');
         $this->newLine();
     }
 


### PR DESCRIPTION
Two bits of polish to how `native:install` signs off.

## Star prompt is no longer a question

The installer ended by asking `Would you mind starring us on GitHub?` and, on yes, shelling out to `open` / `start` / `xdg-open` to launch a browser.

That's a blocking prompt on the very last step of an install, and hijacking the user's browser at the end of a CLI run is a lot to do off a default-yes confirm. It also meant carrying a three-branch platform shim (plus an `xdg-open` presence probe for headless Linux and WSL) purely to open a URL.

It's now a passive two-line gold prompt at the end of the banner — nothing to answer, nothing launched:

```
  ★ Help keep NativePHP free: Star the project on GitHub
  https://github.com/NativePHP/mobile-air
```

## Charge bar removed

The `▰▱` bar under the wordmark animated left → right over ~660ms before revealing the label, and `// supercharged` hung off the right-hand side, leaving SUPERNATIVE visibly off-centre.

The bar is gone. SUPERNATIVE now renders as one static line, with an equal run of cells and a bolt on either side, indented to sit centred under the logo:

```
           ▰▰▰▰▰▰▰▰▰▰ ⚡ S U P E R N A T I V E ⚡ ▰▰▰▰▰▰▰▰▰▰
```

The row-by-row reveal of the ASCII logo itself is untouched, so `$animate` still does its job there.

## Checks

`pint --test` and `phpstan` both clean on the two changed files; full Pest suite green (783 passed). Banner rendering verified against a real ANSI-capable output. No tests referenced the removed prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)