### PR TITLE
feat: expose stored navigation configs on CallbackRegistry

### DIFF
--- a/src/Edge/CallbackRegistry.php
+++ b/src/Edge/CallbackRegistry.php
@@ -169,6 +169,19 @@ class CallbackRegistry
     }
 
     /**
+     * All stored navigation configs, keyed by content-addressed key —
+     * the introspection counterpart to expressions(). Re-registering a
+     * config recomputes the identical key, so consumers (tooling, the
+     * testing harness) can enumerate exactly what a render registered.
+     *
+     * @return array<string, array>
+     */
+    public function navigations(): array
+    {
+        return $this->navigationConfigs;
+    }
+
+    /**
      * Parse a `method('arg', ...)` expression into method + literal args.
      * Public because NativeComponent::emit() reuses it for tag-level
      * `@event="method(...)"` bindings on child-component tags.

--- a/tests/Unit/Edge/CallbackRegistryTest.php
+++ b/tests/Unit/Edge/CallbackRegistryTest.php
@@ -61,3 +61,12 @@ it('derives distinct ids for the same expression under different scopes', functi
         // Same scope reproduces the same id — determinism survives scoping.
         ->and((new CallbackRegistry('card|key:a'))->register('bump'))->toBe($ids[1]);
 });
+
+it('exposes stored navigation configs keyed by stable content-addressed keys', function () {
+    $r = new CallbackRegistry;
+    $key = $r->registerNavigation(['uri' => '/detail/7']);
+
+    expect($r->navigations())->toBe([$key => ['uri' => '/detail/7']])
+        // Same config re-registered anywhere reproduces the identical key.
+        ->and((new CallbackRegistry)->registerNavigation(['uri' => '/detail/7']))->toBe($key);
+});


### PR DESCRIPTION
## What
`navigations()` — the introspection counterpart to the existing `expressions()`: enumerate the navigation configs a render registered, keyed by the stable content-addressed key.

## Why
`expressions()` already exists for the testing harness; navigation configs had no equivalent. Re-registering the same config reproduces the identical key (covered by the new test), so tooling and tests can assert on registered navigation without reaching into internals.

## Testing
New case in `CallbackRegistryTest`; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTcfKtsVapKiGfSKwKT69y