### PR TITLE
Declare the Google Services Gradle plugin the app module already applies

### DIFF
--- a/src/Concerns/RunsAndroid.php
+++ b/src/Concerns/RunsAndroid.php
@@ -21,6 +21,21 @@ trait RunsAndroid
 {
     use PreparesBuild, WatchesAndroid;
 
+    /**
+     * The Gradle plugin that processes google-services.json into Android
+     * resources. Applied by the app module whenever that file is present.
+     */
+    private const GOOGLE_SERVICES_PLUGIN_ID = 'com.google.gms.google-services';
+
+    private const GOOGLE_SERVICES_PLUGIN_VERSION = '4.4.3';
+
+    /**
+     * The same plugin as a buildscript classpath coordinate — the shape the
+     * Firebase documentation used before the plugins DSL, and the one people
+     * reach for when they patch this in by hand.
+     */
+    private const GOOGLE_SERVICES_ARTIFACT = 'com.google.gms:google-services';
+
     protected string $androidLogPath = 'nativephp'.DIRECTORY_SEPARATOR.'android-build.log';
 
     /**
@@ -380,6 +395,114 @@ XML;
         if (File::exists($source)) {
             File::copy($source, $target);
         }
+
+        $this->updateGoogleServicesClasspath(File::exists($target));
+    }
+
+    /**
+     * Put the Google Services Gradle plugin on the build classpath when the
+     * project has a google-services.json, and take it off again when it does
+     * not.
+     *
+     * The app module already applies it conditionally — see
+     * resources/androidstudio/app/build.gradle.kts:
+     *
+     *     val googleServicesJson = file("google-services.json")
+     *     if (googleServicesJson.exists()) {
+     *         apply(plugin = "com.google.gms.google-services")
+     *     }
+     *
+     * but nothing declares it anywhere, so that conditional fires into
+     * nothing and the build stops at "Plugin with id
+     * 'com.google.gms.google-services' not found". Every Firebase feature
+     * needs that file, so the conditional cannot fire without breaking.
+     *
+     * This is done here, on the generated root build file, rather than in the
+     * project template, because the template is copied by `native:install`
+     * and never rewritten afterwards: a template-only fix leaves every
+     * already-installed project broken. And it is conditional so an app that
+     * is not using Firebase does not resolve a plugin it has no use for —
+     * `apply false` still resolves the marker artifact.
+     */
+    private function updateGoogleServicesClasspath(bool $enabled): void
+    {
+        $path = base_path('nativephp/android/build.gradle.kts');
+
+        if (! File::exists($path)) {
+            return;
+        }
+
+        $content = File::get($path);
+        $updated = $this->applyGoogleServicesClasspath($content, $enabled);
+
+        if ($updated === null) {
+            if ($enabled) {
+                $this->components->warn(
+                    'Could not declare the Google Services Gradle plugin: no plugins {} block in '
+                    .'nativephp/android/build.gradle.kts. Add `id("'.self::GOOGLE_SERVICES_PLUGIN_ID.'") '
+                    .'version "'.self::GOOGLE_SERVICES_PLUGIN_VERSION.'" apply false` to it by hand.'
+                );
+            }
+
+            return;
+        }
+
+        if ($updated !== $content) {
+            File::put($path, $updated);
+        }
+    }
+
+    /**
+     * Add or remove the marker-delimited declaration in a root build.gradle.kts.
+     *
+     * Pure, so it can be tested without an Android project on disk. Returns
+     * null when the declaration is wanted and there is no plugins {} block to
+     * put it in — the one case the caller has to report rather than swallow.
+     */
+    public function applyGoogleServicesClasspath(string $content, bool $enabled): ?string
+    {
+        $begin = '// BEGIN nativephp-google-services';
+        $end = '// END nativephp-google-services';
+
+        $blockPattern = '/\n?[ \t]*'.preg_quote($begin, '/').'.*?'.preg_quote($end, '/').'[ \t]*\n?/s';
+
+        // Whatever happens next, the old block goes: it is rebuilt from the
+        // current state rather than patched.
+        $withoutBlock = preg_replace($blockPattern, "\n", $content, 1);
+
+        if (! $enabled) {
+            return $withoutBlock;
+        }
+
+        // Somebody else already declared it — a plugin through
+        // `android.gradle_plugins`, or a hand-written buildscript classpath in
+        // the pre-plugins-DSL shape, which is what people patch in by hand when
+        // they hit this. Declaring it twice is a Gradle error, so theirs wins.
+        $declared = [self::GOOGLE_SERVICES_PLUGIN_ID, self::GOOGLE_SERVICES_ARTIFACT];
+
+        foreach ($declared as $needle) {
+            if (str_contains($withoutBlock, $needle)) {
+                return $withoutBlock;
+            }
+        }
+
+        $block = "\n    ".$begin."\n"
+            ."    // Added because this project has a google-services.json; removed when it goes.\n"
+            .'    id("'.self::GOOGLE_SERVICES_PLUGIN_ID.'") version "'.self::GOOGLE_SERVICES_PLUGIN_VERSION.'" apply false'."\n"
+            .'    '.$end;
+
+        // Insert at the end of the plugins {} block. The root build file's
+        // plugins block contains no nested braces, so the first closing brace
+        // on its own line terminates it.
+        $result = preg_replace(
+            '/(plugins\s*\{.*?)(\n\})/s',
+            '$1'.str_replace('$', '\$', $block).'$2',
+            $withoutBlock,
+            1,
+            $count
+        );
+
+        return $count === 1 ? $result : null;
     }
 
     private function updateIcuConfiguration(): void

--- a/tests/Unit/GoogleServicesClasspathTest.php
+++ b/tests/Unit/GoogleServicesClasspathTest.php
@@ -1,0 +1,404 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\File;
+use Native\Mobile\Concerns\RunsAndroid;
+use Native\Mobile\Plugins\Compilers\AndroidPluginCompiler;
+use Native\Mobile\Plugins\Plugin;
+use Native\Mobile\Plugins\PluginManifest;
+use Native\Mobile\Plugins\PluginRegistry;
+use Tests\TestCase;
+
+/**
+ * The app module applies com.google.gms.google-services whenever a
+ * google-services.json is present. Nothing declared it, so adding that file —
+ * which every Firebase feature requires — stopped the build with
+ * "Plugin with id 'com.google.gms.google-services' not found".
+ */
+class GoogleServicesClasspathTest extends TestCase
+{
+    use RunsAndroid {
+        updateFirebaseConfiguration as public runUpdateFirebaseConfiguration;
+    }
+
+    protected string $testProjectPath;
+
+    /** @var array<int, string> */
+    protected array $warnings = [];
+
+    protected const ROOT_BUILD_FILE = <<<'KTS'
+        // Top-level build file where you can add configuration options common to all sub-projects/modules.
+        plugins {
+            alias(libs.plugins.android.application) apply false
+            alias(libs.plugins.kotlin.android) apply false
+            alias(libs.plugins.kotlin.compose) apply false
+        }
+
+        KTS;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testProjectPath = sys_get_temp_dir().'/nativephp_gms_test_'.uniqid();
+        app()->setBasePath($this->testProjectPath);
+
+        $warnings = &$this->warnings;
+        $this->components = new class($warnings)
+        {
+            public function __construct(protected array &$warnings) {}
+
+            public function task(string $title, callable $callback)
+            {
+                $callback();
+            }
+
+            public function twoColumnDetail(...$args) {}
+
+            public function warn($message = '')
+            {
+                $this->warnings[] = (string) $message;
+            }
+        };
+
+        File::ensureDirectoryExists($this->testProjectPath.'/nativephp/android/app');
+        File::put($this->testProjectPath.'/nativephp/android/build.gradle.kts', self::ROOT_BUILD_FILE);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->testProjectPath);
+        parent::tearDown();
+    }
+
+    protected function addGoogleServicesJson(): void
+    {
+        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
+    }
+
+    protected function rootBuildFile(): string
+    {
+        return File::get($this->testProjectPath.'/nativephp/android/build.gradle.kts');
+    }
+
+    /**
+     * @test
+     *
+     * The defect itself. A project with a google-services.json builds, because
+     * the plugin the app module applies is on the classpath.
+     */
+    public function it_declares_the_plugin_when_the_project_has_a_google_services_json(): void
+    {
+        $this->addGoogleServicesJson();
+
+        $this->runUpdateFirebaseConfiguration();
+
+        $this->assertStringContainsString(
+            'id("com.google.gms.google-services") version "4.4.3" apply false',
+            $this->rootBuildFile()
+        );
+    }
+
+    /**
+     * @test
+     *
+     * The declaration goes inside the plugins {} block. Anywhere else is a
+     * Gradle syntax error, so "the string is in the file" is not enough.
+     */
+    public function it_declares_the_plugin_inside_the_plugins_block(): void
+    {
+        $this->addGoogleServicesJson();
+
+        $this->runUpdateFirebaseConfiguration();
+
+        $this->assertMatchesRegularExpression(
+            '/plugins\s*\{[^}]*id\("com\.google\.gms\.google-services"\)[^}]*\n\}/s',
+            $this->rootBuildFile()
+        );
+    }
+
+    /**
+     * @test
+     *
+     * The declaration is not written into the project template but into the
+     * generated root build file, because `native:install` copies the template
+     * once and nothing rewrites it afterwards. A project that already exists
+     * has to be repaired by a build, or the fix reaches nobody who has run
+     * this tool before.
+     */
+    public function it_repairs_a_project_that_already_exists(): void
+    {
+        $this->addGoogleServicesJson();
+
+        // Exactly what an installed project holds today: the shipped template,
+        // with no knowledge of google-services.
+        $this->assertStringNotContainsString('google-services', $this->rootBuildFile());
+
+        $this->runUpdateFirebaseConfiguration();
+
+        $this->assertStringContainsString('com.google.gms.google-services', $this->rootBuildFile());
+    }
+
+    /**
+     * @test
+     *
+     * `apply false` still resolves the plugin marker, so an app that is not
+     * using Firebase should not be made to download one.
+     */
+    public function it_declares_nothing_for_a_project_without_firebase(): void
+    {
+        $this->runUpdateFirebaseConfiguration();
+
+        $this->assertStringNotContainsString('google-services', $this->rootBuildFile());
+        $this->assertSame(self::ROOT_BUILD_FILE, $this->rootBuildFile());
+    }
+
+    /**
+     * @test
+     *
+     * Removing google-services.json takes the declaration back out. The block
+     * is rebuilt from the current state on every build rather than patched, so
+     * turning Firebase off is a build rather than a manual edit.
+     */
+    public function it_removes_the_declaration_when_the_config_file_goes_away(): void
+    {
+        $this->addGoogleServicesJson();
+        $this->runUpdateFirebaseConfiguration();
+        $this->assertStringContainsString('com.google.gms.google-services', $this->rootBuildFile());
+
+        File::delete($this->testProjectPath.'/google-services.json');
+        File::delete($this->testProjectPath.'/nativephp/android/app/google-services.json');
+
+        $this->runUpdateFirebaseConfiguration();
+
+        $this->assertStringNotContainsString('google-services', $this->rootBuildFile());
+        $this->assertSame(self::ROOT_BUILD_FILE, $this->rootBuildFile());
+    }
+
+    /**
+     * @test
+     *
+     * Five builds, one declaration, and the file is byte-identical after the
+     * first one. A build file that changes on every build takes reproducibility
+     * away from everything downstream of it.
+     */
+    public function it_is_idempotent_across_repeated_builds(): void
+    {
+        $this->addGoogleServicesJson();
+
+        $this->runUpdateFirebaseConfiguration();
+        $afterFirst = $this->rootBuildFile();
+
+        for ($i = 0; $i < 4; $i++) {
+            $this->runUpdateFirebaseConfiguration();
+        }
+
+        $this->assertSame($afterFirst, $this->rootBuildFile());
+        $this->assertSame(1, substr_count($afterFirst, 'BEGIN nativephp-google-services'));
+        $this->assertSame(1, substr_count($afterFirst, 'id("com.google.gms.google-services")'));
+    }
+
+    /**
+     * @test
+     *
+     * A plugin can already declare this through `android.gradle_plugins`, and
+     * a project can have it hand-written. Declaring the same plugin id twice
+     * is a Gradle error, so an existing declaration wins.
+     */
+    public function it_leaves_an_existing_declaration_alone(): void
+    {
+        $this->addGoogleServicesJson();
+
+        File::put($this->testProjectPath.'/nativephp/android/build.gradle.kts', <<<'KTS'
+            plugins {
+                alias(libs.plugins.android.application) apply false
+                // BEGIN nativephp-plugin-gradle-plugins
+                id("com.google.gms.google-services") version "4.4.0" apply false
+                // END nativephp-plugin-gradle-plugins
+            }
+
+            KTS);
+
+        $this->runUpdateFirebaseConfiguration();
+
+        $content = $this->rootBuildFile();
+        $this->assertSame(1, substr_count($content, 'id("com.google.gms.google-services")'));
+        $this->assertStringContainsString('version "4.4.0"', $content);
+        $this->assertStringNotContainsString('BEGIN nativephp-google-services', $content);
+    }
+
+    /**
+     * @test
+     *
+     * The same, for a project that puts it on the buildscript classpath
+     * instead — the shape the Firebase documentation used before the plugins
+     * DSL, and the shape people patch in by hand when they hit this.
+     */
+    public function it_leaves_a_hand_written_buildscript_classpath_alone(): void
+    {
+        $this->addGoogleServicesJson();
+
+        File::put($this->testProjectPath.'/nativephp/android/build.gradle.kts', <<<'KTS'
+            buildscript {
+                dependencies {
+                    classpath("com.google.gms:google-services:4.4.2")
+                }
+            }
+            plugins {
+                alias(libs.plugins.android.application) apply false
+            }
+
+            KTS);
+
+        $this->runUpdateFirebaseConfiguration();
+
+        $this->assertStringNotContainsString('BEGIN nativephp-google-services', $this->rootBuildFile());
+        $this->assertSame(1, substr_count($this->rootBuildFile(), 'google-services'));
+    }
+
+    /**
+     * @test
+     *
+     * The declaration and the plugin compiler's own block are written by
+     * different code paths into the same file. `buildGradlePluginsBlock`
+     * already skips an id declared outside its markers; this pins that it
+     * sees ours, because a duplicate would fail the build the fix exists to
+     * unbreak.
+     */
+    public function the_plugin_compiler_does_not_declare_it_a_second_time(): void
+    {
+        $this->addGoogleServicesJson();
+        $this->runUpdateFirebaseConfiguration();
+
+        $plugin = $this->makePluginDeclaringGoogleServices();
+
+        $compiler = new AndroidPluginCompiler(
+            new Filesystem,
+            $this->createMock(PluginRegistry::class),
+            $this->testProjectPath.'/nativephp'
+        );
+
+        $block = $compiler->buildGradlePluginsBlock(
+            new Collection([$plugin]),
+            $this->rootBuildFile()
+        );
+
+        $this->assertSame('', $block);
+    }
+
+    /**
+     * @test
+     *
+     * Nothing to repair and nothing to crash on: `native:run` on a project
+     * whose Android folder has not been generated yet.
+     */
+    public function it_does_nothing_without_an_android_project(): void
+    {
+        File::delete($this->testProjectPath.'/nativephp/android/build.gradle.kts');
+        $this->addGoogleServicesJson();
+
+        $this->runUpdateFirebaseConfiguration();
+
+        $this->assertFileDoesNotExist($this->testProjectPath.'/nativephp/android/build.gradle.kts');
+        $this->assertSame([], $this->warnings);
+    }
+
+    /**
+     * @test
+     *
+     * A root build file with no plugins {} block cannot be repaired. Saying so
+     * is the whole point — a silent no-op here is the failure this fix is
+     * about, one layer further out.
+     */
+    public function it_warns_when_there_is_no_plugins_block_to_declare_it_in(): void
+    {
+        File::put($this->testProjectPath.'/nativephp/android/build.gradle.kts', "// nothing here\n");
+        $this->addGoogleServicesJson();
+
+        $this->runUpdateFirebaseConfiguration();
+
+        $this->assertCount(1, $this->warnings);
+        $this->assertStringContainsString('com.google.gms.google-services', $this->warnings[0]);
+        $this->assertSame("// nothing here\n", $this->rootBuildFile());
+    }
+
+    /**
+     * @test
+     *
+     * And it stays quiet about a project that never asked for Firebase.
+     */
+    public function it_does_not_warn_about_a_project_without_firebase(): void
+    {
+        File::put($this->testProjectPath.'/nativephp/android/build.gradle.kts', "// nothing here\n");
+
+        $this->runUpdateFirebaseConfiguration();
+
+        $this->assertSame([], $this->warnings);
+    }
+
+    /**
+     * @test
+     *
+     * The copy this method already did keeps working, unchanged.
+     */
+    public function it_still_copies_the_config_into_the_app_module(): void
+    {
+        $this->addGoogleServicesJson();
+
+        $this->runUpdateFirebaseConfiguration();
+
+        $target = $this->testProjectPath.'/nativephp/android/app/google-services.json';
+        $this->assertFileExists($target);
+        $this->assertSame('{"project_id": "test"}', File::get($target));
+    }
+
+    /**
+     * @test
+     *
+     * nativephp/resources/google-services.json wins over the project root, and
+     * either of them turns the declaration on.
+     */
+    public function it_reads_the_config_from_the_resources_directory_too(): void
+    {
+        File::ensureDirectoryExists($this->testProjectPath.'/nativephp/resources');
+        File::put($this->testProjectPath.'/nativephp/resources/google-services.json', '{"project_id": "resources"}');
+
+        $this->runUpdateFirebaseConfiguration();
+
+        $this->assertSame(
+            '{"project_id": "resources"}',
+            File::get($this->testProjectPath.'/nativephp/android/app/google-services.json')
+        );
+        $this->assertStringContainsString('com.google.gms.google-services', $this->rootBuildFile());
+    }
+
+    /**
+     * Supplied by PlatformFileOperations in the real command; nothing under
+     * test here calls it.
+     */
+    protected function removeDirectory(string $path): void
+    {
+        File::deleteDirectory($path);
+    }
+
+    protected function makePluginDeclaringGoogleServices(): Plugin
+    {
+        return new Plugin(
+            name: 'test/gms-plugin',
+            version: '1.0.0',
+            path: $this->testProjectPath.'/plugins/gms-plugin',
+            manifest: new PluginManifest([
+                'name' => 'test/gms-plugin',
+                'namespace' => 'Gms',
+                'android' => [
+                    'gradle_plugins' => [
+                        ['id' => 'com.google.gms.google-services', 'version' => '4.4.3'],
+                    ],
+                ],
+            ]),
+        );
+    }
+}


### PR DESCRIPTION
## The problem

`resources/androidstudio/app/build.gradle.kts` applies the Google Services Gradle plugin whenever the project has a `google-services.json`:

```kotlin
val googleServicesJson = file("google-services.json")
if (googleServicesJson.exists()) {
    apply(plugin = "com.google.gms.google-services")
}
```

and `com.google.gms:google-services` appears on **no classpath anywhere in core** — not the root `build.gradle.kts`, not `settings.gradle.kts`, not `gradle/libs.versions.toml`. The conditional reads exactly right and fires into nothing:

```
* Where: nativephp/android/app/build.gradle.kts line: 9
* What went wrong: Plugin with id 'com.google.gms.google-services' not found.
```

Every Firebase feature requires that file, so the conditional cannot fire without breaking the build. `RunsAndroid::updateFirebaseConfiguration()` copies the file in on every build, so this is core carrying its own feature up to the last step and then stopping. `PushNotifications` is core's own facade, which makes this core's own push story failing at the first build.

## Reproduction

`docs/upstream/reproduce-google-services.sh <empty-dir>` — no device, no Android SDK, no Gradle. It creates a clean Laravel app, requires `nativephp/mobile:^4.0`, scaffolds the Android project the way `InstallsAndroid::createAndroidStudioProject()` does, adds a `google-services.json`, and reads the generated files:

