### PR TITLE
feat: content-addressed callback ids

### DIFF
--- a/src/Edge/CallbackRegistry.php
+++ b/src/Edge/CallbackRegistry.php
@@ -5,19 +5,15 @@ namespace Native\Mobile\Edge;
 class CallbackRegistry
 {
     /**
-     * Process-wide ID counter. Was per-instance, but per-instance IDs
-     * collide across components — when component A registers
-     * `closeSheet` as ID 5 and component B registers `confirmDelete` as
-     * ID 5, an event meant for A's sheet (still visible from a stale
-     * tree) lands on B's active runloop and fires `confirmDelete`
-     * instead. Global counter guarantees IDs from different components
-     * never collide; if an event arrives with an ID this component
-     * doesn't own, `resolve()` returns null and `dispatch()` drops it
-     * instead of mis-firing.
-     *
-     * u32 wire range (≈4B IDs) is plenty even for long-lived sessions.
+     * Scope salt folded into every derived id — empty for a screen's
+     * own registry. Child-component registries pass their identity key
+     * ('user-card|key:a'), so identical expressions in sibling children
+     * ('bump', 'save') derive DISTINCT ids and dispatch resolves
+     * ownership unambiguously. Identity keys are stable across renders
+     * and processes (explicit `key` attr, else tag + occurrence index),
+     * so scoped ids are exactly as deterministic as unscoped ones.
      */
-    protected static int $globalNextId = 1;
+    protected string $scope = '';
 
     protected array $map = [];
 
@@ -36,18 +32,84 @@ class CallbackRegistry
      */
     protected array $kindMap = [];
 
+    /**
+     * IDs are content-addressed: a pure function of the expression string
+     * (fnv1a32). Same expression always yields the same id — in any
+     * process, any request, any registry instance. That removes every
+     * positional-determinism assumption from the protocol: no counter,
+     * no render-order dependence, nothing to replay to rebuild ids.
+     *
+     * Distinct expressions across components get hash-distinct ids, so
+     * the old cross-component collision hazard (two counters both
+     * handing out id 5) can't occur. Two components sharing an
+     * expression share an id — semantically safe: same expression means
+     * same method + literal args.
+     */
+    public function __construct(string $scope = '')
+    {
+        $this->scope = $scope;
+    }
+
+    /**
+     * This registry's scope — parents prepend it when scoping their
+     * children, so nested children chain ('cards|key:a>badge|i:0') and
+     * the same tag at the same index under DIFFERENT parents still
+     * derives distinct ids.
+     */
+    public function scope(): string
+    {
+        return $this->scope;
+    }
+
     public function register(string $expression, ?string $kind = null): int
     {
         if (isset($this->expressionMap[$expression])) {
             $id = $this->expressionMap[$expression];
         } else {
-            $id = self::$globalNextId++;
+            $id = $this->deriveId($expression);
             $this->expressionMap[$expression] = $id;
             $this->map[$id] = self::parse($expression);
         }
 
         if ($kind !== null) {
             $this->kindMap[$id] = $kind;
+        }
+
+        return $id;
+    }
+
+    /**
+     * Hash an expression to a callback id.
+     *
+     * Masked to 31 bits: the Kotlin side reads callback ids as signed
+     * Int (`getInt("on_press")`, `sendPressEvent(callbackId: Int, …)`),
+     * so the sign bit must stay clear or full-u32 ids wrap negative on
+     * the round trip and `resolve()` misses. fnv1a32 never returns 0,
+     * but the mask can produce 0 — nudge to 1 (0 is the "no callback"
+     * sentinel on the native side).
+     *
+     * Cross-expression hash collision (different expression, same id —
+     * ~1 in 2^31): rehash with a salt suffix until free. The result is
+     * deterministic given insertion order, and registration follows
+     * tree order, so replaying the same render reproduces identical
+     * ids.
+     */
+    protected function deriveId(string $expression): int
+    {
+        $input = $this->scope === '' ? $expression : $this->scope."\x1F".$expression;
+
+        $id = Element::fnv1a32($input) & 0x7FFFFFFF;
+
+        if ($id === 0) {
+            $id = 1;
+        }
+
+        for ($salt = 1; isset($this->map[$id]); $salt++) {
+            $id = Element::fnv1a32($input."\x00".$salt) & 0x7FFFFFFF;
+
+            if ($id === 0) {
+                $id = 1;
+            }
         }
 
         return $id;

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -3107,7 +3107,11 @@ abstract class NativeComponent
 
         if ($isNew) {
             $child = new $class;
-            $child->nativeCallbacks = new CallbackRegistry;
+            $child->nativeCallbacks = new CallbackRegistry(
+                ($parentScope = $this->nativeCallbacks->scope()) === ''
+                    ? $identity
+                    : $parentScope.'>'.$identity
+            );
             $child->nativeParentComponent = $this;
             if ($this->nativeRouter !== null) {
                 $child->setRouter($this->nativeRouter);

--- a/tests/Unit/Edge/CallbackRegistryTest.php
+++ b/tests/Unit/Edge/CallbackRegistryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use Native\Mobile\Edge\CallbackRegistry;
+
+// Callback ids are content-addressed (a pure function of the expression
+// string), so the same expression yields the same id in any process,
+// any request, any registry — no counter state to replay. Stale trees
+// (e.g. a native view that outlived a hot-reload PHP restart) resolve
+// to the right callback instead of whatever the counter happened to
+// hand out this boot.
+
+it('derives the same id for the same expression in any registry', function () {
+    $a = new CallbackRegistry;
+    $b = new CallbackRegistry;
+
+    expect($a->register('increment'))->toBe($b->register('increment'))
+        ->and($a->register('add(5)'))->toBe($b->register('add(5)'));
+});
+
+it('is idempotent within a registry', function () {
+    $r = new CallbackRegistry;
+
+    expect($r->register('increment'))->toBe($r->register('increment'));
+});
+
+it('gives distinct expressions distinct ids', function () {
+    $r = new CallbackRegistry;
+    $ids = array_map(fn ($e) => $r->register($e), [
+        'increment', 'decrement', 'add(5)', "openDetail('a')", "__syncProperty('query')",
+    ]);
+
+    expect(array_unique($ids))->toHaveCount(count($ids));
+});
+
+it('keeps ids positive and inside the signed 32-bit range', function () {
+    $r = new CallbackRegistry;
+
+    foreach (['a', 'increment', 'openDetail', 'add(5)', "__syncProperty('query')"] as $expr) {
+        $id = $r->register($expr);
+
+        expect($id)->toBeGreaterThan(0)
+            ->and($id)->toBeLessThanOrEqual(0x7FFFFFFF);
+    }
+});
+
+it('resolves a registered id back to its parsed expression', function () {
+    $r = new CallbackRegistry;
+
+    expect($r->resolve($r->register('add(5)')))->toBe(['method' => 'add', 'args' => [5]])
+        ->and($r->resolve(123456789))->toBeNull();
+});
+
+it('derives distinct ids for the same expression under different scopes', function () {
+    $screen = new CallbackRegistry;
+    $childA = new CallbackRegistry('card|key:a');
+    $childB = new CallbackRegistry('card|key:b');
+
+    $ids = [$screen->register('bump'), $childA->register('bump'), $childB->register('bump')];
+
+    expect(array_unique($ids))->toHaveCount(3)
+        // Same scope reproduces the same id — determinism survives scoping.
+        ->and((new CallbackRegistry('card|key:a'))->register('bump'))->toBe($ids[1]);
+});


### PR DESCRIPTION
## What
Callback ids become a pure function of the expression string (fnv1a32, masked to 31 bits for the Kotlin signed-Int wire) instead of a process-wide counter. Child-component registries fold their stable identity chain into the hash so identical expressions in sibling children still derive distinct ids.

## Why
- **Hot-reload correctness**: a native tree that outlives a PHP restart holds callback ids from the previous process. With a counter, those ids resolve to whatever happened to register at that number this boot — or nothing. Content-addressed ids resolve to the same callback every time.
- **Determinism for tests**: the same screen always yields the same ids, independent of registration order elsewhere. Tests can compute an expected id from an expression directly.
- **No cross-component misfires**: the counter was made global precisely to avoid two components both handing out id 5; hashing gives the same guarantee without shared state, and the identity-chain scope extends it to sibling children sharing an expression.

Collision handling: ~1-in-2³¹ cross-expression collisions rehash with a salt until free; 0 nudges to 1 (the "no callback" sentinel).

## Testing
New `CallbackRegistryTest` covers cross-registry determinism, idempotence, distinctness, the 31-bit range, resolve round-trip, and scope behavior. Full suite green including the nested-component dispatch tests, which exercise sibling children with identical method names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTcfKtsVapKiGfSKwKT69y