### PR TITLE
Honour `platforms`, and stop copying SwiftPM manifests and test targets into the app target

### DIFF
--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -134,13 +134,11 @@ class AndroidPluginCompiler
             throw new PluginConflictException($conflicts);
         }
 
-        $allPlugins = $this->registry->all();
-        $hookRunner = $this->getHookRunner();
-
         // A plugin that declares `platforms: ["ios"]` contributes nothing to an
         // Android build. Hooks still run for every plugin — a hook is the
         // plugin's own code and gets to decide for itself.
-        $allPlugins = $allPlugins->filter(fn (Plugin $p) => $p->supportsPlatform('android'));
+        $allPlugins = $this->registry->all()->filter(fn (Plugin $p) => $p->supportsPlatform('android'));
+        $hookRunner = $this->getHookRunner();
 
         // Run pre-compile hooks
         $hookRunner->runPreCompileHooks();

--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -137,6 +137,11 @@ class AndroidPluginCompiler
         $allPlugins = $this->registry->all();
         $hookRunner = $this->getHookRunner();
 
+        // A plugin that declares `platforms: ["ios"]` contributes nothing to an
+        // Android build. Hooks still run for every plugin — a hook is the
+        // plugin's own code and gets to decide for itself.
+        $allPlugins = $allPlugins->filter(fn (Plugin $p) => $p->supportsPlatform('android'));
+
         // Run pre-compile hooks
         $hookRunner->runPreCompileHooks();
 

--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -8,6 +8,7 @@ use Native\Mobile\Exceptions\PluginConflictException;
 use Native\Mobile\Plugins\Plugin;
 use Native\Mobile\Plugins\PluginHookRunner;
 use Native\Mobile\Plugins\PluginRegistry;
+use Native\Mobile\Plugins\SwiftSourceFilter;
 use Native\Mobile\Support\Stub;
 
 class IOSPluginCompiler
@@ -96,6 +97,12 @@ class IOSPluginCompiler
         $allPlugins = $this->registry->all();
         $hookRunner = $this->getHookRunner();
 
+        // A plugin that declares `platforms: ["android"]` contributes nothing
+        // to an iOS build: no sources, no registrations, no Info.plist keys.
+        // Hooks still run for every plugin — a hook is the plugin's own code
+        // and gets to decide for itself.
+        $iosPlugins = $allPlugins->filter(fn (Plugin $p) => $p->supportsPlatform('ios'));
+
         // Run pre-compile hooks
         $hookRunner->runPreCompileHooks();
 
@@ -108,10 +115,10 @@ class IOSPluginCompiler
         $this->files->ensureDirectoryExists($this->generatedPath);
 
         // Get plugins with iOS code (for copying files)
-        $pluginsWithCode = $allPlugins->filter(fn (Plugin $p) => $p->hasIosCode());
+        $pluginsWithCode = $iosPlugins->filter(fn (Plugin $p) => $p->hasIosCode());
 
         // Get plugins with iOS bridge functions (for registration)
