### PR TITLE
fix(ios): recompute remaining space before placing justified children

### DIFF
--- a/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
+++ b/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
@@ -585,9 +585,20 @@ struct FlexContainer: Layout {
             }
         }
 
-        // Phase 4: Compute justify_content offsets
+        // Phase 4: Compute justify_content offsets.
+        //
+        // Recompute the leftover from the POST-Phase-3 childMains: Phase 3
+        // can grow a child's main size past its Phase-1 ideal (stale/zero
+        // cached ideals, cross-constrained re-measures). Using the Phase-1
+        // `remaining` here over-offsets justify-center/end and pushes
+        // content low/right — the "icons sit low in fixed circles" bug.
+        var placedMain: CGFloat = 0
+        for i in cache.flowIndices {
+            placedMain += childMains[i] + mainMargin(cache.childInfos[i])
+        }
+        let placeRemaining = containerMain - placedMain - gaps
         let (startOffset, interItemSpacing) = justifyOffsets(
-            remaining: remaining > 0 && totalGrow <= 0 ? remaining : 0,
+            remaining: placeRemaining > 0 && totalGrow <= 0 ? placeRemaining : 0,
             count: flowCount
         )
 


### PR DESCRIPTION
## Problem
FlexContainer computes the leftover main-axis space used for justify-content placement **before** Phase 3 sizing finalizes child frames. Justified rows then place children against a stale total — visibly, icons/text in a justified row sit lower than intended (the frame is misplaced; the glyph is correctly centered inside the wrong frame).

## Fix
Recompute `remaining` from the final child sizes immediately before placement.

## Testing
Reproduced with a justified row of icon + text on device; frames land where CSS-equivalent flexbox would put them after the fix. Diagnosed by painting the child frame background to separate frame-placement from glyph-centering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTcfKtsVapKiGfSKwKT69y