### PR TITLE
feat: plugin-registered element attribute capture

### DIFF
--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -101,6 +101,41 @@ class NativeElementCollector
      */
     protected static array $textFrames = [];
 
+    /**
+     * Plugin-registered attribute capture.
+     *
+     * Lets a package ship a custom Blade attribute that works on ANY
+     * element — e.g. an analytics plugin capturing `track="signup-cta"`
+     * into a prop its device SDK reads — without every Element subclass
+     * having to know about it. Registered attributes are lifted into
+     * props in createElement() and stripped before native attribute
+     * handling, so they never leak onto the wire as junk.
+     *
+     * The reserved name 'class' captures the author's RAW class string
+     * as written (Tailwind parsing still runs and is unaffected) — for
+     * tooling that wants the classes themselves rather than the parsed
+     * layout they produce.
+     *
+     * @var array<string, string> attribute name => prop name
+     */
+    protected static array $capturedAttributes = [];
+
+    public static function captureAttribute(string $attribute, string $prop): void
+    {
+        static::$capturedAttributes[$attribute] = $prop;
+    }
+
+    /** @return array<string, string> */
+    public static function capturedAttributes(): array
+    {
+        return static::$capturedAttributes;
+    }
+
+    public static function stopCapturingAttributes(): void
+    {
+        static::$capturedAttributes = [];
+    }
+
     // ── Streaming control ────────────────────────────
 
     public static function setStreaming(bool $enabled): void
@@ -1142,6 +1177,9 @@ class NativeElementCollector
 
     protected static function createElement(string $type, array $attrs): Element
     {
+        // Raw-class capture happens BEFORE parsing consumes the attribute.
+        $rawClass = isset(static::$capturedAttributes['class']) ? ($attrs['class'] ?? null) : null;
+
         // Parse Tailwind classes into attribute array
         if (isset($attrs['class'])) {
             $classAttrs = TailwindParser::parse($attrs['class']);
@@ -1177,6 +1215,25 @@ class NativeElementCollector
             default => ElementRegistry::resolve($type)
                 ?? throw new \RuntimeException("Unknown native element type: {$type}"),
         };
+
+        if ($rawClass !== null) {
+            $element->setProp(static::$capturedAttributes['class'], $rawClass);
+        }
+
+        // Registered capture attributes: lift into props, strip from the
+        // attrs the native pipeline sees. Empty strings are stripped but
+        // not captured — an attribute left blank means "not set".
+        foreach (static::$capturedAttributes as $attribute => $prop) {
+            if ($attribute === 'class' || ! isset($attrs[$attribute])) {
+                continue;
+            }
+
+            if (! is_string($attrs[$attribute]) || $attrs[$attribute] !== '') {
+                $element->setProp($prop, $attrs[$attribute]);
+            }
+
+            unset($attrs[$attribute]);
+        }
 
         // Let plugin elements apply their own attributes
         $element->applyAttributes($attrs);

--- a/tests/Unit/Edge/CapturedAttributesTest.php
+++ b/tests/Unit/Edge/CapturedAttributesTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\NativeElementCollector;
+
+beforeEach(function () {
+    NativeElementCollector::reset();
+    NativeElementCollector::stopCapturingAttributes();
+});
+
+afterEach(function () {
+    NativeElementCollector::reset();
+    NativeElementCollector::stopCapturingAttributes();
+});
+
+function capturedTree(string $type, array $attrs): array
+{
+    NativeElementCollector::leaf($type, $attrs);
+
+    return NativeElementCollector::collect()->toArray(new CallbackRegistry);
+}
+
+it('lifts a registered attribute into a prop and strips it from the element', function () {
+    NativeElementCollector::captureAttribute('track', 'analytics_id');
+
+    $tree = capturedTree('text', ['text' => 'Sign up', 'track' => 'signup-cta']);
+
+    expect($tree['props']['analytics_id'] ?? null)->toBe('signup-cta')
+        ->and($tree['props'])->not->toHaveKey('track');
+});
+
+it('ignores unregistered attributes entirely', function () {
+    $tree = capturedTree('text', ['text' => 'Sign up', 'track' => 'signup-cta']);
+
+    expect($tree['props'] ?? [])->not->toHaveKey('analytics_id');
+});
+
+it('captures the raw class string without disturbing Tailwind parsing', function () {
+    NativeElementCollector::captureAttribute('class', 'raw_class');
+
+    $tree = capturedTree('text', ['text' => 'x', 'class' => 'flex-1 p-4']);
+
+    // The raw string is preserved AND the classes still parsed to layout.
+    expect($tree['props']['raw_class'] ?? null)->toBe('flex-1 p-4')
+        ->and($tree['layout']['flex_grow'] ?? $tree['layout']['padding'] ?? null)->not->toBeNull();
+});
+
+it('strips but does not capture empty string values', function () {
+    NativeElementCollector::captureAttribute('track', 'analytics_id');
+
+    $tree = capturedTree('text', ['text' => 'x', 'track' => '']);
+
+    expect($tree['props'] ?? [])->not->toHaveKey('analytics_id')
+        ->and($tree['props'] ?? [])->not->toHaveKey('track');
+});


### PR DESCRIPTION
## What
`NativeElementCollector::captureAttribute($attribute, $prop)` — packages can ship a custom Blade attribute that works on **any** element, lifted into a prop and stripped before native attribute handling:

```php
// an analytics plugin:
NativeElementCollector::captureAttribute('track', 'analytics_id');
```
```blade
<native:button text="Sign up" track="signup-cta" />
```

Without this, a plugin attribute only works on elements whose `Element` subclass explicitly handles it, and unknown attributes leak through as junk.

The reserved name `class` captures the author's **raw class string** as written (Tailwind parsing still runs and is unaffected) — for tooling that wants the classes themselves rather than the parsed layout they produce.

## Testing
New `CapturedAttributesTest`: capture + strip, unregistered attributes untouched, raw-class capture alongside normal parsing, empty-string semantics. Full suite green. No behavior change when nothing is registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KTcfKtsVapKiGfSKwKT69y