### PR TITLE
Extend shows-indicators to refreshable and lazy-grid

### DIFF
--- a/src/Edge/Elements/LazyGrid.php
+++ b/src/Edge/Elements/LazyGrid.php
@@ -59,6 +59,9 @@ class LazyGrid extends Element
         if (isset($attrs['horizontal'])) {
             $this->horizontal((bool) $attrs['horizontal']);
         }
+        if (isset($attrs['showsIndicators']) || isset($attrs['shows-indicators'])) {
+            $this->showsIndicators((bool) ($attrs['showsIndicators'] ?? $attrs['shows-indicators']));
+        }
     }
 
     public function columns(int $count): static
@@ -83,6 +86,18 @@ class LazyGrid extends Element
     public function horizontal(bool $value = true): static
     {
         $this->gridProps['horizontal'] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Same contract as scroll-view, but the grid's historical default is
+     * HIDDEN — pass true to opt long grids into a scroll-position cue.
+     * iOS-only in effect: Compose's lazy grids draw no indicators anyway.
+     */
+    public function showsIndicators(bool $value = true): static
+    {
+        $this->gridProps['shows_indicators'] = $value;
 
         return $this;
     }

--- a/src/Edge/Elements/Refreshable.php
+++ b/src/Edge/Elements/Refreshable.php
@@ -30,6 +30,8 @@ class Refreshable extends Element
 
     private ?string $refreshMethod = null;
 
+    private ?bool $showsIndicators = null;
+
     public static function make(): static
     {
         return new static;
@@ -42,11 +44,26 @@ class Refreshable extends Element
         return $this;
     }
 
+    /**
+     * Show or hide the scroll indicators, matching scroll-view's prop of
+     * the same name. iOS-only in effect: Compose's LazyColumn draws no
+     * indicators to begin with, so Android accepts and ignores it.
+     */
+    public function showsIndicators(bool $value = true): static
+    {
+        $this->showsIndicators = $value;
+
+        return $this;
+    }
+
     protected function resolveProps(CallbackRegistry $registry): array
     {
         $props = [];
         if ($this->refreshMethod !== null) {
             $props['on_refresh'] = $registry->register($this->refreshMethod);
+        }
+        if ($this->showsIndicators !== null) {
+            $props['shows_indicators'] = $this->showsIndicators;
         }
 
         return $props;

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -3,6 +3,7 @@
 namespace Native\Mobile\Edge;
 
 use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Elements\Refreshable;
 use Native\Mobile\Edge\Elements\Row;
 use Native\Mobile\Edge\Elements\ScrollView;
 use Native\Mobile\Edge\Elements\Stack;
@@ -1520,6 +1521,15 @@ class NativeElementCollector
             // Accept both kebab (`shows-indicators`) and camel
             // (`showsIndicators`) — the precompiler keeps attribute names
             // verbatim, and the rest of the API takes either form.
+            if (isset($attrs['showsIndicators']) || isset($attrs['shows-indicators'])) {
+                $element->showsIndicators((bool) ($attrs['showsIndicators'] ?? $attrs['shows-indicators']));
+            }
+        }
+
+        if ($element instanceof Refreshable) {
+            // Refreshable IS the scrolling container, so it honours the same
+            // indicator prop as scroll-view (iOS-only in effect — Compose's
+            // LazyColumn draws no indicators to begin with).
             if (isset($attrs['showsIndicators']) || isset($attrs['shows-indicators'])) {
                 $element->showsIndicators((bool) ($attrs['showsIndicators'] ?? $attrs['shows-indicators']));
             }

--- a/tests/Unit/Edge/NativeElementCollectorTest.php
+++ b/tests/Unit/Edge/NativeElementCollectorTest.php
@@ -195,6 +195,20 @@ it('applies scroll view props', function () {
     expect($tree['children'])->toHaveCount(1);
 });
 
+it('applies refreshable scroll-indicator props', function () {
+    NativeElementCollector::open('refreshable', [
+        'shows-indicators' => false,
+    ]);
+    NativeElementCollector::leaf('text', ['text' => 'Scrollable']);
+    NativeElementCollector::close();
+
+    $tree = NativeElementCollector::collect()->toArray(new CallbackRegistry);
+
+    expect($tree['type'])->toBe('refreshable');
+    expect($tree['props']['shows_indicators'])->toBeFalse();
+    expect($tree['children'])->toHaveCount(1);
+});
+
 it('applies node-level onPress and onLongPress', function () {
     NativeElementCollector::open('column', [
         '_press' => 'tapColumn',

--- a/tests/Unit/Edge/NativeElementCollectorTest.php
+++ b/tests/Unit/Edge/NativeElementCollectorTest.php
@@ -195,6 +195,28 @@ it('applies scroll view props', function () {
     expect($tree['children'])->toHaveCount(1);
 });
 
+it('applies lazy grid scroll-indicator props', function () {
+    // The lazy_grid type is registered by the native-ui plugin's manifest,
+    // but the element class is core-owned — register it explicitly so this
+    // stays testable without the plugin.
+    \Native\Mobile\Edge\ElementRegistry::register('lazy_grid', \Native\Mobile\Edge\Elements\LazyGrid::class);
+
+    NativeElementCollector::open('lazy_grid', [
+        'columns' => 3,
+        'shows-indicators' => true,
+    ]);
+    NativeElementCollector::leaf('text', ['text' => 'Cell']);
+    NativeElementCollector::close();
+
+    $tree = NativeElementCollector::collect()->toArray(new CallbackRegistry);
+
+    expect($tree['type'])->toBe('lazy_grid');
+    expect($tree['props']['columns'])->toBe(3);
+    expect($tree['props']['shows_indicators'])->toBeTrue();
+
+    \Native\Mobile\Edge\ElementRegistry::reset();
+});
+
 it('applies refreshable scroll-indicator props', function () {
     NativeElementCollector::open('refreshable', [
         'shows-indicators' => false,

--- a/tests/Unit/Edge/NativeElementCollectorTest.php
+++ b/tests/Unit/Edge/NativeElementCollectorTest.php
@@ -2,7 +2,9 @@
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\ElementRegistry;
 use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Elements\LazyGrid;
 use Native\Mobile\Edge\Elements\Text;
 use Native\Mobile\Edge\NativeElementCollector;
 
@@ -199,7 +201,7 @@ it('applies lazy grid scroll-indicator props', function () {
     // The lazy_grid type is registered by the native-ui plugin's manifest,
     // but the element class is core-owned — register it explicitly so this
     // stays testable without the plugin.
-    \Native\Mobile\Edge\ElementRegistry::register('lazy_grid', \Native\Mobile\Edge\Elements\LazyGrid::class);
+    ElementRegistry::register('lazy_grid', LazyGrid::class);
 
     NativeElementCollector::open('lazy_grid', [
         'columns' => 3,
@@ -214,7 +216,7 @@ it('applies lazy grid scroll-indicator props', function () {
     expect($tree['props']['columns'])->toBe(3);
     expect($tree['props']['shows_indicators'])->toBeTrue();
 
-    \Native\Mobile\Edge\ElementRegistry::reset();
+    ElementRegistry::reset();
 });
 
 it('applies refreshable scroll-indicator props', function () {


### PR DESCRIPTION
## What

`:shows-indicators` only worked on `<native:scroll-view>` — on every other scrolling container the attribute was silently dropped. This PR extends the PHP side of the contract to the two core-owned elements:

- **`refreshable`**: `Refreshable::showsIndicators()` + a matching branch in `NativeElementCollector::applyElementProps` (which was gated on `instanceof ScrollView`, the root cause of the silent drop). Serializes `shows_indicators`, default unchanged (shown).
- **`lazy-grid`**: `LazyGrid::showsIndicators()` + attribute handling. The grid's historical behavior is indicators **hidden** on both axes (the iOS renderer hardcodes `false`), so the default stays hidden and the prop is an opt-in for long grids that want a scroll-position cue.

Both accept kebab (`shows-indicators`) and camel (`showsIndicators`) forms, matching scroll-view.

## Renderer counterpart

The iOS renderers that read these props live in nativephp/mobile-ui — companion PR: `feat/refreshable-shows-indicators` there. Android is a documented no-op for both (Compose's lazy containers draw no scroll indicators).

## Tests

- `refreshable` collector test: `shows-indicators => false` → `shows_indicators` false on the wire.
- `lazy_grid` collector test (type registered explicitly — its registration normally comes from the native-ui plugin manifest even though the element class is core-owned).

Full suite: 820 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)