### PR TITLE
Distinguish a locked device from a missing key in SecureStorage

### DIFF
--- a/resources/dist/native.d.ts
+++ b/resources/dist/native.d.ts
@@ -133,8 +133,23 @@ export const Share: {
 // SecureStorage Functions
 // ============================================================================
 
-export function SecureStorageSet(key: string, value: string | null): Promise<{ success: boolean }>;
-export function SecureStorageGet(key: string): Promise<{ value: string | null }>;
+/**
+ * When iOS may decrypt a stored item. All map to `ThisDeviceOnly` Keychain
+ * accessibilities; ignored on Android, where stored values are readable
+ * whenever the app's process can run.
+ */
+export type SecureStorageAccessibility = 'when_unlocked' | 'after_first_unlock' | 'when_passcode_set';
+
+/**
+ * `not_found` and `unavailable` both come back without a value and mean very
+ * different things: nothing is stored, versus the device is locked and the OS
+ * won't decrypt an item that may well be there. Retry an `unavailable` read
+ * after unlock — never treat it as a signed-out user.
+ */
+export type SecureStorageReadStatus = 'found' | 'not_found' | 'unavailable' | 'error';
+
+export function SecureStorageSet(key: string, value: string | null, accessibility?: SecureStorageAccessibility): Promise<{ success: boolean }>;
+export function SecureStorageGet(key: string): Promise<{ status: SecureStorageReadStatus; value: string | null; code?: string; message?: string }>;
 export function SecureStorageDelete(key: string): Promise<{ success: boolean }>;
 
 export const SecureStorage: {

--- a/resources/dist/native.js
+++ b/resources/dist/native.js
@@ -258,8 +258,16 @@ export const Share = {
 // SecureStorage Functions
 // ============================================================================
 
-export async function SecureStorageSet(key, value) {
-    return BridgeCall('SecureStorage.Set', { key, value });
+export async function SecureStorageSet(key, value, accessibility) {
+    const params = { key, value };
+
+    // Omitted unless asked for, so re-setting a key never silently tightens
+    // an accessibility it was deliberately stored with.
+    if (accessibility) {
+        params.accessibility = accessibility;
+    }
+
+    return BridgeCall('SecureStorage.Set', params);
 }
 
 export async function SecureStorageGet(key) {

--- a/resources/jump/dist/native.d.ts
+++ b/resources/jump/dist/native.d.ts
@@ -711,14 +711,29 @@ export const share: {
 // ============================================================================
 
 /**
+ * When iOS may decrypt a stored item. All map to `ThisDeviceOnly` Keychain
+ * accessibilities; ignored on Android, where stored values are readable
+ * whenever the app's process can run.
+ */
+export type SecureStorageAccessibility = 'when_unlocked' | 'after_first_unlock' | 'when_passcode_set';
+
+/**
+ * `not_found` and `unavailable` both come back without a value and mean very
+ * different things: nothing is stored, versus the device is locked and the OS
+ * won't decrypt an item that may well be there. Retry an `unavailable` read
+ * after unlock — never treat it as a signed-out user.
+ */
+export type SecureStorageReadStatus = 'found' | 'not_found' | 'unavailable' | 'error';
+
+/**
  * Store a value securely in the device keychain/keystore
  */
-export function secureStorageSet(key: string, value: string | null): Promise<{ success: boolean }>;
+export function secureStorageSet(key: string, value: string | null, accessibility?: SecureStorageAccessibility): Promise<{ success: boolean }>;
 
 /**
  * Retrieve a value from secure storage
  */
-export function secureStorageGet(key: string): Promise<{ value: string | null }>;
+export function secureStorageGet(key: string): Promise<{ status: SecureStorageReadStatus; value: string | null; code?: string; message?: string }>;
 
 /**
  * Delete a value from secure storage

--- a/resources/jump/dist/native.js
+++ b/resources/jump/dist/native.js
@@ -1325,16 +1325,31 @@ export const share = {
  * Store a value securely in the device keychain/keystore
  * @param {string} key - The key to store the value under
  * @param {string|null} value - The value to store securely (null to delete)
+ * @param {'when_unlocked'|'after_first_unlock'|'when_passcode_set'} [accessibility] - When iOS may
+ *        decrypt the item. Defaults to when_unlocked; ignored on Android.
  * @returns {Promise<{success: boolean}>}
  */
-export async function secureStorageSet(key, value) {
-    return bridgeCall('SecureStorage.Set', { key, value });
+export async function secureStorageSet(key, value, accessibility) {
+    const params = { key, value };
+
+    // Omitted unless asked for, so re-setting a key never silently tightens
+    // an accessibility it was deliberately stored with.
+    if (accessibility) {
+        params.accessibility = accessibility;
+    }
+
+    return bridgeCall('SecureStorage.Set', params);
 }
 
 /**
- * Retrieve a value from secure storage
+ * Retrieve a value from secure storage.
+ *
+ * `not_found` and `unavailable` both come back without a value and mean very
+ * different things: nothing is stored, versus the device is locked and the OS
+ * won't decrypt an item that may well be there.
+ *
  * @param {string} key - The key to retrieve
- * @returns {Promise<{value: string|null}>}
+ * @returns {Promise<{status: 'found'|'not_found'|'unavailable'|'error', value: string|null, code?: string, message?: string}>}
  */
 export async function secureStorageGet(key) {
     return bridgeCall('SecureStorage.Get', { key });

--- a/src/Facades/SecureStorage.php
+++ b/src/Facades/SecureStorage.php
@@ -6,7 +6,8 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static string|null get(string $key)
- * @method static bool set(string $key, ?string $value)
+ * @method static \Native\Mobile\SecureStorageResult read(string $key)
+ * @method static bool set(string $key, ?string $value, ?\Native\Mobile\SecureStorageAccessibility $accessibility = null)
  * @method static bool delete(string $key)
  */
 class SecureStorage extends Facade

--- a/src/SecureStorage.php
+++ b/src/SecureStorage.php
@@ -8,18 +8,32 @@ class SecureStorage
      * Store a secure value in the native keychain or keystore.
      *
      * @param  string  $key  The key to store the value under
-     * @param  string|null  $value  The value to store securely
+     * @param  string|null  $value  The value to store securely (null deletes the key)
+     * @param  SecureStorageAccessibility|null  $accessibility  When iOS may decrypt
+     *                                                          this item; defaults to
+     *                                                          WhenUnlocked. Re-setting
+     *                                                          an existing key with a
+     *                                                          different accessibility
+     *                                                          migrates it in place.
      * @return bool True if successfully stored, false otherwise
      */
-    public function set(string $key, ?string $value): bool
+    public function set(string $key, ?string $value, ?SecureStorageAccessibility $accessibility = null): bool
     {
         if (function_exists('nativephp_call')) {
-            $payload = json_encode([
+            $payload = [
                 'key' => $key,
                 'value' => $value,
-            ]);
+            ];
 
-            $result = nativephp_call('SecureStorage.Set', $payload);
+            // Left out entirely when unset, so the native side can tell "use
+            // the default" from "migrate this item" — re-setting a key without
+            // naming an accessibility must not silently tighten one that was
+            // deliberately stored as AfterFirstUnlock.
+            if ($accessibility !== null) {
+                $payload['accessibility'] = $accessibility->value;
+            }
+
+            $result = nativephp_call('SecureStorage.Set', json_encode($payload));
 
             if ($result) {
                 $decoded = json_decode($result, true);
@@ -34,28 +48,43 @@ class SecureStorage
     /**
      * Retrieve a secure value from the native keychain or keystore.
      *
+     * Null covers every outcome that isn't a hit — including a device locked
+     * too tightly to decrypt the item, which is *not* the same as the key
+     * being absent. Anything that branches on the difference (background sync,
+     * sign-out detection, re-provisioning) should call `read()` instead.
+     *
      * @param  string  $key  The key to retrieve the value for
-     * @return string|null The stored value or null if not found
+     * @return string|null The stored value, or null if it could not be read
      */
     public function get(string $key): ?string
     {
-        if (function_exists('nativephp_call')) {
-            $payload = json_encode([
-                'key' => $key,
-            ]);
+        return $this->read($key)->value;
+    }
 
-            $result = nativephp_call('SecureStorage.Get', $payload);
-
-            if ($result) {
-                $decoded = json_decode($result, true);
-                $value = $decoded['value'] ?? null;
-
-                // Treat empty string as null (not found)
-                return ($value === '' || $value === null) ? null : $value;
-            }
+    /**
+     * Retrieve a secure value along with the reason it isn't there.
+     *
+     * Distinguishes a hit from an empty key, a locked device, and a native
+     * failure (a missing plugin, a corrupt keystore, an unreachable bridge).
+     *
+     * @param  string  $key  The key to retrieve the value for
+     */
+    public function read(string $key): SecureStorageResult
+    {
+        if (! function_exists('nativephp_call')) {
+            return SecureStorageResult::failure(
+                'BRIDGE_UNAVAILABLE',
+                'Secure storage is only available inside a NativePHP app.'
+            );
         }
 
-        return null;
+        $payload = json_encode([
+            'key' => $key,
+        ]);
+
+        return SecureStorageResult::fromBridge(
+            nativephp_call('SecureStorage.Get', $payload)
+        );
     }
 
     /**

--- a/src/SecureStorageAccessibility.php
+++ b/src/SecureStorageAccessibility.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Native\Mobile;
+
+/**
+ * When a stored item may be decrypted.
+ *
+ * Passed to `SecureStorage::set()` per key, so an app can keep a refresh
+ * token locked away while still letting a background sync read the access
+ * token it needs. Every case maps to a `ThisDeviceOnly` iOS accessibility:
+ * secrets written here never sync to iCloud Keychain and never restore onto
+ * a different device.
+ *
+ * Android's EncryptedSharedPreferences master key is not tied to the device
+ * lock state — stored values are readable whenever the app's process can
+ * run, which is already after-first-unlock behaviour — so the plugin accepts
+ * this and ignores it there.
+ */
+enum SecureStorageAccessibility: string
+{
+    /**
+     * Readable only while the device is unlocked
+     * (`kSecAttrAccessibleWhenUnlockedThisDeviceOnly`). The default, and the
+     * safest — but a background read while the phone is locked returns
+     * SecureStorageStatus::Unavailable rather than the value.
+     */
+    case WhenUnlocked = 'when_unlocked';
+
+    /**
+     * Readable after the device has been unlocked once since boot
+     * (`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`). The right choice
+     * for anything background execution has to read while the screen is
+     * locked, e.g. an API access token driving a sync task.
+     */
+    case AfterFirstUnlock = 'after_first_unlock';
+
+    /**
+     * Readable only while unlocked, and only while a passcode is set
+     * (`kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly`). The item is
+     * discarded if the user removes their passcode.
+     */
+    case WhenPasscodeSet = 'when_passcode_set';
+}

--- a/src/SecureStorageResult.php
+++ b/src/SecureStorageResult.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Native\Mobile;
+
+/**
+ * The result of `SecureStorage::read()` — the value plus *why* there isn't
+ * one, which a bare `?string` can't express.
+ *
+ *     $result = SecureStorage::read('access_token');
+ *
+ *     match (true) {
+ *         $result->found()       => $this->sync($result->value),
+ *         $result->missing()     => $this->requireSignIn(),
+ *         $result->unavailable() => $this->retryAfterUnlock(),
+ *         $result->failed()      => report($result->message),
+ *     };
+ */
+final class SecureStorageResult
+{
+    public function __construct(
+        public readonly SecureStorageStatus $status,
+        public readonly ?string $value = null,
+        public readonly ?string $code = null,
+        public readonly ?string $message = null,
+    ) {}
+
+    /**
+     * Interpret a raw `SecureStorage.Get` response.
+     *
+     * Handles both the current vocabulary (an explicit `status`) and the
+     * shape older builds of the secure storage plugin answer with, so a new
+     * core paired with an old plugin still tells locked apart from empty.
+     */
+    public static function fromBridge(?string $json): self
+    {
+        if ($json === null || trim($json) === '') {
+            return self::failure('BRIDGE_UNAVAILABLE', 'The native bridge returned no response.');
+        }
+
+        $decoded = json_decode($json, true);
+
+        if (! is_array($decoded)) {
+            return self::failure('MALFORMED_RESPONSE', "The native bridge returned a response that could not be decoded: {$json}");
+        }
+
+        $value = $decoded['value'] ?? null;
+        $code = isset($decoded['code']) ? (string) $decoded['code'] : null;
+
+        $status = SecureStorageStatus::tryFrom((string) ($decoded['status'] ?? ''));
+
+        // Plugin builds that predate the status vocabulary answer a read with
+        // nothing but {"value": …}, using the empty string for "nothing
+        // stored". Infer from that. A locked read still surfaces there, as
+        // Failed rather than Unavailable — the plugin raises the Keychain's
+        // errSecInteractionNotAllowed through the bridge error envelope — and
+        // Failed-vs-NotFound is the distinction callers actually branch on.
+        $status ??= ($value === null || $value === '')
+            ? SecureStorageStatus::NotFound
+            : SecureStorageStatus::Found;
+
+        // A native side that reports "protected data unavailable" through the
+        // error envelope rather than a status still means the same thing.
+        if ($status === SecureStorageStatus::Failed
+            && in_array($code, ['UNAVAILABLE', 'PROTECTED_DATA_UNAVAILABLE'], true)) {
+            $status = SecureStorageStatus::Unavailable;
+        }
+
+        return new self(
+            $status,
+            $status === SecureStorageStatus::Found && is_scalar($value) ? (string) $value : null,
+            $code,
+            isset($decoded['message']) ? (string) $decoded['message'] : null,
+        );
+    }
+
+    public static function failure(string $code, string $message): self
+    {
+        return new self(SecureStorageStatus::Failed, code: $code, message: $message);
+    }
+
+    public function found(): bool
+    {
+        return $this->status === SecureStorageStatus::Found;
+    }
+
+    /** The key genuinely holds nothing — safe to treat as "never stored". */
+    public function missing(): bool
+    {
+        return $this->status === SecureStorageStatus::NotFound;
+    }
+
+    /**
+     * The device is locked and the OS won't decrypt the item. Transient —
+     * back off and read again once the device unlocks, and never take this
+     * as a signal to clear or re-provision the key.
+     */
+    public function unavailable(): bool
+    {
+        return $this->status === SecureStorageStatus::Unavailable;
+    }
+
+    public function failed(): bool
+    {
+        return $this->status === SecureStorageStatus::Failed;
+    }
+
+    /** The stored value, or $default for anything other than a hit. */
+    public function valueOr(?string $default): ?string
+    {
+        return $this->found() ? $this->value : $default;
+    }
+}

--- a/src/SecureStorageStatus.php
+++ b/src/SecureStorageStatus.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Native\Mobile;
+
+/**
+ * The outcome of a secure storage read.
+ *
+ * Three of these carry a null value, and conflating them is what makes
+ * `SecureStorage::get()` alone unsafe to branch on: "nothing is stored here"
+ * and "the OS won't decrypt this right now" look identical to a caller that
+ * only sees null. On iOS a Keychain item written with the default
+ * `WhenUnlocked` accessibility is unreadable while the device is locked, so a
+ * background job that treats null as "signed out" will happily wipe the very
+ * tokens it should have waited for. `read()` returns the status alongside the
+ * value so callers can retry instead of guessing.
+ *
+ * The string values are the wire vocabulary the native side answers with —
+ * `error` is the shared bridge failure envelope every plugin already emits,
+ * so it maps straight through.
+ */
+enum SecureStorageStatus: string
+{
+    /** The item exists and its value was decrypted. */
+    case Found = 'found';
+
+    /** The item genuinely isn't in the keychain/keystore. */
+    case NotFound = 'not_found';
+
+    /**
+     * The item may well exist, but protected data is unavailable — iOS
+     * refused to decrypt it because the device is locked. Transient: retry
+     * once the device unlocks, or store the key with a looser accessibility
+     * (see SecureStorageAccessibility::AfterFirstUnlock).
+     */
+    case Unavailable = 'unavailable';
+
+    /**
+     * The native call failed outright — the plugin isn't installed, the
+     * keystore is corrupt, the bridge is unreachable. Inspect the result's
+     * `code` and `message`.
+     */
+    case Failed = 'error';
+}

--- a/tests/Unit/SecureStorageTest.php
+++ b/tests/Unit/SecureStorageTest.php
@@ -1,0 +1,198 @@
+<?php
+
+use Native\Mobile\SecureStorage;
+use Native\Mobile\SecureStorageAccessibility;
+use Native\Mobile\SecureStorageResult;
+use Native\Mobile\SecureStorageStatus;
+use Native\Mobile\Testing\FakeBridge;
+
+afterEach(fn () => FakeBridge::disable());
+
+// ── Reads: the four outcomes ────────────────────────
+
+it('reports a hit with its value', function () {
+    FakeBridge::enable()->respondTo('SecureStorage.Get', [
+        'status' => 'found',
+        'value' => 'token-abc',
+    ]);
+
+    $result = (new SecureStorage)->read('access_token');
+
+    expect($result->status)->toBe(SecureStorageStatus::Found)
+        ->and($result->found())->toBeTrue()
+        ->and($result->value)->toBe('token-abc');
+});
+
+it('reports a key that holds nothing', function () {
+    FakeBridge::enable()->respondTo('SecureStorage.Get', [
+        'status' => 'not_found',
+        'value' => null,
+    ]);
+
+    $result = (new SecureStorage)->read('access_token');
+
+    expect($result->missing())->toBeTrue()
+        ->and($result->found())->toBeFalse()
+        ->and($result->value)->toBeNull();
+});
+
+it('reports a locked device apart from a missing key', function () {
+    FakeBridge::enable()->respondTo('SecureStorage.Get', [
+        'status' => 'unavailable',
+        'value' => null,
+        'code' => 'INTERACTION_NOT_ALLOWED',
+        'message' => 'Protected data is unavailable while the device is locked',
+    ]);
+
+    $result = (new SecureStorage)->read('access_token');
+
+    expect($result->unavailable())->toBeTrue()
+        ->and($result->missing())->toBeFalse()
+        ->and($result->code)->toBe('INTERACTION_NOT_ALLOWED');
+});
+
+it('reports a native failure with its code and message', function () {
+    FakeBridge::enable()->respondTo('SecureStorage.Get', [
+        'status' => 'error',
+        'code' => 'FUNCTION_NOT_FOUND',
+        'message' => "Function 'SecureStorage.Get' not found in bridge registry",
+    ]);
+
+    $result = (new SecureStorage)->read('access_token');
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->missing())->toBeFalse()
+        ->and($result->code)->toBe('FUNCTION_NOT_FOUND');
+});
+
+it('treats a locked-device error envelope as unavailable', function () {
+    FakeBridge::enable()->respondTo('SecureStorage.Get', [
+        'status' => 'error',
+        'code' => 'PROTECTED_DATA_UNAVAILABLE',
+        'message' => 'Protected data is unavailable',
+    ]);
+
+    expect((new SecureStorage)->read('access_token')->unavailable())->toBeTrue();
+});
+
+it('fails a read when the bridge answers nothing', function () {
+    FakeBridge::enable();
+
+    $result = (new SecureStorage)->read('access_token');
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->code)->toBe('BRIDGE_UNAVAILABLE');
+});
+
+it('fails a read when the bridge answers something undecodable', function () {
+    FakeBridge::enable()->respondTo('SecureStorage.Get', 'not json at all');
+
+    $result = (new SecureStorage)->read('access_token');
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->code)->toBe('MALFORMED_RESPONSE');
+});
+
+// ── Reads: plugin builds without the status vocabulary ──
+
+it('infers a hit from a bare value', function () {
+    FakeBridge::enable()->respondTo('SecureStorage.Get', ['value' => 'token-abc']);
+
+    expect((new SecureStorage)->read('access_token')->found())->toBeTrue();
+});
+
+it('infers a miss from the empty string an older plugin sends', function () {
+    FakeBridge::enable()->respondTo('SecureStorage.Get', ['value' => '']);
+
+    $result = (new SecureStorage)->read('access_token');
+
+    expect($result->missing())->toBeTrue()
+        ->and($result->value)->toBeNull();
+});
+
+it('keeps a locked read distinguishable on an older plugin', function () {
+    // 1.0.1 raises the Keychain's errSecInteractionNotAllowed through the
+    // generic bridge error envelope — Failed, but still not NotFound.
+    FakeBridge::enable()->respondTo('SecureStorage.Get', [
+        'status' => 'error',
+        'code' => 'EXECUTION_FAILED',
+        'message' => 'Function execution failed: Failed to load from keychain (status: -25308)',
+    ]);
+
+    $result = (new SecureStorage)->read('access_token');
+
+    expect($result->failed())->toBeTrue()
+        ->and($result->missing())->toBeFalse();
+});
+
+// ── get() stays a plain ?string ─────────────────────
+
+it('still returns the value from get', function () {
+    FakeBridge::enable()->respondTo('SecureStorage.Get', [
+        'status' => 'found',
+        'value' => 'token-abc',
+    ]);
+
+    expect((new SecureStorage)->get('access_token'))->toBe('token-abc');
+});
+
+it('still returns null from get for every non-hit', function (array $response) {
+    FakeBridge::enable()->respondTo('SecureStorage.Get', $response);
+
+    expect((new SecureStorage)->get('access_token'))->toBeNull();
+})->with([
+    'not found' => [['status' => 'not_found', 'value' => null]],
+    'unavailable' => [['status' => 'unavailable', 'value' => null]],
+    'failed' => [['status' => 'error', 'code' => 'EXECUTION_FAILED']],
+    'legacy empty string' => [['value' => '']],
+]);
+
+// ── Writes ──────────────────────────────────────────
+
+it('sends no accessibility when none is asked for', function () {
+    $bridge = FakeBridge::enable()->respondTo('SecureStorage.Set', ['success' => true]);
+
+    expect((new SecureStorage)->set('access_token', 'token-abc'))->toBeTrue();
+
+    $bridge->assertCalled('SecureStorage.Set', fn (array $params) => $params === [
+        'key' => 'access_token',
+        'value' => 'token-abc',
+    ]);
+});
+
+it('sends the accessibility a key is stored with', function () {
+    $bridge = FakeBridge::enable()->respondTo('SecureStorage.Set', ['success' => true]);
+
+    (new SecureStorage)->set('access_token', 'token-abc', SecureStorageAccessibility::AfterFirstUnlock);
+
+    $bridge->assertCalled(
+        'SecureStorage.Set',
+        fn (array $params) => $params['accessibility'] === 'after_first_unlock'
+    );
+});
+
+it('still deletes a key by setting null', function () {
+    $bridge = FakeBridge::enable()->respondTo('SecureStorage.Set', ['success' => true]);
+
+    (new SecureStorage)->set('access_token', null);
+
+    $bridge->assertCalled(
+        'SecureStorage.Set',
+        fn (array $params) => array_key_exists('value', $params) && $params['value'] === null
+    );
+});
+
+// ── Result parsing in isolation ─────────────────────
+
+it('falls back to a default for anything but a hit', function () {
+    expect(SecureStorageResult::fromBridge('{"status":"found","value":"v"}')->valueOr('fallback'))->toBe('v')
+        ->and(SecureStorageResult::fromBridge('{"status":"unavailable"}')->valueOr('fallback'))->toBe('fallback')
+        ->and(SecureStorageResult::fromBridge(null)->valueOr('fallback'))->toBe('fallback');
+});
+
+it('keeps an explicitly stored empty string', function () {
+    $result = SecureStorageResult::fromBridge('{"status":"found","value":""}');
+
+    expect($result->found())->toBeTrue()
+        ->and($result->value)->toBe('');
+});


### PR DESCRIPTION
Reported by a user storing API credentials on a physical iPhone. Background sync should read an access token while the phone is locked after first unlock; instead both tokens read as `null` while locked, and the original access token was readable again in the foreground minutes later without any rewrite. That's the Keychain accessibility class working as designed, reported to PHP as if the data were gone.

## The problem

`SecureStorage::get()` returns `null` for a value that isn't there **and** for one the OS refused to decrypt. Those are not the same thing. iOS stores items with `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`, so a locked read fails with `errSecInteractionNotAllowed`, the plugin raises it as a bridge error, and `get()` — which reads only the `value` field — hands back `null`. A background job then concludes the user signed out and clears credentials that were never gone.

## Changes

**`read()` returns the reason alongside the value.**

```php
$result = SecureStorage::read('access_token');

match (true) {
    $result->found()       => $this->sync($result->value),
    $result->missing()     => $this->requireSignIn(),
    $result->unavailable() => $this->retryAfterUnlock(),  // device locked
    $result->failed()      => report($result->message),   // native code + message
};
```

`failed()` also covers what was previously invisible: the plugin not being installed, a corrupt keystore, an unreachable bridge. `get()` keeps its `?string` signature and is now expressed in terms of `read()`.

**`set()` takes an optional per-key accessibility** — `WhenUnlocked` (default), `AfterFirstUnlock`, `WhenPasscodeSet`, all `ThisDeviceOnly` — so an access token a background task needs can be readable after first unlock while the refresh token stays sealed:

```php
SecureStorage::set('access_token', $access, SecureStorageAccessibility::AfterFirstUnlock);
```

It's omitted from the payload entirely when unset, so the native side can tell "use the default" from "migrate this item". A plain overwrite must not silently re-lock a key someone deliberately opened up.

New: `SecureStorageStatus`, `SecureStorageResult`, `SecureStorageAccessibility`. The JS/TS surface in `resources/dist/` and `resources/jump/dist/` mirrors both.

## Works with the currently released plugin

`SecureStorageResult::fromBridge()` reads both the new `status` vocabulary and the bare `{"value": …}` shape older `mobile-secure-storage` builds answer with, so **this fixes the reported blocker on its own**: on plugin 1.0.1 a locked read arrives as the `EXECUTION_FAILED` envelope → `failed()`, still distinct from `missing()`. Verified by running the released plugin's own test suite (61 tests, unmodified) against this branch — all pass.

Two degradations until the plugin ships: `read()` never reports `unavailable` (locked reads land in `failed()` instead), and `set(..., $accessibility)` is a silent no-op — the old native `Set` ignores the extra field and still returns `{"success": true}`. Worth deciding whether `set()` should return `false` when a requested accessibility isn't echoed back.

## Pairs with

NativePHP/mobile-secure-storage#2 — the native half: `errSecInteractionNotAllowed` mapped to `unavailable` instead of thrown, per-key accessibility applied, `kSecAttrAccessible` carried on `SecItemUpdate` so existing items can migrate. **Ship this first** — the plugin's new `status` field is harmless to older cores, but `read()` and `SecureStorageAccessibility` only exist here.

## Testing

20 new tests covering all four statuses, the legacy response shape, `get()`'s unchanged contract, and the payload `set()` emits. Full suite: 838 passing. Pint clean; PHPStan unchanged (the 4 pre-existing `Commands/JumpCommand.php` QR-builder errors remain).

Not covered: the Keychain behaviour itself needs a physical device — store a key, background the app, lock the phone, read during background execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
