### PR TITLE
feat(ios): implement UI.SetBackground for parity with Android

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/functions/UIFunctions.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/functions/UIFunctions.kt
@@ -1,6 +1,7 @@
 package com.nativephp.mobile.bridge.functions
 
 import android.graphics.Color
+import android.graphics.drawable.Drawable
 import android.os.Handler
 import android.os.Looper
 import androidx.fragment.app.FragmentActivity
@@ -32,14 +33,40 @@ object UIFunctions {
      * Controls what shows behind transparent system bars and safe area insets.
      *
      * Parameters:
-     *   - color: string - hex color e.g. "#0F172A"
+     *   - color: string|null - hex color e.g. "#0F172A". null / missing / ""
+     *     CLEARS the override, restoring the theme's original window
+     *     background — the call is app-global sticky state, so screens
+     *     that set it should clear it in unmount(). (iOS twin:
+     *     Bridge/Functions/UIFunctions.swift, same contract.)
      */
     class SetBackground(private val activity: FragmentActivity) : BridgeFunction {
+        companion object {
+            /** The decor background before the first override, for restore. */
+            private var originalBackground: Drawable? = null
+            private var hasOverride = false
+        }
+
         override fun execute(parameters: Map<String, Any>): Map<String, Any> {
-            val colorStr = parameters["color"] as? String ?: return mapOf("success" to false)
+            val colorStr = parameters["color"] as? String
+
+            if (colorStr.isNullOrEmpty()) {
+                Handler(Looper.getMainLooper()).post {
+                    if (hasOverride) {
+                        activity.window.decorView.background = originalBackground
+                        originalBackground = null
+                        hasOverride = false
+                    }
+                }
+                return mapOf("success" to true)
+            }
+
             return try {
                 val color = Color.parseColor(colorStr)
                 Handler(Looper.getMainLooper()).post {
+                    if (!hasOverride) {
+                        originalBackground = activity.window.decorView.background
+                        hasOverride = true
+                    }
                     activity.window.decorView.setBackgroundColor(color)
                 }
                 mapOf("success" to true)

--- a/resources/xcode/NativePHP/Bridge/BridgeFunctionRegistration.swift
+++ b/resources/xcode/NativePHP/Bridge/BridgeFunctionRegistration.swift
@@ -19,6 +19,11 @@ func registerBridgeFunctions() {
     registry.register("System.OpenAppSettings", function: SystemFunctions.OpenAppSettings())
     registry.register("System.GetAppearance", function: SystemFunctions.GetAppearance())
 
+    // UI.* — core built-in. Android twin: bridge/functions/UIFunctions.kt
+    // (which also registers UI.SetTransition; iOS transitions ride the
+    // tree publish path, so only SetBackground is implemented here).
+    registry.register("UI.SetBackground", function: UIFunctions.SetBackground())
+
     // Dialog.* — core built-in (migrated from the nativephp/mobile-dialog
     // plugin). Android twin: bridge/functions/DialogFunctions.kt.
     registry.register("Dialog.Alert", function: DialogFunctions.Alert())

--- a/resources/xcode/NativePHP/Bridge/Functions/UIFunctions.swift
+++ b/resources/xcode/NativePHP/Bridge/Functions/UIFunctions.swift
@@ -1,0 +1,99 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+// MARK: - UI Function Namespace
+//
+// Functions related to native UI control. Android twin:
+// `bridge/functions/UIFunctions.kt`. (Android also registers
+// `UI.SetTransition` there; iOS drives transitions through the tree
+// publish path, so only `UI.SetBackground` is implemented here.)
+
+/// App-wide window background override set from PHP via `UI.SetBackground`.
+///
+/// Three surfaces read it (falling back to `systemBackground` when unset):
+///   1. `ContentView` — the base layer each native screen renders over,
+///      visible during screen transitions and before first content.
+///   2. `NativeRootStackRenderer` — NavigationStack hosts its screens on
+///      its own container background (systemBackground, no SwiftUI
+///      override hook), so each stack screen backgrounds itself with
+///      this color instead.
+///   3. The UIKit windows, so overscroll and inset regions match.
+///
+/// `color` is only mutated on the main queue (see `SetBackground`).
+final class WindowBackgroundState: ObservableObject {
+    static let shared = WindowBackgroundState()
+
+    /// nil = no override → keep the platform default (systemBackground).
+    @Published var color: Color?
+
+    private init() {}
+}
+
+/// Functions related to native UI control
+/// Namespace: "UI.*"
+enum UIFunctions {
+
+    // MARK: - UI.SetBackground
+
+    /// Set the window background color — what shows behind screen content,
+    /// during transitions, and in safe-area / overscroll regions.
+    /// Controls what shows behind transparent system bars and safe area
+    /// insets (same contract as the Android implementation).
+    ///
+    /// Parameters:
+    ///   - color: string - hex color e.g. "#0F172A" (#RGB / #RRGGBB / #AARRGGBB)
+    /// Returns:
+    ///   - success: boolean
+    class SetBackground: BridgeFunction {
+        func execute(parameters: [String: Any]) throws -> [String: Any] {
+            guard let colorStr = parameters["color"] as? String,
+                  let uiColor = UIColor(nativePhpHex: colorStr) else {
+                return ["success": false, "error": "Invalid color"]
+            }
+
+            DispatchQueue.main.async {
+                WindowBackgroundState.shared.color = Color(uiColor)
+                // Also paint the UIKit windows so regions SwiftUI never
+                // covers (keyboard underlap, rotation gaps) match.
+                for scene in UIApplication.shared.connectedScenes {
+                    guard let windowScene = scene as? UIWindowScene else { continue }
+                    for window in windowScene.windows {
+                        window.backgroundColor = uiColor
+                    }
+                }
+            }
+
+            return ["success": true]
+        }
+    }
+}
+
+extension UIColor {
+    /// Parse "#RGB", "#RRGGBB" or "#AARRGGBB" (Android `Color.parseColor`
+    /// compatible) into a UIColor. Returns nil for anything else.
+    convenience init?(nativePhpHex: String) {
+        var hex = nativePhpHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard hex.hasPrefix("#") else { return nil }
+        hex.removeFirst()
+        if hex.count == 3 {
+            hex = hex.map { "\($0)\($0)" }.joined()
+        }
+        guard hex.count == 6 || hex.count == 8,
+              let value = UInt64(hex, radix: 16) else { return nil }
+
+        let a, r, g, b: UInt64
+        if hex.count == 8 {
+            (a, r, g, b) = (value >> 24 & 0xFF, value >> 16 & 0xFF, value >> 8 & 0xFF, value & 0xFF)
+        } else {
+            (a, r, g, b) = (0xFF, value >> 16 & 0xFF, value >> 8 & 0xFF, value & 0xFF)
+        }
+
+        self.init(
+            red: CGFloat(r) / 255,
+            green: CGFloat(g) / 255,
+            blue: CGFloat(b) / 255,
+            alpha: CGFloat(a) / 255
+        )
+    }
+}

--- a/resources/xcode/NativePHP/Bridge/Functions/UIFunctions.swift
+++ b/resources/xcode/NativePHP/Bridge/Functions/UIFunctions.swift
@@ -42,13 +42,30 @@ enum UIFunctions {
     /// insets (same contract as the Android implementation).
     ///
     /// Parameters:
-    ///   - color: string - hex color e.g. "#0F172A" (#RGB / #RRGGBB / #AARRGGBB)
+    ///   - color: string|null - hex color e.g. "#0F172A" (#RGB / #RRGGBB /
+    ///     #AARRGGBB). null / missing / "" CLEARS the override, restoring
+    ///     the platform default — the call is app-global sticky state, so
+    ///     screens that set it should clear it in unmount().
     /// Returns:
     ///   - success: boolean
     class SetBackground: BridgeFunction {
         func execute(parameters: [String: Any]) throws -> [String: Any] {
-            guard let colorStr = parameters["color"] as? String,
-                  let uiColor = UIColor(nativePhpHex: colorStr) else {
+            let colorStr = parameters["color"] as? String ?? ""
+            guard !colorStr.isEmpty else {
+                DispatchQueue.main.async {
+                    WindowBackgroundState.shared.color = nil
+                    for scene in UIApplication.shared.connectedScenes {
+                        guard let windowScene = scene as? UIWindowScene else { continue }
+                        for window in windowScene.windows {
+                            window.backgroundColor = nil
+                        }
+                    }
+                }
+
+                return ["success": true]
+            }
+
+            guard let uiColor = UIColor(nativePhpHex: colorStr) else {
                 return ["success": false, "error": "Invalid color"]
             }
 

--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -11,7 +11,16 @@ struct ContentView: View {
     @State private var phpOutput = ""
     @ObservedObject private var nativeUIBridge = NativeUIBridge.shared
     @ObservedObject private var bootState = BootState.shared
+    // PHP-set window background (`UI.SetBackground`); nil keeps the
+    // platform default. Shows behind screens and during transitions.
+    @ObservedObject private var windowBackground = WindowBackgroundState.shared
     @Environment(\.colorScheme) private var colorScheme
+
+    /// The base color native screens render over — the PHP override when
+    /// set, otherwise the system default.
+    private var screenBackground: Color {
+        windowBackground.color ?? Color(.systemBackground)
+    }
 
     var body: some View {
         // When native UI is active, render JUST the native tree —
@@ -39,7 +48,7 @@ struct ContentView: View {
                     ForEach(activeScreens(currentTree: tree)) { screen in
                         NativeTreeRenderer(tree: screen.tree)
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
-                            .background(Color(.systemBackground))
+                            .background(screenBackground)
                             .modifier(ScreenExitModifier(
                                 isExiting: screen.isOutgoing,
                                 transition: nativeUIBridge.outgoingScreen?.transition
@@ -69,7 +78,7 @@ struct ContentView: View {
                 // plain background under the splash. Mounting the WebView
                 // container here would create the WKWebView and spawn its
                 // WebKit processes for nothing.
-                Color(.systemBackground).ignoresSafeArea()
+                screenBackground.ignoresSafeArea()
             }
         }
         .overlay(alignment: .top) {

--- a/resources/xcode/NativePHP/NativeRender/NativeRootStackRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeRootStackRenderer.swift
@@ -258,7 +258,16 @@ struct NativeRootStackRenderer: View {
             // a container, the per-glass-effect animation isn't scoped
             // and the press transition renders as a visible flicker
             // behind the touched element. iOS 26+ only.
-            NodeView(node: node).withGlassContainer()
+            NodeView(node: node)
+                .withGlassContainer()
+                // NavigationStack hosts screens on its own container
+                // background (systemBackground — white in light mode) and
+                // SwiftUI exposes no override hook for it, so a dark app
+                // gets a white band in the bottom safe-area inset. When
+                // PHP set a window background (`UI.SetBackground`), paint
+                // it behind the screen extended through the safe areas.
+                // No-op when unset, preserving the stock appearance.
+                .modifier(StackScreenBackgroundModifier())
         } else {
             Color.clear
         }
@@ -438,3 +447,21 @@ private struct NavigationSubtitleModifier: ViewModifier {
     }
 }
 
+
+/// Backgrounds a stack-hosted screen with the PHP-set window background
+/// (`UI.SetBackground`), extended through the safe areas. NavigationStack
+/// draws its own `systemBackground` container behind screen content with
+/// no SwiftUI override hook — without this, a dark app shows a white band
+/// in the bottom safe-area inset on every stack screen. No-op when no
+/// override is set, preserving the stock appearance.
+private struct StackScreenBackgroundModifier: ViewModifier {
+    @ObservedObject private var windowBackground = WindowBackgroundState.shared
+
+    func body(content: Content) -> some View {
+        if let color = windowBackground.color {
+            content.background(color.ignoresSafeArea())
+        } else {
+            content
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`UI.SetBackground` is implemented on Android only (`UIFunctions.kt` paints the decor view). On iOS the call silently no-ops — and separately, iOS has no way to control what renders behind screen content. Dark-themed apps get a **white band in the bottom safe-area inset on every NavigationStack-hosted screen**: `NavigationStack` draws its own `systemBackground` container and SwiftUI exposes no override hook for it. The only app-side workaround today is moving dark screens out of stack layouts entirely.

## Fix

Adds the iOS handler with the same contract as Android (`{color: "#0F172A"}` → `{success: true}`, accepting `#RGB` / `#RRGGBB` / `#AARRGGBB` per `Color.parseColor`). The color lands in a new `WindowBackgroundState` observable read by three surfaces, all falling back to `systemBackground` when unset — zero behavior change for apps that never call it:

1. **`ContentView`** — the per-screen base layer and the boot placeholder, so the color shows during screen transitions (no more white flash between dark screens) and before first content.
2. **`NativeRootStackRenderer`** — each stack screen backgrounds itself with the color, extended through the safe areas (no-op-when-unset `ViewModifier`), fixing the white bottom band.
3. **UIKit windows** — so overscroll and rotation gaps match.

(`UI.SetTransition`, Android's other UI.* function, intentionally has no iOS twin — transitions ride the tree publish path there.)

## Testing

- Template compiles clean: 284 Swift files, zero errors (simulator SDK; the linker step needs the app-embedded workspace, unrelated to this change).
- Verified in the demo app that dark screens calling `UI.SetBackground` in `mount()` previously showed the white bottom band on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)