### PR TITLE
feat: GatedBridge contract + FakeBridge capability deny-list

### DIFF
--- a/src/Contracts/GatedBridge.php
+++ b/src/Contracts/GatedBridge.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Native\Mobile\Contracts;
+
+/**
+ * A bridge that can answer capability queries honestly.
+ *
+ * nativephp_can() assumes every method is available (true on device,
+ * and the safe default for Jump / plain FakeBridge tests). A bridge
+ * standing in for the native runtime — a test double stubbing a subset
+ * of methods, a Jump session that knows what the connected device
+ * actually registered — implements this so app code can feature-gate
+ * on what the runtime really provides, without core naming any
+ * concrete bridge class.
+ */
+interface GatedBridge
+{
+    public function can(string $method): bool;
+}

--- a/src/Testing/FakeBridge.php
+++ b/src/Testing/FakeBridge.php
@@ -32,9 +32,33 @@ use PHPUnit\Framework\Assert;
  * TestableComponent forwards unknown methods here, so macros (and the
  * built-in helpers) chain straight off the harness.
  */
-class FakeBridge
+class FakeBridge implements \Native\Mobile\Contracts\GatedBridge
 {
     use Macroable;
+
+    /**
+     * Methods this fake claims NOT to support — the seam for testing
+     * nativephp_can()-gated fallback paths, which previously could not
+     * be exercised at all (every bridge answered "available").
+     *
+     *     FakeBridge::enable()->withoutCapability('Camera.GetPhoto');
+     *     expect(nativephp_can('Camera.GetPhoto'))->toBeFalse();
+     *
+     * @var string[]
+     */
+    protected array $unsupported = [];
+
+    public function withoutCapability(string ...$methods): static
+    {
+        array_push($this->unsupported, ...$methods);
+
+        return $this;
+    }
+
+    public function can(string $method): bool
+    {
+        return ! in_array($method, $this->unsupported, true);
+    }
 
     /** Every tree passed to nativephp_element_publish(), oldest first. */
     public array $publishes = [];

--- a/src/Testing/FakeBridge.php
+++ b/src/Testing/FakeBridge.php
@@ -3,6 +3,7 @@
 namespace Native\Mobile\Testing;
 
 use Illuminate\Support\Traits\Macroable;
+use Native\Mobile\Contracts\GatedBridge;
 use Native\Mobile\Support\NativeCallbacks;
 use PHPUnit\Framework\Assert;
 
@@ -32,7 +33,7 @@ use PHPUnit\Framework\Assert;
  * TestableComponent forwards unknown methods here, so macros (and the
  * built-in helpers) chain straight off the harness.
  */
-class FakeBridge implements \Native\Mobile\Contracts\GatedBridge
+class FakeBridge implements GatedBridge
 {
     use Macroable;
 

--- a/src/jump_bridge_functions.php
+++ b/src/jump_bridge_functions.php
@@ -1,5 +1,6 @@
 <?php
 
+use Native\Mobile\Contracts\GatedBridge;
 use Native\Mobile\JumpBridge;
 use Native\Mobile\Testing\FakeBridge;
 
@@ -53,7 +54,7 @@ if (! function_exists('nativephp_can')) {
     {
         $bridge = FakeBridge::current();
 
-        if ($bridge instanceof \Native\Mobile\Contracts\GatedBridge) {
+        if ($bridge instanceof GatedBridge) {
             return $bridge->can($method);
         }
 

--- a/src/jump_bridge_functions.php
+++ b/src/jump_bridge_functions.php
@@ -42,11 +42,21 @@ if (! function_exists('nativephp_can')) {
     /**
      * Check if a native bridge function is available.
      *
-     * In Jump hybrid mode, we assume all functions are available
-     * on the connected device.
+     * When a capability-gated bridge is driving, only what that bridge
+     * actually provides is available, so app code can feature-gate
+     * honestly — and tests can finally exercise the capability-missing
+     * branch. Device behavior is untouched (this file never loads
+     * there); bridges that don't implement the contract keep assuming
+     * everything is available.
      */
     function nativephp_can(string $method): bool
     {
+        $bridge = FakeBridge::current();
+
+        if ($bridge instanceof \Native\Mobile\Contracts\GatedBridge) {
+            return $bridge->can($method);
+        }
+
         return true;
     }
 }

--- a/tests/Unit/GatedBridgeTest.php
+++ b/tests/Unit/GatedBridgeTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Native\Mobile\Testing\FakeBridge;
+
+afterEach(fn () => FakeBridge::disable());
+
+it('assumes every capability is available by default', function () {
+    FakeBridge::enable();
+
+    expect(nativephp_can('Camera.GetPhoto'))->toBeTrue()
+        ->and(nativephp_can('Anything.AtAll'))->toBeTrue();
+});
+
+it('lets a fake deny capabilities so gated fallbacks are testable', function () {
+    FakeBridge::enable()->withoutCapability('Camera.GetPhoto', 'Nfc.Scan');
+
+    expect(nativephp_can('Camera.GetPhoto'))->toBeFalse()
+        ->and(nativephp_can('Nfc.Scan'))->toBeFalse()
+        ->and(nativephp_can('Dialog.Alert'))->toBeTrue();
+});
+
+it('answers true with no bridge at all', function () {
+    FakeBridge::disable();
+
+    expect(nativephp_can('Camera.GetPhoto'))->toBeTrue();
+});


### PR DESCRIPTION
## What
`nativephp_can()` consults a new `Contracts\GatedBridge` interface when the active bridge implements it. `FakeBridge` implements it with a `withoutCapability()` deny-list.

## Why
`nativephp_can()` currently answers "available" unconditionally outside a device, so the capability-missing branch of gated app code has never been testable — and Jump sessions claim support for everything regardless of what the connected device registered. This adds the seam:

```php
FakeBridge::enable()->withoutCapability('Camera.GetPhoto');
expect(nativephp_can('Camera.GetPhoto'))->toBeFalse();
```

Default behavior is unchanged everywhere (empty deny-list answers true; bridges that don't implement the contract keep assuming everything is available). Follow-up potential: JumpBridge implementing the contract with the device's actual registered function list.

## Testing
New `GatedBridgeTest`; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTcfKtsVapKiGfSKwKT69y