### PR TITLE
Fix - Expose tree publication revisions on Android

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeElementBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeElementBridge.kt
@@ -374,7 +374,7 @@ class NativeElementBridge private constructor() {
                             // animation with a slide overlay.
                             if (isFreshStackMount) NavigationCoordinator.reset()
                             if (isNav && !nativeChromeContinuation) NativeUIBridge.screenKey.intValue++
-                            NativeUIBridge.currentTree.value = diffedTree
+                            NativeUIBridge.publishTree(diffedTree)
                             // First publish after a hot-reload dismisses
                             // the "Reloading…" pill and clears the
                             // tree-preservation flag. Both are set by

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeUIBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeUIBridge.kt
@@ -2,6 +2,7 @@ package com.nativephp.mobile.ui.nativerender
 
 import android.util.Log
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 
 /**
@@ -18,6 +19,14 @@ class NativeUIBridge private constructor() {
 
         /** Current parsed tree — observed by the Compose renderer */
         val currentTree = mutableStateOf<NativeUITree?>(null)
+
+        /** Public revision for observing every mounted tree publication, including equal trees. */
+        val treePublicationId = mutableLongStateOf(0L)
+
+        internal fun publishTree(tree: NativeUITree) {
+            currentTree.value = tree
+            treePublicationId.longValue++
+        }
 
         /** Whether the native UI system is active */
         val isActive = mutableStateOf(false)

--- a/resources/androidstudio/app/src/test/java/com/nativephp/mobile/ui/nativerender/NativeUIBridgeTest.kt
+++ b/resources/androidstudio/app/src/test/java/com/nativephp/mobile/ui/nativerender/NativeUIBridgeTest.kt
@@ -1,0 +1,53 @@
+package com.nativephp.mobile.ui.nativerender
+
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.snapshots.Snapshot
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class NativeUIBridgeTest {
+    @Test
+    fun identicalTreePublicationsAdvanceTheObservableRevisionIndependently() = runBlocking {
+        val tree = NativeUITree(
+            version = 0,
+            callbackCount = 0,
+            root = NativeUINode(
+                id = 1,
+                type = "column",
+                layout = null,
+                style = null,
+                props = GenericProps(),
+                onPress = 0,
+                onLongPress = 0,
+                children = emptyList(),
+            ),
+        )
+        val initialPublicationId = NativeUIBridge.treePublicationId.longValue
+        val observedPublicationIds = mutableListOf<Long>()
+        val observation = launch(start = CoroutineStart.UNDISPATCHED) {
+            snapshotFlow { NativeUIBridge.treePublicationId.longValue }
+                .take(3)
+                .toList(observedPublicationIds)
+        }
+
+        NativeUIBridge.publishTree(tree)
+        Snapshot.sendApplyNotifications()
+        yield()
+        NativeUIBridge.publishTree(tree)
+        Snapshot.sendApplyNotifications()
+        observation.join()
+
+        assertSame(tree, NativeUIBridge.currentTree.value)
+        assertEquals(
+            listOf(initialPublicationId, initialPublicationId + 1L, initialPublicationId + 2L),
+            observedPublicationIds,
+        )
+    }
+}


### PR DESCRIPTION
Resolves #279 

## Summary
- expose a monotonically increasing Android tree-publication revision;
- route every successfully mounted native tree through one publication boundary;
- preserve the existing structural equality behavior of `currentTree`;
- cover repeated publication of the exact same tree with a focused unit test.

## Problem
Android currently exposes the latest native UI tree through a Compose `MutableState<NativeUITree?>`:

```kotlin
val currentTree = mutableStateOf<NativeUITree?>(null)
```

Compose's default state policy suppresses an assignment when the incoming tree compares equal to the current value. That behavior is correct for consumers interested only in changed state, but it means a consumer cannot observe that NativePHP successfully processed a new authoritative publication whose payload is equal to the previous tree.

An equal publication can still be meaningful. For example, a native control may have temporarily updated local state while an event was sent to PHP. If PHP rejects or normalizes that event and republishes the unchanged authoritative tree, the control needs to observe the publication so it can reconcile. Today, the Android bridge makes that publication indistinguishable from no publication.

The equivalent iOS bridge uses `@Published`, whose subscribers can observe each assignment, including an equal value.

## Solution

Add a public, observable `treePublicationId` and an internal `publishTree` boundary:

```kotlin
val currentTree = mutableStateOf<NativeUITree?>(null)
val treePublicationId = mutableLongStateOf(0L)

internal fun publishTree(tree: NativeUITree) {
    currentTree.value = tree
    treePublicationId.longValue++
}
```

`NativeElementBridge` now calls `publishTree(diffedTree)` after a tree has been successfully parsed, diffed, and posted to the main thread.

Consumers that need assignment/publication semantics can observe `treePublicationId` and then read `currentTree`. Existing consumers that only need changed-tree semantics can continue observing `currentTree` unchanged.

## Why a separate revision?

Changing `currentTree` to `neverEqualPolicy()` would force every equal tree assignment to invalidate all Compose consumers of the tree. That would turn a targeted publication requirement into a global recomposition policy and discard the useful structural equality behavior already present.

The explicit revision keeps the two contracts separate:

- `currentTree` is the latest tree state;
- `treePublicationId` records that another authoritative tree was mounted.

The publication method is internal so plugins can observe the revision but cannot manufacture core tree publications.

## Behavior preserved

- `currentTree` retains its existing structural equality policy.
- Existing tree-diff and subtree-reuse behavior is unchanged.
- Existing screen navigation revision behavior is unchanged.
- Failed tree parses do not advance the publication revision.
- Stopping the native UI system and clearing `currentTree` do not masquerade as mounted tree publications.
- No iOS code or public event payload is changed.

## Test plan

- [x] Add a unit test that publishes the exact same `NativeUITree` instance twice.
- [x] Assert that `currentTree` still contains that tree.
- [x] Assert that an observer sees the initial revision and both subsequent increments.
- [x] Run the focused unit test from a generated Android host.
- [x] Run the complete Android JVM unit-test task from a fresh rerun.
- [x] Run `git show --check` on the resulting commit.

Commands:

```bash
./gradlew testDebugUnitTest --tests com.nativephp.mobile.ui.nativerender.NativeUIBridgeTest
./gradlew testDebugUnitTest --rerun-tasks
git show --check HEAD
```

Results:

- Focused regression: `BUILD SUCCESSFUL`.
- Full Android JVM unit suite: `BUILD SUCCESSFUL`; 2 tests, 0 failures.
- Patch whitespace/error check: passed.

## Scope

This change adds the missing Android publication signal only. It does not change tree equality, tree diffing, navigation transitions, event dispatch, or renderer state policy.

