### PR TITLE
Accept format v4 — event channel is a queue, and pin the binaries release

### DIFF
--- a/docs/event-channel-pointer-refactor.md
+++ b/docs/event-channel-pointer-refactor.md
@@ -193,6 +193,13 @@ Widened (event channel only — render-direction flat/prop buffers untouched):
 4. **Version handshake** — `NPHP_FORMAT_VERSION` (nphp_element.h),
    `expectedFormatVersion` (Swift), `EXPECTED_FORMAT_VERSION` (Kotlin) all → 3.
 
+> These three are on **4** now, not 3. v4 turned the event channel into a FIFO
+> queue: before it, a second post landing before PHP drained the first
+> overwrote it silently, which the async-task lane in #228 hit hard (five
+> posting threads). The per-frame wire format is identical to v3, so nothing
+> in the widening described above changed — only the region's event fields and
+> the version they're guarded by.
+
 `tabChange` keeps its u16 (it's an index, not a length).
 
 Render-direction caps (`npui_write_str` u16, node `prop_size`/`raw_children` u16)

--- a/resources/androidstudio/app/src/main/cpp/bridge_jni.cpp
+++ b/resources/androidstudio/app/src/main/cpp/bridge_jni.cpp
@@ -42,7 +42,10 @@ static void element_write_event(JNIEnv*, jclass, jint, jint, jint, jbyteArray);
 extern "C" uint32_t nphp_get_format_version(void);
 extern "C" uint32_t nphp_get_runtime_flags(void);
 extern "C" void     nphp_set_runtime_flags(uint32_t flags);
-extern "C" void     nphp_element_post_event(int type, int callback_id, int node_id,
+// Returns 1 if the event was queued, 0 if dropped (no region, or the queue is
+// over its backlog cap because PHP stopped draining). Was void before format
+// v4 — the declaration has to match the definition in nphp_element.c.
+extern "C" int      nphp_element_post_event(int type, int callback_id, int node_id,
                                             const uint8_t *data, uint32_t data_len);
 
 // Phase 3 — active-buffer accessors. These do the acquire-load on the
@@ -319,6 +322,13 @@ void NativeUI_UnregisterRegion(void) {
 /*
  * Element region struct — must match nphp_element_region_t in nphp_element.h EXACTLY.
  * Uses void* for zval* since we don't have php.h here.
+ *
+ * Only a prefix of the real struct: everything the extension has appended
+ * since (format_version, runtime_flags, the A/B buffer pair, the event queue)
+ * sits after `current_tree` and is reached through exported accessor functions
+ * instead. That's why appending to nphp_element_region_t doesn't break this
+ * mirror — but inserting a field ANYWHERE above does. If you add one, add it
+ * to both, in the same place, and bump NPHP_FORMAT_VERSION (§5.4).
  */
 struct NphpElementRegion {
     uint32_t magic;
@@ -336,7 +346,11 @@ struct NphpElementRegion {
     pthread_mutex_t event_mutex;
     pthread_cond_t  event_cond;
 
-    /* Events */
+    /* Events — DEAD, do not use. Present only to keep the offsets below
+     * correct. Post events with nphp_element_post_event(). As of format v4
+     * the channel is a queue of separately allocated frames: event_buffer is
+     * never written, event_size is the head frame's size rather than "the"
+     * event's, and event_count is a depth rather than a 0/1 flag. */
     std::atomic<uint32_t> event_size;
     std::atomic<uint32_t> event_count;
     uint8_t event_buffer[4096];

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeElementBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeElementBridge.kt
@@ -84,8 +84,16 @@ class NativeElementBridge private constructor() {
          * v2 (Phase 2) — appended `flags` byte to flat node (stride 161).
          * v3 — event-channel framing widened uint16 → uint32 (header data_size
          *      + body string length prefixes); lifts the 64KB native→PHP cap.
+         * v4 — native→PHP event channel is a FIFO queue instead of a single
+         *      slot, so concurrent posts (async-task pool + watchdog) queue
+         *      instead of overwriting each other. Nothing changes for this
+         *      reader: the per-frame wire format is identical, the flat/prop
+         *      buffers are untouched, and events are still posted through
+         *      nativeElementWriteEvent → nphp_element_post_event. The version
+         *      moved because the region's event fields changed meaning, and a
+         *      stale libphp.a should fail loud rather than be quietly wrong.
          */
-        private const val EXPECTED_FORMAT_VERSION = 3
+        private const val EXPECTED_FORMAT_VERSION = 4
 
         /** Latched at startWatching(). 0 until then. Readable for telemetry. */
         @JvmStatic

--- a/resources/xcode/Include/Bridge/PHP.h
+++ b/resources/xcode/Include/Bridge/PHP.h
@@ -67,10 +67,15 @@ uint8_t *nphp_get_active_flat_buffer(uint32_t *size_out);
 uint8_t *nphp_get_active_prop_buffer(uint32_t *size_out);
 
 // Native → PHP event producer. Swift hands the event body bytes here; the
-// extension owns the event mutex, the growable heap buffer, and the header
-// framing (single source of truth for the wire format). Replaces Swift poking
-// the region's inline event buffer by offset, and lifts the 4KB payload cap.
-void nphp_element_post_event(int type, int callback_id, int node_id,
-                             const uint8_t *data, uint32_t data_len);
+// extension owns the event mutex, the event queue, and the header framing
+// (single source of truth for the wire format). Replaces Swift poking the
+// region's inline event buffer by offset, and lifts the 4KB payload cap.
+//
+// Returns 1 if the event was queued, 0 if it was dropped (no region, or the
+// queue is over its backlog cap because PHP has stopped draining). Was void
+// before format v4; ignoring the result is still fine, but a caller that
+// needs to know its event will be delivered can now check.
+int nphp_element_post_event(int type, int callback_id, int node_id,
+                            const uint8_t *data, uint32_t data_len);
 
 #endif

--- a/resources/xcode/NativePHP/NativeRender/NativeElementBridge.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeElementBridge.swift
@@ -48,6 +48,14 @@ final class NativeElementBridge {
         static let nodeCount: Int        = 16
         static let flatBufferSize: Int   = 20
         static let propBufferSize: Int   = 24
+        // Event fields — DEAD, do not use. Kept only because removing them
+        // would make the offsets below look like they'd shifted (they haven't).
+        //
+        // Post events with `nphp_element_post_event()` instead. As of format
+        // v4 the channel is a queue of separately allocated frames: eventBuffer
+        // is never written, eventSize is the head frame's size rather than "the"
+        // event's, and eventCount is a depth rather than a 0/1 flag. Writing
+        // here would be silently ignored; reading would be garbage.
         static let eventMutex: Int       = 144
         static let eventCond: Int        = 208
         static let eventSize: Int        = 256
@@ -73,7 +81,15 @@ final class NativeElementBridge {
     /// v2 (Phase 2) — appended `flags` byte to flat node (stride 161).
     /// v3 — event-channel framing widened uint16 → uint32 (header data_size +
     ///      body string length prefixes); lifts the 64KB native→PHP cap.
-    private static let expectedFormatVersion: UInt32 = 3
+    /// v4 — native→PHP event channel is a FIFO queue instead of a single slot,
+    ///      so concurrent posts (async-task pool + watchdog) queue instead of
+    ///      overwriting each other. Nothing changes for this reader: the
+    ///      per-frame wire format is identical, the flat/prop buffers are
+    ///      untouched, and events are still posted through
+    ///      `nativeElementWriteEvent` → `nphp_element_post_event`. The version
+    ///      moved because the region's event fields changed meaning, and a
+    ///      stale libphp.a should fail loud rather than be quietly wrong.
+    private static let expectedFormatVersion: UInt32 = 4
 
     /// Phase 0 — latched after the one-shot check in `postTreeUpdateFromRegion()`.
     /// NPHP_FLAG_* bitfield in nphp_element.h.
@@ -519,10 +535,16 @@ final class NativeElementBridge {
     /// Event format: [magic:u32][type:u8][callback_id:u32][node_id:u32][timestamp:u64][data_size:u16][data...]
     static func nativeElementWriteEvent(_ type: Int32, _ callbackId: Int32, _ nodeId: Int32, _ data: UnsafePointer<UInt8>?, _ dataSize: Int32) {
         // Hand the body bytes to the PHP extension, which owns the event mutex,
-        // the growable heap buffer, and the header framing
-        // (nphp_element_post_event in nphp_element.c). No more region poking by
-        // offset, no 4KB cap, no hand-rolled framing.
-        nphp_element_post_event(type, callbackId, nodeId, data, UInt32(max(0, dataSize)))
+        // the event queue, and the header framing (nphp_element_post_event in
+        // nphp_element.c). No more region poking by offset, no 4KB cap, no
+        // hand-rolled framing.
+        //
+        // The return value (1 = queued, 0 = dropped) is discarded: a UI event
+        // has nothing useful to do about a drop, and a dropped one is already
+        // logged by the extension with the callback_id it would have woken.
+        // A caller that DOES care — an async-task completion, say — should
+        // check it rather than copy this.
+        _ = nphp_element_post_event(type, callbackId, nodeId, data, UInt32(max(0, dataSize)))
     }
 
     static func sendPressEvent(_ callbackId: Int, nodeId: Int) {

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -9,6 +9,7 @@ use Native\Mobile\Concerns\DisplaysMarketingBanners;
 use Native\Mobile\Concerns\InstallsAndroid;
 use Native\Mobile\Concerns\InstallsIos;
 use Native\Mobile\Concerns\PlatformFileOperations;
+use Native\Mobile\Support\PhpBinaries;
 
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;
@@ -265,7 +266,7 @@ class InstallCommand extends Command
     protected function fetchVersionsManifest(): void
     {
         $branch = $this->getBinaryBranch();
-        $versionsUrl = "https://bin.nativephp.com/{$branch}/versions.json";
+        $versionsUrl = PhpBinaries::manifestUrl($branch);
 
         try {
             $this->versionsManifest = json_decode(
@@ -273,7 +274,22 @@ class InstallCommand extends Command
                 true
             );
         } catch (RequestException $e) {
-            error("Failed to fetch versions manifest from: {$versionsUrl}");
+            // A 404 here is specific: the manifest is named for the binary
+            // release this package pins, so a missing one means that release
+            // was withdrawn — not that the CDN is down. Say which, because the
+            // fixes are completely different.
+            if ($e->getResponse()?->getStatusCode() === 404) {
+                error(sprintf(
+                    'PHP binaries release %s is no longer published.'
+                    ."\n".'Update nativephp/mobile to a version that pins a current release:'
+                    ."\n".'    composer update nativephp/mobile',
+                    PhpBinaries::VERSION
+                ));
+
+                return;
+            }
+
+            error("Failed to fetch the PHP binaries manifest from: {$versionsUrl}");
         }
     }
 

--- a/src/Concerns/InstallsAndroid.php
+++ b/src/Concerns/InstallsAndroid.php
@@ -5,6 +5,7 @@ namespace Native\Mobile\Concerns;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Facades\File;
+use Native\Mobile\Support\PhpBinaries;
 use ZipArchive;
 
 use function Laravel\Prompts\error;
@@ -129,8 +130,15 @@ trait InstallsAndroid
         $phpVersion = $this->phpVersion;
         $versions = $this->versionsManifest;
 
-        if (! $versions || ! isset($versions['versions'][$phpVersion])) {
-            error("PHP {$phpVersion} binaries not available");
+        // No manifest at all means the fetch already failed and explained
+        // itself. Repeating "not available" here would point at the PHP
+        // version, which isn't the problem.
+        if (! $versions) {
+            return;
+        }
+
+        if (! isset($versions['versions'][$phpVersion])) {
+            error("PHP {$phpVersion} binaries are not part of release ".PhpBinaries::VERSION);
 
             return;
         }

--- a/src/Concerns/InstallsIos.php
+++ b/src/Concerns/InstallsIos.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
+use Native\Mobile\Support\PhpBinaries;
 use ZipArchive;
 
 use function Laravel\Prompts\error;
@@ -61,8 +62,14 @@ trait InstallsIos
         $phpVersion = $this->phpVersion;
         $versions = $this->versionsManifest;
 
-        if (! $versions || ! isset($versions['versions'][$phpVersion])) {
-            error("PHP {$phpVersion} binaries not available");
+        // No manifest at all means the fetch already failed and explained
+        // itself — see the Android equivalent.
+        if (! $versions) {
+            return;
+        }
+
+        if (! isset($versions['versions'][$phpVersion])) {
+            error("PHP {$phpVersion} binaries are not part of release ".PhpBinaries::VERSION);
 
             return;
         }

--- a/src/Support/PhpBinaries.php
+++ b/src/Support/PhpBinaries.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Native\Mobile\Support;
+
+/**
+ * Which release of the prebuilt PHP binaries this package installs.
+ *
+ * The binaries are built in NativePHP/php-bin-mobile and published as a
+ * manifest named for the release — `4.0.0.json` — listing the artifacts that
+ * belong to it. Pinning the version here rather than fetching a floating
+ * `versions.json` means a given release of this package always resolves to
+ * the binaries it was tested against, and publishing a newer set can't reach
+ * an install that hasn't opted into it.
+ *
+ * Because it lives in this package, `composer.lock` already pins it. There's
+ * nothing to record in `nativephp.lock`.
+ *
+ * ## When to bump
+ *
+ * Whenever you want the binaries this package installs to change. The one
+ * case that is NOT optional: if the new release changes
+ * `NPHP_FORMAT_VERSION` in the extension, the Swift and Kotlin readers must
+ * move in the same release too — `EXPECTED_FORMAT_VERSION` in
+ * `NativeElementBridge.kt` and `expectedFormatVersion` in
+ * `NativeElementBridge.swift`. They compare the number on the first publish
+ * and refuse to render at all on a mismatch, so an app built with mismatched
+ * halves runs normally and never draws anything.
+ */
+class PhpBinaries
+{
+    /**
+     * Release of the PHP binaries to install.
+     *
+     * Matches NATIVEPHP_VERSION in php-bin-mobile's config/versions.sh.
+     */
+    public const VERSION = '4.0.0';
+
+    public const HOST = 'https://bin.nativephp.com';
+
+    /** URL of the manifest listing every artifact in this release. */
+    public static function manifestUrl(string $branch = 'main'): string
+    {
+        return self::HOST.'/'.$branch.'/'.self::VERSION.'.json';
+    }
+}

--- a/tests/Unit/Support/PhpBinariesTest.php
+++ b/tests/Unit/Support/PhpBinariesTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Unit\Support;
+
+use Native\Mobile\Support\PhpBinaries;
+use PHPUnit\Framework\TestCase;
+
+class PhpBinariesTest extends TestCase
+{
+    public function test_manifest_url_is_named_for_the_pinned_release(): void
+    {
+        $this->assertSame(
+            'https://bin.nativephp.com/main/'.PhpBinaries::VERSION.'.json',
+            PhpBinaries::manifestUrl()
+        );
+    }
+
+    public function test_manifest_url_honours_the_branch(): void
+    {
+        $this->assertSame(
+            'https://bin.nativephp.com/my-feature/'.PhpBinaries::VERSION.'.json',
+            PhpBinaries::manifestUrl('my-feature')
+        );
+    }
+
+    /**
+     * The whole point of pinning: the URL must carry the version, so a given
+     * release of this package can only ever resolve to the binaries it was
+     * tested against. A floating name like `versions.json` would let a newer
+     * publish reach an install that never opted into it.
+     */
+    public function test_manifest_url_is_not_a_floating_name(): void
+    {
+        $this->assertStringNotContainsString('versions.json', PhpBinaries::manifestUrl());
+        $this->assertStringEndsWith('/'.PhpBinaries::VERSION.'.json', PhpBinaries::manifestUrl());
+    }
+
+    public function test_version_is_a_semver_string(): void
+    {
+        $this->assertMatchesRegularExpression('/^\d+\.\d+\.\d+$/', PhpBinaries::VERSION);
+    }
+}


### PR DESCRIPTION
App-side half of the format v4 bump. The extension-side change — NativePHP/php-bin-mobile#20, "Make the native→PHP event channel a queue" — turns the single-slot native→PHP event channel into a FIFO queue. This PR updates the iOS and Android readers to accept it, and pins which release of the PHP binaries we install.

> [!WARNING]
> **Do not merge or release this until php-bin-mobile#20 is released.**
>
> `4.0.0.json` does not exist on `bin.nativephp.com` yet. Until that release is published, this branch pins a manifest that 404s and every `native:install` fails at the fetch. php-bin-mobile#20 is still a draft.

## Why these two changes are one change

They look unrelated — a version constant and a URL — but the second exists because of the first.

Until now the installer fetched `{branch}/versions.json`, a floating name: whatever binaries were published most recently. That was survivable only while every published build spoke the same wire format. **This is the first time that stops being true.** Once v3 and v4 binaries both exist, a floating manifest hands an install whichever was published last, with no relationship to the `expectedFormatVersion` compiled into the Swift and Kotlin readers sitting next to it.

The failure that produces is the quiet kind. The readers compare the format number on the first publish and refuse to render on a mismatch — so the app launches, runs, and simply never draws anything. No crash, no error, nothing pointing at the binaries.

So the version handshake moving to 4 is what forces the pin. They ship together or the pin is pointless.

## The format change

**Version handshake → 4** — `expectedFormatVersion` (`NativeElementBridge.swift`), `EXPECTED_FORMAT_VERSION` (`NativeElementBridge.kt`).

Nothing changes for either reader: the per-frame wire format is identical to v3, and the flat/prop render-direction buffers are untouched. The version moved because the *region's event fields changed meaning*, so a stale `libphp.a` fails loud rather than being quietly wrong.

The motivating bug: before v4, a second event posted before PHP drained the first **silently overwrote it**. The async-task lane in NativePHP/php-bin-mobile#228 hits this hard — five posting threads against one slot.

**`nphp_element_post_event` is now `int`, not `void`** — `PHP.h`, `bridge_jni.cpp`.

Returns `1` if the event was queued, `0` if dropped (no region, or the queue is over its backlog cap because PHP stopped draining). Both declarations had to move to match the definition in `nphp_element.c`. Swift's `nativeElementWriteEvent` explicitly discards the result — a UI event has nothing useful to do about a drop, and the extension already logs it with the `callback_id` it would have woken — with a note that callers who *do* care (async-task completions) should check rather than copy that.

**Region event mirrors marked dead** — `NativeElementBridge.swift` offsets, `NphpElementRegion` in `bridge_jni.cpp`.

`event_size` / `event_count` / `event_buffer` are kept only so the surrounding offsets stay correct. Under a queue of separately allocated frames, `event_buffer` is never written, `event_size` is the head frame's size rather than "the" event's, and `event_count` is a depth rather than a 0/1 flag. Writing there is silently ignored; reading gives garbage. The JNI struct comment also now spells out that it is only a *prefix* of the real `nphp_element_region_t` — appending to the real struct is safe, inserting above `current_tree` is not.

## The pin

**New `src/Support/PhpBinaries.php`** — holds `VERSION = '4.0.0'`, matching `NATIVEPHP_VERSION` in php-bin-mobile's `config/versions.sh`, and builds the manifest URL from it. Install now fetches `{branch}/4.0.0.json` instead of `{branch}/versions.json`.

`composer.lock` already pins this package, so the binaries are transitively pinned too — nothing to record in `nativephp.lock`. The class docblock spells out the bump rule: whenever you want the installed binaries to change, and *mandatorily* whenever the new release moves `NPHP_FORMAT_VERSION`, in which case the two reader constants have to move in the same release.

**Sharper failures**, because pinning introduces a new way to fail and the old messages misdirect:

- A 404 on the manifest now means something specific — the manifest is named for the release this package pins, so a missing one means that release was withdrawn, not that the CDN is down. It says so and points at `composer update nativephp/mobile`.
- When the manifest is missing entirely, the iOS and Android installers return quietly instead of adding `PHP {version} binaries not available`. The fetch already explained itself, and that message blames the PHP version, which isn't the problem.
- When the manifest is present but lacks the requested PHP version, name the release it was missing from.

## Testing

`tests/Unit/Support/PhpBinariesTest.php` — 4 tests covering the URL shape, branch handling, that the name is *not* floating, and that `VERSION` is semver. All passing.

The format side has no behaviour change beyond the version constant — same event path, framing, and buffers. It needs a build against the v4 `libphp.a` to confirm the handshake passes on both platforms, which is blocked on the release above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
