### PR TITLE
Fix native route middleware during in-app navigation

### DIFF
--- a/src/Edge/NativeRouter.php
+++ b/src/Edge/NativeRouter.php
@@ -2,6 +2,12 @@
 
 namespace Native\Mobile\Edge;
 
+use Illuminate\Http\Request;
+use Illuminate\Routing\Pipeline;
+use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Facade;
+use Symfony\Component\HttpFoundation\Response;
+
 class NativeRouter
 {
     /**
@@ -80,9 +86,9 @@ class NativeRouter
      * URI → component class registry.
      * Populated by Route::native() calls.
      *
-     * Each entry: ['class' => string, 'layout' => ?string]
+     * Each entry: ['class' => string, 'layout' => ?string, 'route' => ?Route]
      *
-     * @var array<string, array{class: string, layout: ?string}>
+     * @var array<string, array{class: string, layout: ?string, route: ?Route}>
      */
     protected static array $routes = [];
 
@@ -128,12 +134,13 @@ class NativeRouter
 
     // ── Static registry ─────────────────────────────
 
-    public static function register(string $uri, string $class, ?string $layout = null): void
+    public static function register(string $uri, string $class, ?string $layout = null, ?Route $route = null): void
     {
         $pattern = '/'.ltrim($uri, '/');
         static::$routes[$pattern] = [
             'class' => $class,
             'layout' => $layout ?? static::$currentGroupLayout,
+            'route' => $route,
         ];
     }
 
@@ -145,7 +152,10 @@ class NativeRouter
      */
     public static function registeredRoutes(): array
     {
-        return static::$routes;
+        return array_map(fn (array $entry) => [
+            'class' => $entry['class'],
+            'layout' => $entry['layout'],
+        ], static::$routes);
     }
 
     /**
@@ -338,6 +348,12 @@ class NativeRouter
                 continue;
             }
 
+            if ($this->runRouteMiddleware($uri) !== null) {
+                static::debugLog("preloadStack: skipped $uri — route middleware blocked navigation");
+
+                continue;
+            }
+
             try {
                 $component = $this->createComponent(
                     $resolved['class'],
@@ -367,9 +383,9 @@ class NativeRouter
      * Entry point. Init shared memory, run the navigation loop,
      * shutdown when done.
      *
-     * @return string|null Exit URI for redirect, or null
+     * @return Response|string|null Middleware response, exit URI, or null
      */
-    public function start(string $class, array $params = [], string $uri = ''): ?string
+    public function start(string $class, array $params = [], string $uri = ''): Response|string|null
     {
         NativeComponent::registerDumpHandler();
 
@@ -406,7 +422,7 @@ class NativeRouter
      * Navigation loop — runs until the stack is empty or
      * we need to exit to a web route.
      */
-    protected function loop(): ?string
+    protected function loop(): Response|string|null
     {
         $freshPush = true;
 
@@ -474,6 +490,15 @@ class NativeRouter
                         return $intent->uri;
                     }
 
+                    $middlewareResponse = $this->runRouteMiddleware($intent->uri);
+                    if ($middlewareResponse !== null) {
+                        static::debugLog('NAVIGATE: route middleware blocked navigation with status '.$middlewareResponse->getStatusCode());
+                        $component->unmount();
+                        $this->stack = [];
+
+                        return $middlewareResponse;
+                    }
+
                     static::debugLog("NAVIGATE: resolved to {$resolved['class']}, deferring transition");
                     $this->deferredTransition = $intent->transition ?? Transition::SlideFromRight;
 
@@ -523,6 +548,15 @@ class NativeRouter
                         $this->stack = [];
 
                         return $intent->uri;
+                    }
+
+                    $middlewareResponse = $this->runRouteMiddleware($intent->uri);
+                    if ($middlewareResponse !== null) {
+                        static::debugLog('REPLACE: route middleware blocked navigation with status '.$middlewareResponse->getStatusCode());
+                        $component->unmount();
+                        $this->stack = [];
+
+                        return $middlewareResponse;
                     }
 
                     static::debugLog("REPLACE: resolved to {$resolved['class']}");
@@ -580,6 +614,120 @@ class NativeRouter
         }
 
         static::debugLog('loop: stack empty, returning null');