```
=== what the app module does with it ===
7:val googleServicesJson = file("google-services.json")
8-if (googleServicesJson.exists()) {
9-    apply(plugin = "com.google.gms.google-services")
10-}

=== where the plugin is declared ===
nowhere: not the root build file, not settings.gradle.kts, not the version catalog.
```

<details><summary>The script</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail

WORK="${1:?usage: reproduce-google-services.sh <empty-dir>}"
mkdir -p "$WORK"; cd "$WORK"

composer create-project laravel/laravel app --no-interaction --quiet
cd app
composer require nativephp/mobile:^4.0 --no-interaction --quiet

# What InstallsAndroid::createAndroidStudioProject() does, minus the PHP binaries.
php -r '
mkdir("nativephp/android", 0755, true);
$src = "vendor/nativephp/mobile/resources/androidstudio";
$it = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($src, FilesystemIterator::SKIP_DOTS), RecursiveIteratorIterator::SELF_FIRST);
foreach ($it as $item) {
    $dest = "nativephp/android/" . substr($item->getPathname(), strlen($src) + 1);
    $item->isDir() ? @mkdir($dest, 0755, true) : copy($item->getPathname(), $dest);
}
'

echo '{ "project_info": { "project_id": "reproduction" } }' > google-services.json
cp google-services.json nativephp/android/app/google-services.json

