### PR TITLE
feat: #[Locked] properties — bindings cannot write identity props

### DIFF
--- a/src/Attributes/Locked.php
+++ b/src/Attributes/Locked.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Native\Mobile\Attributes;
+
+use Attribute;
+
+/**
+ * Marks a public property as not settable through state-sync bindings.
+ *
+ *     #[Locked]
+ *     public int $userId;
+ *
+ * Two-way binding (`native:model`, and anything else that routes
+ * through __syncProperty) throws LockedPropertyException instead of
+ * writing the property — a guardrail for identity-ish props (ids,
+ * owner keys, tenant scopes) that must only ever change server-side.
+ * Component methods may still assign the property freely.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Locked {}

--- a/src/Edge/Exceptions/LockedPropertyException.php
+++ b/src/Edge/Exceptions/LockedPropertyException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Native\Mobile\Edge\Exceptions;
+
+class LockedPropertyException extends \RuntimeException
+{
+    public function __construct(string $component, string $property)
+    {
+        parent::__construct(
+            "Cannot sync [{$property}] on [{$component}]: the property is #[Locked]. "
+            .'Locked properties only change through component methods, never through bindings.'
+        );
+    }
+}

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -2981,6 +2981,10 @@ abstract class NativeComponent
             return;
         }
 
+        if ((new \ReflectionProperty($this, $property))->getAttributes(\Native\Mobile\Attributes\Locked::class) !== []) {
+            throw new \Native\Mobile\Edge\Exceptions\LockedPropertyException(static::class, $property);
+        }
+
         $this->{$property} = $value;
 
         // A state change can invalidate any computed value (incl.

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -9,6 +9,7 @@ use Illuminate\View\View;
 use Livewire\Features\SupportEvents\BaseOn;
 use Native\Mobile\Attributes\Computed;
 use Native\Mobile\Attributes\Lazy;
+use Native\Mobile\Attributes\Locked;
 use Native\Mobile\Attributes\On;
 use Native\Mobile\Attributes\OnNative;
 use Native\Mobile\Attributes\Poll;
@@ -19,6 +20,7 @@ use Native\Mobile\Edge\Elements\NativeRootStack;
 use Native\Mobile\Edge\Elements\NativeRootTabs;
 use Native\Mobile\Edge\Elements\TabAccessory;
 use Native\Mobile\Edge\Elements\TopBarTitle;
+use Native\Mobile\Edge\Exceptions\LockedPropertyException;
 use Native\Mobile\Edge\Layouts\Builders\NavBar;
 use Native\Mobile\Edge\Layouts\Builders\NavBarOptions;
 use Native\Mobile\Edge\Layouts\Builders\TabBar;
@@ -2981,8 +2983,8 @@ abstract class NativeComponent
             return;
         }
 
-        if ((new \ReflectionProperty($this, $property))->getAttributes(\Native\Mobile\Attributes\Locked::class) !== []) {
-            throw new \Native\Mobile\Edge\Exceptions\LockedPropertyException(static::class, $property);
+        if ((new \ReflectionProperty($this, $property))->getAttributes(Locked::class) !== []) {
+            throw new LockedPropertyException(static::class, $property);
         }
 
         $this->{$property} = $value;

--- a/tests/Unit/Edge/LockedPropertyTest.php
+++ b/tests/Unit/Edge/LockedPropertyTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use Native\Mobile\Attributes\Locked;
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\Exceptions\LockedPropertyException;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Testing\Native;
+
+class LockedPropsScreen extends NativeComponent
+{
+    #[Locked]
+    public int $userId = 7;
+
+    public string $name = 'anon';
+
+    public function impersonate(int $id): void
+    {
+        $this->userId = $id;
+    }
+
+    public function render(): Element
+    {
+        return Column::make(Text::make("User {$this->userId}: {$this->name}"));
+    }
+}
+
+it('throws when a binding syncs a #[Locked] property', function () {
+    Native::test(LockedPropsScreen::class)->set('userId', 999);
+})->throws(LockedPropertyException::class, 'userId');
+
+it('leaves the locked value untouched when a sync is rejected', function () {
+    $screen = Native::test(LockedPropsScreen::class);
+
+    try {
+        $screen->set('userId', 999);
+    } catch (LockedPropertyException) {
+    }
+
+    expect($screen->instance()->userId)->toBe(7);
+});
+
+it('still syncs unlocked properties normally', function () {
+    Native::test(LockedPropsScreen::class)
+        ->set('name', 'shane')
+        ->assertSee('User 7: shane');
+});
+
+it('lets component methods assign locked properties freely', function () {
+    $screen = Native::test(LockedPropsScreen::class)->call('impersonate', 42);
+
+    expect($screen->instance()->userId)->toBe(42);
+});


### PR DESCRIPTION
## What
A Livewire-style `#[Locked]` attribute completing the existing set (`#[Computed]`, `#[On]`, `#[Lazy]`, `#[Poll]`): two-way binding (`native:model` / `__syncProperty`) throws `LockedPropertyException` instead of writing the property. Component methods still assign freely.

## Why
`native:model="userId"` is one typo away from letting a text input rewrite an identity prop. Locked makes the intent declarative and enforced:

```php
#[Locked]
public int $userId;
```

Anyone coming from Livewire already knows the semantics.

## Testing
New `LockedPropertyTest`: binding throws and leaves the value untouched, unlocked props sync normally, methods assign freely. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTcfKtsVapKiGfSKwKT69y