### PR TITLE
Fold the runtime dir list onto BundleExclusions and guard it by name

### DIFF
--- a/src/Concerns/PreparesBuild.php
+++ b/src/Concerns/PreparesBuild.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
 use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Support\BundleExclusions;
 use Native\Mobile\Support\BundleFileManager;
 use Symfony\Component\Process\Process as SymfonyProcess;
 
@@ -246,9 +247,10 @@ trait PreparesBuild
             $srcDir = base_path('vendor/nativephp/mobile/bootstrap/android');
 
             $this->logToFile('  Copying Laravel source...');
+            // The copy restores BundleExclusions::REQUIRED_DIRECTORIES on the
+            // way out, so the tree composer install boots into below already
+            // has the directories Laravel needs.
             $this->components->task('Copying Laravel source', fn () => BundleFileManager::copy($source, $tempDir, $configExcludes));
-
-            File::ensureDirectoryExists($tempDir.DIRECTORY_SEPARATOR.'bootstrap'.DIRECTORY_SEPARATOR.'cache');
 
             $composerArgs = $excludeDevDependencies ? '--no-dev --no-interaction' : '--no-interaction';
 
@@ -381,14 +383,7 @@ trait PreparesBuild
             // Pre-create the runtime dirs Laravel needs at boot so they land in
             // the archive — 7-Zip stores empty dirs matched by "$source\*",
             // mirroring the addEmptyDir() guarantee of the ZipArchive branch
-            $requiredDirs = [
-                'bootstrap/cache',
-                'storage/framework/cache',
-                'storage/framework/sessions',
-                'storage/framework/views',
-            ];
-
-            foreach ($requiredDirs as $dir) {
+            foreach (BundleExclusions::REQUIRED_DIRECTORIES as $dir) {
                 File::ensureDirectoryExists($source.DIRECTORY_SEPARATOR.str_replace('/', '\\', $dir));
             }
 
@@ -446,14 +441,9 @@ trait PreparesBuild
 
         $this->addDirectoryToZip($zip, $source, '', $configExcludes);
 
-        $requiredDirs = [
-            'bootstrap/cache',
-            'storage/framework/cache',
-            'storage/framework/sessions',
-            'storage/framework/views',
-        ];
-
-        foreach ($requiredDirs as $dir) {
+        // The cleanup pass strips these before the archive is built, so they
+        // are re-added as empty entries to match the copy's carve-out.
+        foreach (BundleExclusions::REQUIRED_DIRECTORIES as $dir) {
             if (! $zip->statName($dir)) {
                 $zip->addEmptyDir($dir);
             }

--- a/tests/Feature/ReleaseBuildBundleTest.php
+++ b/tests/Feature/ReleaseBuildBundleTest.php
@@ -113,6 +113,44 @@ class ReleaseBuildBundleTest extends TestCase
         $zip->close();
     }
 
+    public function test_runtime_storage_dirs_exist_before_composer_install_runs(): void
+    {
+        // storage/framework is excluded from the copy, but composer install
+        // triggers package:discover, which boots Laravel and resolves the
+        // Blade compiler's cache path — realpath(storage/framework/views)
+        // must not be false at that point (#245). The fake closure runs at
+        // install time, so it observes the tree exactly as composer would.
+        // The names are spelled out rather than read from
+        // BundleExclusions::REQUIRED_DIRECTORIES so that dropping one from
+        // that list fails here instead of passing vacuously.
+        $missingAtInstallTime = [];
+
+        Process::fake([
+            'composer install*' => function () use (&$missingAtInstallTime) {
+                foreach ([
+                    'bootstrap/cache',
+                    'storage/framework/cache',
+                    'storage/framework/sessions',
+                    'storage/framework/views',
+                ] as $dir) {
+                    if (! is_dir($this->testProjectPath.'/nativephp/android/laravel/'.$dir)) {
+                        $missingAtInstallTime[] = $dir;
+                    }
+                }
+
+                return Process::result();
+            },
+            'composer dump-autoload*' => Process::result(),
+        ]);
+
+        $this->createAndroidProjectFixture();
+
+        (new ReleaseBuildTester)->testPrepareLaravelBundle();
+
+        Process::assertRan('composer install --no-dev --no-interaction');
+        $this->assertSame([], $missingAtInstallTime);
+    }
+
     protected function createAndroidProjectFixture(): void
     {
         File::ensureDirectoryExists($this->testProjectPath.'/app');


### PR DESCRIPTION
Follow-up to #247, picking up the parts of the competing #246 that still apply. Both PRs fixed the same report — #245, where `native:run` dies at `composer install` with `Please provide a valid cache path` because `package:discover` boots Laravel in a copied tree that has no `storage/framework/views`. #247 was the one to merge: it restores the directories at the end of `BundleFileManager::copy()`, so iOS gets the fix too, where #246 only touched the Android path. Three things from #246 are worth keeping.

## createZipBundle() no longer spells the list out

The four directories were hardcoded twice more in `createZipBundle()`, once for the 7-Zip branch and once for ZipArchive. That left the archive's carve-out free to drift from the copy's. Both now read `BundleExclusions::REQUIRED_DIRECTORIES`, which is where #247 put the list.

## The hand-created bootstrap/cache is gone

`prepareLaravelBundle()` created `bootstrap/cache` itself right after the copy, which the copy now covers for every caller. A comment in its place points at where the guarantee comes from — an absent call is otherwise the kind of thing that gets helpfully re-added.

## The regression test names the directories

The test #247 shipped iterates `REQUIRED_DIRECTORIES`, so it cannot see that list shrink. Dropping `storage/framework/views` from the constant leaves it passing while the build breaks exactly as reported. #246's test names the four directories and reads the tree from inside the faked `composer install`, which is the moment `package:discover` boots the app and the moment #245 struck. Both mutations were checked: removing the restore loop from `copy()` fails this test and #247's; shrinking the list fails only this one.

`composer test` 789 passed, `pint --test` clean. PHPStan reports 4 pre-existing errors in `Commands/JumpCommand.php` (Endroid QrCode builder params), identical on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)