### PR TITLE
Fix top-bar background_color not rendering at the scroll edge (iOS)

### DIFF
--- a/resources/xcode/NativePHP/NativeRender/NativeRootStackRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeRootStackRenderer.swift
@@ -408,9 +408,20 @@ private struct StackBarBackgroundModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         if argb != 0 {
-            if #available(iOS 26.0, *) {
+            if #available(iOS 18.0, *) {
+                // `containerBackground(for: .navigation)` themes the WHOLE
+                // navigation surface — the scroll edge, the expanded
+                // large-title region, and the status-bar area — while bar
+                // visibility stays automatic. Without it the bar color only
+                // renders after scrolling (toolbarBackground alone does not
+                // paint at the scroll edge, exactly where a large title
+                // lives), and forcing `.visible` paints the band but
+                // suppresses the large title at the scroll edge under
+                // Liquid Glass. toolbarBackground still tints the collapsed
+                // bar after scrolling.
                 content
                     .toolbarBackground(Color(argb: argb), for: .navigationBar)
+                    .containerBackground(Color(argb: argb), for: .navigation)
             } else {
                 content
                     .toolbarBackground(Color(argb: argb), for: .navigationBar)


### PR DESCRIPTION
An explicit `top-bar background_color` feeds `.toolbarBackground`, which does not paint at the scroll edge — exactly where an expanded large title lives — so the color only appears after scrolling, and themed apps show a system-background band behind the large title (white in light mode, black in dark).

Forcing `.toolbarBackground(.visible)` paints the band but **suppresses the large title at the scroll edge under Liquid Glass** (title only appears once collapsed) — we hit both failure modes in a real app before landing on this.

## The fix

On iOS 18+, use `containerBackground(for: .navigation)` — the first-class API for theming the whole navigation surface (scroll edge, expanded large-title region, status-bar area) — while bar visibility stays automatic and the large title renders normally. `toolbarBackground` still tints the collapsed bar after scrolling. Pre-18 keeps the forced-visible fallback (no Liquid Glass interaction there).

`ContainerBackgroundPlacement.navigation` availability (iOS 18) verified against the SDK swiftinterface.

## Verified

Themed app (Galactica), light and dark: at rest the full surface carries the theme background with the large title intact; scrolled, the collapsed bar keeps the tint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)