-        $pluginsWithFunctions = $allPlugins->filter(function (Plugin $p) {
+        $pluginsWithFunctions = $iosPlugins->filter(function (Plugin $p) {
             $functions = $p->getBridgeFunctions();
             foreach ($functions as $function) {
                 if (! empty($function['ios'])) {
@@ -123,12 +130,12 @@ class IOSPluginCompiler
         });
 
         // Get plugins with iOS info_plist entries or dependencies
-        $pluginsWithIosData = $allPlugins->filter(function (Plugin $p) {
+        $pluginsWithIosData = $iosPlugins->filter(function (Plugin $p) {
             return ! empty($p->getIosInfoPlist()) || ! empty($p->getIosDependencies());
         });
 
         // Check for plugins with iOS UI component renderers
-        $pluginsWithRenderers = $allPlugins->filter(function (Plugin $p) {
+        $pluginsWithRenderers = $iosPlugins->filter(function (Plugin $p) {
             foreach ($p->getComponents() as $component) {
                 if (! empty($component['ios_renderer'])) {
                     return true;
@@ -160,32 +167,32 @@ class IOSPluginCompiler
         // Copy plugin source files
         $pluginsWithCode->each(fn (Plugin $plugin) => $this->copyPluginSources($plugin));
 
-        // Generate the registration file (uses all plugins, filters for iOS functions internally)
-        $this->generateBridgeFunctionRegistration($allPlugins);
+        // Generate the registration file (filters for iOS functions internally)
+        $this->generateBridgeFunctionRegistration($iosPlugins);
 
         // Generate UI plugin renderer registration
-        $this->generateRendererRegistration($allPlugins);
+        $this->generateRendererRegistration($iosPlugins);
 
         // Merge Info.plist entries (for any plugins with iOS permissions)
-        $this->mergeInfoPlistEntries($allPlugins);
+        $this->mergeInfoPlistEntries($iosPlugins);
 
         // Write per-locale InfoPlist.strings for any localized permission entries
-        $this->writeInfoPlistLocalizations($allPlugins);
+        $this->writeInfoPlistLocalizations($iosPlugins);
 
         // Merge background modes into Info.plist
-        $this->mergeBackgroundModes($allPlugins);
+        $this->mergeBackgroundModes($iosPlugins);
 
         // Merge entitlements from plugins
-        $this->mergeEntitlements($allPlugins);
+        $this->mergeEntitlements($iosPlugins);
 
         // Add Swift Package dependencies
-        $this->addSwiftPackageDependencies($allPlugins);
+        $this->addSwiftPackageDependencies($iosPlugins);
 
         // Add CocoaPods dependencies
-        $this->addPodDependencies($allPlugins);
+        $this->addPodDependencies($iosPlugins);
 
         // Update Xcode project file
-        $this->updateXcodeProject($allPlugins);
+        $this->updateXcodeProject($iosPlugins);
 
         // Copy manifest-declared assets
         $hookRunner->copyManifestAssets();
@@ -212,40 +219,72 @@ class IOSPluginCompiler
         $pluginDir = $this->generatedPath.'/'.$plugin->getNamespace();
         $this->files->ensureDirectoryExists($pluginDir);
 
-        // Copy all Swift files recursively
+        $explicit = $plugin->getIosSources();
+
+        if ($explicit !== []) {
+            $this->copyDeclaredSwiftSources($plugin, $sourcePath, $pluginDir, $explicit);
+
+            return;
+        }
+
         $this->copySwiftFilesRecursively($sourcePath, $pluginDir);
     }
 
     /**
-     * Recursively copy Swift files, preserving directory structure
+     * Copy only the paths a plugin names in `ios.sources`.
+     *
+     * A named file is copied as-is; a named directory is walked with the same
+     * exclusions as the automatic path, so an explicit list still cannot drag
+     * a test target into the app.
+     *
+     * @param  list<string>  $sources
+     */
+    protected function copyDeclaredSwiftSources(Plugin $plugin, string $source, string $destination, array $sources): void
+    {
+        foreach ($sources as $relative) {
+            $relative = trim($relative, '/');
+            $path = $source.'/'.$relative;
+
+            if ($this->files->isDirectory($path)) {
+                $this->copySwiftFilesRecursively($path, $destination.'/'.$relative);
+
+                continue;
+            }
+
+            if (! $this->files->isFile($path)) {
+                $this->warn("Plugin '{$plugin->name}': ios.sources names a path that does not exist: {$relative}");
+
+                continue;
+            }
+
+            $this->files->ensureDirectoryExists(dirname($destination.'/'.$relative));
+            $this->files->copy($path, $destination.'/'.$relative);
+        }
+    }
+
+    /**
+     * Recursively copy Swift files, preserving directory structure.
+     *
+     * SwiftPM manifests, test targets and build residue are skipped —
+     * see SwiftSourceFilter for why each one cannot compile in an app target.
      */
     protected function copySwiftFilesRecursively(string $source, string $destination): void
     {
-        // First, copy any Swift files at the root level
-        $rootFiles = glob($source.'/*.swift') ?: [];
-        foreach ($rootFiles as $file) {
-            $filename = basename($file);
-            $this->files->copy($file, $destination.'/'.$filename);
-        }
-
-        // Then recursively handle subdirectories
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($source, \RecursiveDirectoryIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::SELF_FIRST
-        );
-
-        foreach ($iterator as $item) {
-            $relativePath = substr($item->getPathname(), strlen($source) + 1);
+        foreach (SwiftSourceFilter::collect($source) as $relativePath) {
             $destPath = $destination.'/'.$relativePath;
 
-            if ($item->isDir()) {
-                $this->files->ensureDirectoryExists($destPath);
-            } elseif ($item->isFile() && $item->getExtension() === 'swift') {
-                // Skip root files (already copied above)
-                if (dirname($item->getPathname()) !== $source) {
-                    $this->files->copy($item->getPathname(), $destPath);
-                }
-            }
+            $this->files->ensureDirectoryExists(dirname($destPath));
+            $this->files->copy($source.'/'.$relativePath, $destPath);
+        }
+    }
+
+    /**
+     * Surface a build-time warning, when there is an output to surface it on.
+     */
+    protected function warn(string $message): void
+    {
+        if ($this->output !== null && method_exists($this->output, 'warn')) {
+            $this->output->warn($message);
         }
     }
 

--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -94,14 +94,12 @@ class IOSPluginCompiler
             throw new PluginConflictException($conflicts);
         }
 
-        $allPlugins = $this->registry->all();
-        $hookRunner = $this->getHookRunner();
-
         // A plugin that declares `platforms: ["android"]` contributes nothing
         // to an iOS build: no sources, no registrations, no Info.plist keys.
         // Hooks still run for every plugin — a hook is the plugin's own code
         // and gets to decide for itself.
-        $iosPlugins = $allPlugins->filter(fn (Plugin $p) => $p->supportsPlatform('ios'));
+        $allPlugins = $this->registry->all()->filter(fn (Plugin $p) => $p->supportsPlatform('ios'));
+        $hookRunner = $this->getHookRunner();
 
         // Run pre-compile hooks
         $hookRunner->runPreCompileHooks();
@@ -115,10 +113,10 @@ class IOSPluginCompiler
         $this->files->ensureDirectoryExists($this->generatedPath);
 
         // Get plugins with iOS code (for copying files)
-        $pluginsWithCode = $iosPlugins->filter(fn (Plugin $p) => $p->hasIosCode());
+        $pluginsWithCode = $allPlugins->filter(fn (Plugin $p) => $p->hasIosCode());
 
         // Get plugins with iOS bridge functions (for registration)
-        $pluginsWithFunctions = $iosPlugins->filter(function (Plugin $p) {
+        $pluginsWithFunctions = $allPlugins->filter(function (Plugin $p) {
             $functions = $p->getBridgeFunctions();
             foreach ($functions as $function) {
                 if (! empty($function['ios'])) {
@@ -130,12 +128,12 @@ class IOSPluginCompiler
         });
 
         // Get plugins with iOS info_plist entries or dependencies
-        $pluginsWithIosData = $iosPlugins->filter(function (Plugin $p) {
+        $pluginsWithIosData = $allPlugins->filter(function (Plugin $p) {
             return ! empty($p->getIosInfoPlist()) || ! empty($p->getIosDependencies());
         });
 
         // Check for plugins with iOS UI component renderers
-        $pluginsWithRenderers = $iosPlugins->filter(function (Plugin $p) {
+        $pluginsWithRenderers = $allPlugins->filter(function (Plugin $p) {
             foreach ($p->getComponents() as $component) {
                 if (! empty($component['ios_renderer'])) {
                     return true;
@@ -168,31 +166,31 @@ class IOSPluginCompiler
         $pluginsWithCode->each(fn (Plugin $plugin) => $this->copyPluginSources($plugin));
 
         // Generate the registration file (filters for iOS functions internally)
-        $this->generateBridgeFunctionRegistration($iosPlugins);
+        $this->generateBridgeFunctionRegistration($allPlugins);
 
         // Generate UI plugin renderer registration
-        $this->generateRendererRegistration($iosPlugins);
+        $this->generateRendererRegistration($allPlugins);
 
         // Merge Info.plist entries (for any plugins with iOS permissions)
-        $this->mergeInfoPlistEntries($iosPlugins);
+        $this->mergeInfoPlistEntries($allPlugins);
 
         // Write per-locale InfoPlist.strings for any localized permission entries
-        $this->writeInfoPlistLocalizations($iosPlugins);
+        $this->writeInfoPlistLocalizations($allPlugins);
 
         // Merge background modes into Info.plist
-        $this->mergeBackgroundModes($iosPlugins);
+        $this->mergeBackgroundModes($allPlugins);
 
         // Merge entitlements from plugins
-        $this->mergeEntitlements($iosPlugins);
+        $this->mergeEntitlements($allPlugins);
 
         // Add Swift Package dependencies
-        $this->addSwiftPackageDependencies($iosPlugins);
+        $this->addSwiftPackageDependencies($allPlugins);
 
         // Add CocoaPods dependencies
-        $this->addPodDependencies($iosPlugins);
+        $this->addPodDependencies($allPlugins);
 
         // Update Xcode project file
-        $this->updateXcodeProject($iosPlugins);
+        $this->updateXcodeProject($allPlugins);
 
         // Copy manifest-declared assets
         $hookRunner->copyManifestAssets();

--- a/src/Plugins/Plugin.php
+++ b/src/Plugins/Plugin.php
@@ -19,6 +19,21 @@ class Plugin
         return $this->manifest->namespace;
     }
 
+    /**
+     * Platforms this plugin declares native code for.
+     *
+     * @return list<string>
+     */
+    public function getPlatforms(): array
+    {
+        return $this->manifest->platforms;
+    }
+
+    public function supportsPlatform(string $platform): bool
+    {
+        return in_array(strtolower($platform), $this->manifest->platforms, true);
+    }
+
     public function getDescription(): string
     {
         return $this->description;
@@ -238,6 +253,10 @@ class Plugin
 
     public function hasAndroidCode(): bool
     {
+        if (! $this->supportsPlatform('android')) {
+            return false;
+        }
+
         $path = $this->getAndroidSourcePath();
 
         if (! is_dir($path)) {
@@ -266,30 +285,31 @@ class Plugin
 
     public function hasIosCode(): bool
     {
-        $path = $this->getIosSourcePath();
-
-        if (! is_dir($path)) {
+        if (! $this->supportsPlatform('ios')) {
             return false;
         }
 
-        // Check if there are any .swift files in the directory
-        $files = glob($path.'/*.swift') ?: [];
-        if (! empty($files)) {
-            return true;
-        }
+        return SwiftSourceFilter::hasAny($this->getIosSourcePath());
+    }
 
-        // Check subdirectories recursively
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS)
-        );
+    /**
+     * An explicit allow-list of iOS sources, from the manifest's
+     * `ios.sources`. Paths are relative to the plugin's iOS source path and
+     * may name a file or a directory.
+     *
+     * When present it is authoritative: nothing outside it is copied. It is
+     * the escape hatch for a layout the automatic exclusions get wrong.
+     *
+     * @return list<string>
+     */
+    public function getIosSources(): array
+    {
+        $sources = $this->manifest->ios['sources'] ?? [];
 
-        foreach ($iterator as $file) {
-            if ($file->isFile() && $file->getExtension() === 'swift') {
-                return true;
-            }
-        }
-
-        return false;
+        return array_values(array_filter(
+            is_array($sources) ? $sources : [],
+            fn ($source) => is_string($source) && $source !== ''
+        ));
     }
 
     public function getAndroidSourceFiles(): array
@@ -321,21 +341,12 @@ class Plugin
             return [];
         }
 
-        $files = [];
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator(
-                $this->getIosSourcePath(),
-                \RecursiveDirectoryIterator::SKIP_DOTS
-            )
+        $root = $this->getIosSourcePath();
+
+        return array_map(
+            fn (string $relative) => $root.'/'.$relative,
+            SwiftSourceFilter::collect($root)
         );
-
-        foreach ($iterator as $file) {
-            if ($file->isFile() && $file->getExtension() === 'swift') {
-                $files[] = $file->getPathname();
-            }
-        }
-
-        return $files;
     }
 
     public function toArray(): array

--- a/src/Plugins/PluginManifest.php
+++ b/src/Plugins/PluginManifest.php
@@ -7,7 +7,21 @@ use JsonSerializable;
 
 class PluginManifest implements JsonSerializable
 {
+    /**
+     * Every platform a plugin may declare support for.
+     */
+    public const PLATFORMS = ['android', 'ios'];
+
     public readonly string $namespace;
+
+    /**
+     * Platforms this plugin ships native code for, from the manifest's
+     * `platforms` key. Absent means both, so a manifest written before this
+     * key was read keeps working.
+     *
+     * @var list<string>
+     */
+    public readonly array $platforms;
 
     public readonly array $bridgeFunctions;
 
@@ -33,6 +47,7 @@ class PluginManifest implements JsonSerializable
         $data = $this->normalizeToNewFormat($data);
 
         $this->namespace = $data['namespace'];
+        $this->platforms = $this->normalizePlatforms($data['platforms'] ?? null);
         $this->bridgeFunctions = $data['bridge_functions'] ?? [];
         $this->components = $data['components'] ?? [];
         $this->android = $data['android'] ?? [];
@@ -41,6 +56,55 @@ class PluginManifest implements JsonSerializable
         $this->events = $data['events'] ?? [];
         $this->hooks = $data['hooks'] ?? [];
         $this->secrets = $data['secrets'] ?? [];
+    }
+
+    /**
+     * Read the manifest's `platforms` key.
+     *
+     * Absent, null or empty means both platforms: the key has been emitted by
+     * `native:plugin:create` for a long time without being read, so treating
+     * "not stated" as "android only" would break existing plugins.
+     *
+     * A typo is rejected rather than ignored. Silently dropping `"IOS"` would
+     * turn a spelling mistake into "this plugin has no iOS code", which is
+     * exactly the failure this key exists to prevent.
+     *
+     * @return list<string>
+     */
+    protected function normalizePlatforms(mixed $platforms): array
+    {
+        if ($platforms === null || $platforms === []) {
+            return static::PLATFORMS;
+        }
+
+        if (! is_array($platforms)) {
+            throw new InvalidArgumentException(
+                'Plugin manifest field `platforms` must be an array of '.implode(', ', static::PLATFORMS)
+            );
+        }
+
+        $normalized = [];
+
+        foreach ($platforms as $platform) {
+            if (! is_string($platform)) {
+                throw new InvalidArgumentException(
+                    'Plugin manifest field `platforms` must contain strings'
+                );
+            }
+
+            $platform = strtolower(trim($platform));
+
+            if (! in_array($platform, static::PLATFORMS, true)) {
+                throw new InvalidArgumentException(
+                    "Plugin manifest declares unknown platform: {$platform}. ".
+                    'Allowed: '.implode(', ', static::PLATFORMS)
+                );
+            }
+
+            $normalized[$platform] = true;
+        }
+
+        return array_keys($normalized);
     }
 
     /**
@@ -235,6 +299,7 @@ class PluginManifest implements JsonSerializable
     {
         return [
             'namespace' => $this->namespace,
+            'platforms' => $this->platforms,
             'bridge_functions' => $this->bridgeFunctions,
             'components' => $this->components,
             'android' => $this->android,

--- a/src/Plugins/SwiftSourceFilter.php
+++ b/src/Plugins/SwiftSourceFilter.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Native\Mobile\Plugins;
+
+/**
+ * Decides which of a plugin's `.swift` files belong in the host app's iOS
+ * target.
+ *
+ * The app's `NativePHP` folder is a PBXFileSystemSynchronizedRootGroup, so
+ * every file copied under it becomes a member of the compile sources phase
+ * automatically. There is no per-file opt-out. Anything copied that cannot
+ * compile in an app target therefore breaks the build of every application
+ * that installs the plugin.
+ *
+ * Three kinds of file can never compile there:
+ *
+ * - `Package.swift` — a SwiftPM manifest. It imports `PackageDescription`,
+ *   which exists only inside SwiftPM's own build.
+ * - Anything under `Tests/` — imports `XCTest`/`Testing` and uses
+ *   `@testable import`, none of which an app target has.
+ * - Anything under a dot directory — `.build`, `.swiftpm`. Build residue,
+ *   frequently containing generated Swift.
+ *
+ * A nested directory holding a `Package.swift` is an embedded Swift package.
+ * Xcode consumes those as package dependencies, not as loose source files, so
+ * the whole subtree is skipped rather than copied file by file.
+ */
+class SwiftSourceFilter
+{
+    /**
+     * Relative paths of every `.swift` file under $root that may be copied
+     * into an app target, in depth-first order.
+     *
+     * @return list<string>
+     */
+    public static function collect(string $root): array
+    {
+        if (! is_dir($root)) {
+            return [];
+        }
+
+        $files = [];
+        static::walk($root, '', $files);
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * Whether $root holds at least one copyable `.swift` file.
+     *
+     * Cheaper than collect() only in intent; kept separate so callers read
+     * clearly. Plugins ship tens of files, not thousands.
+     */
+    public static function hasAny(string $root): bool
+    {
+        return static::collect($root) !== [];
+    }
+
+    /**
+     * Is this a directory the walk must not descend into?
+     */
+    public static function isExcludedDirectory(string $path): bool
+    {
+        $name = basename($path);
+
+        // .build, .swiftpm, .git — build residue and tooling state.
+        if (str_starts_with($name, '.')) {
+            return true;
+        }
+
+        // SwiftPM's test target convention.
+        if ($name === 'Tests') {
+            return true;
+        }
+
+        // An embedded Swift package. Xcode takes these as package
+        // dependencies; copying their sources loose duplicates every symbol.
+        return is_file($path.'/Package.swift');
+    }
+
+    /**
+     * @param  list<string>  $files
+     */
+    protected static function walk(string $directory, string $prefix, array &$files): void
+    {
+        $entries = scandir($directory);
+
+        if ($entries === false) {
+            return;
+        }
+
+        foreach ($entries as $entry) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $directory.'/'.$entry;
+            $relative = $prefix === '' ? $entry : $prefix.'/'.$entry;
+
+            if (is_dir($path)) {
+                if (static::isExcludedDirectory($path)) {
+                    continue;
+                }
+
+                static::walk($path, $relative, $files);
+
+                continue;
+            }
+
+            if (! is_file($path) || pathinfo($path, PATHINFO_EXTENSION) !== 'swift') {
+                continue;
+            }
+
+            // A manifest at the root of the source path, where the directory
+            // check above never sees it.
+            if ($entry === 'Package.swift') {
+                continue;
+            }
+
+            $files[] = $relative;
+        }
+    }
+}

--- a/tests/Feature/Plugins/IOSCompilerTest.php
+++ b/tests/Feature/Plugins/IOSCompilerTest.php
@@ -906,6 +906,175 @@ class NestedClass {}');
     }
 
     /**
+     * @test
+     *
+     * A Swift Package under resources/ios/ must not be copied into the app
+     * target. The app's NativePHP folder is a synchronized root group, so
+     * every file copied under it joins the compile sources phase — and a
+     * SwiftPM manifest imports PackageDescription, which an app target has no
+     * access to.
+     */
+    public function it_does_not_copy_an_embedded_swift_package(): void
+    {
+        $pluginPath = $this->testBasePath.'/plugins/swiftpm-plugin';
+        $iosPath = $pluginPath.'/resources/ios';
+
+        $this->files->ensureDirectoryExists($iosPath.'/Core/Sources/Core');
+        $this->files->ensureDirectoryExists($iosPath.'/Core/Tests/CoreTests');
+        $this->files->ensureDirectoryExists($iosPath.'/Core/.build/debug');
+
+        $this->files->put($iosPath.'/PluginFunctions.swift', 'import Foundation');
+        $this->files->put($iosPath.'/Core/Package.swift', "import PackageDescription\nlet package = Package(name: \"Core\")");
+        $this->files->put($iosPath.'/Core/Sources/Core/Core.swift', 'public enum Core {}');
+        $this->files->put($iosPath.'/Core/Tests/CoreTests/CoreTests.swift', "import XCTest\n@testable import Core");
+        $this->files->put($iosPath.'/Core/.build/debug/Generated.swift', 'let generated = true');
+
+        $plugin = $this->createTestPlugin([], $pluginPath);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $copiedDir = $this->testBasePath.'/ios/NativePHP/Bridge/Plugins/TestPlugin';
+
+        // The bridge file is the plugin's actual iOS surface.
+        $this->assertFileExists($copiedDir.'/PluginFunctions.swift');
+
+        // None of the package's files may reach the app target.
+        $this->assertFileDoesNotExist($copiedDir.'/Core/Package.swift');
+        $this->assertFileDoesNotExist($copiedDir.'/Core/Sources/Core/Core.swift');
+        $this->assertFileDoesNotExist($copiedDir.'/Core/Tests/CoreTests/CoreTests.swift');
+        $this->assertFileDoesNotExist($copiedDir.'/Core/.build/debug/Generated.swift');
+    }
+
+    /**
+     * @test
+     *
+     * A Tests/ directory is SwiftPM's test-target convention. Its files import
+     * XCTest and use @testable, neither of which an app target has.
+     */
+    public function it_does_not_copy_a_tests_directory(): void
+    {
+        $pluginPath = $this->testBasePath.'/plugins/tests-plugin';
+        $iosPath = $pluginPath.'/resources/ios';
+
+        $this->files->ensureDirectoryExists($iosPath.'/Tests');
+        $this->files->put($iosPath.'/PluginFunctions.swift', 'import Foundation');
+        $this->files->put($iosPath.'/Tests/PluginTests.swift', 'import XCTest');
+
+        $plugin = $this->createTestPlugin([], $pluginPath);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $copiedDir = $this->testBasePath.'/ios/NativePHP/Bridge/Plugins/TestPlugin';
+
+        $this->assertFileExists($copiedDir.'/PluginFunctions.swift');
+        $this->assertFileDoesNotExist($copiedDir.'/Tests/PluginTests.swift');
+    }
+
+    /**
+     * @test
+     *
+     * A plugin that declares `platforms: ["android"]` contributes nothing to
+     * an iOS build, whatever it happens to have under resources/ios/.
+     */
+    public function it_skips_plugins_that_do_not_declare_ios_support(): void
+    {
+        $pluginPath = $this->testBasePath.'/plugins/android-only';
+        $iosPath = $pluginPath.'/resources/ios';
+
+        $this->files->ensureDirectoryExists($iosPath);
+        $this->files->put($iosPath.'/PluginFunctions.swift', 'import Foundation');
+
+        $plugin = $this->createTestPlugin([
+            'platforms' => ['android'],
+            'bridge_functions' => [
+                ['name' => 'Test.Execute', 'android' => 'com.test.Execute', 'ios' => 'TestFunctions.Execute'],
+            ],
+            'ios' => ['info_plist' => ['NSCameraUsageDescription' => 'Should not be merged']],
+        ], $pluginPath);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $this->assertFileDoesNotExist(
+            $this->testBasePath.'/ios/NativePHP/Bridge/Plugins/TestPlugin/PluginFunctions.swift'
+        );
+
+        // No registration for a class that was never copied — that would be a
+        // link error rather than a compile error.
+        $registration = $this->files->get(
+            $this->testBasePath.'/ios/NativePHP/Bridge/Plugins/PluginBridgeFunctionRegistration.swift'
+        );
+        $this->assertStringNotContainsString('TestFunctions.Execute', $registration);
+
+        // And no Info.plist keys from a plugin that is not part of this build.
+        $plist = $this->files->get($this->testBasePath.'/ios/NativePHP/Info.plist');
+        $this->assertStringNotContainsString('NSCameraUsageDescription', $plist);
+    }
+
+    /**
+     * @test
+     *
+     * A plugin whose manifest says nothing about platforms is treated as
+     * supporting both, so nothing that worked before this key was read breaks.
+     */
+    public function it_still_copies_sources_when_platforms_is_absent(): void
+    {
+        $pluginPath = $this->testBasePath.'/plugins/no-platforms';
+        $iosPath = $pluginPath.'/resources/ios';
+
+        $this->files->ensureDirectoryExists($iosPath);
+        $this->files->put($iosPath.'/PluginFunctions.swift', 'import Foundation');
+
+        $plugin = $this->createTestPlugin([], $pluginPath);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $this->assertFileExists(
+            $this->testBasePath.'/ios/NativePHP/Bridge/Plugins/TestPlugin/PluginFunctions.swift'
+        );
+    }
+
+    /**
+     * @test
+     *
+     * `ios.sources` is the escape hatch for a layout the exclusions get wrong:
+     * when it is present, it is the whole list.
+     */
+    public function it_copies_only_the_declared_ios_sources(): void
+    {
+        $pluginPath = $this->testBasePath.'/plugins/declared-sources';
+        $iosPath = $pluginPath.'/resources/ios';
+
+        $this->files->ensureDirectoryExists($iosPath.'/Renderers');
+        $this->files->ensureDirectoryExists($iosPath.'/Scratch');
+
+        $this->files->put($iosPath.'/PluginFunctions.swift', 'import Foundation');
+        $this->files->put($iosPath.'/Renderers/Badge.swift', 'import SwiftUI');
+        $this->files->put($iosPath.'/Scratch/Draft.swift', 'import Foundation');
+
+        $plugin = $this->createTestPlugin([
+            'ios' => ['sources' => ['PluginFunctions.swift', 'Renderers']],
+        ], $pluginPath);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $copiedDir = $this->testBasePath.'/ios/NativePHP/Bridge/Plugins/TestPlugin';
+
+        $this->assertFileExists($copiedDir.'/PluginFunctions.swift');
+        $this->assertFileExists($copiedDir.'/Renderers/Badge.swift');
+        $this->assertFileDoesNotExist($copiedDir.'/Scratch/Draft.swift');
+    }
+
+    /**
      * Helper method to create a test Plugin instance.
      */
     private function createTestPlugin(array $manifestData = [], ?string $path = null): Plugin

--- a/tests/Unit/Plugins/PluginTest.php
+++ b/tests/Unit/Plugins/PluginTest.php
@@ -532,4 +532,130 @@ class PluginTest extends TestCase
         $this->assertIsArray($files);
         $this->assertEmpty($files);
     }
+
+    /**
+     * @test
+     *
+     * A manifest that says nothing about platforms supports both, so plugins
+     * written before the key was read keep working.
+     */
+    public function it_defaults_to_both_platforms(): void
+    {
+        $this->assertEquals(['android', 'ios'], $this->plugin->getPlatforms());
+        $this->assertTrue($this->plugin->supportsPlatform('android'));
+        $this->assertTrue($this->plugin->supportsPlatform('ios'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_reports_the_declared_platforms(): void
+    {
+        $plugin = $this->pluginForPlatforms(['android']);
+
+        $this->assertEquals(['android'], $plugin->getPlatforms());
+        $this->assertTrue($plugin->supportsPlatform('android'));
+        $this->assertFalse($plugin->supportsPlatform('ios'));
+    }
+
+    /**
+     * @test
+     *
+     * Swift under resources/ios/ does not make a plugin an iOS plugin. The
+     * manifest decides.
+     */
+    public function it_has_no_ios_code_when_ios_is_not_a_declared_platform(): void
+    {
+        $plugin = $this->pluginForPlatforms(['android'], $this->nativeCodePluginPath);
+
+        $this->assertTrue($plugin->hasAndroidCode());
+        $this->assertFalse($plugin->hasIosCode());
+        $this->assertEmpty($plugin->getIosSourceFiles());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_no_android_code_when_android_is_not_a_declared_platform(): void
+    {
+        $plugin = $this->pluginForPlatforms(['ios'], $this->nativeCodePluginPath);
+
+        $this->assertFalse($plugin->hasAndroidCode());
+        $this->assertTrue($plugin->hasIosCode());
+        $this->assertEmpty($plugin->getAndroidSourceFiles());
+    }
+
+    /**
+     * @test
+     *
+     * A typo is rejected rather than ignored: silently dropping "IOS" would
+     * turn a spelling mistake into "this plugin has no iOS code".
+     */
+    public function it_rejects_an_unknown_platform(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('unknown platform: windows');
+
+        new PluginManifest([
+            'namespace' => 'Test',
+            'platforms' => ['windows'],
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_normalizes_platform_casing_and_duplicates(): void
+    {
+        $manifest = new PluginManifest([
+            'namespace' => 'Test',
+            'platforms' => ['iOS', ' ios ', 'Android'],
+        ]);
+
+        $this->assertEquals(['ios', 'android'], $manifest->platforms);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_an_empty_ios_sources_list_by_default(): void
+    {
+        $this->assertEquals([], $this->plugin->getIosSources());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_the_declared_ios_sources(): void
+    {
+        $manifest = new PluginManifest([
+            'namespace' => 'Test',
+            'ios' => ['sources' => ['TestFunctions.swift', 'Renderers', '', 5]],
+        ]);
+
+        $plugin = new Plugin(
+            name: 'test/plugin',
+            version: '1.0.0',
+            path: $this->nativeCodePluginPath,
+            manifest: $manifest
+        );
+
+        $this->assertEquals(['TestFunctions.swift', 'Renderers'], $plugin->getIosSources());
+    }
+
+    /**
+     * @param  list<string>  $platforms
+     */
+    private function pluginForPlatforms(array $platforms, ?string $path = null): Plugin
+    {
+        return new Plugin(
+            name: 'test/plugin',
+            version: '1.0.0',
+            path: $path ?? $this->validPluginPath,
+            manifest: new PluginManifest([
+                'namespace' => 'Test',
+                'platforms' => $platforms,
+            ])
+        );
+    }
 }


### PR DESCRIPTION
## The problem

`IOSPluginCompiler::copySwiftFilesRecursively()` copies **every** `.swift` file under a plugin's `resources/ios/` into `ios/NativePHP/Bridge/Plugins/<Namespace>/`, recursively, excluding nothing.

That directory is inside a `PBXFileSystemSynchronizedRootGroup`:

```
95BD5DC32D178E9D00C72704 /* NativePHP */ = {
    isa = PBXFileSystemSynchronizedRootGroup;
    exceptions = (
        /* Exceptions for "NativePHP" folder in "NativePHP" target */,
        /* Exceptions for "NativePHP" folder in "NativePHP-simulator" target */,
    );
```

…and both exception sets list only `Info.plist`. So every file copied under `NativePHP/` becomes a member of the compile sources phase of both app targets automatically, with no per-file opt-out.

Three kinds of file cannot compile in an app target:

| File | Why it fails |
|---|---|
| `Package.swift` | `import PackageDescription` — that module exists only inside SwiftPM's own build |
| `Tests/**/*.swift` | `import XCTest` / `import Testing` and `@testable import` |
| `.build/**/*.swift` | `swift build` leaves generated Swift there |

So a plugin that develops its platform-neutral Swift as a Swift Package — the normal way to unit-test Swift logic outside Xcode, and on a machine that isn't a Mac — breaks the iOS build of **every application that installs it**.

The second half is that the decision to copy at all comes from `Plugin::hasIosCode()`, which is true if any `.swift` file exists anywhere under `resources/ios/`. It never consults the manifest's `platforms`. `native:plugin:create` has emitted that key for a long time (`PluginCreateCommand.php:341`) and the generated plugin test asserts its values (`:1016`), but nothing in core reads it — `PluginManifest` does not even keep it. An Android-only plugin therefore still contributes sources, bridge registrations and `Info.plist` keys to an iOS build.

## Reproduction

Runs on Linux; the damage is done in PHP long before `xcodebuild`. Full script in the collapsed block below — it creates a clean Laravel app, installs a plugin whose `resources/ios/` holds a Swift Package, scaffolds the Xcode project the way `InstallsIos::createXcodeProject()` does, and calls the same `IOSPluginCompiler::compile()` that `BuildIosAppCommand` calls.

The plugin's manifest says:

```json
{ "namespace": "Hello", "platforms": ["android"] }
```

**Before:**

```
nativephp/ios/NativePHP/Bridge/Plugins/Hello/HelloCore/.build/debug/HelloCore.build.swift
nativephp/ios/NativePHP/Bridge/Plugins/Hello/HelloCore/Package.swift
nativephp/ios/NativePHP/Bridge/Plugins/Hello/HelloCore/Sources/HelloCore/Hello.swift
nativephp/ios/NativePHP/Bridge/Plugins/Hello/HelloCore/Tests/HelloCoreTests/HelloTests.swift
nativephp/ios/NativePHP/Bridge/Plugins/Hello/HelloFunctions.swift
```

Five files, from a plugin that declares no iOS support at all. `Package.swift` and `HelloTests.swift` both fail to compile.

**After:** nothing is copied.

**After, with the same plugin declaring `"platforms": ["android", "ios"]`:**

```
nativephp/ios/NativePHP/Bridge/Plugins/Hello/HelloFunctions.swift
```

The bridge file — which is the plugin's actual iOS surface — and nothing else.

## The fix

**`platforms` is read, validated and honoured**, by both compilers. Absent, null or empty means both platforms, so no existing plugin changes behaviour. An unknown value throws rather than being dropped: silently ignoring `"IOS"` would turn a typo into "this plugin has no iOS code", which is the failure the key exists to prevent.

**`SwiftSourceFilter`** holds the exclusions in one place — the copier, `hasIosCode()` and `getIosSourceFiles()` all use it, so they cannot disagree about what a plugin's iOS sources are. A nested directory containing a `Package.swift` is skipped as a subtree, because Xcode consumes embedded packages as package dependencies rather than as loose sources; copying them file by file duplicates every symbol.

**`ios.sources`** is a new optional allow-list, relative to the plugin's iOS source path, naming files or directories. When present it is the whole list. It is the escape hatch for a layout the automatic exclusions get wrong, and it makes a plugin's iOS surface explicit and reviewable.

Hooks are deliberately left alone: a hook is the plugin's own code and gets to decide for itself whether it has anything to do on a given platform.

## Tests

13 new tests. All of them fail on `main` and pass here:

- `IOSCompilerTest`: an embedded Swift package is not copied; a `Tests/` directory is not copied; a plugin without declared iOS support contributes no sources, no registrations and no `Info.plist` keys; a plugin with no `platforms` key still gets its sources copied (the regression guard); `ios.sources` copies exactly what it names.
- `PluginTest`: `platforms` defaults to both, is normalised for case and duplicates, rejects unknown values, and gates `hasIosCode()`/`hasAndroidCode()` and the source-file listings in both directions.

`vendor/bin/pest`, `vendor/bin/pint --test` and `vendor/bin/phpstan analyse` are all clean. (Two pre-existing failures in `ReleaseBuildBundleTest` are a missing local `ZipArchive` extension and are identical on `main`.)

## Not in this PR

- **The Android analogue of the exclusions.** `platforms` now gates the Android compiler too, but `AndroidPluginCompiler` maps Kotlin files by their `package` declaration rather than by path, so a path allow-list there would mean something different. A plugin shipping a Gradle module under `resources/android/` with a `src/test/` tree has the same class of problem and deserves its own change.
- **A `native:plugin:validate` warning** when `resources/ios/` holds Swift that `platforms` excludes. Useful, but it is a new diagnostic rather than a fix.

<details>
<summary>Reproduction script</summary>

```bash
#!/usr/bin/env bash
#
# Reproduce: a plugin that ships a Swift Package under resources/ios/ has that
# package's Package.swift and test target copied into the host app's iOS target.
#
# Runs on Linux. It does not need Xcode: the failure happens in PHP, in
# IOSPluginCompiler, before xcodebuild is ever invoked.
#
# Usage: ./reproduce.sh /path/to/empty/dir
set -euo pipefail

WORK="${1:?usage: reproduce.sh <empty-dir>}"
mkdir -p "$WORK"
cd "$WORK"

# ---------------------------------------------------------------- 1. clean app
composer create-project laravel/laravel app --no-interaction --quiet
cd app
composer require nativephp/mobile:^4.0 --no-interaction --quiet

# ------------------------------------------------- 2. a plugin with a SwiftPM package
#
# Shape is the one `native:plugin:create` generates (flat resources/ios/) plus a
# Swift Package alongside it — the layout you use when platform-neutral logic is
# developed and unit-tested outside Xcode.
PLUGIN=packages/acme-hello
mkdir -p "$PLUGIN/src" \
         "$PLUGIN/resources/ios/HelloCore/Sources/HelloCore" \
         "$PLUGIN/resources/ios/HelloCore/Tests/HelloCoreTests" \
         "$PLUGIN/resources/ios/HelloCore/.build/debug"

cat > "$PLUGIN/composer.json" <<'JSON'
{
    "name": "acme/hello",
    "version": "1.0.0",
    "type": "nativephp-plugin",
    "autoload": { "psr-4": { "Acme\\Hello\\": "src/" } },
    "extra": { "laravel": { "providers": ["Acme\\Hello\\HelloServiceProvider"] } }
}
JSON

# platforms says android only. The compiler never reads it.
cat > "$PLUGIN/nativephp.json" <<'JSON'
{
    "name": "acme/hello",
    "namespace": "Hello",
    "platforms": ["android"],
    "bridge_functions": [
        { "name": "Hello.Ping", "android": "com.acme.hello.Ping" }
    ]
}
JSON

cat > "$PLUGIN/src/HelloServiceProvider.php" <<'PHP'
<?php

namespace Acme\Hello;

use Illuminate\Support\ServiceProvider;

class HelloServiceProvider extends ServiceProvider {}
PHP

cat > "$PLUGIN/resources/ios/HelloFunctions.swift" <<'SWIFT'
import Foundation

// A normal bridge file. This one *should* be copied — on iOS.
enum HelloFunctions {}
SWIFT

cat > "$PLUGIN/resources/ios/HelloCore/Package.swift" <<'SWIFT'
// swift-tools-version: 5.9
import PackageDescription

let package = Package(
    name: "HelloCore",
    products: [.library(name: "HelloCore", targets: ["HelloCore"])],
    targets: [
        .target(name: "HelloCore"),
        .testTarget(name: "HelloCoreTests", dependencies: ["HelloCore"]),
    ]
)
SWIFT

cat > "$PLUGIN/resources/ios/HelloCore/Sources/HelloCore/Hello.swift" <<'SWIFT'
import Foundation

public enum Hello {
    public static func greet() -> String { "hi" }
}
SWIFT

cat > "$PLUGIN/resources/ios/HelloCore/Tests/HelloCoreTests/HelloTests.swift" <<'SWIFT'
import XCTest
@testable import HelloCore

final class HelloTests: XCTestCase {
    func testGreet() { XCTAssertEqual(Hello.greet(), "hi") }
}
SWIFT

# SwiftPM build residue. `swift build` leaves generated .swift files here.
cat > "$PLUGIN/resources/ios/HelloCore/.build/debug/HelloCore.build.swift" <<'SWIFT'
// generated build artifact
let generated = true
SWIFT

php -r '
$f = "composer.json";
$j = json_decode(file_get_contents($f), true);
$j["repositories"] = [["type" => "path", "url" => "packages/acme-hello", "options" => ["symlink" => false]]];
$j["require"]["acme/hello"] = "*";
file_put_contents($f, json_encode($j, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
'
composer update acme/hello --no-interaction --quiet

# Plugins are opt-in: publish the provider, then register.
php artisan vendor:publish --tag=nativephp-plugins-provider --quiet
php artisan native:plugin:register acme/hello --quiet

# ------------------------------------------------- 3. scaffold the Xcode project
# Exactly what InstallsIos::createXcodeProject() does, minus the PHP binaries
# (which need no part in this).
php -r '
mkdir("nativephp/ios", 0755, true);
$src = "vendor/nativephp/mobile/resources/xcode";
$it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($src, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::SELF_FIRST);
foreach ($it as $item) {
    $dest = "nativephp/ios/" . substr($item->getPathname(), strlen($src) + 1);
    $item->isDir() ? @mkdir($dest, 0755, true) : copy($item->getPathname(), $dest);
}
'

# ------------------------------------------------- 4. run the iOS plugin compile
# This is the same call BuildIosAppCommand makes (line 1213/1226). It is the
# whole reproduction: no Mac needed, the damage is done in PHP.
php -r '
require "vendor/autoload.php";
$app = require "bootstrap/app.php";
$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
$app->make(Native\Mobile\Plugins\Compilers\IOSPluginCompiler::class)->compile();
'

echo
echo "=== what landed in the app target ==="
find nativephp/ios/NativePHP/Bridge/Plugins -type f | sort
```

</details>
