### PR TITLE
feat(edge): dispatch screen lifecycle events from the navigation loop

### DIFF
--- a/src/Edge/NativeRouter.php
+++ b/src/Edge/NativeRouter.php
@@ -2,6 +2,10 @@
 
 namespace Native\Mobile\Edge;
 
+use Native\Mobile\Events\Screen\ScreenMounted;
+use Native\Mobile\Events\Screen\ScreenResumed;
+use Native\Mobile\Events\Screen\ScreenUnmounted;
+
 class NativeRouter
 {
     /**
@@ -423,9 +427,11 @@ class NativeRouter
                     $component->publishPlaceholder();
                     static::debugLog('loop: calling mount() on '.get_class($component));
                     $component->mount();
+                    $this->announce(new ScreenMounted(get_class($component), $entry['uri'] ?? null));
                 } else {
                     static::debugLog('loop: calling onResume() on '.get_class($component));
                     $component->onResume();
+                    $this->announce(new ScreenResumed(get_class($component), $entry['uri'] ?? null));
                 }
             } catch (NativeDumpException $e) {
                 $component->renderDumpScreen($e);
@@ -448,7 +454,7 @@ class NativeRouter
 
             if ($intent === null) {
                 static::debugLog('loop: no intent, popping '.get_class($component));
-                $component->unmount();
+                $this->unmountComponent($component);
                 array_pop($this->stack);
                 $freshPush = false;
 
@@ -468,7 +474,7 @@ class NativeRouter
 
                     if ($resolved === null) {
                         static::debugLog('NAVIGATE: unresolved, exiting to web');
-                        $component->unmount();
+                        $this->unmountComponent($component);
                         $this->stack = [];
 
                         return $intent->uri;
@@ -499,7 +505,7 @@ class NativeRouter
 
                 case NavigationIntent::BACK:
                     static::debugLog('BACK: popping '.get_class($component));
-                    $component->unmount();
+                    $this->unmountComponent($component);
                     array_pop($this->stack);
                     $freshPush = false;
 
@@ -519,14 +525,14 @@ class NativeRouter
 
                     if ($resolved === null) {
                         static::debugLog('REPLACE: unresolved, exiting to web');
-                        $component->unmount();
+                        $this->unmountComponent($component);
                         $this->stack = [];
 
                         return $intent->uri;
                     }
 
                     static::debugLog("REPLACE: resolved to {$resolved['class']}");
-                    $component->unmount();
+                    $this->unmountComponent($component);
                     array_pop($this->stack);
 
                     static::debugLog('REPLACE: deferring transition, stack='.count($this->stack));
@@ -561,7 +567,7 @@ class NativeRouter
 
                 case NavigationIntent::EXIT_WEB:
                     static::debugLog("EXIT_WEB: uri={$intent->uri}");
-                    $component->unmount();
+                    $this->unmountComponent($component);
                     $this->stack = [];
 
                     return $intent->uri;
@@ -570,7 +576,7 @@ class NativeRouter
                     static::debugLog('RESTART: hot reload — PHP will exit, Kotlin handles re-execution');
                     // Unmount the entire stack — clean exit
                     while (! empty($this->stack)) {
-                        $this->stack[count($this->stack) - 1]['component']->unmount();
+                        $this->unmountComponent($this->stack[count($this->stack) - 1]['component']);
                         array_pop($this->stack);
                     }
 
@@ -582,6 +588,37 @@ class NativeRouter
         static::debugLog('loop: stack empty, returning null');
 
         return null;
+    }
+
+    /**
+     * Unmount a component and tell the app it happened.
+     *
+     * Every pop in the loop above goes through here, so the event has one
+     * home rather than seven.
+     */
+    protected function unmountComponent(NativeComponent $component): void
+    {
+        $component->unmount();
+        $this->announce(new ScreenUnmounted(get_class($component), $this->currentUri()));
+    }
+
+    /**
+     * Fire a lifecycle event, best-effort.
+     *
+     * A listener that throws must not take the navigation loop down with
+     * it — an observer is not allowed to break the app it observes. The
+     * guard also keeps the router usable outside a booted container,
+     * which the testing helpers rely on.
+     */
+    protected function announce(object $event): void
+    {
+        try {
+            if (function_exists('event')) {
+                event($event);
+            }
+        } catch (\Throwable $e) {
+            static::debugLog('lifecycle event failed: '.$e->getMessage());
+        }
     }
 
     protected function createComponent(string $class, array $params = [], array $data = []): NativeComponent

--- a/src/Events/Screen/ScreenMounted.php
+++ b/src/Events/Screen/ScreenMounted.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Native\Mobile\Events\Screen;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * A screen was pushed onto the stack and mounted.
+ *
+ * Dispatched by [[NativeRouter]] around the component's own lifecycle
+ * hook, so an observer does not have to subclass or wrap anything:
+ *
+ *     Event::listen(ScreenMounted::class, fn ($e) => ...);
+ *
+ * This exists for cross-cutting listeners — telemetry, analytics, crash
+ * breadcrumbs — that need the screen lifecycle without competing with the
+ * app for the `mount()` / `onResume()` / `unmount()` overrides.
+ */
+class ScreenMounted
+{
+    use Dispatchable;
+
+    public function __construct(
+        /** @var class-string */
+        public string $component,
+        public ?string $uri = null,
+    ) {}
+}

--- a/src/Events/Screen/ScreenResumed.php
+++ b/src/Events/Screen/ScreenResumed.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Native\Mobile\Events\Screen;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * A screen was revealed again after the screen above it was popped.
+ *
+ * Dispatched by [[NativeRouter]] around the component's own lifecycle
+ * hook, so an observer does not have to subclass or wrap anything:
+ *
+ *     Event::listen(ScreenResumed::class, fn ($e) => ...);
+ *
+ * This exists for cross-cutting listeners — telemetry, analytics, crash
+ * breadcrumbs — that need the screen lifecycle without competing with the
+ * app for the `mount()` / `onResume()` / `unmount()` overrides.
+ */
+class ScreenResumed
+{
+    use Dispatchable;
+
+    public function __construct(
+        /** @var class-string */
+        public string $component,
+        public ?string $uri = null,
+    ) {}
+}

--- a/src/Events/Screen/ScreenUnmounted.php
+++ b/src/Events/Screen/ScreenUnmounted.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Native\Mobile\Events\Screen;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * A screen was left the stack for good.
+ *
+ * Dispatched by [[NativeRouter]] around the component's own lifecycle
+ * hook, so an observer does not have to subclass or wrap anything:
+ *
+ *     Event::listen(ScreenUnmounted::class, fn ($e) => ...);
+ *
+ * This exists for cross-cutting listeners — telemetry, analytics, crash
+ * breadcrumbs — that need the screen lifecycle without competing with the
+ * app for the `mount()` / `onResume()` / `unmount()` overrides.
+ */
+class ScreenUnmounted
+{
+    use Dispatchable;
+
+    public function __construct(
+        /** @var class-string */
+        public string $component,
+        public ?string $uri = null,
+    ) {}
+}

--- a/tests/Unit/Edge/ScreenLifecycleEventsTest.php
+++ b/tests/Unit/Edge/ScreenLifecycleEventsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use Illuminate\Support\Facades\Event;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Events\Screen\ScreenUnmounted;
+
+/*
+ * The lifecycle events exist so cross-cutting observers — telemetry,
+ * analytics, crash breadcrumbs — can follow the screen stack without
+ * competing with the app for the mount()/onResume()/unmount() overrides.
+ * The navigation loop itself needs the device bridge, so these pin the
+ * seam the loop calls into.
+ */
+
+class LifecycleProbeScreen extends NativeComponent
+{
+    public bool $unmounted = false;
+
+    public function unmount(): void
+    {
+        $this->unmounted = true;
+    }
+}
+
+class ExposedRouter extends NativeRouter
+{
+    public function unmountAndAnnounce(NativeComponent $component): void
+    {
+        $this->unmountComponent($component);
+    }
+}
+
+it('announces a screen leaving the stack', function () {
+    Event::fake();
+
+    (new ExposedRouter)->unmountAndAnnounce($component = new LifecycleProbeScreen);
+
+    expect($component->unmounted)->toBeTrue();
+
+    Event::assertDispatched(
+        ScreenUnmounted::class,
+        fn (ScreenUnmounted $event): bool => $event->component === LifecycleProbeScreen::class,
+    );
+});
+
+it('does not let a failing listener take the navigation loop down', function () {
+    Event::listen(ScreenUnmounted::class, function (): void {
+        throw new RuntimeException('a listener misbehaved');
+    });
+
+    // An observer is not allowed to break the app it observes.
+    (new ExposedRouter)->unmountAndAnnounce($component = new LifecycleProbeScreen);
+
+    expect($component->unmounted)->toBeTrue();
+});


### PR DESCRIPTION
## The problem

Cross-cutting observers — telemetry, analytics, crash breadcrumbs — have nowhere to attach to the screen lifecycle today.

`NativeRouter` constructs components with `new $class`, the router itself is constructed directly rather than resolved from the container, and no events are dispatched. So the only way in is to override `mount()` / `onResume()` / `unmount()` from a shared base class — and that competes with the app for those methods. A screen that defines its own `mount()` silently replaces the instrumented one, and the observer goes quiet on exactly the screens someone bothered to write logic for. An observer you can't trust to be complete isn't much use.

## The change

Dispatch `ScreenMounted` / `ScreenResumed` / `ScreenUnmounted` from the navigation loop, *alongside* the component's own hook rather than in place of it. Nothing about the existing lifecycle changes.

- The seven `unmount()` call sites in `loop()` now route through one `unmountComponent()` helper, so the event has a single home rather than seven.
- Listener exceptions are caught and sent to `debugLog()`. An observer must not be able to take the navigation loop down with it.
- `announce()` guards on `function_exists('event')`, so the router stays usable outside a booted container — which the testing helpers rely on.
- Preloaded stacks (hot restart) deliberately stay quiet: those screens are being restored, not navigated to. Happy to change that if you'd rather they fire.

Events carry the component class and the uri, and use plain `Dispatchable` — not `BroadcastsGlobally`, since these originate in PHP rather than from the native side.

```php
Event::listen(ScreenMounted::class, fn ($e) => ...); // $e->component, $e->uri
```

## Verification

Ran against `main` on PHP 8.4:

- test suite **787 → 789 passed** (the two added here), same 4 risky / 3 skipped as the baseline
- `phpstan` clean

## Context

Found while adding NativePHP support to [cboxdk/laravel-telemetry](https://github.com/cboxdk/laravel-telemetry). The runloop holding a single request open for the lifetime of a screen means `Kernel::terminate()` never fires, so anything built around the request lifecycle needs different anchor points — these events are the missing ones. That package works without this change, but the mount/unmount half of the instrumentation has to be left out to stay honest.

Open to a different shape here — naming, payload, whether the router is the right place to dispatch from. Happy to rework.
