### PR TITLE
Make the Android plugin dependency block marker-delimited, so build.gradle.kts stops growing a comment per build

### DIFF
--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -1361,56 +1361,122 @@ KOTLIN;
     }
 
     /**
-     * Add Gradle dependencies from plugins
+     * Declare each plugin's Android dependencies in the app module's
+     * dependencies {} block, inside a marker-delimited block rebuilt on every
+     * compile — the same shape as injectGradlePlugins() and the proguard
+     * rules block. Declared from `android.dependencies` in nativephp.json.
+     *
+     * Before this was marker-delimited, every compile appended a fresh
+     * "// NativePHP Plugin Dependencies" header: the dependency lines under
+     * it were guarded against duplication, the header was not. A project
+     * built a few hundred times accumulates a few hundred header comments,
+     * and — more importantly than the noise — its build.gradle.kts is a
+     * different file after every build, so nothing downstream of it can be
+     * reproducible. Those stale headers are removed here as well.
      */
     protected function addGradleDependencies(Collection $plugins): void
     {
         $buildGradlePath = $this->androidProjectPath.'/app/build.gradle.kts';
         $buildGradle = $this->files->get($buildGradlePath);
 
+        $original = $buildGradle;
+
+        // Drop headers written by versions that did not delimit the block.
+        // Comments only: the dependency lines an earlier build wrote are
+        // valid declarations and are left exactly where they are, which is
+        // also what keeps buildGradleDependenciesBlock() from declaring them
+        // a second time.
+        $buildGradle = preg_replace(
+            '/\n[ \t]*\/\/ NativePHP Plugin Dependencies[ \t]*(?=\n)/',
+            '',
+            $buildGradle
+        );
+
+        $begin = '// BEGIN nativephp-plugin-dependencies';
+        $end = '// END nativephp-plugin-dependencies';
+
+        $block = $this->buildGradleDependenciesBlock($plugins, $buildGradle);
+
+        if (str_contains($buildGradle, $begin) && str_contains($buildGradle, $end)) {
+            $buildGradle = preg_replace(
+                '/[ \t]*'.preg_quote($begin, '/').'.*?'.preg_quote($end, '/').'\n?/s',
+                $block,
+                $buildGradle,
+                1
+            );
+        } elseif ($block !== '') {
+            $buildGradle = preg_replace(
+                '/(dependencies\s*\{[ \t]*\r?\n)/s',
+                '$1'.$block,
+                $buildGradle,
+                1
+            );
+        }
+
+        if ($buildGradle === $original) {
+            return;
+        }
+
+        $this->files->put($buildGradlePath, $buildGradle);
+    }
+
+    /**
+     * Build the marker-delimited dependency declarations. Pure (no IO on the
+     * android project) so it is unit-testable. Returns '' when no plugin
+     * declares anything. $existingContent is used to skip coordinates the
+     * build file already declares outside our markers.
+     */
+    public function buildGradleDependenciesBlock(Collection $plugins, string $existingContent = ''): string
+    {
+        // What the build file declares outside our own block. Our block is
+        // excluded, or a rebuild would consider everything it wrote last time
+        // "already present" and emit an empty block.
+        $outside = $existingContent === '' ? '' : (preg_replace(
+            '/\/\/ BEGIN nativephp-plugin-dependencies.*?\/\/ END nativephp-plugin-dependencies/s',
+            '',
+            $existingContent
+        ) ?? $existingContent);
+
         $dependenciesByType = [];
 
         foreach ($plugins as $plugin) {
-            $androidDeps = $plugin->getAndroidDependencies();
-
-            foreach ($androidDeps as $type => $libraries) {
-                if (! isset($dependenciesByType[$type])) {
-                    $dependenciesByType[$type] = [];
-                }
+            foreach ($plugin->getAndroidDependencies() as $type => $libraries) {
                 foreach ($libraries as $library) {
                     $dependenciesByType[$type][] = $library;
                 }
             }
         }
 
-        if (empty($dependenciesByType)) {
-            return;
-        }
+        $lines = [];
 
-        // Find dependencies block and add new ones
-        $dependencyBlock = "\n    // NativePHP Plugin Dependencies\n";
         foreach ($dependenciesByType as $type => $libraries) {
             foreach (array_unique($libraries) as $dep) {
-                if (! str_contains($buildGradle, $dep)) {
-                    // Handle platform() BOMs specially - they need platform() outside the quotes
-                    if (preg_match('/^platform\((.+)\)$/', $dep, $matches)) {
-                        $dependencyBlock .= "    {$type}(platform(\"{$matches[1]}\"))\n";
-                    } else {
-                        $dependencyBlock .= "    {$type}(\"{$dep}\")\n";
-                    }
+                // Handle platform() BOMs specially - they need platform() outside the quotes
+                $isBom = (bool) preg_match('/^platform\((.+)\)$/', $dep, $matches);
+                $coordinate = $isBom ? $matches[1] : $dep;
+
+                // Compare on the coordinate rather than on the declaration:
+                // a BOM arrives as `platform(group:artifact:version)` and is
+                // written as `platform("group:artifact:version")`, so testing
+                // the raw form never matched and every build re-declared it.
+                if ($outside !== '' && str_contains($outside, $coordinate)) {
+                    continue;
                 }
+
+                $lines[] = $isBom
+                    ? "    {$type}(platform(\"{$coordinate}\"))"
+                    : "    {$type}(\"{$coordinate}\")";
             }
         }
 
-        // Insert into dependencies block
-        $buildGradle = preg_replace(
-            '/(dependencies\s*\{)/s',
-            '$1'.$dependencyBlock,
-            $buildGradle,
-            1
-        );
+        if (empty($lines)) {
+            return '';
+        }
 
-        $this->files->put($buildGradlePath, $buildGradle);
+        return "    // BEGIN nativephp-plugin-dependencies\n"
+            ."    // Auto-generated on every build from installed plugins — do not edit.\n"
+            .implode("\n", $lines)."\n"
+            ."    // END nativephp-plugin-dependencies\n";
     }
 
     /**

--- a/tests/Feature/Plugins/AndroidCompilerTest.php
+++ b/tests/Feature/Plugins/AndroidCompilerTest.php
@@ -502,6 +502,182 @@ object TestFunctions {
     /**
      * @test
      *
+     * The dependency block is marker-delimited and rewritten in full, so a
+     * project that is built repeatedly does not grow a header per build.
+     *
+     * The individual dependency lines were already guarded against
+     * duplication; the header comment above them was not, so it was appended
+     * on every single compile.
+     */
+    public function it_does_not_accumulate_a_dependency_header_per_build(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'dependencies' => [
+                    'implementation' => ['com.example:library:1.0.0'],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$plugin]));
+
+        $gradlePath = $this->testBasePath.'/android/app/build.gradle.kts';
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->compiler->compile();
+        }
+
+        $content = $this->files->get($gradlePath);
+
+        $this->assertEquals(1, substr_count($content, 'BEGIN nativephp-plugin-dependencies'));
+        $this->assertEquals(1, substr_count($content, 'END nativephp-plugin-dependencies'));
+        $this->assertStringNotContainsString('// NativePHP Plugin Dependencies', $content);
+    }
+
+    /**
+     * @test
+     *
+     * Two consecutive compiles with nothing changed in between leave
+     * build.gradle.kts byte-identical. Without that, no build downstream of
+     * it can be reproducible.
+     */
+    public function it_leaves_the_build_file_byte_identical_across_compiles(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'dependencies' => [
+                    'implementation' => ['com.example:library:1.0.0'],
+                    'api' => ['com.example:api-lib:2.0.0'],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$plugin]));
+
+        $gradlePath = $this->testBasePath.'/android/app/build.gradle.kts';
+
+        $this->compiler->compile();
+        $after = $this->files->get($gradlePath);
+
+        $this->compiler->compile();
+        $this->compiler->compile();
+
+        $this->assertSame($after, $this->files->get($gradlePath));
+    }
+
+    /**
+     * @test
+     *
+     * Headers left behind by a version that did not delimit the block are
+     * removed, so upgrading cleans a project up rather than freezing its
+     * existing pile in place.
+     */
+    public function it_removes_headers_left_by_an_earlier_version(): void
+    {
+        $gradlePath = $this->testBasePath.'/android/app/build.gradle.kts';
+
+        $this->files->put($gradlePath, str_replace(
+            "dependencies {\n",
+            "dependencies {\n".str_repeat("\n    // NativePHP Plugin Dependencies\n", 12),
+            $this->files->get($gradlePath)
+        ));
+
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'dependencies' => [
+                    'implementation' => ['com.example:library:1.0.0'],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $content = $this->files->get($gradlePath);
+
+        $this->assertStringNotContainsString('// NativePHP Plugin Dependencies', $content);
+        $this->assertStringContainsString('implementation("com.example:library:1.0.0")', $content);
+    }
+
+    /**
+     * @test
+     *
+     * A platform() BOM is declared once. The presence check compared the raw
+     * `platform(group:artifact:version)` form against a file that holds
+     * `platform("group:artifact:version")`, so it never matched and every
+     * build declared the BOM again.
+     */
+    public function it_declares_a_platform_bom_once(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'dependencies' => [
+                    'implementation' => ['platform(com.google.firebase:firebase-bom:33.1.0)'],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+        $this->compiler->compile();
+        $this->compiler->compile();
+
+        $content = $this->files->get($this->testBasePath.'/android/app/build.gradle.kts');
+
+        $this->assertEquals(
+            1,
+            substr_count($content, 'platform("com.google.firebase:firebase-bom:33.1.0")')
+        );
+    }
+
+    /**
+     * @test
+     *
+     * A dependency the app already declares by hand is not declared a second
+     * time inside the generated block.
+     */
+    public function it_does_not_redeclare_a_dependency_the_app_already_has(): void
+    {
+        $gradlePath = $this->testBasePath.'/android/app/build.gradle.kts';
+
+        $this->files->put($gradlePath, str_replace(
+            "dependencies {\n",
+            "dependencies {\n    implementation(\"com.example:library:1.0.0\")\n",
+            $this->files->get($gradlePath)
+        ));
+
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'dependencies' => [
+                    'implementation' => ['com.example:library:1.0.0'],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry
+            ->shouldReceive('all')
+            ->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $content = $this->files->get($gradlePath);
+
+        $this->assertEquals(1, substr_count($content, 'com.example:library:1.0.0'));
+    }
+
+    /**
+     * @test
+     *
      * Should clean generated plugin files.
      */
     public function it_cleans_generated_files(): void


### PR DESCRIPTION
## What goes wrong

`AndroidPluginCompiler::addGradleDependencies()` guards the dependency lines against duplication and does not guard the comment above them:

```php
$dependencyBlock = "\n    // NativePHP Plugin Dependencies\n";   // always added
foreach (...) {
    if (! str_contains($buildGradle, $dep)) {                    // lines: guarded
        $dependencyBlock .= "    {$type}(\"{$dep}\")\n";
    }
}
$buildGradle = preg_replace('/(dependencies\s*\{)/s', '$1'.$dependencyBlock, $buildGradle, 1);
```

So from the second compile onwards the block is a bare header, and it is appended anyway. One header per build, forever.

This is not hypothetical. In a project that has been developed against for a few weeks:

```
$ grep -c '// NativePHP Plugin Dependencies' nativephp/android/app/build.gradle.kts
165
$ wc -l nativephp/android/app/build.gradle.kts
566
```

330 of those 566 lines are the header and the blank line in front of it.

It looks cosmetic and it is not. **`build.gradle.kts` is a different file after every build**, so nothing downstream of it can be reproducible, and a check that watches only `AndroidManifest.xml` — which genuinely does not move — reports "idempotent" while this grows underneath it. That is how it went unnoticed for so long on our side: five consecutive builds left the manifest byte-identical every time, and `build.gradle.kts` had moved on every one of them.

## Reproduction

No device, no Gradle, no Android Studio — the append happens in PHP, before `gradlew` is ever invoked.

```bash
./reproduce-gradle-dependencies.sh /tmp/repro
```

The script (below, collapsed) creates a clean Laravel app, installs `nativephp/mobile:^4.0`, adds a one-dependency plugin, and runs `AndroidPluginCompiler::compile()` five times with nothing changed in between. On `main`:

```
after compile 1: 1 header(s), md5 69402407f08da6606206da83d8a0c810
after compile 2: 2 header(s), md5 6a74b4be80d3e6ff03334b0e665cda15
after compile 3: 3 header(s), md5 f39da1ecd87ff36b193b28aba151c1e8
after compile 4: 4 header(s), md5 c9024d2fb7422897d9a27d900dd3aa2a
after compile 5: 5 header(s), md5 70dc4393786dc4e169c83915ec43b857
```

## The fix

The block is delimited and rewritten in full on every compile — the same shape `injectGradlePlugins()` and `buildPluginProguardBlock()` already use, one method away in the same file. `addGradleDependencies` simply predates them.

```kotlin
dependencies {
    // BEGIN nativephp-plugin-dependencies
    // Auto-generated on every build from installed plugins — do not edit.
    implementation("com.example:library:1.0.0")
    // END nativephp-plugin-dependencies
```

Headers written by earlier versions are removed, so upgrading cleans a project up rather than freezing its existing pile in place. Only the comments are removed: the dependency lines an earlier build wrote are valid declarations, they are left exactly where they are, and the presence check then treats them as already declared rather than declaring them twice.

Two smaller things came out of the same read and are in this PR because they are the same three lines:

- **A `platform()` BOM was re-declared on every build.** The presence check compared the raw `platform(group:artifact:version)` form against a file that holds `platform("group:artifact:version")`, so it never matched. It now compares on the coordinate. Anyone shipping a Firebase BOM through a plugin has been accumulating real declarations, not just comments.
- **The build file is only written when it actually changed.**

## Tests

`tests/Feature/Plugins/AndroidCompilerTest.php`, five new cases. Four of them fail on `main`:

| Test | on `main` |
|---|---|
| `it_does_not_accumulate_a_dependency_header_per_build` | ✗ 5 headers after 5 compiles |
| `it_leaves_the_build_file_byte_identical_across_compiles` | ✗ |
| `it_removes_headers_left_by_an_earlier_version` | ✗ |
| `it_declares_a_platform_bom_once` | ✗ 3 declarations after 3 compiles |
| `it_does_not_redeclare_a_dependency_the_app_already_has` | ✓ regression guard |

```
Tests:  812 passed   (main: 807 passed)
```

The two `ReleaseBuildBundleTest` failures in my run are present on `main` as well and are a `ZipArchive` environment issue on this machine, not related to this change.

`vendor/bin/pint --dirty` is clean.

## Not in this PR

Stated plainly so the scope is not read as larger than it is.

- **The dependency lines an earlier version left outside the markers stay there.** They are correct, Gradle-valid declarations and removing them would mean deleting lines this compiler cannot prove it wrote. The accumulation stops and the build file becomes stable; it does not become tidy in one step. Adopting them into the block is possible but it is a judgement call about editing a user's build file, so it is left to you.
- **No change to `injectGradlePlugins` or the proguard block.** They already do this correctly; this PR only brings the third one into line.
- **`ext-zip`-related test failures on `main`** are untouched.


<details>
<summary>Reproduction script</summary>

```bash
#!/usr/bin/env bash
#
# Reproduce: every Android plugin compile appends another
# "// NativePHP Plugin Dependencies" comment to the app module's
# build.gradle.kts, so the file is different after every build and a project
# that has been built a few hundred times holds a few hundred copies.
#
# Runs on Linux. It needs no device and no Gradle: the append happens in PHP,
# in AndroidPluginCompiler::addGradleDependencies(), long before gradlew.
#
# Usage: ./reproduce-gradle-dependencies.sh /path/to/empty/dir
set -euo pipefail

WORK="${1:?usage: reproduce-gradle-dependencies.sh <empty-dir>}"
mkdir -p "$WORK"
cd "$WORK"

# ---------------------------------------------------------------- 1. clean app
composer create-project laravel/laravel app --no-interaction --quiet
cd app
composer require nativephp/mobile:^4.0 --no-interaction --quiet

# ------------------------------------------- 2. a plugin with one dependency
#
# One `android.dependencies` entry is enough. Its coordinate is guarded against
# duplication; the comment above it is not.
PLUGIN=packages/acme-dep
mkdir -p "$PLUGIN/src" "$PLUGIN/resources/android"

cat > "$PLUGIN/composer.json" <<'JSON'
{
    "name": "acme/dep",
    "version": "1.0.0",
    "type": "nativephp-plugin",
    "autoload": { "psr-4": { "Acme\\Dep\\": "src/" } },
    "extra": { "laravel": { "providers": ["Acme\\Dep\\DepServiceProvider"] } }
}
JSON

cat > "$PLUGIN/nativephp.json" <<'JSON'
{
    "name": "acme/dep",
    "namespace": "Dep",
    "android": {
        "dependencies": {
            "implementation": ["com.squareup.okio:okio:3.9.0"]
        }
    },
    "bridge_functions": [
        { "name": "Dep.Ping", "android": "com.acme.dep.DepFunctions.Ping" }
    ]
}
JSON

cat > "$PLUGIN/src/DepServiceProvider.php" <<'PHP'
<?php

namespace Acme\Dep;

use Illuminate\Support\ServiceProvider;

class DepServiceProvider extends ServiceProvider {}
PHP

cat > "$PLUGIN/resources/android/DepFunctions.kt" <<'KOTLIN'
package com.acme.dep

import android.content.Context

object DepFunctions {
    class Ping(private val context: Context) {
        fun handle(): Map<String, Any> = mapOf("pong" to true)
    }
}
KOTLIN

php -r '
$f = "composer.json";
$j = json_decode(file_get_contents($f), true);
$j["repositories"] = [["type" => "path", "url" => "packages/acme-dep", "options" => ["symlink" => false]]];
$j["require"]["acme/dep"] = "*";
file_put_contents($f, json_encode($j, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
'
composer update acme/dep --no-interaction --quiet

php artisan vendor:publish --tag=nativephp-plugins-provider --quiet
php artisan native:plugin:register acme/dep --quiet

# ------------------------------------------- 3. scaffold the Android project
# What InstallsAndroid does, minus the PHP binaries, which take no part here.
php -r '
mkdir("nativephp/android", 0755, true);
$src = "vendor/nativephp/mobile/resources/androidstudio";
$it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($src, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::SELF_FIRST);
foreach ($it as $item) {
    $dest = "nativephp/android/" . substr($item->getPathname(), strlen($src) + 1);
    $item->isDir() ? @mkdir($dest, 0755, true) : copy($item->getPathname(), $dest);
}
'

# ------------------------------------------- 4. compile five times over
# The same call AndroidPluginCompiler makes during a build. Nothing changes
# between the runs — no source edit, no manifest edit, nothing.
for i in 1 2 3 4 5; do
    php -r '
    require "vendor/autoload.php";
    $app = require "bootstrap/app.php";
    $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
    $app->make(Native\Mobile\Plugins\Compilers\AndroidPluginCompiler::class)->compile();
    ' >/dev/null
    printf 'after compile %d: %s header(s), md5 %s\n' \
        "$i" \
        "$(grep -c '// NativePHP Plugin Dependencies' nativephp/android/app/build.gradle.kts || true)" \
        "$(md5sum nativephp/android/app/build.gradle.kts | cut -d' ' -f1)"
done

echo
echo "=== the dependencies block ==="
sed -n '/^dependencies {/,/^}/p' nativephp/android/app/build.gradle.kts
```

</details>
