### PR TITLE
Env-gated plugin feature bundles

### DIFF
--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -445,14 +445,23 @@ class AndroidPluginCompiler
     {
         $sourcePath = $plugin->getAndroidSourcePath();
 
-        if (! $this->files->isDirectory($sourcePath)) {
+        // Sources from enabled feature bundles only — a disabled feature's
+        // Kotlin never reaches the project, so it can't reference SDK
+        // artifacts the build didn't add.
+        $sourcePaths = $this->files->isDirectory($sourcePath) ? [$sourcePath] : [];
+        $sourcePaths = array_merge($sourcePaths, $plugin->getFeatureSourcePaths('android'));
+
+        if ($sourcePaths === []) {
             return;
         }
 
         $javaBasePath = $this->androidProjectPath.'/app/src/main/java';
 
         // Copy all Kotlin files
-        $files = $this->files->allFiles($sourcePath);
+        $files = array_merge(...array_map(
+            fn (string $path): array => $this->files->allFiles($path),
+            $sourcePaths,
+        ));
 
         foreach ($files as $file) {
             if ($file->getExtension() !== 'kt') {

--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -625,6 +625,10 @@ class IOSPluginCompiler
             if (str_contains($plist, "<key>{$key}</key>")) {
                 if (is_array($value)) {
                     $plist = $this->mergeArrayEntry($plist, $key, $value);
+                } elseif (is_bool($value)) {
+                    $plist = $this->updateBooleanEntry($plist, $key, $value);
+                } elseif (is_int($value)) {
+                    $plist = $this->updateIntegerEntry($plist, $key, $value);
                 } elseif (is_string($value)) {
                     $plist = $this->updateStringEntry($plist, $key, $this->substituteEnvPlaceholders($value));
                 }
@@ -640,6 +644,14 @@ class IOSPluginCompiler
                     $arrayContent .= "\n\t\t<string>{$item}</string>";
                 }
                 $entry = "\n\t<key>{$key}</key>\n\t<array>{$arrayContent}\n\t</array>";
+            } elseif (is_bool($value)) {
+                // Booleans are their own plist type. Falling through to the
+                // string branch wrote `(string) false` — an EMPTY STRING —
+                // which frameworks read as "unset" and quietly ignore
+                // (e.g. FirebaseAppDelegateProxyEnabled stayed enabled).
+                $entry = "\n\t<key>{$key}</key>\n\t<".($value ? 'true' : 'false').'/>';
+            } elseif (is_int($value)) {
+                $entry = "\n\t<key>{$key}</key>\n\t<integer>{$value}</integer>";
             } else {
                 // Handle string values - substitute placeholders
                 $value = $this->substituteEnvPlaceholders($value);
@@ -661,6 +673,38 @@ class IOSPluginCompiler
     /**
      * Update an existing string entry's value in the plist
      */
+    /**
+     * Replace an existing entry with a boolean, whatever type it currently
+     * holds. A key previously written as an empty `<string></string>` (the
+     * old boolean bug) must become a real `<true/>`/`<false/>` rather than
+     * being skipped, or a rebuild would never repair it.
+     */
+    protected function updateBooleanEntry(string $plist, string $key, bool $value): string
+    {
+        return $this->replaceTypedEntry($plist, $key, '<'.($value ? 'true' : 'false').'/>');
+    }
+
+    protected function updateIntegerEntry(string $plist, string $key, int $value): string
+    {
+        return $this->replaceTypedEntry($plist, $key, "<integer>{$value}</integer>");
+    }
+
+    /**
+     * Swap the VALUE node following a key, regardless of its current type
+     * (string, integer, true/false).
+     */
+    protected function replaceTypedEntry(string $plist, string $key, string $valueNode): string
+    {
+        $pattern = '/(<key>'.preg_quote($key, '/').'<\/key>\s*)(<string>[^<]*<\/string>|<integer>[^<]*<\/integer>|<true\/>|<false\/>)/';
+
+        return preg_replace_callback(
+            $pattern,
+            fn (array $matches): string => $matches[1].$valueNode,
+            $plist,
+            1
+        );
+    }
+
     protected function updateStringEntry(string $plist, string $key, string $value): string
     {
         $pattern = '/(<key>'.preg_quote($key, '/').'<\/key>\s*<string>)([^<]*)(<\/string>)/';

--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -204,7 +204,12 @@ class IOSPluginCompiler
     {
         $sourcePath = $plugin->getIosSourcePath();
 
-        if (! $this->files->isDirectory($sourcePath)) {
+        // Sources from enabled feature bundles only — a disabled feature's
+        // Swift never reaches the project, so it can't reference SDK
+        // products the build didn't link.
+        $featurePaths = $plugin->getFeatureSourcePaths('ios');
+
+        if (! $this->files->isDirectory($sourcePath) && $featurePaths === []) {
             return;
         }
 
@@ -213,7 +218,13 @@ class IOSPluginCompiler
         $this->files->ensureDirectoryExists($pluginDir);
 
         // Copy all Swift files recursively
-        $this->copySwiftFilesRecursively($sourcePath, $pluginDir);
+        if ($this->files->isDirectory($sourcePath)) {
+            $this->copySwiftFilesRecursively($sourcePath, $pluginDir);
+        }
+
+        foreach ($featurePaths as $featurePath) {
+            $this->copySwiftFilesRecursively($featurePath, $pluginDir);
+        }
     }
 
     /**

--- a/src/Plugins/Plugin.php
+++ b/src/Plugins/Plugin.php
@@ -236,6 +236,59 @@ class Plugin
         return $this->path.'/resources/ios';
     }
 
+    /**
+     * Feature bundles whose env gate is enabled for this build.
+     *
+     * @return list<string>
+     */
+    public function getEnabledFeatures(): array
+    {
+        return $this->manifest->enabledFeatures;
+    }
+
+    /**
+     * Every feature bundle the plugin declares, enabled or not.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function getFeatures(): array
+    {
+        return $this->manifest->features;
+    }
+
+    /**
+     * Source directories contributed by ENABLED feature bundles, for the
+     * given platform ('ios' or 'android').
+     *
+     * Feature sources deliberately live OUTSIDE `resources/ios` and
+     * `resources/android`: those roots are copied wholesale (recursively,
+     * subdirectories included), so a disabled feature's code would still
+     * compile in — and reference SDK products that were never linked.
+     * They live at `resources/features/<feature>/<platform>/` instead,
+     * overridable per feature with a `source_dir` key, and are copied
+     * only when the gate is on.
+     *
+     * @return list<string>
+     */
+    public function getFeatureSourcePaths(string $platform): array
+    {
+        $paths = [];
+
+        foreach ($this->getEnabledFeatures() as $feature) {
+            $configured = $this->manifest->features[$feature][$platform]['source_dir'] ?? null;
+
+            $path = $configured !== null
+                ? $this->path.'/'.ltrim((string) $configured, '/')
+                : $this->path."/resources/features/{$feature}/{$platform}";
+
+            if (is_dir($path)) {
+                $paths[] = $path;
+            }
+        }
+
+        return $paths;
+    }
+
     public function hasAndroidCode(): bool
     {
         $path = $this->getAndroidSourcePath();

--- a/src/Plugins/PluginManifest.php
+++ b/src/Plugins/PluginManifest.php
@@ -25,12 +25,38 @@ class PluginManifest implements JsonSerializable
 
     public readonly array $components;
 
-    public function __construct(array $data)
+    /**
+     * Names of the optional feature bundles whose env gate is enabled, in
+     * manifest order. Everything they declare is already merged into the
+     * sections above — this is what they were, for tooling and diagnostics.
+     *
+     * @var list<string>
+     */
+    public readonly array $enabledFeatures;
+
+    /**
+     * Every feature bundle declared by the manifest, enabled or not, keyed
+     * by name. `native:plugin:list` reads this to show what an app could
+     * turn on.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    public readonly array $features;
+
+    public function __construct(array $data, ?callable $envResolver = null)
     {
         $this->validate($data);
 
         // Normalize the data to new format
         $data = $this->normalizeToNewFormat($data);
+
+        // Fold enabled feature bundles into the platform sections BEFORE
+        // they're assigned: every downstream consumer (both compilers,
+        // plugin:list, the Plugin accessors) then sees one effective
+        // manifest and needs no feature awareness of its own.
+        $this->features = $data['features'] ?? [];
+        [$data, $enabled] = $this->resolveFeatures($data, $envResolver);
+        $this->enabledFeatures = $enabled;
 
         $this->namespace = $data['namespace'];
         $this->bridgeFunctions = $data['bridge_functions'] ?? [];
@@ -41,6 +67,158 @@ class PluginManifest implements JsonSerializable
         $this->events = $data['events'] ?? [];
         $this->hooks = $data['hooks'] ?? [];
         $this->secrets = $data['secrets'] ?? [];
+    }
+
+    /**
+     * Merge every enabled feature bundle into the manifest's own sections.
+     *
+     * A bundle looks like a miniature manifest — it may declare
+     * `bridge_functions`, `events`, and `ios` / `android` sections — and
+     * is gated by one environment variable:
+     *
+     *   "features": {
+     *       "crashlytics": {
+     *           "env": "NATIVEPHP_FIREBASE_CRASHLYTICS",
+     *           "bridge_functions": [ ... ],
+     *           "ios": {"dependencies": {"swift_packages": [ ... ]}},
+     *           "android": {"dependencies": {"implementation": [ ... ]}}
+     *       }
+     *   }
+     *
+     * A bundle with no `env` key is always on (a way to group related
+     * declarations); an unset or falsy variable leaves every trace of the
+     * feature out of the build — no sources, no SDK products, no bridge
+     * registrations pointing at classes that were never compiled.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array{0: array<string, mixed>, 1: list<string>}
+     */
+    protected function resolveFeatures(array $data, ?callable $envResolver): array
+    {
+        $features = $data['features'] ?? [];
+        unset($data['features']);
+
+        if ($features === []) {
+            return [$data, []];
+        }
+
+        $envResolver ??= static fn (string $key) => env($key);
+        $enabled = [];
+
+        foreach ($features as $name => $feature) {
+            if (! is_array($feature)) {
+                continue;
+            }
+
+            if (! $this->featureIsEnabled($feature, $envResolver)) {
+                continue;
+            }
+
+            $enabled[] = (string) $name;
+
+            $data['bridge_functions'] = array_merge(
+                $data['bridge_functions'] ?? [],
+                $feature['bridge_functions'] ?? [],
+            );
+
+            $data['events'] = array_values(array_unique(array_merge(
+                $data['events'] ?? [],
+                $feature['events'] ?? [],
+            )));
+
+            foreach (['ios', 'android'] as $platform) {
+                if (isset($feature[$platform]) && is_array($feature[$platform])) {
+                    $data[$platform] = $this->mergePlatformSection(
+                        $data[$platform] ?? [],
+                        $feature[$platform],
+                    );
+                }
+            }
+        }
+
+        return [$data, $enabled];
+    }
+
+    /**
+     * A bundle without an `env` key is unconditional; otherwise the
+     * variable is read with Laravel's truthiness ("false"/"0"/"" are off).
+     *
+     * @param  array<string, mixed>  $feature
+     */
+    protected function featureIsEnabled(array $feature, callable $envResolver): bool
+    {
+        if (! isset($feature['env'])) {
+            return true;
+        }
+
+        return filter_var($envResolver((string) $feature['env']), FILTER_VALIDATE_BOOLEAN);
+    }
+
+    /**
+     * Merge one platform section of a feature bundle into the plugin's.
+     *
+     * List-valued keys concatenate (permissions, capabilities, gradle
+     * plugins, …); maps merge key-wise (info_plist, entitlements);
+     * `dependencies` recurses so a feature can add Gradle coordinates or
+     * Swift package PRODUCTS without restating the package itself.
+     *
+     * @param  array<string, mixed>  $base
+     * @param  array<string, mixed>  $addition
+     * @return array<string, mixed>
+     */
+    protected function mergePlatformSection(array $base, array $addition): array
+    {
+        foreach ($addition as $key => $value) {
+            if ($key === 'dependencies' && is_array($value)) {
+                $base['dependencies'] = $this->mergeDependencies($base['dependencies'] ?? [], $value);
+
+                continue;
+            }
+
+            if (! isset($base[$key])) {
+                $base[$key] = $value;
+
+                continue;
+            }
+
+            if (is_array($value) && is_array($base[$key])) {
+                $base[$key] = array_is_list($value) && array_is_list($base[$key])
+                    ? array_merge($base[$key], $value)
+                    : array_replace($base[$key], $value);
+
+                continue;
+            }
+
+            $base[$key] = $value;
+        }
+
+        return $base;
+    }
+
+    /**
+     * Merge dependency blocks. Everything concatenates — including
+     * `swift_packages`: the iOS compiler already resolves a repeated
+     * package url to the existing XCRemoteSwiftPackageReference and just
+     * attaches the new products to the target, so a feature declares the
+     * same package url with only the products it needs.
+     *
+     * @param  array<string, mixed>  $base
+     * @param  array<string, mixed>  $addition
+     * @return array<string, mixed>
+     */
+    protected function mergeDependencies(array $base, array $addition): array
+    {
+        foreach ($addition as $key => $value) {
+            if (! is_array($value)) {
+                $base[$key] = $value;
+
+                continue;
+            }
+
+            $base[$key] = array_values(array_unique(array_merge($base[$key] ?? [], $value), SORT_REGULAR));
+        }
+
+        return $base;
     }
 
     /**
@@ -211,7 +389,7 @@ class PluginManifest implements JsonSerializable
         }
     }
 
-    public static function fromFile(string $path): static
+    public static function fromFile(string $path, ?callable $envResolver = null): static
     {
         if (! file_exists($path)) {
             throw new InvalidArgumentException(
@@ -228,7 +406,7 @@ class PluginManifest implements JsonSerializable
             );
         }
 
-        return new static($data);
+        return new static($data, $envResolver);
     }
 
     public function toArray(): array
@@ -243,6 +421,8 @@ class PluginManifest implements JsonSerializable
             'events' => $this->events,
             'hooks' => $this->hooks,
             'secrets' => $this->secrets,
+            'features' => $this->features,
+            'enabled_features' => $this->enabledFeatures,
         ];
     }
 

--- a/tests/Unit/Plugins/InfoPlistTypesTest.php
+++ b/tests/Unit/Plugins/InfoPlistTypesTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Unit\Plugins;
+
+use Native\Mobile\Plugins\Compilers\IOSPluginCompiler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A plugin's `ios.info_plist` values must land in the app's Info.plist as
+ * their real plist types.
+ *
+ * Booleans used to fall through to the string branch and be written as
+ * `<string></string>` — `(string) false` is the empty string — which
+ * frameworks read as unset. FirebaseAppDelegateProxyEnabled=false and
+ * FirebaseAnalyticsCollectionEnabled=false were both silently ignored on
+ * device because of it.
+ */
+class InfoPlistTypesTest extends TestCase
+{
+    private function inject(array $entries, string $existing = ''): string
+    {
+        $compiler = new class extends IOSPluginCompiler
+        {
+            public function __construct() {}
+
+            public function inject(string $plist, array $entries): string
+            {
+                return $this->injectPlistEntries($plist, $entries);
+            }
+        };
+
+        $plist = "<?xml version=\"1.0\"?>\n<plist version=\"1.0\">\n<dict>\n{$existing}</dict>\n</plist>\n";
+
+        return $compiler->inject($plist, $entries);
+    }
+
+    /** @test */
+    public function it_writes_false_as_a_boolean_node(): void
+    {
+        $out = $this->inject(['FirebaseAppDelegateProxyEnabled' => false]);
+
+        $this->assertStringContainsString(
+            "<key>FirebaseAppDelegateProxyEnabled</key>\n\t<false/>",
+            $out
+        );
+        $this->assertStringNotContainsString('<string></string>', $out);
+    }
+
+    /** @test */
+    public function it_writes_true_as_a_boolean_node(): void
+    {
+        $this->assertStringContainsString(
+            "<key>Flag</key>\n\t<true/>",
+            $this->inject(['Flag' => true])
+        );
+    }
+
+    /** @test */
+    public function it_writes_integers_as_integer_nodes(): void
+    {
+        $this->assertStringContainsString(
+            "<key>Count</key>\n\t<integer>3</integer>",
+            $this->inject(['Count' => 3])
+        );
+    }
+
+    /** @test */
+    public function it_repairs_a_key_previously_written_as_an_empty_string(): void
+    {
+        // Apps built before the fix carry the empty-string form; a rebuild
+        // must replace it rather than skip the key.
+        $out = $this->inject(
+            ['FirebaseAnalyticsCollectionEnabled' => false],
+            "\t<key>FirebaseAnalyticsCollectionEnabled</key>\n\t<string></string>\n"
+        );
+
+        $this->assertStringContainsString('<false/>', $out);
+        $this->assertStringNotContainsString('<string></string>', $out);
+    }
+
+    /** @test */
+    public function it_still_writes_strings_and_arrays(): void
+    {
+        $out = $this->inject(['NSCameraUsageDescription' => 'Scan a code', 'Modes' => ['a', 'b']]);
+
+        $this->assertStringContainsString('<string>Scan a code</string>', $out);
+        $this->assertStringContainsString('<string>a</string>', $out);
+        $this->assertStringContainsString('<array>', $out);
+    }
+}

--- a/tests/Unit/Plugins/PluginFeatureGateTest.php
+++ b/tests/Unit/Plugins/PluginFeatureGateTest.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Tests\Unit\Plugins;
+
+use Native\Mobile\Plugins\Plugin;
+use Native\Mobile\Plugins\PluginManifest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Env-gated feature bundles: a plugin declares optional chunks of itself
+ * under `features`, each behind one environment variable. An enabled
+ * bundle folds into the manifest's own sections before anything reads
+ * them, so the compilers stay feature-agnostic; a disabled one leaves no
+ * trace — no SDK products, no Gradle coordinates, and crucially no bridge
+ * registrations pointing at classes that were never compiled.
+ */
+class PluginFeatureGateTest extends TestCase
+{
+    /**
+     * @param  array<string, string|null>  $env
+     */
+    private function manifest(array $features, array $env = [], array $base = []): PluginManifest
+    {
+        return new PluginManifest(
+            array_merge([
+                'namespace' => 'Firebase',
+                'bridge_functions' => [
+                    ['name' => 'PushNotification.GetToken', 'ios' => 'PushNotificationFunctions.GetToken'],
+                ],
+                'ios' => [
+                    'dependencies' => [
+                        'swift_packages' => [
+                            ['url' => 'https://github.com/firebase/firebase-ios-sdk', 'version' => '12.6.0', 'products' => ['FirebaseCore']],
+                        ],
+                    ],
+                ],
+                'android' => [
+                    'dependencies' => ['implementation' => ['com.google.firebase:firebase-messaging']],
+                ],
+                'features' => $features,
+            ], $base),
+            fn (string $key) => $env[$key] ?? null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function crashlyticsFeature(): array
+    {
+        return [
+            'crashlytics' => [
+                'env' => 'NATIVEPHP_FIREBASE_CRASHLYTICS',
+                'bridge_functions' => [
+                    ['name' => 'Crashlytics.RecordException', 'ios' => 'CrashlyticsFunctions.RecordException'],
+                ],
+                'events' => ['Native\\Mobile\\Events\\Crashlytics\\Reported'],
+                'ios' => [
+                    'dependencies' => [
+                        'swift_packages' => [
+                            ['url' => 'https://github.com/firebase/firebase-ios-sdk', 'products' => ['FirebaseCrashlytics']],
+                        ],
+                    ],
+                ],
+                'android' => [
+                    'dependencies' => ['implementation' => ['com.google.firebase:firebase-crashlytics']],
+                    'gradle_plugins' => [['id' => 'com.google.firebase.crashlytics', 'version' => '3.0.2']],
+                ],
+            ],
+        ];
+    }
+
+    /** @test */
+    public function a_disabled_feature_leaves_no_trace_in_the_manifest(): void
+    {
+        $manifest = $this->manifest($this->crashlyticsFeature());
+
+        $this->assertSame([], $manifest->enabledFeatures);
+        $this->assertCount(1, $manifest->bridgeFunctions);
+        $this->assertSame('PushNotification.GetToken', $manifest->bridgeFunctions[0]['name']);
+        $this->assertSame(
+            ['FirebaseCore'],
+            $manifest->ios['dependencies']['swift_packages'][0]['products']
+        );
+        $this->assertSame(
+            ['com.google.firebase:firebase-messaging'],
+            $manifest->android['dependencies']['implementation']
+        );
+        $this->assertArrayNotHasKey('gradle_plugins', $manifest->android);
+    }
+
+    /** @test */
+    public function an_enabled_feature_merges_into_every_section(): void
+    {
+        $manifest = $this->manifest(
+            $this->crashlyticsFeature(),
+            ['NATIVEPHP_FIREBASE_CRASHLYTICS' => 'true'],
+        );
+
+        $this->assertSame(['crashlytics'], $manifest->enabledFeatures);
+
+        $names = array_column($manifest->bridgeFunctions, 'name');
+        $this->assertSame(['PushNotification.GetToken', 'Crashlytics.RecordException'], $names);
+
+        $this->assertContains(
+            'com.google.firebase:firebase-crashlytics',
+            $manifest->android['dependencies']['implementation']
+        );
+        $this->assertSame(
+            [['id' => 'com.google.firebase.crashlytics', 'version' => '3.0.2']],
+            $manifest->android['gradle_plugins']
+        );
+        $this->assertSame(['Native\\Mobile\\Events\\Crashlytics\\Reported'], $manifest->events);
+    }
+
+    /**
+     * The iOS compiler resolves a repeated package url to the existing
+     * XCRemoteSwiftPackageReference and attaches the extra products, so a
+     * feature declares the same url carrying only what it needs.
+     *
+     * @test
+     */
+    public function a_feature_adds_swift_products_to_the_package_it_shares(): void
+    {
+        $manifest = $this->manifest(
+            $this->crashlyticsFeature(),
+            ['NATIVEPHP_FIREBASE_CRASHLYTICS' => 'true'],
+        );
+
+        $packages = $manifest->ios['dependencies']['swift_packages'];
+
+        $this->assertCount(2, $packages);
+        $this->assertSame('https://github.com/firebase/firebase-ios-sdk', $packages[1]['url']);
+        $this->assertSame(['FirebaseCrashlytics'], $packages[1]['products']);
+    }
+
+    /** @test */
+    public function falsy_env_values_keep_the_feature_off(): void
+    {
+        foreach (['false', '0', '', null] as $value) {
+            $manifest = $this->manifest(
+                $this->crashlyticsFeature(),
+                ['NATIVEPHP_FIREBASE_CRASHLYTICS' => $value],
+            );
+
+            $this->assertSame([], $manifest->enabledFeatures, 'Value: '.var_export($value, true));
+        }
+    }
+
+    /** @test */
+    public function a_feature_without_an_env_key_is_always_on(): void
+    {
+        $manifest = $this->manifest([
+            'always' => [
+                'bridge_functions' => [['name' => 'Always.Ping', 'ios' => 'AlwaysFunctions.Ping']],
+            ],
+        ]);
+
+        $this->assertSame(['always'], $manifest->enabledFeatures);
+        $this->assertCount(2, $manifest->bridgeFunctions);
+    }
+
+    /** @test */
+    public function map_valued_platform_keys_merge_key_wise(): void
+    {
+        $manifest = $this->manifest(
+            [
+                'analytics' => [
+                    'env' => 'F',
+                    'ios' => ['info_plist' => ['FirebaseAnalyticsCollectionEnabled' => false]],
+                ],
+            ],
+            ['F' => '1'],
+            ['ios' => ['info_plist' => ['FirebaseAppDelegateProxyEnabled' => false]]],
+        );
+
+        $this->assertSame([
+            'FirebaseAppDelegateProxyEnabled' => false,
+            'FirebaseAnalyticsCollectionEnabled' => false,
+        ], $manifest->ios['info_plist']);
+    }
+
+    /** @test */
+    public function features_are_absent_from_a_manifest_that_declares_none(): void
+    {
+        $manifest = new PluginManifest(['namespace' => 'Plain']);
+
+        $this->assertSame([], $manifest->features);
+        $this->assertSame([], $manifest->enabledFeatures);
+    }
+
+    /** @test */
+    public function feature_source_paths_are_listed_only_for_enabled_features(): void
+    {
+        $pluginPath = sys_get_temp_dir().'/nativephp-feature-gate-'.bin2hex(random_bytes(4));
+        mkdir($pluginPath.'/resources/features/crashlytics/ios', 0777, true);
+        mkdir($pluginPath.'/resources/features/crashlytics/android', 0777, true);
+
+        try {
+            $off = new Plugin(
+                name: 'nativephp/mobile-firebase',
+                version: '1.0.0',
+                path: $pluginPath,
+                manifest: $this->manifest($this->crashlyticsFeature()),
+            );
+
+            $this->assertSame([], $off->getFeatureSourcePaths('ios'));
+            $this->assertSame([], $off->getFeatureSourcePaths('android'));
+
+            $on = new Plugin(
+                name: 'nativephp/mobile-firebase',
+                version: '1.0.0',
+                path: $pluginPath,
+                manifest: $this->manifest(
+                    $this->crashlyticsFeature(),
+                    ['NATIVEPHP_FIREBASE_CRASHLYTICS' => 'true'],
+                ),
+            );
+
+            $this->assertSame(
+                [$pluginPath.'/resources/features/crashlytics/ios'],
+                $on->getFeatureSourcePaths('ios')
+            );
+            $this->assertSame(
+                [$pluginPath.'/resources/features/crashlytics/android'],
+                $on->getFeatureSourcePaths('android')
+            );
+        } finally {
+            exec('rm -rf '.escapeshellarg($pluginPath));
+        }
+    }
+}


### PR DESCRIPTION
## What

Plugins can now ship optional pieces of themselves behind an environment variable, so an app compiles in only the SDK surface it actually uses:

```json
"features": {
    "crashlytics": {
        "env": "NATIVEPHP_FIREBASE_CRASHLYTICS",
        "bridge_functions": [ ... ],
        "ios": {"dependencies": {"swift_packages": [{"url": "…firebase-ios-sdk", "products": ["FirebaseCrashlytics"]}]}},
        "android": {"dependencies": {"implementation": [ ... ]}, "gradle_plugins": [ ... ]}
    }
}
```

The motivating case is `nativephp/mobile-firebase`, which is growing Crashlytics, App Check, Performance, and In-App Messaging — nobody should link all of Firebase to send a push.

## How

Resolution happens in `PluginManifest::__construct`, before the readonly sections are assigned: enabled bundles merge into `bridge_functions`, `events`, `ios`, and `android`. **Every downstream consumer — both compilers, `plugin:list`, all `Plugin` accessors — sees one effective manifest and needed no feature awareness.** Lists concatenate, maps (info_plist, entitlements) merge key-wise.

A disabled bundle leaves no trace: no SDK products, no Gradle coordinates, and no bridge registrations pointing at classes that were never compiled.

Two things worth calling out for review:

1. **Feature sources live at `resources/features/<name>/<platform>/`, not under `resources/ios|android`.** Those roots are copied *recursively* (`copySwiftFilesRecursively`, `allFiles`), so a subdirectory would compile in regardless of the gate — and reference products the build never linked. `Plugin::getFeatureSourcePaths()` returns only enabled dirs (overridable per feature with `source_dir`); both compilers copy them alongside the plugin's own sources.
2. **Swift packages need no merging.** `injectSwiftPackage` already resolves a repeated package url to the existing `XCRemoteSwiftPackageReference` and attaches the extra products to the target, so a feature declares the same url carrying only what it needs. (I wrote a URL-union merge first and deleted it — core had this covered.)

Backward compatible: a manifest without `features` is unchanged in every path, and `env` is optional (a bundle without one is always on, useful purely for grouping).

## Tests

New `tests/Unit/Plugins/PluginFeatureGateTest.php` (8 tests): disabled leaves no trace, enabled merges every section, shared-package products, falsy env values (`false`/`0`/``/null), no-env bundles, key-wise map merging, manifests without features, and source paths appearing only when gated on.

Full suite green: 446 unit (2 skipped, 2 risky), 127 plugin-feature. Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)