+
+        return null;
+    }
+
+    /**
+     * Run the Laravel route middleware associated with an in-app navigation.
+     *
+     * A null response means the middleware pipeline reached its destination.
+     * Any response means middleware short-circuited and the screen must not mount.
+     */
+    protected function runRouteMiddleware(string $uri): ?Response
+    {
+        $resolved = static::resolve($uri);
+        if ($resolved === null) {
+            return null;
+        }
+
+        $pattern = $this->routePatternFor($uri);
+        $registeredRoute = $pattern !== null ? (static::$routes[$pattern]['route'] ?? null) : null;
+        if (! $registeredRoute instanceof Route) {
+            return null;
+        }
+        $route = clone $registeredRoute;
+
+        $currentRequest = app('request');
+        $path = parse_url($uri, PHP_URL_PATH) ?: '/';
+        $queryString = parse_url($uri, PHP_URL_QUERY) ?: '';
+        parse_str($queryString, $query);
+
+        $server = $currentRequest->server->all();
+        $server['REQUEST_METHOD'] = 'GET';
+        $server['REQUEST_URI'] = $uri;
+        $server['PATH_INFO'] = $path;
+        $server['QUERY_STRING'] = $queryString;
+
+        /** @var Request $request */
+        $request = $currentRequest->duplicate(
+            query: $query,
+            request: [],
+            attributes: [],
+            files: [],
+            server: $server,
+        );
+        $request->setMethod('GET');
+
+        $route->setContainer(app());
+        $route->bind($request);
+        $request->setRouteResolver(fn () => $route);
+
+        $router = app('router');
+        $currentRoute = $router->getCurrentRoute();
+        $currentRouterRequest = $router->getCurrentRequest();
+        $middleware = app()->bound('middleware.disable') && app('middleware.disable') === true
+            ? []
+            : $router->gatherRouteMiddleware($route);
+        $destination = new \stdClass;
+
+        $hadRouteBinding = app()->bound(Route::class);
+        $currentRouteBinding = $hadRouteBinding ? app(Route::class) : null;
+
+        app()->instance('request', $request);
+        app()->instance(Route::class, $route);
+        Facade::clearResolvedInstance('request');
+
+        // Router has no public current-route setter, but route middleware may
+        // legitimately use the Route facade. Scope the same context Laravel's
+        // normal dispatch establishes, then restore the long-lived request.
+        (function (Route $route): void {
+            $this->current = $route;
+        })->call($router, $route);
+        (function (Request $request): void {
+            $this->currentRequest = $request;
+        })->call($router, $request);
+
+        try {
+            $result = (new Pipeline(app()))
+                ->send($request)
+                ->through($middleware)
+                ->then(fn () => $destination);
+
+            return $result === $destination
+                ? null
+                : $router->prepareResponse($request, $result);
+        } finally {
+            app()->instance('request', $currentRequest);
+            if ($hadRouteBinding) {
+                app()->instance(Route::class, $currentRouteBinding);
+            } else {
+                app()->forgetInstance(Route::class);
+            }
+            (function (?Route $route): void {
+                $this->current = $route;
+            })->call($router, $currentRoute);
+            (function (?Request $request): void {
+                $this->currentRequest = $request;
+            })->call($router, $currentRouterRequest);
+            Facade::clearResolvedInstance('request');
+        }
+    }
+
+    protected function routePatternFor(string $uri): ?string
+    {
+        $path = '/'.ltrim(parse_url($uri, PHP_URL_PATH) ?: '/', '/');
+
+        if (isset(static::$routes[$path])) {
+            return $path;
+        }
+
+        foreach (array_keys(static::$routes) as $pattern) {
+            $regex = preg_replace('/\{(\w+)\}/', '[^/]+', $pattern);
+            if (preg_match('#^'.$regex.'$#', $path)) {
+                return $pattern;
+            }
+        }
 
         return null;
     }

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -51,6 +51,7 @@ use Native\Mobile\Plugins\PluginRegistry;
 use Native\Mobile\Support\Ios\PhpUrlGenerator;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Symfony\Component\HttpFoundation\Response;
 
 class NativeServiceProvider extends PackageServiceProvider
 {
@@ -302,9 +303,7 @@ class NativeServiceProvider extends PackageServiceProvider
         });
 
         Route::macro('native', function (string $uri, string $componentClass) {
-            NativeRouter::register($uri, $componentClass);
-
-            return Route::get($uri, function () use ($componentClass) {
+            $route = Route::get($uri, function () use ($componentClass) {
                 // HTTP feature tests ($this->get('/')) must never enter the
                 // runloop: it blocks in wait_event against the REAL bridge —
                 // with a live Jump session that's ~90s of reconnect spinning
@@ -366,6 +365,10 @@ class NativeServiceProvider extends PackageServiceProvider
 
                 $exitUri = $router->start($componentClass, $params, $path);
 
+                if ($exitUri instanceof Response) {
+                    return $exitUri;
+                }
+
                 if ($exitUri !== null) {
                     return redirect($exitUri);
                 }
@@ -377,6 +380,10 @@ class NativeServiceProvider extends PackageServiceProvider
 
                 return '';
             });
+
+            NativeRouter::register($uri, $componentClass, route: $route);
+
+            return $route;
         });
 
         // Route::nativeGroup(layout: TabsLayout::class, function () { ... })

--- a/tests/Feature/NativeRouteMiddlewareTest.php
+++ b/tests/Feature/NativeRouteMiddlewareTest.php
@@ -1,0 +1,283 @@
+<?php
+
+use Illuminate\Auth\GenericUser;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route as LaravelRoute;
+use Illuminate\Support\Facades\Request as RequestFacade;
+use Illuminate\Support\Facades\Route;
+use Illuminate\View\View;
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Testing\Native;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\Fixtures\Edge\CounterScreen;
+
+beforeEach(function () {
+    NativeRouter::clearRoutes();
+    RecordingNativeRouteMiddleware::$requests = [];
+    RedirectNativeRouteMiddleware::$response = null;
+    BlockingNativeRouteMiddleware::$response = null;
+    ThrowingNativeRouteMiddleware::$exception = null;
+    AllowingNativeRouteMiddleware::$calls = 0;
+    MountedNativeRouteScreen::$mounts = 0;
+});
+
+afterEach(function () {
+    NativeRouter::clearRoutes();
+});
+
+function runNativeRouteMiddleware(NativeRouter $router, string $uri): ?Response
+{
+    return (fn () => $this->runRouteMiddleware($uri))->call($router);
+}
+
+it('runs route middleware before an in-app native navigation continues', function () {
+    app('router')->aliasMiddleware('native.record', RecordingNativeRouteMiddleware::class);
+
+    Route::native('/protected/{id}', CounterScreen::class)
+        ->middleware('native.record');
+
+    $originalRequest = request();
+    $user = new GenericUser(['id' => 42]);
+    app('auth')->guard()->setUser($user);
+    $originalFacadePath = RequestFacade::path();
+    $originalRoute = Route::current();
+    $originalRouterRequest = app('router')->getCurrentRequest();
+
+    $response = runNativeRouteMiddleware(new NativeRouter, '/protected/42');
+
+    expect($response)->toBeNull()
+        ->and(request())->toBe($originalRequest)
+        ->and(RequestFacade::path())->toBe($originalFacadePath)
+        ->and(Route::current())->toBe($originalRoute)
+        ->and(app('router')->getCurrentRequest())->toBe($originalRouterRequest)
+        ->and(RecordingNativeRouteMiddleware::$requests)->toBe([
+            [
+                'path' => 'protected/42',
+                'facade_path' => 'protected/42',
+                'id' => '42',
+                'bound_id' => '42',
+                'facade_id' => '42',
+                'router_path' => 'protected/42',
+                'user' => $user,
+            ],
+        ]);
+});
+
+it('does not overwrite parameters on the registered route while checking another URI', function () {
+    $route = Route::native('/patients/{id}', CounterScreen::class)
+        ->middleware(AllowingNativeRouteMiddleware::class);
+    $route->bind(Request::create('/patients/1', 'GET'));
+
+    $response = runNativeRouteMiddleware(new NativeRouter, '/patients/2');
+
+    expect($response)->toBeNull()
+        ->and($route->parameter('id'))->toBe('1');
+});
+
+it('returns a redirect response when route middleware blocks native navigation', function () {
+    Route::native('/protected', CounterScreen::class)
+        ->middleware(RedirectNativeRouteMiddleware::class);
+
+    $response = runNativeRouteMiddleware(new NativeRouter, '/protected');
+
+    expect($response)->not->toBeNull()
+        ->and($response->isRedirect())->toBeTrue()
+        ->and($response->headers->get('Location'))->toEndWith('/login');
+});
+
+it('does not preload a protected screen when its route middleware redirects', function () {
+    Route::native('/protected', CounterScreen::class)
+        ->middleware(RedirectNativeRouteMiddleware::class);
+
+    $router = new NativeRouter;
+    $router->preloadStack([['uri' => '/protected']]);
+
+    expect($router->stackDepth())->toBe(0);
+});
+
+it('runs middleware and mounts an allowed preloaded screen', function () {
+    Route::native('/allowed', MountedNativeRouteScreen::class)
+        ->middleware(AllowingNativeRouteMiddleware::class);
+
+    $router = new NativeRouter;
+    $router->preloadStack([['uri' => '/allowed']]);
+
+    expect(AllowingNativeRouteMiddleware::$calls)->toBe(1)
+        ->and(MountedNativeRouteScreen::$mounts)->toBe(1)
+        ->and($router->stackDepth())->toBe(1);
+});
+
+it('returns the middleware redirect instead of mounting a navigated screen', function () {
+    Route::native('/protected', CounterScreen::class)
+        ->middleware(RedirectNativeRouteMiddleware::class);
+
+    Native::fakeBridge();
+
+    $exitUri = (new NativeRouter)->start(NavigateToProtectedScreen::class, uri: '/');
+
+    expect($exitUri)->toBe(RedirectNativeRouteMiddleware::$response)
+        ->and($exitUri->getStatusCode())->toBe(307)
+        ->and($exitUri->headers->get('X-Native-Middleware'))->toBe('blocked')
+        ->and($exitUri->headers->get('Location'))->toEndWith('/login');
+});
+
+it('returns the middleware redirect instead of mounting a replaced screen', function () {
+    Route::native('/protected', CounterScreen::class)
+        ->middleware(RedirectNativeRouteMiddleware::class);
+
+    Native::fakeBridge();
+
+    $exitUri = (new NativeRouter)->start(ReplaceWithProtectedScreen::class, uri: '/');
+
+    expect($exitUri)->toBe(RedirectNativeRouteMiddleware::$response)
+        ->and($exitUri->getStatusCode())->toBe(307);
+});
+
+it('returns a non-redirect middleware response instead of mounting the screen', function () {
+    Route::native('/protected', CounterScreen::class)
+        ->middleware(BlockingNativeRouteMiddleware::class);
+
+    Native::fakeBridge();
+
+    $response = (new NativeRouter)->start(NavigateToProtectedScreen::class, uri: '/');
+
+    expect($response)->toBe(BlockingNativeRouteMiddleware::$response)
+        ->and($response->getStatusCode())->toBe(403)
+        ->and($response->headers->get('X-Native-Middleware'))->toBe('forbidden');
+});
+
+it('reports and renders exceptions thrown by route middleware', function () {
+    $exception = new RuntimeException('middleware failed');
+    ThrowingNativeRouteMiddleware::$exception = $exception;
+
+    $handler = Mockery::mock(ExceptionHandler::class);
+    $handler->shouldReceive('report')->once()->with($exception);
+    $handler->shouldReceive('render')->once()->with(Mockery::type(Request::class), $exception)
+        ->andReturn(response('rendered', 500));
+    app()->instance(ExceptionHandler::class, $handler);
+
+    Route::native('/protected', CounterScreen::class)
+        ->middleware(ThrowingNativeRouteMiddleware::class);
+
+    $response = runNativeRouteMiddleware(new NativeRouter, '/protected');
+
+    expect($response?->getStatusCode())->toBe(500)
+        ->and($response?->getContent())->toBe('rendered');
+});
+
+class RecordingNativeRouteMiddleware
+{
+    public static array $requests = [];
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        self::$requests[] = [
+            'path' => $request->path(),
+            'facade_path' => RequestFacade::path(),
+            'id' => $request->route('id'),
+            'bound_id' => app(LaravelRoute::class)->parameter('id'),
+            'facade_id' => Route::current()?->parameter('id'),
+            'router_path' => app('router')->getCurrentRequest()?->path(),
+            'user' => $request->user(),
+        ];
+
+        return $next($request);
+    }
+}
+
+class RedirectNativeRouteMiddleware
+{
+    public static ?Response $response = null;
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        return self::$response = redirect('/login', 307, [
+            'X-Native-Middleware' => 'blocked',
+        ]);
+    }
+}
+
+class BlockingNativeRouteMiddleware
+{
+    public static ?Response $response = null;
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        return self::$response = response('Forbidden', 403, [
+            'X-Native-Middleware' => 'forbidden',
+        ]);
+    }
+}
+
+class ThrowingNativeRouteMiddleware
+{
+    public static ?RuntimeException $exception = null;
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        throw self::$exception ?? new RuntimeException('middleware failed');
+    }
+}
+
+class AllowingNativeRouteMiddleware
+{
+    public static int $calls = 0;
+
+    public function handle(Request $request, Closure $next): mixed
+    {
+        self::$calls++;
+
+        return $next($request);
+    }
+}
+
+class MountedNativeRouteScreen extends NativeComponent
+{
+    public static int $mounts = 0;
+
+    public function mount(): void
+    {
+        self::$mounts++;
+    }
+
+    public function runLoop(): void
+    {
+        // The router only needs a finite lifecycle for this fixture.
+    }
+
+    public function render(): Element|View
+    {
+        return Column::make(Text::make('Allowed'));
+    }
+}
+
+class NavigateToProtectedScreen extends NativeComponent
+{
+    public function runLoop(): void
+    {
+        $this->navigate('/protected');
+    }
+
+    public function render(): Element|View
+    {
+        return Column::make(Text::make('Root'));
+    }
+}
+
+class ReplaceWithProtectedScreen extends NativeComponent
+{
+    public function runLoop(): void
+    {
+        $this->replace('/protected');
+    }
+
+    public function render(): Element|View
+    {
+        return Column::make(Text::make('Root'));
+    }
+}


