### PR TITLE
fix: measure cross-axis size against the resolved main size

### DIFF
--- a/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
+++ b/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
@@ -622,6 +622,16 @@ struct FlexContainer: Layout {
                 finalCross = containerCross - crossMargin(info)
                 crossPos = (isRow ? bounds.minY : bounds.minX) + crossMarginBefore(info)
             } else {
+                // Measure the child's natural cross size against the main size
+                // it will actually be placed at, not `.unspecified`. A flexed
+                // child (`flex-1`) is narrower than its unconstrained width, so
+                // an unconstrained measure reports a single-line height for text
+                // that will really wrap. Centring on that stale height places the
+                // child too high and it then overflows downward.
+                let naturalProposal = isRow
+                    ? ProposedViewSize(width: childMain, height: nil)
+                    : ProposedViewSize(width: nil, height: childMain)
+
                 switch effectiveAlign {
                 case AlignItems.stretch:
                     // No FILL: use natural size, align to start (like Android).
@@ -629,19 +639,19 @@ struct FlexContainer: Layout {
                     // proposes crossAvail, which makes container children (e.g.
                     // a flex column) fill the cross axis and report container
                     // cross size, not their natural content size.
-                    let natural = crossSize(subviews[i].sizeThatFits(.unspecified))
+                    let natural = crossSize(subviews[i].sizeThatFits(naturalProposal))
                     finalCross = min(natural, containerCross - crossMargin(info))
                     crossPos = (isRow ? bounds.minY : bounds.minX) + crossMarginBefore(info)
 
                 case AlignItems.center:
                     // Center: measure natural size, center within container
-                    let natural = crossSize(subviews[i].sizeThatFits(.unspecified))
+                    let natural = crossSize(subviews[i].sizeThatFits(naturalProposal))
                     finalCross = min(natural, containerCross - crossMargin(info))
                     crossPos = (isRow ? bounds.minY : bounds.minX) + (containerCross - finalCross) / 2
 
                 case AlignItems.end:
                     // End: measure natural size, align to end
-                    let natural = crossSize(subviews[i].sizeThatFits(.unspecified))
+                    let natural = crossSize(subviews[i].sizeThatFits(naturalProposal))
                     finalCross = min(natural, containerCross - crossMargin(info))
                     crossPos = (isRow ? bounds.minY : bounds.minX) + containerCross - finalCross - crossMarginBefore(info)
 


### PR DESCRIPTION
## The bug

In the classic list row — icon, `flex-1` text, chevron — the text sits visibly low when it wraps. The icon and chevron centre correctly; only the flexed child is off. On a 96pt card I measured **30pt above the glyphs vs 11pt below**, with the text overflowing the container's bottom padding.

It reads as intermittent because it only bites when the flexed child wraps *and* becomes the row's tallest item. Shorten the string so it fits on one line and it looks fine.

## Cause

`FlexContainer`'s cross-axis placement phase measures every child with:

```swift
let natural = crossSize(subviews[i].sizeThatFits(.unspecified))
```

A flexed child is placed **narrower** than its unconstrained width, so an unconstrained measure reports a **single-line** height for text that will really wrap to two.

For `AlignItems.center` the child is then centred as if it were one line tall and grows downward from there. `AlignItems.end` misplaces it the same way, and `stretch` under-reports the height it clamps against.

## Fix

Measure against the main size the child will actually be placed at. This matches flexbox ordering — main size is resolved first, cross size is measured against it.

```swift
let naturalProposal = isRow
    ? ProposedViewSize(width: childMain, height: nil)
    : ProposedViewSize(width: nil, height: childMain)
```

`childMain` is already resolved at this point (post Phase 3), so it needs no extra plumbing.

## Verification

Built to the simulator and measured card edges and glyph extents per-pixel — a ~9pt offset is indistinguishable from ordinary font leading by eye.

| | before | after |
|---|---|---|
| card 1 text offset | +9.3pt | **+1.0pt** |
| card 2 text offset | +7.0pt | **−1.3pt** |
| top/bottom delta | 56px @3x | **6px @3x** |
| icon / chevron | 0.0pt | 0.0pt (unchanged) |

Reproduced independently in a second layout with no nested gaps — just `<native:icon>` + `<native:text class="flex-1">` in an `items-center` row — which rules out the nesting as a factor.

Also confirmed this is **not** the same issue as `fix/flex-justify-remaining`: building with that branch gave byte-identical layout, since it targets main-axis `justifyOffsets`.

Android (Compose) was never affected.

## Minimal repro

```blade
<native:row class="w-full gap-4 items-center p-5">
    <native:column center class="w-14 h-14 rounded-full bg-theme-primary/20">
        <native:icon name="cloud" :size="22" />
    </native:column>
    <native:column class="flex-1 gap-1">
        <native:text class="text-lg font-bold">Title</native:text>
        <native:text class="text-sm">A subtitle long enough to wrap onto two lines</native:text>
    </native:column>
</native:row>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)