### PR TITLE
Restrict the testing suite's visible-text check to announced-text props

### DIFF
--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -1700,7 +1700,29 @@ class TestableComponent
         return false;
     }
 
-    /** Every string prop value in the subtree (visible text, titles, …). */
+    /**
+     * Prop keys whose values are user-visible / announced text. collectText()
+     * harvests only these, so string props that merely configure appearance
+     * (colors, icon names, font names) don't count as "visible text" for
+     * assertSee(), tap()-by-text, or the a11y audit — a styled icon-only
+     * pressable used to slip past the audit because its `dark_bg_color`
+     * string satisfied the visible-text check.
+     *
+     * The *_json keys carry serialized swipe-action / badge specs whose
+     * `label` fields are user-visible; the whole blob is searched so
+     * assertSee('Archive') keeps matching swipe actions.
+     *
+     * @var list<string>
+     */
+    protected const TEXT_PROP_KEYS = [
+        'text', 'label', 'title', 'subtitle', 'placeholder', 'value',
+        'alt', 'a11y_label', 'a11y_hint', 'headline', 'supporting',
+        'overline', 'heading', 'options', 'leading_value', 'trailing_value',
+        'nav_title', 'nav_subtitle', 'search_placeholder', 'nav_search_placeholder',
+        'leading_actions_json', 'trailing_actions_json', 'trailing_badges_json',
+    ];
+
+    /** Every announced-text prop value in the subtree (visible text, titles, …). */
     protected function collectText(array $node, array &$found = []): array
     {
         $walkProps = function ($value) use (&$walkProps, &$found): void {
@@ -1713,7 +1735,11 @@ class TestableComponent
             }
         };
 
-        $walkProps($node['props'] ?? []);
+        foreach (self::TEXT_PROP_KEYS as $key) {
+            if (isset($node['props'][$key])) {
+                $walkProps($node['props'][$key]);
+            }
+        }
 
         foreach ($node['children'] ?? [] as $child) {
             $this->collectText($child, $found);

--- a/tests/Fixtures/Edge/A11yScreen.php
+++ b/tests/Fixtures/Edge/A11yScreen.php
@@ -37,8 +37,13 @@ class A11yScreen extends NativeComponent
                 Icon::make('gear')->onPress('noop'),
                 // Clickable image, no alt.
                 Image::make('https://example.com/tap.png')->onPress('noop'),
-                // Pressable with neither text nor a11y label.
-                Pressable::make()->onPress('noop'),
+                // Pressable with neither text nor a11y label. Styled with a
+                // color prop and wrapping an icon — string props that aren't
+                // announced text must not satisfy the visible-text check
+                // (regression: `dark_bg_color` used to count as text).
+                Pressable::make(Icon::make('paperplane'))
+                    ->setProp('dark_bg_color', '#8B5CF6')
+                    ->onPress('noop'),
                 // Input with no label, placeholder, or a11y label.
                 TextInput::make()->onChange("__syncProperty('accessible')"),
                 // Toggle with no label of any kind.


### PR DESCRIPTION
## The bug

`TestableComponent::collectText()` walked **every string prop** in a subtree and treated each as visible text. Any styled element therefore "had visible text": an icon-only send button's `dark_bg_color: '#8B5CF6'`, or its icon child's `color: '#FFFFFF'`, satisfied the check.

Consequences:

- The a11y audit's *"pressable with neither visible text nor an a11y-label"* rule was dead code in real apps — only a completely unstyled pressable could ever violate it. Stripping the `a11y-label` off a styled icon-only button still passed `assertAccessible()`.
- `assertSee('#7f1d1d')` and `tap()`-by-text could match color values, icon names, and font names.

The package's own fixture never caught this because its violating pressable was `Pressable::make()->onPress('noop')` — zero props.

## The fix

`collectText()` now harvests only an allowlist of announced-text prop keys (`text`, `label`, `title`, `placeholder`, `headline`, `supporting`, `options`, the swipe-action/badge `*_json` blobs, etc.). Appearance props no longer count as text for `assertSee()`, `tap()`-by-text, the a11y audit, or violation locators.

The `A11yScreen` fixture's violating pressable now carries a `dark_bg_color` prop and an icon child — the real-world shape — pinning the regression.

## Verification

- Package suite: 783 passed.
- Against the demo app (60+ screens): the stricter audit surfaced 5 genuinely unlabeled icon-only pressables on `/explore/buttons` that had been slipping through, and no false positives — every `assertSee()` / `tap()`-by-text usage in both suites still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)