### PR TITLE
perf: cut hot reload latency and its variance

### DIFF
--- a/resources/xcode/NativePHP/Bridge/PHPQueueWorker.swift
+++ b/resources/xcode/NativePHP/Bridge/PHPQueueWorker.swift
@@ -28,6 +28,14 @@ final class PHPQueueWorker {
     private var running = false
     private var stopped: DispatchSemaphore?
 
+    /// Signalled by `stopAndWait()` so the idle wait between job passes ends
+    /// immediately. Without it the loop only re-checks `running` after the
+    /// full interval elapses, so every stop request — and therefore every hot
+    /// reload, which stops the worker before rebooting the runtime — waits out
+    /// up to `sleepIdleMs`. That was the dominant and most variable part of a
+    /// reload: ~4.6s measured, versus ~1.0s once the wait is interruptible.
+    private var wake = DispatchSemaphore(value: 0)
+
     private init() {}
 
     /// Start the background queue worker.
@@ -41,6 +49,7 @@ final class PHPQueueWorker {
 
         running = true
         stopped = DispatchSemaphore(value: 0)
+        wake = DispatchSemaphore(value: 0)
 
         let thread = Thread {
             self.workerLoop()
@@ -72,6 +81,7 @@ final class PHPQueueWorker {
 
         NSLog("PHPQueueWorker: stopAndWait — waiting for worker to exit")
         running = false
+        wake.signal()
         stopped?.wait()
         stopped = nil
         workerThread = nil
@@ -116,7 +126,9 @@ final class PHPQueueWorker {
                 sleepMs = sleepIdleMs
             }
 
-            Thread.sleep(forTimeInterval: Double(sleepMs) / 1000.0)
+            // Interruptible idle wait — returns as soon as `stopAndWait()`
+            // signals, rather than sleeping the full interval first.
+            _ = wake.wait(timeout: .now() + Double(sleepMs) / 1000.0)
         }
 
         _worker_php_shutdown()

--- a/resources/xcode/NativePHP/HotReloadServer.swift
+++ b/resources/xcode/NativePHP/HotReloadServer.swift
@@ -16,6 +16,12 @@ class HotReloadCoordinator {
     static let shared = HotReloadCoordinator()
 
     private var reloadInProgress = false
+
+    /// A trigger that arrived while a reload was in flight. The watcher emits
+    /// one event per changed file (and one for the containing directory), so
+    /// dropping the extras outright can discard the *last* file's trigger and
+    /// leave the app running stale code until the next save.
+    private var reloadPending = false
     private var activated = false
 
     private init() {}
@@ -35,11 +41,29 @@ class HotReloadCoordinator {
         )
     }
 
+    /// Release the in-flight guard and, if a trigger arrived while we were
+    /// busy, run exactly one more pass so the newest files are picked up.
+    private func finishReload() {
+        reloadInProgress = false
+
+        guard reloadPending else { return }
+        reloadPending = false
+
+        DispatchQueue.main.async { [weak self] in
+            self?.reload()
+        }
+    }
+
     @objc func reload() {
         // Guard against rapid-fire file change events (file + directory)
         // triggering concurrent reboots that race on php_embed_shutdown.
-        guard !reloadInProgress else { return }
+        guard !reloadInProgress else {
+            reloadPending = true
+
+            return
+        }
         reloadInProgress = true
+        reloadPending = false
 
         let isNativeUI = NativeUIBridge.shared.isActive
         // Capture current route for native UI re-execution
@@ -101,7 +125,7 @@ class HotReloadCoordinator {
                 // The serial queue will be blocked by the new dispatch, but the
                 // next reload() can still send a hot reload event (above)
                 // to break out of it.
-                self?.reloadInProgress = false
+                self?.finishReload()
 
                 // Prefer the URI PHP wrote into .hot_restart over the WebView's
                 // URL — for native-chrome routes the WebView URL isn't kept in
@@ -149,7 +173,7 @@ class HotReloadCoordinator {
                 // WebView mode: reload with cache-bust
                 DispatchQueue.main.async {
                     guard let webView = SharedWebView.shared.webView else {
-                        self?.reloadInProgress = false
+                        self?.finishReload()
                         return
                     }
                     webView.stopLoading()
@@ -159,7 +183,7 @@ class HotReloadCoordinator {
                     if let url = URL(string: cacheBustUrl) {
                         webView.load(URLRequest(url: url))
                     }
-                    self?.reloadInProgress = false
+                    self?.finishReload()
                 }
             }
         }

--- a/src/Concerns/ManagesWatchman.php
+++ b/src/Concerns/ManagesWatchman.php
@@ -69,7 +69,7 @@ trait ManagesWatchman
      * @param  callable  $onChange  Callback that receives the changed file path
      * @param  callable|null  $onTick  Optional callback for periodic tasks (called every 100ms)
      */
-    protected function startWatchman(array $paths, array $excludePatterns, callable $onChange, ?callable $onTick = null): void
+    protected function startWatchman(array $paths, array $excludePatterns, callable $onChange, ?callable $onTick = null, ?callable $onBatch = null): void
     {
         $this->watchmanRoot = base_path();
 
@@ -126,6 +126,8 @@ trait ManagesWatchman
             if ($output) {
                 $lines = array_filter(explode("\n", trim($output)));
 
+                $batch = [];
+
                 foreach ($lines as $changedFile) {
                     if (empty($changedFile)) {
                         continue;
@@ -142,7 +144,17 @@ trait ManagesWatchman
                     // Check if file matches any of our watch paths
                     if ($this->fileMatchesWatchPaths($changedFile, $paths)) {
                         $onChange($absolutePath);
+                        $batch[] = $absolutePath;
                     }
+                }
+
+                // One save typically emits several lines — the file plus its
+                // containing directory. Handing the whole cycle over at once
+                // lets the caller sync every file and then trigger a single
+                // reload, instead of firing one per file and relying on the
+                // app to discard the extras.
+                if ($batch !== [] && $onBatch !== null) {
+                    $onBatch($batch);
                 }
             }
 
@@ -151,7 +163,9 @@ trait ManagesWatchman
                 $onTick();
             }
 
-            usleep(100_000); // 100ms
+            // Short poll: this interval is pure latency between watchman
+            // reporting a change and the file reaching the device.
+            usleep(25_000); // 25ms
         }
 
         // If we get here, the process stopped unexpectedly

--- a/src/Concerns/WatchesIos.php
+++ b/src/Concerns/WatchesIos.php
@@ -120,9 +120,12 @@ trait WatchesIos
                 $this->getIosWatchPaths(),
                 $this->getIosExcludePatterns(),
                 function (string $changedFile) use ($basePath, $destinationPath, $viteHotFile) {
-                    $this->handleIosFileChange($changedFile, $basePath, $destinationPath, $viteHotFile);
+                    $this->syncIosFile($changedFile, $basePath, $destinationPath, $viteHotFile);
                 },
                 fn () => $this->pumpWatchTerminal(),
+                function (array $changedFiles) use ($basePath, $viteHotFile) {
+                    $this->triggerIosReloadForBatch($changedFiles, $basePath, $viteHotFile);
+                },
             );
         } finally {
             // Reached when the watcher stops on its own (watchman died); the
@@ -154,6 +157,7 @@ trait WatchesIos
                     $this->handleIosFileChangeDevice($changedFile, $basePath, $target, $appId);
                 },
                 fn () => $this->pumpWatchTerminal(),
+                fn () => $this->triggerIosReload(),
             );
         } finally {
             // Reached when the watcher stops on its own (watchman died); the
@@ -174,12 +178,15 @@ trait WatchesIos
             $this->watchSynced($relativePath);
         }
 
-        // Physical devices can't reach the Vite dev server on localhost,
-        // so always trigger a full reload regardless of Vite status
-        $this->triggerIosReload();
+        // Physical devices can't reach the Vite dev server on localhost, so a
+        // full reload always applies — fired once per batch by the caller.
     }
 
