### PR TITLE
Create storage/framework runtime dirs before composer install

### DIFF
--- a/src/Concerns/PreparesBuild.php
+++ b/src/Concerns/PreparesBuild.php
@@ -14,6 +14,18 @@ trait PreparesBuild
     use CleansEnvFile, InstallsAndroidSplashScreen, InstallsAppIcon, PlatformFileOperations;
 
     /**
+     * Runtime directories Laravel needs at boot. Excluded from the source
+     * copy, so they must exist before composer install (package:discover
+     * boots the app) and be re-added as empty entries in the final bundle.
+     */
+    private const RUNTIME_DIRS = [
+        'bootstrap/cache',
+        'storage/framework/cache',
+        'storage/framework/sessions',
+        'storage/framework/views',
+    ];
+
+    /**
      * Validate required environment variables for building
      */
     protected function validateBuildEnvironment(): bool
@@ -248,7 +260,9 @@ trait PreparesBuild
             $this->logToFile('  Copying Laravel source...');
             $this->components->task('Copying Laravel source', fn () => BundleFileManager::copy($source, $tempDir, $configExcludes));
 
-            File::ensureDirectoryExists($tempDir.DIRECTORY_SEPARATOR.'bootstrap'.DIRECTORY_SEPARATOR.'cache');
+            foreach (self::RUNTIME_DIRS as $dir) {
+                File::ensureDirectoryExists($tempDir.DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $dir));
+            }
 
             $composerArgs = $excludeDevDependencies ? '--no-dev --no-interaction' : '--no-interaction';
 
@@ -381,14 +395,7 @@ trait PreparesBuild
             // Pre-create the runtime dirs Laravel needs at boot so they land in
             // the archive — 7-Zip stores empty dirs matched by "$source\*",
             // mirroring the addEmptyDir() guarantee of the ZipArchive branch
-            $requiredDirs = [
-                'bootstrap/cache',
-                'storage/framework/cache',
-                'storage/framework/sessions',
-                'storage/framework/views',
-            ];
-
-            foreach ($requiredDirs as $dir) {
+            foreach (self::RUNTIME_DIRS as $dir) {
                 File::ensureDirectoryExists($source.DIRECTORY_SEPARATOR.str_replace('/', '\\', $dir));
             }
 
@@ -446,14 +453,7 @@ trait PreparesBuild
 
         $this->addDirectoryToZip($zip, $source, '', $configExcludes);
 
-        $requiredDirs = [
-            'bootstrap/cache',
-            'storage/framework/cache',
-            'storage/framework/sessions',
-            'storage/framework/views',
-        ];
-
-        foreach ($requiredDirs as $dir) {
+        foreach (self::RUNTIME_DIRS as $dir) {
             if (! $zip->statName($dir)) {
                 $zip->addEmptyDir($dir);
             }

--- a/tests/Feature/ReleaseBuildBundleTest.php
+++ b/tests/Feature/ReleaseBuildBundleTest.php
@@ -113,6 +113,41 @@ class ReleaseBuildBundleTest extends TestCase
         $zip->close();
     }
 
+    public function test_runtime_storage_dirs_exist_before_composer_install_runs(): void
+    {
+        // storage/framework is excluded from the copy, but composer install
+        // triggers package:discover, which boots Laravel and resolves the
+        // Blade compiler's cache path — realpath(storage/framework/views)
+        // must not be false at that point (#245). The fake closure runs at
+        // install time, so it observes the tree exactly as composer would.
+        $missingAtInstallTime = [];
+
+        Process::fake([
+            'composer install*' => function () use (&$missingAtInstallTime) {
+                foreach ([
+                    'bootstrap/cache',
+                    'storage/framework/cache',
+                    'storage/framework/sessions',
+                    'storage/framework/views',
+                ] as $dir) {
+                    if (! is_dir($this->testProjectPath.'/nativephp/android/laravel/'.$dir)) {
+                        $missingAtInstallTime[] = $dir;
+                    }
+                }
+
+                return Process::result();
+            },
+            'composer dump-autoload*' => Process::result(),
+        ]);
+
+        $this->createAndroidProjectFixture();
+
+        (new ReleaseBuildTester)->testPrepareLaravelBundle();
+
+        Process::assertRan('composer install --no-dev --no-interaction');
+        $this->assertSame([], $missingAtInstallTime);
+    }
+
     protected function createAndroidProjectFixture(): void
     {
         File::ensureDirectoryExists($this->testProjectPath.'/app');


### PR DESCRIPTION
Fixes #245

## Problem

`native:run` fails on a fresh app during "Installing Composer dependencies" with:

```
InvalidArgumentException
Please provide a valid cache path.
at vendor/laravel/framework/src/Illuminate/View/Compilers/Compiler.php:75
```

Bundle prep excludes `storage/framework` from the copy (`BundleExclusions::PROJECT`) but only recreated `bootstrap/cache` before running `composer install`. Composer's `post-autoload-dump` runs `package:discover`, which boots the app in the temp tree; the Blade compiler resolves `view.compiled` via `realpath(storage_path('framework/views'))`, which returns `false` for the missing directory. The empty `storage/framework/{cache,sessions,views}` dirs were only added later, in `createZipBundle()` — after Composer.

## Fix

Ensure `storage/framework/{cache,sessions,views}` alongside `bootstrap/cache` before `composer install` runs, exactly as suggested in the issue. The list was already duplicated in both `createZipBundle()` branches (ZipArchive and 7-Zip), so it's consolidated into a single `RUNTIME_DIRS` constant used by all three sites.

## Test

New regression test in `ReleaseBuildBundleTest` uses a `Process::fake` closure — evaluated at install time — to observe the temp tree exactly as `composer install` would. It fails without the fix (all three `storage/framework` dirs missing) and passes with it. Full suite: 788 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)