grep -n -A3 'val googleServicesJson' nativephp/android/app/build.gradle.kts
grep -rn 'com\.google\.gms[.:]google-services' \
    nativephp/android/build.gradle.kts \
    nativephp/android/settings.gradle.kts \
    nativephp/android/gradle/libs.versions.toml || echo "declared nowhere"
```

</details>

### And with Gradle, on a real project

The script stops at the state because an Android SDK is a big ask of a reviewer. The build itself was run on a real app (Galaxy S23, `nativephp/mobile 4.0.1`, the app's own `google-services.json` from the Firebase CLI):

| Root `build.gradle.kts` | Result |
|---|---|
| The shipped template, untouched | `BUILD FAILED in 2s` — `Plugin with id 'com.google.gms.google-services' not found.` at `app/build.gradle.kts` line 9 |
| The same tree, plus the declaration this PR writes | `BUILD SUCCESSFUL in 49s`, APK installed |

Nothing else differed between the two runs.

## The fix

One method, called from the one that already copies `google-services.json` in.

**It writes the generated root build file, not the template.** That is the part worth reviewing rather than the regex. `resources/androidstudio/` is copied by `native:install` and nothing rewrites it afterwards, so a template-only fix repairs projects created *after* it ships and leaves every existing project failing exactly as before. Patching core's template first and watching the second build fail identically to the first is how this was found.

**It is conditional both ways.** The declaration goes in when the app module has a `google-services.json` and comes back out when it does not — `apply false` still resolves the plugin marker, so an app that has nothing to do with Firebase should not be made to fetch one. The block is marker-delimited and rebuilt from the current state on every build, the same shape `injectGradlePlugins` and the ProGuard rules block already use, so it is idempotent and a build file is not a different file after every build.

**An existing declaration wins**, in either shape:

- a plugin's own `android.gradle_plugins` entry, which `AndroidPluginCompiler::injectGradlePlugins()` writes into the same `plugins {}` block;
- a hand-written `classpath("com.google.gms:google-services:…")` in a `buildscript` block — the pre-plugins-DSL shape, and exactly what people add when they hit this.

Declaring the same plugin id twice is a Gradle error, so both are left alone. The plugin compiler already skips ids declared outside its own markers, and a test pins that it sees this one.

**And when it cannot, it says so.** A root build file with no `plugins {}` block gets a warning naming the line to add by hand, rather than a silent no-op — which is the failure mode this whole PR is about, one layer further out.

## Tests

`tests/Unit/GoogleServicesClasspathTest.php`, 14 tests. They run the real `RunsAndroid::updateFirebaseConfiguration()` against a project on disk — worth noting, because `ConfigurationUpdatesTest` reimplements that method locally, so core's own copy step had no test exercising it either.

| | On `main` | On this branch |
|---|---|---|
| 8 tests | **fail** | pass |
| 6 regression guards | pass | pass |

The eight that fail are the behaviour being added: the declaration appears, it is inside the `plugins {}` block, an existing project is repaired, it is removed again when the config file goes, five builds leave one declaration and a byte-identical file, the plugin compiler does not add a second, the no-`plugins`-block case warns, and `nativephp/resources/google-services.json` counts as a source too.

The six that pass on both are the guards: the copy still happens and still copies the right bytes, a project without Firebase gets nothing added and no warning, an existing plugin declaration is left alone, a hand-written buildscript classpath is left alone, and a project with no Android folder is a no-op rather than a crash.

| Check | Result |
|---|---|
| `vendor/bin/pest`, before | 816 pass, 0 fail |
| `vendor/bin/pest`, after | 830 pass, 0 fail |
| `vendor/bin/pint --test` | passed |
| `vendor/bin/phpstan analyse` | no errors |

## Not in this PR

- **The plugin version is a constant** (`4.4.3`, the version core's own test fixtures use), not a config key. A published `config/nativephp.php` does not gain keys on upgrade, so an escape hatch here needs a `config(…, $default)` read and a documented key, and that is a small feature rather than this fix.
- **`PushNotification.*` has no Android bridge implementation.** `PushNotifications::getToken()` calls `nativephp_call('PushNotification.GetToken')`; the Android bridge registers `Camera.*`, `Device.*`, `Dialog.*`, `File.*`, `Location.*`, `Perf.*`, `System.*` and `UI.*`, and nothing push. With this PR a Firebase app builds and its token still comes back null on Android. That is a separate, larger gap and it deserves its own change.
- **iOS.** `GoogleService-Info.plist` has no equivalent conditional to be broken by, and nothing here touches the iOS build.
- **Reformatting the template.** `resources/androidstudio/build.gradle.kts` is untouched on purpose, so that a project which never adds a `google-services.json` resolves exactly the plugins it does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
