### PR TITLE
Recreate the runtime directories Laravel needs in the bundle copy

### DIFF
--- a/src/Support/BundleExclusions.php
+++ b/src/Support/BundleExclusions.php
@@ -50,6 +50,27 @@ class BundleExclusions
         'artisan',
     ];
 
+    /**
+     * Working directories recreated after the exclusions above have run.
+     *
+     * Their contents are excluded on purpose, being compiled output and one
+     * machine's sessions, but the directories themselves are not optional:
+     * composer install runs package:discover in the copied tree, and that
+     * boots Laravel.
+     *
+     * storage/framework/views is the one that stops a build outright. A
+     * fresh skeleton publishes no config/view.php, so the framework
+     * default applies, and it wraps the path in realpath(), which
+     * answers false for a directory that is not there. Blade
+     * refuses a false path, and nothing is built.
+     */
+    public const REQUIRED_DIRECTORIES = [
+        'bootstrap/cache',
+        'storage/framework/cache',
+        'storage/framework/sessions',
+        'storage/framework/views',
+    ];
+
     /** Non-runtime patterns inside vendor packages. */
     public const VENDOR_PATTERNS = [
         '*.md',

--- a/src/Support/BundleFileManager.php
+++ b/src/Support/BundleFileManager.php
@@ -66,6 +66,12 @@ class BundleFileManager
         } else {
             self::copyWithRsync($source, $destination, $configPaths);
         }
+
+        // Put back what the exclusions removed but Laravel still needs to
+        // boot, since composer install runs package:discover in here.
+        foreach (BundleExclusions::REQUIRED_DIRECTORIES as $directory) {
+            File::ensureDirectoryExists($destination.'/'.$directory);
+        }
     }
 
     private static function copyWithRsync(string $source, string $destination, array $configPaths): void

--- a/tests/Feature/IosBuildCopyTest.php
+++ b/tests/Feature/IosBuildCopyTest.php
@@ -147,6 +147,27 @@ class IosBuildCopyTest extends TestCase
         });
     }
 
+    public function test_copy_recreates_the_directories_laravel_needs_to_boot(): void
+    {
+        // composer install runs package:discover inside this copy, which boots
+        // the app. These directories have their contents excluded on purpose,
+        // but they still have to exist: a fresh skeleton publishes no
+        // config/view.php, so the framework default applies, and that
+        // wraps the path in realpath() — false for a directory that
+        // is absent, which the Blade compiler refuses with
+        // "Please provide a valid cache path".
+        $appPath = $this->fakeRsyncAndGetAppPath();
+
+        BundleFileManager::copy(base_path(), $appPath);
+
+        foreach (BundleExclusions::REQUIRED_DIRECTORIES as $directory) {
+            $this->assertDirectoryExists(
+                rtrim($appPath, '/').'/'.$directory,
+                "Laravel cannot boot in the copied tree without {$directory}"
+            );
+        }
+    }
+
     public function test_copy_throws_on_rsync_failure(): void
     {
         $appPath = $this->fakeRsyncAndGetAppPath(exitCode: 1);


### PR DESCRIPTION
`native:run` stops at `composer install` with `Please provide a valid cache path`, before a build starts. It hits any app that has not published `config/view.php`, which is every fresh skeleton.

`BundleFileManager::copy()` excludes `storage/framework`, then composer runs `package:discover` in the copied tree, which boots Laravel. Without a published view config the framework default applies, and it wraps the path in `realpath()`. That returns false for a directory that is not there, and the Blade compiler refuses a false path.

The zip copy this replaced already handled it: it excluded the same contents, then added `bootstrap/cache`, `storage/framework/cache`, `storage/framework/sessions` and `storage/framework/views` back as empty entries. Consolidating onto `BundleFileManager` carried the exclusions across but not that restoration. Android kept `bootstrap/cache` by hand, iOS kept none.

This adds `BundleExclusions::REQUIRED_DIRECTORIES` and recreates them at the end of the copy, so the exclusion set and the carve-out it makes necessary stay in one place and every caller gets both.

Test fails without the change and passes with it. Verified on iOS & Android emulators.