### PR TITLE
Port the background-layer core seams from the dev core (Android)

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeCompositionLocals.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeCompositionLocals.kt
@@ -12,3 +12,11 @@ val LocalSafeAreaTop = compositionLocalOf { 0f }
 val LocalSafeAreaBottom = compositionLocalOf { 0f }
 val LocalAvailableWidth = compositionLocalOf { 390f }
 val LocalAvailableHeight = compositionLocalOf { 844f }
+
+/**
+ * True when a root host renders a persistent background layer beneath the
+ * content (e.g. mobile-ui's `background_layer` map). Chrome that normally
+ * paints an opaque canvas — the tabs Scaffold — goes transparent so the
+ * layer shows through.
+ */
+val LocalBackgroundLayerPresent = compositionLocalOf { false }

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootTabsRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootTabsRenderer.kt
@@ -241,6 +241,13 @@ fun NativeRootTabsRenderer(node: NativeUINode, modifier: Modifier = Modifier) {
     }
 
     Scaffold(
+        // A persistent background layer (map behind the app) needs the
+        // content canvas transparent; otherwise keep the themed surface.
+        containerColor = if (LocalBackgroundLayerPresent.current) {
+            androidx.compose.ui.graphics.Color.Transparent
+        } else {
+            MaterialTheme.colorScheme.background
+        },
         topBar = {
             if (hasNavBar && !hideNavBar && !isOnSearchTab) {
                 TopAppBar(


### PR DESCRIPTION
## What

Ports the Android background-layer core seams from the dev core (super-native-web, commit `210c941` "neutral core seams") into mobile-air. Two files, port-only — no new behavior beyond what already ships in the dev core.

### The composition local

`NativeCompositionLocals.kt` gains:

```kotlin
val LocalBackgroundLayerPresent = compositionLocalOf { false }
```

It signals that a root host renders a persistent background layer beneath the content (e.g. mobile-ui's `background_layer` map), so chrome that normally paints an opaque canvas should go transparent.

### The tabs transparency consumption

`NativeRootTabsRenderer.kt`'s `Scaffold` now derives its `containerColor` from the local: `Color.Transparent` when a background layer is present, otherwise the existing `MaterialTheme.colorScheme.background` (which is also the Material3 default, so behavior is unchanged when no provider sets the local).

These are the only two `LocalBackgroundLayerPresent` sites committed on the dev core's main.

## Why

The mobile-ui background-layer feature (NativePHP/mobile-ui#37) references this composition local, but it only existed in the dev core — every app on mobile-air failed to compile on Android until NativePHP/mobile-ui#40 removed the reference as a stopgap. With this seam in the distribution core, the plugin can restore its provider and the transparency signal.

## Notes

- Android port only. iOS transparency coordination deliberately remains a gap — no Swift changes here.
- PHP untouched; `vendor/bin/pest tests/Unit` passes (437 passed, 2 skipped, 2 risky).

🤖 Generated with [Claude Code](https://claude.com/claude-code)