### PR TITLE
Serialise every lane's php_embed_init: two concurrent boots SIGSEGV the process

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
@@ -130,6 +130,34 @@ class PHPBridge(private val context: Context) {
         @Volatile
         private var persistentBooted = false
 
+        /**
+         * Every `php_embed_init` / `php_embed_shutdown` in this process runs
+         * under this lock, whichever lane asks for it.
+         *
+         * `php_embed_init` is process-global however many TSRM contexts the
+         * lanes end up owning: it walks the module registry and allocates
+         * thread-resource ids, and two of them running at once corrupt that
+         * state rather than sharing it. Two concurrent boots SEGV inside
+         * `ts_allocate_fast_id` → `tsrm_update_active_threads` →
+         * `cwd_globals_ctor` → `_emalloc`, and the crash takes the whole
+         * process down — including the activity that was booting.
+         *
+         * The persistent lane has always taken this lock (see
+         * `LaravelEnvironment.extractionLock`, whose comment describes the
+         * same hazard against the classic embed cycles). The worker lane, the
+         * webview lane and the ephemeral lane did not, and the ephemeral one
+         * has no wrapper at all — a plugin reaches it through the raw
+         * `nativeEphemeralBoot` external. A background job starting while the
+         * user opens the app is not an unusual moment; for anything shipping
+         * a widget, a shortcut or a notification it is the normal one.
+         *
+         * Held across boot *and* shutdown, because a shutdown landing in the
+         * middle of another lane's boot is the same collision from the other
+         * side. Not held for the life of a runtime: the lanes are built to
+         * run concurrently once they exist, and they do.
+         */
+        internal val embedLifecycleLock = LaravelEnvironment.extractionLock
+
         init {
             System.loadLibrary("php_wrapper")
         }
@@ -247,7 +275,9 @@ class PHPBridge(private val context: Context) {
         }
 
         val future = phpExecutor.submit<Unit> {
-            nativePersistentShutdown()
+            embedLifecycleLock.withLock {
+                nativePersistentShutdown()
+            }
             persistentBooted = false
             Log.i(TAG, "Persistent runtime shut down")
         }
@@ -279,7 +309,7 @@ class PHPBridge(private val context: Context) {
      * Boot the worker PHP runtime on a dedicated TSRM context.
      * Does NOT use phpExecutor — no contention with UI requests.
      */
-    fun bootWorkerRuntime(): Boolean {
+    fun bootWorkerRuntime(): Boolean = embedLifecycleLock.withLock {
         ensureRuntimeInitialized()
         val result = nativeWorkerBoot(workerBootstrapScript)
         if (result == 0) {
@@ -301,9 +331,57 @@ class PHPBridge(private val context: Context) {
     /**
      * Shut down the worker runtime.
      */
-    fun shutdownWorkerRuntime() {
+    fun shutdownWorkerRuntime() = embedLifecycleLock.withLock {
         nativeWorkerShutdown()
         Log.i(TAG, "Worker runtime shut down")
+    }
+
+    /**
+     * Boot the ephemeral PHP runtime — the generic background TSRM context
+     * documented for plugin use, and the lane a WorkManager job takes when it
+     * started the process after the app was killed.
+     *
+     * Runs on the caller's thread and must: `ephemeral_embed_init` does
+     * `ts_resource(0)` on whichever thread calls it and the shutdown does
+     * `ts_free_thread()`, so boot, run and shutdown all belong to one thread.
+     * Callers are expected to own a single-thread lane for that reason.
+     *
+     * Prefer this over calling [nativeEphemeralBoot] directly: the raw
+     * external does not serialise against the other lanes' `php_embed_init`,
+     * and a background job booting at the same moment as a cold app launch
+     * SEGVs the process. See [embedLifecycleLock].
+     */
+    fun bootEphemeralRuntime(bootstrapPath: String = persistentBootstrapScript): Boolean =
+        embedLifecycleLock.withLock {
+            ensureRuntimeInitialized()
+            val result = nativeEphemeralBoot(bootstrapPath)
+            if (result == 0) {
+                Log.i(TAG, "Ephemeral runtime booted")
+            } else {
+                Log.e(TAG, "Ephemeral runtime boot FAILED (code=$result)")
+            }
+            return result == 0
+        }
+
+    /**
+     * Run an artisan command through the ephemeral interpreter. The lane has
+     * no dispatch: an artisan command is how background PHP is reached.
+     *
+     * Deliberately not under [embedLifecycleLock] — the command is the work,
+     * it can run for minutes, and holding the lock would make every other
+     * lane (a cold app launch among them) wait for it. Only the init and the
+     * shutdown have to be exclusive.
+     */
+    fun runEphemeralArtisan(command: String): String = nativeEphemeralArtisan(command)
+
+    /**
+     * Shut the ephemeral runtime down. Always — an ephemeral runtime left
+     * booted by a background job is a `php_embed_init` the user's next app
+     * launch has to survive.
+     */
+    fun shutdownEphemeralRuntime() = embedLifecycleLock.withLock {
+        nativeEphemeralShutdown()
+        Log.i(TAG, "Ephemeral runtime shut down")
     }
 
     fun handleLaravelRequest(request: PHPRequest): String {

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/WebviewPHPRuntime.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/WebviewPHPRuntime.kt
@@ -223,7 +223,9 @@ class WebviewPHPRuntime(private val bridge: PHPBridge) {
 
         executor.execute {
             if (booted) {
-                bridge.nativeWebviewPhpShutdown()
+                PHPBridge.embedLifecycleLock.withLock {
+                    bridge.nativeWebviewPhpShutdown()
+                }
                 booted = false
                 Log.i(TAG, "context released")
             }
@@ -247,7 +249,13 @@ class WebviewPHPRuntime(private val bridge: PHPBridge) {
             return
         }
 
-        val rc = bridge.nativeWebviewPhpBoot(bridge.webviewBootstrapScript)
+        // Serialised against every other lane's php_embed_init. The comment
+        // above describes this collision for the persistent reboot only; the
+        // worker and ephemeral lanes can arrive at the same moment and are
+        // not covered by `rebootInFlight`.
+        val rc = PHPBridge.embedLifecycleLock.withLock {
+            bridge.nativeWebviewPhpBoot(bridge.webviewBootstrapScript)
+        }
         booted = rc == 0
         // Leave the door open on failure — the next request retries rather
         // than leaving the webview permanently dead.
@@ -271,7 +279,9 @@ class WebviewPHPRuntime(private val bridge: PHPBridge) {
             // ambiguous for a Unit-returning lambda.
             executor.submit(Runnable {
                 if (booted) {
-                    bridge.nativeWebviewPhpShutdown()
+                    PHPBridge.embedLifecycleLock.withLock {
+                        bridge.nativeWebviewPhpShutdown()
+                    }
                     booted = false
                     Log.i(TAG, "context suspended for runtime reboot")
                 }

--- a/tests/Unit/PhpEmbedLifecycleLockTest.php
+++ b/tests/Unit/PhpEmbedLifecycleLockTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `php_embed_init` is process-global however many TSRM contexts the four PHP
+ * lanes end up owning. Two of them initialising at once corrupt the module
+ * registry and the thread-resource table rather than sharing them, and the
+ * result is a SIGSEGV that takes the whole process down.
+ *
+ * The invariant is therefore: every native boot and every native shutdown, on
+ * every lane, runs under PHPBridge.embedLifecycleLock. It is asserted here
+ * against the shipped Kotlin because there is no JVM test harness in this
+ * repository — a source assertion is a guard against the lock being dropped
+ * again, not a proof that the runtime is correct.
+ */
+class PhpEmbedLifecycleLockTest extends TestCase
+{
+    /**
+     * Every call site that has to be serialised, by file.
+     *
+     * @var array<string, list<string>>
+     */
+    private const GUARDED_CALLS = [
+        'PHPBridge.kt' => [
+            'nativePersistentBoot',
+            'nativePersistentShutdown',
+            'nativeWorkerBoot',
+            'nativeWorkerShutdown',
+            'nativeEphemeralBoot',
+            'nativeEphemeralShutdown',
+        ],
+        'WebviewPHPRuntime.kt' => [
+            'nativeWebviewPhpBoot',
+            'nativeWebviewPhpShutdown',
+        ],
+    ];
+
+    private function bridgeSource(string $file): string
+    {
+        $path = __DIR__.'/../../resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/'.$file;
+
+        $this->assertFileExists($path);
+
+        return (string) file_get_contents($path);
+    }
+
+    /**
+     * Call sites of $callee that are not inside a `withLock { … }` block.
+     *
+     * Walks the file keeping a stack of the lines that opened each still-open
+     * brace, so "inside a lock" means one of the enclosing blocks was opened
+     * by a line that takes the lock — which survives reformatting in a way
+     * that looking N lines backwards does not.
+     *
+     * @return list<string> the offending lines, `<line number>: <text>`
+     */
+    private function unguardedCallSites(string $source, string $callee): array
+    {
+        $depthOpenedByLock = [];
+        $unguarded = [];
+        $depth = 0;
+
+        foreach (explode("\n", $source) as $index => $line) {
+            $code = trim(preg_replace('~//.*$~', '', $line) ?? '');
+
+            $isCall = str_contains($code, $callee.'(')
+                && ! str_starts_with($code, 'external fun')
+                && ! str_contains($code, 'fun '.$callee);
+
+            // The call is judged before this line's own braces are counted,
+            // so `withLock { nativeXBoot(…) }` on one line still reads as
+            // guarded via the same line's opener below.
+            $locked = $depthOpenedByLock !== [] || str_contains($code, 'withLock');
+
+            if ($isCall && ! $locked) {
+                $unguarded[] = ($index + 1).': '.trim($line);
+            }
+
+            $opens = substr_count($code, '{');
+            $closes = substr_count($code, '}');
+
+            for ($i = 0; $i < $opens; $i++) {
+                $depth++;
+                if (str_contains($code, 'withLock')) {
+                    $depthOpenedByLock[$depth] = true;
+                }
+            }
+
+            for ($i = 0; $i < $closes; $i++) {
+                unset($depthOpenedByLock[$depth]);
+                $depth--;
+            }
+        }
+
+        return $unguarded;
+    }
+
+    /** @test */
+    public function every_native_php_boot_and_shutdown_is_serialised(): void
+    {
+        foreach (self::GUARDED_CALLS as $file => $callees) {
+            $source = $this->bridgeSource($file);
+
+            foreach ($callees as $callee) {
+                $this->assertStringContainsString(
+                    $callee,
+                    $source,
+                    "{$file} no longer mentions {$callee} — update this test with the lane's new name."
+                );
+
+                $this->assertSame(
+                    [],
+                    $this->unguardedCallSites($source, $callee),
+                    "{$callee} is called outside embedLifecycleLock in {$file}. Two concurrent "
+                    .'php_embed_init calls SEGV the process; every lane has to take the same lock.'
+                );
+            }
+        }
+    }
+
+    /** @test */
+    public function the_lock_is_declared_once_and_shared(): void
+    {
+        $source = $this->bridgeSource('PHPBridge.kt');
+
+        $this->assertStringContainsString(
+            'internal val embedLifecycleLock',
+            $source,
+            'PHPBridge must expose the embed lifecycle lock so every lane, including plugin '
+            .'code compiled into this module, takes the same one.'
+        );
+    }
+
+    /**
+     * @test
+     *
+     * The ephemeral lane is documented for plugin use and had no wrapper at
+     * all, so a plugin reached it through the raw external and got no
+     * serialisation with it. A supported entry point is half of the fix.
+     */
+    public function the_ephemeral_lane_has_a_public_wrapper(): void
+    {
+        $source = $this->bridgeSource('PHPBridge.kt');
+
+        foreach (['fun bootEphemeralRuntime', 'fun runEphemeralArtisan', 'fun shutdownEphemeralRuntime'] as $wrapper) {
+            $this->assertStringContainsString($wrapper, $source);
+        }
+    }
+}


### PR DESCRIPTION
## What goes wrong

`php_embed_init` is process-global however many TSRM contexts the four PHP lanes end up owning — it walks the module registry and allocates thread-resource ids. Two of them running at once corrupt that state rather than sharing it, and the process takes a SIGSEGV.

**One lane out of four knows this.** `PHPBridge.bootPersistentRuntime()` takes `LaravelEnvironment.extractionLock`, and that lock's own comment says why:

> `PHPBridge.bootPersistentRuntime` takes this same lock so the persistent `php_embed_init` can never overlap the classic embed init/shutdown cycles […] the two paths use different native mutexes

The other three do not:

| Lane | Boot | Serialised against the others? |
|---|---|---|
| persistent | `bootPersistentRuntime()` | yes, `extractionLock` |
| worker | `bootWorkerRuntime()` | **no** — `nativeWorkerBoot` bare |
| webview | `WebviewPHPRuntime.boot()` | **no** — guards a persistent *reboot* only, via its own `rebootInFlight` |
| ephemeral | *no wrapper exists* | **no** — a plugin calls `external fun nativeEphemeralBoot` directly |

The ephemeral lane is the one the C source calls a *"generic background TSRM context for plugin use"*, with its cold path documented as *"WorkManager started the process after the app was killed"*. It is the lane a plugin is told to use, it is the only lane with no Kotlin wrapper at all, and using it as documented crashes the host app whenever the user opens the app at the same moment.

## Measured

Galaxy S23, SM-S918B, Android 16 / One UI, `nativephp/mobile` 4.0.1. The app's process is killed, a home-screen widget is tapped. The widget's tap handler does the two things a widget tap does: it enqueues background work (WorkManager → the ephemeral lane) and it opens the app.

```
09:31:29.193 START … MainActivity … LAUNCH_SINGLE_TOP … BAL_ALLOW_GRACE_PERIOD
09:31:29.223 D/DeepLink  🔔 Notification URL: /tasks/create?widget=tasks&widget_instance=17
09:31:29.331 I/ActivityTaskManager  Displayed …/MainActivity for user 0: +145ms
09:31:29.422 I/PHP-Native  ephemeral_boot: initializing with bootstrap=…/persistent.php
09:31:29.429 I/PHP-Native  persistent_boot: initializing with bootstrap=…/persistent.php
09:31:29.430 F/libc       Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0
                          in tid 11033 (nativephp-widge), pid 10969
```

Seven milliseconds apart. The tombstone:

```
#00 pc 000000000154742c  libphp_wrapper.so (_emalloc+44)
#01 pc 0000000001652808  libphp_wrapper.so (cwd_globals_ctor+32)
#02 pc 00000000014dfb04  libphp_wrapper.so (tsrm_update_active_threads+188)
#03 pc 00000000014dfc5c  libphp_wrapper.so (ts_allocate_fast_id+236)
#04 pc 0000000001657950  libphp_wrapper.so (zend_startup+64)
#05 pc 00000000014e38e4  libphp_wrapper.so (php_module_startup+340)
#06 pc 000000000165afac  libphp_wrapper.so (php_embed_init+96)
#07 pc 00000000011eee24  libphp_wrapper.so (ephemeral_embed_init+460)
#08 pc 00000000011eea88  libphp_wrapper.so (native_ephemeral_boot+176)
```

Reproduced twice with the same two lines and the same stack.

**The user-visible symptom is not a crash, which is what made it hard to find.** The activity is destroyed with the process, so `pendingDeepLink` — a field on that activity — goes with it. The widget's deeplink simply never happens: no window, no error, and `dumpsys activity activities` holds no record for the package. WorkManager then restarts the process to retry the job, so the widget even repaints correctly. Everything looks like a dropped navigation. I spent the first half of this investigation inside `handleDeepLinkIntent`, which turned out to be entirely correct — it queues the intent properly and four separate `am start` measurements all deliver the route.

## The fix

One process-wide lock — the existing `extractionLock`, exposed as `PHPBridge.embedLifecycleLock` — taken by **every** lane's boot and shutdown.

The shutdowns are included because a `php_embed_shutdown` landing inside another lane's init is the same collision from the other side, which is what the `extractionLock` comment already warns about.

The lock is **not** held for the life of a runtime, and `runEphemeralArtisan` deliberately does not take it: the lanes are built to run concurrently once they exist, and they do. Only the init and the shutdown have to be exclusive. A background job that runs for a minute does not block a cold app launch for a minute — it blocks it for the length of one `php_embed_init`, which measured 181 ms here.

It also adds a supported entry point to the ephemeral lane, so a plugin never has to reach for the raw external again:

```kotlin
fun bootEphemeralRuntime(bootstrapPath: String = persistentBootstrapScript): Boolean
fun runEphemeralArtisan(command: String): String
fun shutdownEphemeralRuntime()
```

## Verified on the device

Same tap, same cold app, with the equivalent lock applied on the plugin side (it can take `extractionLock` itself today — it is `internal` and the plugin's Kotlin compiles into the same module, which is the only reason a fix from that side is possible at all):

```
09:56:06.104 D/DeepLink   🔔 Notification URL: /tasks/create?widget=tasks&widget_instance=17&focus=title
09:56:06.302 I/PHP-Native persistent_boot: initializing
09:56:06.483 I/PHP-Native persistent_boot: PHP interpreter is now persistent and Laravel is booted
09:56:06.483 I/PHPBridge  Persistent runtime booted in 181ms
09:56:06.484 I/PHP-Native ephemeral_boot: initializing        ← 1 ms after the lock was released
09:56:06.615 D/DeepLink   🚀 Loading final URL after WebView setup: http://127.0.0.1/tasks/create?…
```

The ephemeral boot waits and starts one millisecond after the persistent boot releases the lock. No crash, and the route runs — confirmed on the device rather than by a window appearing:

```json
{"probe":"quickadd.opened","at":"2026-08-03 07:56:06","widget":"tasks","instance":17,"focus":"title"}
```

Before: 7 ms apart, SIGSEGV, no route. After: serialised, no crash, route 511 ms after the tap.

## Tests

`tests/Unit/PhpEmbedLifecycleLockTest.php`. Three cases, **all three fail on `main`**:

| Test | on `main` |
|---|---|
| `every_native_php_boot_and_shutdown_is_serialised` | ✗ `nativePersistentShutdown`, `nativeWorkerBoot`, `nativeWorkerShutdown`, `nativeEphemeralBoot`, `nativeEphemeralShutdown`, `nativeWebviewPhpBoot`, `nativeWebviewPhpShutdown` all outside the lock |
| `the_lock_is_declared_once_and_shared` | ✗ |
| `the_ephemeral_lane_has_a_public_wrapper` | ✗ |

They assert on the shipped Kotlin: every call site of a native boot or shutdown must sit inside a `withLock` block, checked by walking the file with a stack of the lines that opened each still-open brace, so it survives reformatting.

**I want to be plain about what that is.** It is a guard against the lock being dropped again, not a proof that the runtime is correct. There is no JVM or instrumentation harness in this repository to hold a real concurrency test, and the failure itself is a native TSRM race that only a device or emulator can show. If you would rather have an instrumentation test, or would rather not have a source-shape assertion in the PHP suite at all, say so and I will change it — the fix stands on the tombstone either way.

```
Tests:  810 passed   (main: 807 passed)
```

The two `ReleaseBuildBundleTest` failures in my run are present on `main` as well — a `ZipArchive` environment issue on this machine, unrelated.

`vendor/bin/pint --dirty` is clean.

## Not in this PR

- **No device-free reproduction.** The failure is a native race inside `libphp_wrapper.so`; there is nothing in PHP to reproduce it with, and the `.so` is not built from this repository. What is here instead is the tombstone, the two log lines that bracket it, and the timing before and after. To reproduce it yourself: from a plugin, call `PHPBridge(context).nativeEphemeralBoot(bootstrap)` on a background thread while starting `MainActivity`. Any plugin shipping a widget, a shortcut or a notification does that on every tap.
- **No change to the C layer.** Serialising the callers is a Kotlin-side fix for a native invariant. Making `php_embed_init` itself safe to call concurrently would be the better fix and it is not in this repository.
- **No change to `handleDeepLinkIntent`.** It queues the intent correctly and consumes it correctly; it was the symptom's address, not its cause. There is a separate observation — `pendingDeepLink` has exactly one consumer, so any failure of the boot pipeline loses the deeplink with no log — but that is a hardening question and not this crash, so it is not mixed in here.
- **`WORKER_START_DELAY_MS` is untouched.** The 2500 ms delay in front of `PHPQueueWorker` makes the worker lane usually miss the persistent boot, which is why this has stayed rare for core's own lanes. It is a timing accident rather than a guarantee, and the lock is what makes it a guarantee.
