### PR TITLE
Restore the zip error detail lost by the SuperNative squash

### DIFF
--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -887,7 +887,9 @@ class BuildIosAppCommand extends Command
         $result = Process::run($command);
 
         if (! $result->successful()) {
-            throw new \Exception('Failed to create ZIP file');
+            $error = trim($result->errorOutput()) ?: trim($result->output());
+
+            throw new \Exception('Failed to create ZIP file: '.($error ?: 'exit code '.$result->exitCode()));
         }
 
         $this->createBundledVersionFile($zipPath);


### PR DESCRIPTION
Follow-up from the squash audit discussed in #217. When `zip` fails during the iOS build, the exception currently reports a bare `Failed to create ZIP file` with no indication of why (disk full, permissions, unreadable file). #138 added the underlying error to the message, but the SuperNative squash (#173) carried a pre-#138 copy of `createAppZip`, silently reverting it.

This restores the original behavior: zip's stderr first, stdout as fallback, exit code as last resort. Since this exception is the only thing a user sees when a build dies at the zip step, the detail is what turns an undiagnosable support thread into a self-solvable error.