### PR DESCRIPTION
Closes #252.

## Problem

`Route::native()` returns a real Laravel route, so chained middleware runs when the screen is entered through the initial HTTP request. In-app navigation takes a different path: `NativeRouter` resolves the URI and mounts the component directly for push, replace, and hot-reload stack restoration.

That means route middleware such as `auth`, `can`, and custom guards can be silently skipped after the app starts. A protected native screen can therefore mount when reached from another native screen even though the same URL is guarded on cold start.

## Fix

- Retain the Laravel route associated with each native route without changing the public native-route registry shape.
- Before in-app push, replace, or stack preload, clone and bind that route to a synthetic request for the destination URI.
- Resolve aliases, groups, exclusions, and priority through Laravel's real route middleware resolver.
- Scope the request, route binding, Route facade, and router request context while running Laravel's routing pipeline, then restore the long-lived context.
- Return blocked middleware responses unchanged, preserving redirect status, cookies, headers, and non-redirect responses.
- Skip protected historical entries during hot-reload stack restoration.
- Leave the cold-start HTTP path unchanged so middleware is not run twice.

The stored route is cloned before parameter binding, preventing navigation between values of the same route pattern from mutating earlier route state.

## Verification

- `php84 vendor/bin/pest` — 800 passed, 2,799 assertions
- `php84 vendor/bin/phpstan analyse --no-progress` — no errors
- Pint and `git diff --check` pass
- iOS simulator reproduction:
  - released `4.0.1`: in-app navigation mounted the protected component
  - fixed branch: the same navigation ran middleware and redirected before mount

Regression coverage includes allowed middleware, aliases and route parameters, auth/request/route context, push, replace, allowed and denied preload, exact redirect and 403 response preservation, exception reporting/rendering, and same-pattern parameter isolation.
