### PR TITLE
Ship the real app name in CFBundleName (OAuth consent alert fix)

### DIFF
--- a/src/Concerns/RunsIos.php
+++ b/src/Concerns/RunsIos.php
@@ -266,6 +266,8 @@ trait RunsIos
         Process::path($basePath)
             ->run('lsof -ti tcp:9999 | xargs kill -9 2>/dev/null');
 
+        $this->fixProductBundleName($basePath, 'build/Build/Products/Debug-iphonesimulator/NativePHP-simulator.app');
+
         $this->components->task('Installing app on simulator', function () use ($basePath, $target, $verbose) {
             Process::path($basePath)
                 ->forever()
@@ -311,6 +313,8 @@ trait RunsIos
         $installFailed = false;
         $isRelease = $this->option('build') === 'release';
         $configuration = $isRelease ? 'Release' : 'Debug';
+
+        $this->fixProductBundleName($basePath, "build/Build/Products/{$configuration}-iphoneos/NativePHP.app", resign: true);
 
         $this->components->task('Deploying app to device', function () use ($basePath, $target, $verbose, &$installFailed, $configuration) {
             $installResult = Process::path($basePath)
@@ -429,5 +433,48 @@ trait RunsIos
             label: 'Select a target device/simulator',
             options: $options
         );
+    }
+
+    /**
+     * Xcode's generated Info.plist pins CFBundleName to PRODUCT_NAME
+     * ("NativePHP") and, with GENERATE_INFOPLIST_FILE=YES, that generated
+     * value overrides a CFBundleName entry in the source Info.plist. System
+     * surfaces that read CFBundleName — most visibly the
+     * ASWebAuthenticationSession consent alert ("X" Wants to Use "site" to
+     * Sign In) — therefore introduce every app as "NativePHP". Patch the
+     * BUILT product's plist and re-sign it with the identity that already
+     * signed it, so the installed app carries the real app name.
+     */
+    private function fixProductBundleName(string $basePath, string $appRelativePath, bool $resign = false): void
+    {
+        $app = rtrim($basePath, '/').'/'.$appRelativePath;
+        $name = (string) config('app.name');
+
+        if ($name === '' || ! is_dir($app)) {
+            return;
+        }
+
+        $plist = $app.'/Info.plist';
+
+        $set = Process::run(['/usr/libexec/PlistBuddy', '-c', "Set :CFBundleName {$name}", $plist]);
+
+        if (! $set->successful()) {
+            Process::run(['/usr/libexec/PlistBuddy', '-c', "Add :CFBundleName string {$name}", $plist]);
+        }
+
+        if (! $resign) {
+            return;
+        }
+
+        // Editing the bundle invalidated its signature; re-sign with the
+        // same identity (first Authority of the existing signature).
+        $info = Process::run(['codesign', '-dvv', $app]);
+        preg_match('/Authority=([^\n]+)/', $info->errorOutput().$info->output(), $m);
+        $identity = trim($m[1] ?? 'Apple Development');
+
+        Process::run([
+            'codesign', '--force', '--sign', $identity,
+            '--preserve-metadata=identifier,entitlements,flags', $app,
+        ]);
     }
 }


### PR DESCRIPTION
Every NativePHP app doing OAuth via `Browser::auth()` introduces itself as **"NativePHP"** in the `ASWebAuthenticationSession` consent alert ("X" Wants to Use "site" to Sign In) — that surface reads `CFBundleName`, which Xcode's generated Info.plist pins to `PRODUCT_NAME`.

Empirically verified dead ends before this fix:
- `CFBundleDisplayName` (already set from `app.name`) does not reach the consent alert — a build carrying `CFBundleDisplayName = Galactica` still showed "NativePHP".
- With `GENERATE_INFOPLIST_FILE = YES`, a `CFBundleName` entry in the **source** Info.plist is overridden by the generated value — confirmed by diffing the source plist against the built product.
- Renaming `PRODUCT_NAME` would fix it but ripples through every hardcoded `NativePHP.app` path in the pipeline.

## The fix

Post-build, pre-install: patch `CFBundleName` in the **built product's** Info.plist (PlistBuddy Set-with-Add-fallback), then re-sign the bundle with the identity that already signed it (first `Authority` of the existing signature, `--preserve-metadata=identifier,entitlements,flags`) so `devicectl` accepts the modified bundle. Applied on both the device and simulator install paths; no-op when `app.name` is empty or the product is missing.

## Verified

Real-device OAuth flow now presents "**Galactica** Wants to Use … to Sign In".

🤖 Generated with [Claude Code](https://claude.com/claude-code)