### PR TITLE
feat: NativeRouteFallback — apps decide what a browser sees on native routes

### DIFF
--- a/src/Edge/Contracts/NativeRouteFallback.php
+++ b/src/Edge/Contracts/NativeRouteFallback.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Native\Mobile\Edge\Contracts;
+
+/**
+ * App-decided response for a native route reached WITHOUT a native
+ * runtime — a shared app link opened in a plain desktop browser, a
+ * crawler, a misconfigured deploy. Those requests can't be satisfied by
+ * the runloop (there is no device attached to them), so left unbound
+ * they behave exactly as before; bind an implementation to show
+ * something useful instead — a landing page, an app-store redirect, a
+ * QR handoff to the phone:
+ *
+ *     $this->app->singleton(NativeRouteFallback::class, StoreRedirect::class);
+ */
+interface NativeRouteFallback
+{
+    /**
+     * Answer the current request for a native screen route.
+     *
+     * @return mixed a response or renderable
+     */
+    public function handle(string $componentClass);
+}

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -37,6 +37,7 @@ use Native\Mobile\Commands\ValidateCommand;
 use Native\Mobile\Commands\VersionCommand;
 use Native\Mobile\Commands\WatchCommand;
 use Native\Mobile\Edge\ComponentRegistry;
+use Native\Mobile\Edge\Contracts\NativeRouteFallback;
 use Native\Mobile\Edge\ElementRegistry;
 use Native\Mobile\Edge\Elements;
 use Native\Mobile\Edge\NativeComponent;
@@ -305,6 +306,17 @@ class NativeServiceProvider extends PackageServiceProvider
             NativeRouter::register($uri, $componentClass);
 
             return Route::get($uri, function () use ($componentClass) {
+                // Native route reached without a native runtime — a shared
+                // app link opened in a plain browser, a crawler, a
+                // misconfigured deploy. The runloop can never satisfy these
+                // (no device is attached to the request), so if the app
+                // bound a fallback, let it answer (landing page, app-store
+                // redirect). Unbound, everything below is unchanged.
+                if (! env('NATIVEPHP_RUNNING') && ! config('nativephp-internal.running')
+                    && app()->bound(NativeRouteFallback::class)) {
+                    return app(NativeRouteFallback::class)->handle($componentClass);
+                }
+
                 // HTTP feature tests ($this->get('/')) must never enter the
                 // runloop: it blocks in wait_event against the REAL bridge —
                 // with a live Jump session that's ~90s of reconnect spinning

--- a/tests/Feature/NativeRouteFallbackTest.php
+++ b/tests/Feature/NativeRouteFallbackTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Native\Mobile\Edge\Contracts\NativeRouteFallback;
+use Native\Mobile\Edge\NativeRouter;
+use Tests\Fixtures\Edge\CounterScreen;
+
+beforeEach(fn () => NativeRouter::clearRoutes());
+afterEach(fn () => NativeRouter::clearRoutes());
+
+it('lets a bound fallback answer a native route reached without a runtime', function () {
+    Route::native('/counter-fallback', CounterScreen::class);
+
+    app()->singleton(NativeRouteFallback::class, fn () => new class implements NativeRouteFallback
+    {
+        public function handle(string $componentClass)
+        {
+            return response('Get the app to view '.class_basename($componentClass), 200);
+        }
+    });
+
+    $this->get('/counter-fallback')
+        ->assertOk()
+        ->assertSee('Get the app to view CounterScreen');
+});
+
+it('changes nothing when no fallback is bound', function () {
+    // Clean container — another package may have bound a fallback.
+    unset(app()[NativeRouteFallback::class]);
+
+    Route::native('/counter-plain', CounterScreen::class);
+
+    $this->get('/counter-plain')
+        ->assertOk()
+        ->assertSee('test it with Native::test()');
+});

--- a/tests/Feature/NativeRouteHttpTest.php
+++ b/tests/Feature/NativeRouteHttpTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Native\Mobile\Edge\Contracts\NativeRouteFallback;
 use Native\Mobile\Edge\NativeRouter;
 use Native\Mobile\Testing\Native;
 use Tests\Fixtures\Edge\CounterScreen;
@@ -15,6 +16,10 @@ afterEach(function () {
 });
 
 it('answers native routes with a stub response instead of entering the runloop', function () {
+    // This asserts the UNBOUND default — a package may have bound a
+    // NativeRouteFallback, which takes precedence over the stub.
+    unset(app()[NativeRouteFallback::class]);
+
     Route::native('/native-home', CounterScreen::class);
 
     $this->get('/native-home')


### PR DESCRIPTION
## What
A native route reached **without a native runtime** — a shared app link opened in a desktop browser, a crawler, a misconfigured deploy — can never be satisfied by the runloop: no device is attached to the request. Today those requests fall into the runloop anyway and hang against the bridge.

This adds `Edge\Contracts\NativeRouteFallback`: if the app binds it, the handler answers those requests (a landing page, an app-store redirect, a QR handoff to the phone). **Unbound, behavior is byte-for-byte unchanged** — Jump, tests, and devices are unaffected.

```php
$this->app->singleton(NativeRouteFallback::class, StoreRedirect::class);
```

## Testing
New `NativeRouteFallbackTest` (bound handler answers; unbound default unchanged). The existing route smoke test gains an explicit "assert the unbound default" guard since a package may bind a fallback. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTcfKtsVapKiGfSKwKT69y