### PR TITLE
Port signed-zero inset anchoring from the dev core (parser + iOS + Android)

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/ComposeFlexLayout.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/ComposeFlexLayout.kt
@@ -92,9 +92,12 @@ fun FlexContainer(
             }
             // Render absolute children on top — anchor to the appropriate
             // corner based on which edge insets are set, then offset inward.
-            // Same convention as iOS FlexContainer.placeAbsolute: when
-            // `right` is set and `left` is 0, anchor to the right edge;
-            // same for bottom vs top.
+            // Same convention as iOS FlexContainer.placeAbsolute: +0.0 means
+            // unset, any non-zero value anchors (negatives overhang — the
+            // `-right-8` Tailwind bleed), and IEEE -0.0 is an authored
+            // explicit zero (`bottom-0`, `right-0`), which anchors to that
+            // edge too. When both opposing edges are authored, left/top win
+            // (CSS precedence).
             childNodes.forEachIndexed { i, node ->
                 if ((node.layout?.positionType ?: 0) == PositionType.ABSOLUTE) {
                     val left = node.layout?.positionLeft ?: 0f
@@ -102,20 +105,19 @@ fun FlexContainer(
                     val right = node.layout?.positionRight ?: 0f
                     val bottom = node.layout?.positionBottom ?: 0f
 
-                    // NON-ZERO rather than positive, so NEGATIVE insets work:
-                    // `-right-8` anchors trailing and offsets OUTWARD,
-                    // deliberately overhanging the edge (Tailwind's bleed).
-                    // Zero still reads as "no anchor on that edge" — the
-                    // packed node struct has no spare byte to distinguish an
-                    // unset edge from an explicit `right-0`.
+                    // -0.0f == 0f in Kotlin, so authored zeros need the
+                    // raw sign bit.
+                    fun isSet(v: Float) = v != 0f || v.toRawBits() != 0
+                    val anchorEnd = isSet(right) && !isSet(left)
+                    val anchorBottom = isSet(bottom) && !isSet(top)
                     val anchor = when {
-                        right != 0f && bottom != 0f -> Alignment.BottomEnd
-                        right != 0f                 -> Alignment.TopEnd
-                        bottom != 0f                -> Alignment.BottomStart
-                        else                        -> Alignment.TopStart
+                        anchorEnd && anchorBottom -> Alignment.BottomEnd
+                        anchorEnd                 -> Alignment.TopEnd
+                        anchorBottom              -> Alignment.BottomStart
+                        else                      -> Alignment.TopStart
                     }
-                    val offsetX = if (right != 0f) (-right).dp else left.dp
-                    val offsetY = if (bottom != 0f) (-bottom).dp else top.dp
+                    val offsetX = if (anchorEnd) (-right).dp else left.dp
+                    val offsetY = if (anchorBottom) (-bottom).dp else top.dp
 
                     Box(
                         modifier = Modifier

--- a/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
+++ b/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
@@ -725,27 +725,58 @@ struct FlexContainer: Layout {
         }
     }
 
+    /// Whether an absolute inset edge was authored. The packed node has no
+    /// spare byte for a "set" bitmask, so the wire convention is: +0.0 means
+    /// unset, any non-zero value (including negatives — Tailwind's `-right-8`
+    /// bleed) means set, and IEEE **-0.0** means "the author wrote an explicit
+    /// zero" (`bottom-0`, `inset-0`). The PHP TailwindParser emits -0.0 for
+    /// authored zeros; the sign bit survives the f32 wire bit-exactly.
+    private static func insetIsSet(_ v: CGFloat) -> Bool {
+        v != 0 || v.sign == .minus
+    }
+
     /// Place an absolute-positioned child using position insets.
+    ///
+    /// CSS semantics: one edge set anchors to it; BOTH opposing edges set
+    /// stretches the child between them (`inset-0` fills the container).
+    /// Neither set falls back to the top/leading origin.
     private func placeAbsolute(_ subview: LayoutSubview, info: ChildInfo, in bounds: CGRect) {
-        let ideal = subview.sizeThatFits(.unspecified)
+        let hasLeft = Self.insetIsSet(info.positionLeft)
+        let hasRight = Self.insetIsSet(info.positionRight)
+        let hasTop = Self.insetIsSet(info.positionTop)
+        let hasBottom = Self.insetIsSet(info.positionBottom)
 
-        // Resolve horizontal position. A NON-ZERO right inset (with no left)
-        // anchors to the trailing edge; `!= 0` rather than `> 0` so NEGATIVE
-        // insets work — `-right-8` resolves to maxX - width + 8, deliberately
-        // overhanging the edge (Tailwind's `-right-8` bleed). Zero still means
-        // "no right anchor", since the packed node struct has no spare byte to
-        // distinguish an unset edge from an explicit `right-0`.
-        var x = bounds.minX + info.positionLeft
-        if info.positionRight != 0 && info.positionLeft == 0 {
-            x = bounds.maxX - ideal.width - info.positionRight
+        let stretchWidth: CGFloat? = hasLeft && hasRight
+            ? max(0, bounds.width - info.positionLeft - info.positionRight)
+            : nil
+        let stretchHeight: CGFloat? = hasTop && hasBottom
+            ? max(0, bounds.height - info.positionTop - info.positionBottom)
+            : nil
+
+        // Measure with any stretched dimension proposed, so content that
+        // adapts (text wrapping, maps, images) sizes against the real box.
+        let measured = subview.sizeThatFits(ProposedViewSize(
+            width: stretchWidth, height: stretchHeight
+        ))
+        let size = CGSize(
+            width: stretchWidth ?? measured.width,
+            height: stretchHeight ?? measured.height
+        )
+
+        var x = bounds.minX
+        if hasLeft {
+            x = bounds.minX + info.positionLeft
+        } else if hasRight {
+            x = bounds.maxX - size.width - info.positionRight
         }
 
-        // Resolve vertical position — same convention.
-        var y = bounds.minY + info.positionTop
-        if info.positionBottom != 0 && info.positionTop == 0 {
-            y = bounds.maxY - ideal.height - info.positionBottom
+        var y = bounds.minY
+        if hasTop {
+            y = bounds.minY + info.positionTop
+        } else if hasBottom {
+            y = bounds.maxY - size.height - info.positionBottom
         }
 
-        subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(ideal))
+        subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
     }
 }

--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -457,14 +457,14 @@ class TailwindParser
             // Inset shorthands. `inset-x-`/`inset-y-` MUST precede the bare
             // `inset-` branch, which would otherwise match them first and try
             // to parse "x-0" as a spacing value.
-            str_starts_with($class, 'inset-x-') => self::parseInset(substr($class, 8), ['positionLeft', 'positionRight']),
-            str_starts_with($class, 'inset-y-') => self::parseInset(substr($class, 8), ['positionTop', 'positionBottom']),
-            str_starts_with($class, 'inset-') => self::parseInset(substr($class, 6), ['positionTop', 'positionRight', 'positionBottom', 'positionLeft']),
+            str_starts_with($class, 'inset-x-') => self::explicitInsets(self::parseInset(substr($class, 8), ['positionLeft', 'positionRight'])),
+            str_starts_with($class, 'inset-y-') => self::explicitInsets(self::parseInset(substr($class, 8), ['positionTop', 'positionBottom'])),
+            str_starts_with($class, 'inset-') => self::explicitInsets(self::parseInset(substr($class, 6), ['positionTop', 'positionRight', 'positionBottom', 'positionLeft'])),
 
-            str_starts_with($class, 'left-') => self::parseSpacingUniform('positionLeft', substr($class, 5)),
-            str_starts_with($class, 'top-') => self::parseSpacingUniform('positionTop', substr($class, 4)),
-            str_starts_with($class, 'right-') => self::parseSpacingUniform('positionRight', substr($class, 6)),
-            str_starts_with($class, 'bottom-') => self::parseSpacingUniform('positionBottom', substr($class, 7)),
+            str_starts_with($class, 'left-') => self::explicitInsets(self::parseSpacingUniform('positionLeft', substr($class, 5))),
+            str_starts_with($class, 'top-') => self::explicitInsets(self::parseSpacingUniform('positionTop', substr($class, 4))),
+            str_starts_with($class, 'right-') => self::explicitInsets(self::parseSpacingUniform('positionRight', substr($class, 6))),
+            str_starts_with($class, 'bottom-') => self::explicitInsets(self::parseSpacingUniform('positionBottom', substr($class, 7))),
 
             // Colors and text
             // Theme-aware tokens: `bg-theme-primary`, `text-theme-on-surface`, etc.
@@ -812,6 +812,29 @@ class TailwindParser
      * @param  list<string>  $edges
      * @return array<string, mixed>|null
      */
+    /**
+     * Mark explicitly-authored zero insets as IEEE -0.0. The wire's packed
+     * node has no spare byte to distinguish "unset" from "explicit 0", so
+     * +0.0 means unset and the sign bit carries "the author wrote
+     * `bottom-0`" — which must anchor to the bottom edge, not fall through
+     * to the top default. -0.0 survives the f32 wire bit-exactly; the
+     * native layout treats `!= 0 || signbit` as "edge is set".
+     */
+    private static function explicitInsets(?array $parsed): ?array
+    {
+        if ($parsed === null) {
+            return null;
+        }
+
+        foreach ($parsed as $key => $value) {
+            if ($value === 0 || $value === 0.0) {
+                $parsed[$key] = -0.0;
+            }
+        }
+
+        return $parsed;
+    }
+
     private static function parseInset(string $value, array $edges): ?array
     {
         $result = [];

--- a/tests/Unit/Edge/TailwindParserTest.php
+++ b/tests/Unit/Edge/TailwindParserTest.php
@@ -754,9 +754,24 @@ it('emits gradient props only when there is an axis and two stops', function () 
 
 it('expands inset shorthands to the position edges', function () {
     expect(TailwindParser::parse('inset-0'))->toBe([
-        'positionTop' => 0, 'positionRight' => 0, 'positionBottom' => 0, 'positionLeft' => 0,
+        'positionTop' => -0.0, 'positionRight' => -0.0, 'positionBottom' => -0.0, 'positionLeft' => -0.0,
     ]);
     expect(TailwindParser::parse('inset-x-2'))->toBe(['positionLeft' => 8, 'positionRight' => 8]);
     expect(TailwindParser::parse('inset-y-4'))->toBe(['positionTop' => 16, 'positionBottom' => 16]);
     expect(TailwindParser::parse('inset-bogus'))->toBe([]);
+});
+
+it('marks authored zero insets with the -0.0 sentinel so bottom-0 can anchor', function () {
+    // +0.0 on the wire means "edge unset"; an authored zero must be
+    // distinguishable or `bottom-0` / `right-0` silently anchor top-left.
+    // The sign bit is the only spare storage in the packed f32 slot.
+    $bottom = TailwindParser::parse('bottom-0')['positionBottom'];
+    expect(fdiv(1, $bottom))->toBe(-INF);
+
+    $right = TailwindParser::parse('right-0')['positionRight'];
+    expect(fdiv(1, $right))->toBe(-INF);
+
+    // Non-zero insets are unaffected, negatives keep their bleed meaning.
+    expect(TailwindParser::parse('bottom-2'))->toBe(['positionBottom' => 8]);
+    expect(TailwindParser::parse('-right-8'))->toBe(['positionRight' => -32.0]);
 });


### PR DESCRIPTION
## Why

The packed wire node has no spare byte for a "set" bitmask on position insets, so an **authored zero** (`bottom-0`, `right-0`, `inset-0`) was indistinguishable from an **unset** edge — both read as `0.0`, and absolute children silently anchored to the top-left instead of the edge the author wrote.

The dev core (super-native-web) fixed this with an IEEE **-0.0 sentinel**: `+0.0` means unset, any non-zero value means set (negatives keep their `-right-8` overhang/bleed meaning), and `-0.0` means "the author wrote an explicit zero". The sign bit survives the f32 wire bit-exactly. That work never landed in this repo, which is what apps actually consume — so the already-merged mobile-ui stack-renderer fix (NativePHP/mobile-ui#39), which reads this same convention, is currently inert for apps. This PR hand-ports the stack (the cores have diverged, so hunks were applied by hand, not cherry-picked).

## What

- **`src/Edge/TailwindParser.php`** — new `explicitInsets()` rewrites parsed `0`/`0.0` insets to `-0.0`, wrapped around the seven inset branches (`inset-x-`, `inset-y-`, `inset-`, `left-`, `top-`, `right-`, `bottom-`). Margins are untouched — the sentinel applies to position insets only.
- **`tests/Unit/Edge/TailwindParserTest.php`** — sentinel coverage: `bottom-0` / `right-0` emit `-0.0` (asserted via `fdiv(1, $v) === -INF`), `inset-0` expands to four `-0.0` edges, non-zero and negative insets are unaffected.
- **`resources/xcode/NativePHP/NativeRender/FlexContainer.swift`** — `insetIsSet(v) = v != 0 || v.sign == .minus`; right/bottom anchor only when the opposing left/top edge is NOT set (CSS precedence); both opposing edges set stretches the child between them so `inset-0` fills the container, measuring content against the stretched box.
- **`resources/androidstudio/.../ComposeFlexLayout.kt`** — port of the Android original (NativePHP/super-native-web#1): `fun isSet(v: Float) = v != 0f || v.toRawBits() != 0` (Kotlin's `-0.0f == 0f` hides the sign bit), `anchorEnd`/`anchorBottom` with left/top precedence, updated convention comment.

Kept intact: mobile-air's own drift (iOS `naturalProposal` cross-size measure fix, justify placement) — only the inset-anchoring hunks were ported.

## Testing

- `vendor/bin/pest tests/Unit`: **438 passed** (1415 assertions, 2 risky, 2 skipped)
- Swift/Kotlin hunks self-reviewed against the super-native-web originals; the Kotlin file is now byte-identical to the dev core's, the Swift file differs only by mobile-air's own measure fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)