-    private function handleIosFileChange(string $changedFile, string $basePath, string $destinationPath, string $viteHotFile): void
+    /**
+     * Copy one changed file into the simulator's app container. Reloading is
+     * deliberately not done here — see [triggerIosReloadForBatch].
+     */
+    private function syncIosFile(string $changedFile, string $basePath, string $destinationPath, string $viteHotFile): void
     {
         // Get relative path from source
         $relativePath = str_replace($basePath.'/', '', $changedFile);
@@ -196,13 +203,33 @@ trait WatchesIos
             copy($changedFile, $destinationFile);
             $this->watchSynced($relativePath);
         }
+    }
 
-        // Skip reload for files that Vite handles via HMR
-        if (file_exists($viteHotFile) && $this->isViteHandledIosFile($relativePath)) {
+    /**
+     * Trigger at most one reload for a whole batch of changed files, and only
+     * once every file in it has been synced.
+     *
+     * A single save usually produces several watchman events — the file plus
+     * its containing directory. Triggering per file raced the copies against
+     * the reload: the app coalesces triggers that arrive mid-reload, so the
+     * later files could be synced but never picked up.
+     */
+    private function triggerIosReloadForBatch(array $changedFiles, string $basePath, string $viteHotFile): void
+    {
+        $viteIsRunning = file_exists($viteHotFile);
+
+        foreach ($changedFiles as $changedFile) {
+            $relativePath = str_replace($basePath.'/', '', $changedFile);
+
+            // Vite owns its own HMR; a native reload would fight it.
+            if ($viteIsRunning && $this->isViteHandledIosFile($relativePath)) {
+                continue;
+            }
+
+            $this->triggerIosReload();
+
             return;
         }
-
-        $this->triggerIosReload();
     }
 
     /**


### PR DESCRIPTION
Hot reload on iOS took **~4.8s** and varied wildly — sometimes near-instant, sometimes several seconds for the same edit.

I instrumented each phase rather than guessing, and the reboot turned out never to be the problem:

| phase | before |
|---|---|
| queueWait (break PHP out of its event loop) | 2 ms |
| **`PHPQueueWorker.stopAndWait()`** | **4592 ms** |
| runtime reboot | 168 ms |
| `artisan view:clear` | 74 ms |

## Cause

`PHPQueueWorker`'s loop is:

```swift
while running {
    artisan("queue:work --once --quiet")
    Thread.sleep(3s idle / 1s after a job)   // only re-checks `running` on wake
}
```

`stopAndWait()` sets `running = false` and blocks on a semaphore — so it waits out **whatever remains of that sleep**. Every reload calls it before rebooting the runtime.

That is exactly the variance: save just before the worker wakes and the reload is quick; save just after it goes to sleep and you wait the full 3s.

## Fix

The idle wait becomes a semaphore that `stopAndWait()` signals, so a stop request ends it immediately. The only remaining wait is an in-flight `queue:work --once` pass, which shouldn't be interrupted mid-job.

**Measured on the simulator, same harness, begin → runtime ready:**

| | workerStop | total |
|---|---|---|
| before | 4592 ms | ~4836 ms |
| **after (steady state)** | **4 ms** | **388–479 ms** |
| after (worker mid-pass) | 1598 ms | 1846 ms |

Roughly **12× faster** in steady state, and the run-to-run variance is gone.

## Two related fixes to the same path

**Dropped triggers → coalesced.** A trigger arriving mid-reload was discarded outright. One save emits several watchman events (the file plus its containing directory), so the *last* file's trigger could be thrown away, leaving the app on stale code until the next save — which reads as "hot reload is flaky". A pending trigger now runs exactly one more pass when the in-flight reload finishes.

**One trigger per file → one per batch.** The watcher opened a TCP connection per changed file, racing the copies against the reload. It now syncs every file in a poll cycle and triggers once, via a new optional `onBatch` callback on `startWatchman()` (the existing `onChange` contract is unchanged, so `WatchesAndroid` is unaffected). Applied to both the simulator and physical-device paths.

The watchman poll also drops from 100 ms to 25 ms — that interval is pure latency between watchman reporting a change and the file reaching the device.

## Verification

Five consecutive saves against a live app: 5 reloads, **zero dropped triggers** (previously every save produced one), app still rendering correctly after all of them.

## Not addressed here

I also measured `artisan view:clear` and tried removing it — it costs only ~74 ms and removing it made no measurable difference, so I left it alone rather than ship an unjustified change.

There's a separate, genuine crash on this path worth its own issue: a double-free during hot reload, `abort()` in `_efree` ← `nphp_element_shutdown` ← `zm_shutdown_nativephp` ← `php_embed_shutdown`, while another thread sits in `HotReloadCoordinator.reload()` → `reboot()` → `persistent_php_shutdown`. This PR reduces exposure (far less time spent in that window) but does not fix the race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)