### PR TITLE
fix: parse flex-row / flex-col direction utilities

### DIFF
--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -380,6 +380,10 @@ class TailwindParser
 
         // Exact matches
         return match (true) {
+            // Direction — lets any container (notably pressable, which
+            // defaults to column) flip axis via class, matching web flexbox.
+            $class === 'flex-row', $class === 'flex-row-reverse' => ['flexDirection' => 1],
+            $class === 'flex-col', $class === 'flex-col-reverse' => ['flexDirection' => 0],
             $class === 'flex-1' => ['flexGrow' => 1, 'flexShrink' => 1, 'flexBasis' => 0],
             $class === 'flex-grow' => ['flexGrow' => 1],
             $class === 'flex-grow-0' => ['flexGrow' => 0],

--- a/tests/Unit/Edge/TailwindParserTest.php
+++ b/tests/Unit/Edge/TailwindParserTest.php
@@ -80,6 +80,13 @@ it('parses height from spacing scale', function () {
 
 // ── Flex & Alignment ────────────────────────────────
 
+it('parses flex direction', function () {
+    expect(TailwindParser::parse('flex-row'))->toBe(['flexDirection' => 1]);
+    expect(TailwindParser::parse('flex-row-reverse'))->toBe(['flexDirection' => 1]);
+    expect(TailwindParser::parse('flex-col'))->toBe(['flexDirection' => 0]);
+    expect(TailwindParser::parse('flex-col-reverse'))->toBe(['flexDirection' => 0]);
+});
+
 it('parses flex utilities', function () {
     // flex-1 is `flex: 1 1 0%` in Tailwind — grow, shrink, AND zero basis.
     expect(TailwindParser::parse('flex-1'))->toBe(['flexGrow' => 1, 'flexShrink' => 1, 'flexBasis' => 0]);


### PR DESCRIPTION
## Problem
`TailwindParser` silently ignores `flex-row`, `flex-row-reverse`, `flex-col`, and `flex-col-reverse`. Containers whose element defaults to the other axis (e.g. `pressable`, which defaults to column) cannot flip direction via class, and the classes just vanish.

## Fix
Map the four utilities to `flexDirection`, with unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTcfKtsVapKiGfSKwKT69y