### PR TITLE
Fix deep link delivery in native-ui (EDGE) apps on iOS

### DIFF
--- a/resources/xcode/NativePHP/DeepLinkRouter.swift
+++ b/resources/xcode/NativePHP/DeepLinkRouter.swift
@@ -20,9 +20,20 @@ final class DeepLinkRouter {
     }
 
     private func processePendingURLIfReady() {
-        DebugLogger.shared.log("🔗 processePendingURLIfReady() - WebView: \(isWebViewReady), PHP: \(isPhpReady), Pending: \(pendingURL != nil)")
-        // Only process pending URL when both WebView and PHP are ready
-        if isWebViewReady && isPhpReady, let pendingURL = pendingURL {
+        DebugLogger.shared.log("🔗 processePendingURLIfReady() - WebView: \(isWebViewReady), PHP: \(isPhpReady), NativeUI: \(NativeUIBridge.shared.isActive), Pending: \(pendingURL != nil)")
+        // Native-ui apps never mark the WebView ready (see handle()) — once
+        // PHP is up, replay through the __deeplink event instead of a WebView
+        // load, which would queue behind the blocked native-ui loop.
+        guard isPhpReady, let pendingURL = pendingURL else {
+            return
+        }
+
+        if NativeUIBridge.shared.isActive {
+            let route = pendingURL.replacingOccurrences(of: "php://127.0.0.1", with: "")
+            DebugLogger.shared.log("🔗 Processing pending deep link via native-ui: \(route)")
+            dispatchNativeUIDeepLink(route.isEmpty ? "/" : route)
+            self.pendingURL = nil
+        } else if isWebViewReady {
             DebugLogger.shared.log("🔗 Processing pending URL: \(pendingURL)")
             self.redirectToURL(pendingURL)
             self.pendingURL = nil
@@ -31,6 +42,13 @@ final class DeepLinkRouter {
 
     func hasPendingURL() -> Bool {
         return pendingURL != nil
+    }
+
+    /// Re-attempt delivery of a parked deep link — called when native-ui
+    /// activates, since a cold-start link can arrive before the runtime
+    /// that handles __deeplink events is up.
+    func replayPendingDeepLink() {
+        processePendingURLIfReady()
     }
 
     func handle(url: URL) {
@@ -113,25 +131,26 @@ final class DeepLinkRouter {
 
         DebugLogger.shared.log("🔗 Normalized to: \(newURLString)")
 
-        // 3. Either navigate immediately or store for later
-        if isWebViewReady && isPhpReady {
+        // 3. Either navigate immediately or store for later.
+        // Native-UI (edge) apps never mark the WebView ready — it is only the
+        // php:// transport, no page-load callback fires — so gating on
+        // isWebViewReady would park every warm deep link as pending forever
+        // (OAuth auth-session callbacks included). The native-ui dispatch
+        // below goes through NativeElementBridge and never touches the
+        // WebView; PHP readiness is all it needs.
+        if isPhpReady && (isWebViewReady || NativeUIBridge.shared.isActive) {
             // App is already running. How we navigate depends on the runtime:
             if NativeUIBridge.shared.isActive {
-                // Native-UI (edge) app: the WebView is only the php:// transport,
-                // and its single PHP event loop is blocked running the current
-                // screen — a fresh webView.load(php://…) for a Route::native
-                // screen never commits (it queues behind the running loop), so
-                // warm deep/universal links would be silently dropped.
-                // Instead, wake the running loop with a native event carrying the
-                // target route; NativeComponent::dispatchNativeEvent turns it into
-                // a NavigationIntent::NAVIGATE and NativeRouter pushes the screen —
-                // the same path an in-app @tap navigate uses.
-                let escaped = normalizedRoute
-                    .replacingOccurrences(of: "\\", with: "\\\\")
-                    .replacingOccurrences(of: "\"", with: "\\\"")
-                let json = "{\"uri\":\"\(escaped)\"}"
-                DebugLogger.shared.log("🔗 Both ready (native-ui), dispatching __deeplink event: \(normalizedRoute)")
-                NativeElementBridge.sendNativeEvent(eventName: "__deeplink", payloadJson: json)
+                // Native-UI (edge) app: the single PHP event loop is blocked
+                // running the current screen — a fresh webView.load(php://…)
+                // for a Route::native screen never commits (it queues behind
+                // the running loop), so warm deep/universal links would be
+                // silently dropped.
+                // Instead, wake the running loop with a native event carrying
+                // the target route; NativeComponent::dispatchNativeEvent turns
+                // it into a NavigationIntent::NAVIGATE and NativeRouter pushes
+                // the screen — the same path an in-app @tap navigate uses.
+                dispatchNativeUIDeepLink(normalizedRoute)
             } else {
                 // Inertia/WebView SPA: use the SPA router to preserve state.
                 // This prevents Inertia from returning raw JSON on subsequent
@@ -141,9 +160,20 @@ final class DeepLinkRouter {
             }
         } else {
             DebugLogger.shared.log("🔗 Not ready, storing as pending URL")
-            // Store the URL to handle once both WebView and PHP are ready
+            // Store the URL to handle once the runtime is ready
             pendingURL = newURLString
         }
+    }
+
+    /// Wake the blocked native-ui PHP loop with the deep-link route (the
+    /// same path an in-app @tap navigate uses).
+    private func dispatchNativeUIDeepLink(_ route: String) {
+        let escaped = route
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        let json = "{\"uri\":\"\(escaped)\"}"
+        DebugLogger.shared.log("🔗 native-ui: dispatching __deeplink event: \(route)")
+        NativeElementBridge.sendNativeEvent(eventName: "__deeplink", payloadJson: json)
     }
 
     private func redirectToURL(_ urlString: String) {

--- a/resources/xcode/NativePHP/NativeRender/NativeUIBridge.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeUIBridge.swift
@@ -11,7 +11,16 @@ final class NativeUIBridge: ObservableObject {
     @Published var currentTree: NativeUITree?
 
     /// Whether the native UI system is active
-    @Published var isActive: Bool = false
+    @Published var isActive: Bool = false {
+        didSet {
+            // A deep link that launched the app (cold start) can arrive
+            // before native-ui takes over; replay it once the runtime that
+            // handles __deeplink events is actually active.
+            if isActive && !oldValue {
+                DeepLinkRouter.shared.replayPendingDeepLink()
+            }
+        }
+    }
 
     /// True between the start of a hot-reload event and the next tree
     /// publish from the rebooted PHP runtime. Drives the small Liquid


### PR DESCRIPTION
## The bug

Native-ui apps never call `markWebViewReady()` — the WebView is only the `php://` transport and no page-load callback ever fires — so `DeepLinkRouter`'s `isWebViewReady && isPhpReady` gate parks **every warm deep link as "pending" forever**.

The headline casualty: **all OAuth flows in native-ui apps are dead on arrival.** `Browser::auth()` completes, the custom-scheme callback reaches `DeepLinkRouter.handle()`, normalization succeeds… and the route is stored and never delivered:

```
🔗 DeepLinkRouter.handle() called with: galactica://auth/callback/12%7CETAb…
🔗 Current state - WebView ready: false, PHP ready: true
🔗 Normalized to: php://127.0.0.1/auth/callback/12|ETAb…
🔗 Not ready, storing as pending URL        ← dropped forever
```

## The fix

- **Warm path**: gate on `isPhpReady && (isWebViewReady || NativeUIBridge.shared.isActive)`. The native-ui branch dispatches through `NativeElementBridge.sendNativeEvent("__deeplink", …)` and never touches the WebView — PHP readiness is all it needs. Dispatch extracted into `dispatchNativeUIDeepLink()`.
- **Pending replay**: same gating; in native-ui mode it replays through the `__deeplink` event instead of `redirectToURL()`, whose WebView load would queue behind the blocked native-ui loop.
- **Cold-start race**: `NativeUIBridge.isActive` gained a `didSet` calling the new `DeepLinkRouter.replayPendingDeepLink()` — a launch-by-deep-link can arrive before native-ui takes over (`markPhpReady` fires first), and the replay would otherwise no-op with the link stuck.

Android is unaffected: `MainActivity.navigateWarm()` already gates on `bootReady` alone and dispatches `__deeplink` when native-ui is active.

## Verified

End-to-end GitHub OAuth in the iOS simulator: `Browser::auth()` → ASWebAuthenticationSession → custom-scheme callback → `/auth/callback/{token}` native route mounts and stores the token. Also exercised warm dispatch via `xcrun simctl openurl`.

Two adjacent traps hit while diagnosing (docs candidates, not part of this PR): the ASWebAuthenticationSession fallback callback scheme is the literal string `native` while docs examples imply `nativephp://`, and OAuth tokens containing `|` (Sanctum's format) must be percent-encoded or iOS's URL parser rejects the callback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)