### PR TITLE
fix: hot reload permanently wedging when a trigger lands mid-reboot

### DIFF
--- a/resources/xcode/NativePHP/HotReloadServer.swift
+++ b/resources/xcode/NativePHP/HotReloadServer.swift
@@ -24,6 +24,11 @@ class HotReloadCoordinator {
     private var reloadPending = false
     private var activated = false
 
+    /// Invalidation counter for the hot-reload event retrigger loop — see
+    /// `scheduleEventRetrigger`. Bumping it orphans any scheduled re-post.
+    /// Only touched on the main queue.
+    private var retriggerGeneration = 0
+
     private init() {}
 
     /// Register for reload notifications. Called once at app launch —
@@ -51,6 +56,41 @@ class HotReloadCoordinator {
 
         DispatchQueue.main.async { [weak self] in
             self?.reload()
+        }
+    }
+
+    private func startEventRetrigger() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.retriggerGeneration += 1
+            self.scheduleEventRetrigger(self.retriggerGeneration, attempt: 0)
+        }
+    }
+
+    private func stopEventRetrigger() {
+        retriggerGeneration += 1
+    }
+
+    /// Re-post the hot-reload event every 500ms until the reboot block starts.
+    ///
+    /// Re-posts that land while the region is dead are destroyed with it —
+    /// harmless. The first one to land after the rebooted PHP re-registers the
+    /// region and enters its event loop unblocks the serial queue, at which
+    /// point the reboot block cancels this loop. Fires and cancellation both
+    /// run on the main queue, so no re-post can slip in after cancellation.
+    /// Bounded as a backstop: if PHP hasn't come back after 30s something
+    /// bigger is wrong, and re-posting forever would only mask it.
+    private func scheduleEventRetrigger(_ generation: Int, attempt: Int) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            guard let self, self.retriggerGeneration == generation else { return }
+
+            guard attempt < 60 else {
+                print("⚠️ Hot reload retrigger gave up after 30s — PHP never left its event loop")
+                return
+            }
+
+            NativeUIBridge.sendHotReloadEvent()
+            self.scheduleEventRetrigger(generation, attempt: attempt + 1)
         }
     }
 
@@ -85,11 +125,26 @@ class HotReloadCoordinator {
             // loop and return from dispatch() — which frees the serial queue so
             // the block below can execute.
             NativeUIBridge.sendHotReloadEvent()
+
+            // That post is fire-and-forget, and the event ring buffer does not
+            // survive a runtime reboot. When this trigger lands inside another
+            // reload's reboot window (a rapid second save, or the
+            // `reloadPending` replay — `finishReload` runs before the previous
+            // pass's dispatch re-registers the region), the event is destroyed
+            // with the buffer. The serial queue then stays blocked by the
+            // previous dispatch, the block below never runs, and
+            // `reloadInProgress` latches shut for the rest of the app session.
+            // Keep re-posting until the block below starts and cancels us.
+            startEventRetrigger()
         }
 
         // All reboot work runs off the main thread — persistent_php_shutdown
         // blocks on a semaphore and must not run on the main queue.
         PersistentPHPRuntime.shared.executeOnPHPThreadAsync { [weak self] in
+            // Reaching here proves the serial queue was freed — the hot-reload
+            // event was consumed — so stop re-posting it.
+            DispatchQueue.main.async { self?.stopEventRetrigger() }
+
             // By the time this block runs, the native route dispatch has already
             // returned (the hot reload event caused PHP to exit its event loop).
             if isNativeUI {


### PR DESCRIPTION
## The bug

On iOS, `native:watch` hot reload works for a while and then silently stops for the rest of the app session — files keep syncing, the trigger connections keep landing, but the app never reloads again until it's relaunched.

The hot-reload event that `HotReloadCoordinator.reload()` posts is fire-and-forget into the PHP extension's event ring buffer, and that buffer does not survive a runtime reboot. A trigger arriving inside another reload's ~3s reboot window — a rapid second save, or the `reloadPending` replay (`finishReload` runs before the previous pass's dispatch re-registers the region) — posts its event into a buffer that is about to be destroyed, or before the rebooted PHP has re-registered it. The event is lost, the serial queue stays blocked by the previous dispatch, the queued reboot block never runs, and `reloadInProgress` latches shut permanently.

**Signature in an affected session:** a rapid pair of reboots seconds apart in the container logs, then `HOT_RELOAD` never appears again in `edge-nav.log` while navigation keeps working (PHP is healthy and sitting in its event loop — the triggers just never reach it).

## The fix

Re-post the hot-reload event every 500ms until the reboot block starts executing, which proves the event was consumed (the previous dispatch returned and freed the serial queue).

- Re-posts that land while the region is dead are destroyed with the buffer — harmless.
- Fires and cancellation are both main-queue confined behind a generation counter, so no re-post can slip in after cancellation and cause a phantom extra reload.
- Bounded at 60 attempts (30s) as a backstop so a genuinely dead runtime isn't masked by silent infinite re-posting.

Reproduced and verified against a session exhibiting the wedge (three occurrences in one morning, each preceded by the rapid-pair signature); with the patch, rapid consecutive saves during reboot windows recover within ~500ms.

A deeper follow-up would be to buffer pre-registration events in `nphp_element.c` so the trigger is inherently lossless, but this heals the latch without touching the extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)