### PR TITLE
fix(ios): keep background cold launches headless

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/BridgeFunctionRegistration.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/BridgeFunctionRegistration.kt
@@ -29,6 +29,7 @@ fun registerBridgeFunctions(activity: FragmentActivity, context: Context) {
     // plugin). iOS twin: Bridge/Functions/SystemFunctions.swift.
     registry.register("System.OpenAppSettings", SystemFunctions.OpenAppSettings(context))
     registry.register("System.GetAppearance", SystemFunctions.GetAppearance(context))
+    registry.register("System.GetExecutionContext", SystemFunctions.GetExecutionContext(context))
     registry.register("System.MinimizeApp", SystemFunctions.MinimizeApp(activity))
 
     // Dialog.* — core built-in (migrated from the nativephp/mobile-dialog

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/functions/SystemFunctions.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/functions/SystemFunctions.kt
@@ -1,10 +1,12 @@
 package com.nativephp.mobile.bridge.functions
 
 import android.app.Activity
+import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
 import android.net.Uri
+import android.os.UserManager
 import android.provider.Settings
 import android.util.Log
 import com.nativephp.mobile.bridge.BridgeError
@@ -76,6 +78,51 @@ object SystemFunctions {
             val night = (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
                 Configuration.UI_MODE_NIGHT_YES
             return mapOf("appearance" to if (night) "dark" else "light")
+        }
+    }
+
+    /**
+     * Where this process is running and why it started — backs
+     * `Native\Mobile\Facades\ExecutionContext`. iOS twin:
+     * `Bridge/Functions/SystemFunctions.swift` (GetExecutionContext).
+     *
+     * Android's runtime is started by MainActivity, so the launch is always
+     * a foreground one and `headless` is always false — the shape iOS reports
+     * for a BGTaskScheduler cold launch has no Android equivalent. What does
+     * carry over is whether we are currently on screen (process importance)
+     * and whether protected storage is readable, which on Android is the
+     * direct-boot user-unlocked state.
+     *
+     * Returns the same keys as the iOS twin so PHP has one code path.
+     */
+    class GetExecutionContext(private val context: Context) : BridgeFunction {
+        override fun execute(parameters: Map<String, Any>): Map<String, Any> {
+            val info = ActivityManager.RunningAppProcessInfo()
+            ActivityManager.getMyMemoryState(info)
+
+            // FOREGROUND = a visible activity. FOREGROUND_SERVICE and lower
+            // importances mean the user is not looking at us.
+            val active = info.importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            val foreground = info.importance <= ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE
+
+            val unlocked = context.getSystemService(Context.USER_SERVICE)
+                ?.let { (it as UserManager).isUserUnlocked }
+                ?: true
+
+            return mapOf(
+                "launch" to "foreground",
+                "state" to when {
+                    active -> "active"
+                    foreground -> "inactive"
+                    else -> "background"
+                },
+                "foreground" to foreground,
+                "active" to active,
+                "has_become_active" to true,
+                "headless" to false,
+                "protected_data_available" to unlocked,
+                "interactive_boot_started" to true,
+            )
         }
     }
 }

--- a/resources/xcode/NativePHP/AppDelegate.swift
+++ b/resources/xcode/NativePHP/AppDelegate.swift
@@ -36,6 +36,14 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
+        // Record WHY this process started before anything can boot off it.
+        // iOS cold-launches the app into the background for BGTaskScheduler
+        // work, silent pushes and background fetch — often on a locked device.
+        // ExecutionContext turns that into the gate the boot path and PHP both
+        // read, so the interactive start route stays parked until the app is
+        // genuinely on screen.
+        ExecutionContext.shared.start(launchState: application.applicationState)
+
         // Check if the app was launched from a URL (custom scheme)
         if let url = launchOptions?[UIApplication.LaunchOptionsKey.url] as? URL {
             DebugLogger.shared.log("📱 AppDelegate: Cold start with custom scheme URL: \(url)")
@@ -51,6 +59,17 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             DebugLogger.shared.log("📱 AppDelegate: Cold start with Universal Link: \(url)")
             // Pass the URL to the DeepLinkRouter
             DeepLinkRouter.shared.handle(url: url)
+        }
+
+        // A background launch never connects a scene, so SplashView.onAppear
+        // never fires and nothing would boot the PHP runtime that the work we
+        // were woken for needs. Boot it here instead — headlessly: the
+        // interactive phase stays parked inside NativePHPBootstrap until the
+        // app becomes active. (Idempotent, so a foreground launch that
+        // reaches onAppear first is unaffected.)
+        if ExecutionContext.shared.launchedInBackground {
+            DebugLogger.shared.log("📱 AppDelegate: headless background cold launch — booting PHP without UI")
+            NativePHPBootstrap.shared.start()
         }
 
         return true

--- a/resources/xcode/NativePHP/AppUpdateManager.swift
+++ b/resources/xcode/NativePHP/AppUpdateManager.swift
@@ -739,16 +739,11 @@ class AppUpdateManager {
     private func runMigrationsAndClearCaches() {
         print("🔄 Running migrations and clearing caches...")
 
-        guard let app = NativePHPApp.shared else {
-            print("❌ NativePHPApp.shared not available")
-            return
-        }
-
         // Run migrations
-        _ = app.artisan(additionalArgs: ["migrate", "--force"])
+        _ = NativePHPApp.artisan(additionalArgs: ["migrate", "--force"])
 
         // Clear caches
-        _ = app.artisan(additionalArgs: ["view:clear"])
+        _ = NativePHPApp.artisan(additionalArgs: ["view:clear"])
 
         print("✅ Migrations and cache clearing completed")
     }

--- a/resources/xcode/NativePHP/Bridge/BridgeFunctionRegistration.swift
+++ b/resources/xcode/NativePHP/Bridge/BridgeFunctionRegistration.swift
@@ -18,6 +18,7 @@ func registerBridgeFunctions() {
     // plugin). Android twin: bridge/functions/SystemFunctions.kt.
     registry.register("System.OpenAppSettings", function: SystemFunctions.OpenAppSettings())
     registry.register("System.GetAppearance", function: SystemFunctions.GetAppearance())
+    registry.register("System.GetExecutionContext", function: SystemFunctions.GetExecutionContext())
 
     // UI.* — core built-in. Android twin: bridge/functions/UIFunctions.kt
     // (which also registers UI.SetTransition; iOS transitions ride the

--- a/resources/xcode/NativePHP/Bridge/Functions/SystemFunctions.swift
+++ b/resources/xcode/NativePHP/Bridge/Functions/SystemFunctions.swift
@@ -50,4 +50,35 @@ enum SystemFunctions {
             return ["appearance": mode]
         }
     }
+
+    // MARK: - System.GetExecutionContext
+
+    /// Where this process is running and why it started — backs
+    /// `Native\Mobile\Facades\ExecutionContext`.
+    ///
+    /// The signal that matters for scheduled work is `headless`: true when
+    /// iOS cold-launched the app in the background (BGTaskScheduler, silent
+    /// push, background fetch) and it has never been on screen. Code woken
+    /// that way should do its job and return rather than touch the UI, and
+    /// `protected_data_available` tells it whether the device is unlocked
+    /// enough to read keychain items and protected files.
+    ///
+    /// Reads a lock-guarded mirror of the UIKit lifecycle state, so it is
+    /// safe from the PHP worker thread — no hop to main, no deadlock when
+    /// main is itself waiting on PHP.
+    ///
+    /// Returns:
+    ///   - launch: string - "foreground" or "background"
+    ///   - state: string - "active", "inactive" or "background"
+    ///   - foreground: boolean - not backgrounded (active or inactive)
+    ///   - active: boolean - frontmost and receiving events
+    ///   - has_become_active: boolean - has been on screen at least once
+    ///   - headless: boolean - background launch that never became active
+    ///   - protected_data_available: boolean - Data Protection unlocked
+    ///   - interactive_boot_started: boolean - start URL has been dispatched
+    class GetExecutionContext: BridgeFunction {
+        func execute(parameters: [String: Any]) throws -> [String: Any] {
+            ExecutionContext.shared.snapshot()
+        }
+    }
 }

--- a/resources/xcode/NativePHP/HotReloadServer.swift
+++ b/resources/xcode/NativePHP/HotReloadServer.swift
@@ -172,7 +172,7 @@ class HotReloadCoordinator {
                 _ = PersistentPHPRuntime.shared.artisan(command: "view:clear")
                 PHPQueueWorker.shared.start()
             } else {
-                _ = NativePHPApp.shared?.artisan(additionalArgs: ["view:clear"])
+                _ = NativePHPApp.artisan(additionalArgs: ["view:clear"])
             }
 
             if isNativeUI {

--- a/resources/xcode/NativePHP/Lifecycle/ExecutionContext.swift
+++ b/resources/xcode/NativePHP/Lifecycle/ExecutionContext.swift
@@ -1,0 +1,236 @@
+import Foundation
+import UIKit
+
+/// Where this process is running, and why it started.
+///
+/// iOS cold-launches an app straight into the **background** for
+/// BGTaskScheduler work, silent pushes and background fetch — routinely while
+/// the device is locked and Data Protection has sealed the keychain and
+/// protected files. Such a launch has to stay headless: the start route must
+/// not be dispatched, no WKWebView may be created, no component may mount, and
+/// no polling may start. Only the work the system actually woke us for should
+/// run.
+///
+/// This is the single source of truth for that decision. The boot path gates
+/// its interactive phase on `whenInteractive(_:)`; PHP reads the same state
+/// through the `System.GetExecutionContext` bridge function, which backs
+/// `Native\Mobile\Facades\ExecutionContext`.
+///
+/// Reads are safe from any thread: UIKit state is *mirrored* under a lock from
+/// main-thread lifecycle notifications rather than read live. Bridge functions
+/// run on the PHP worker thread, and hopping to main from there deadlocks
+/// whenever main is itself waiting on PHP.
+///
+/// Android twin: `bridge/functions/SystemFunctions.kt` (GetExecutionContext).
+final class ExecutionContext: @unchecked Sendable {
+    static let shared = ExecutionContext()
+
+    /// Why this process started.
+    enum Launch: String {
+        /// The user (or a deep link / notification tap) opened the app — UI
+        /// is expected.
+        case foreground
+        /// The system started us headlessly for background work. No UI is
+        /// expected until the app is actually brought to the foreground.
+        case background
+    }
+
+    /// Mirror of `UIApplication.State`.
+    enum RunState: String {
+        case active, inactive, background
+
+        init(_ state: UIApplication.State) {
+            switch state {
+            case .active: self = .active
+            case .inactive: self = .inactive
+            case .background: self = .background
+            @unknown default: self = .background
+            }
+        }
+    }
+
+    private let lock = NSLock()
+
+    private var _launch: Launch = .foreground
+    private var _state: RunState = .inactive
+    private var _hasBecomeActive = false
+    private var _protectedDataAvailable = true
+    private var _interactiveBootStarted = false
+
+    /// Work parked until the app is interactive. Drained exactly once, in
+    /// registration order, on the first `didBecomeActive`.
+    private var pendingInteractive: [() -> Void] = []
+
+    private var started = false
+
+    private init() {}
+
+    // MARK: - Reads (safe from any thread)
+
+    var launch: Launch { lock.withLock { _launch } }
+
+    /// "active" | "inactive" | "background".
+    var state: RunState { lock.withLock { _state } }
+
+    /// Foreground covers `.active` **and** `.inactive` — the latter is a
+    /// transient on-screen state (app switcher, incoming call banner, system
+    /// permission alert), not a background launch.
+    var isForeground: Bool { lock.withLock { _state != .background } }
+
+    var isBackground: Bool { !isForeground }
+
+    var isActive: Bool { lock.withLock { _state == .active } }
+
+    /// True when iOS cold-launched this process into the background.
+    var launchedInBackground: Bool { launch == .background }
+
+    /// True once the app has been active at least once in this process. A
+    /// headless background launch never sets this.
+    var hasBecomeActive: Bool { lock.withLock { _hasBecomeActive } }
+
+    /// A background launch that has never been brought on screen — the state
+    /// in which scheduled Artisan / queue work should run, and in which
+    /// nothing may touch the UI.
+    var isHeadless: Bool {
+        lock.withLock { _launch == .background && !_hasBecomeActive }
+    }
+
+    /// False while the device is locked with Data Protection engaged:
+    /// keychain items and protected files are unreadable until first unlock.
+    var isProtectedDataAvailable: Bool { lock.withLock { _protectedDataAvailable } }
+
+    /// True once the interactive boot (ContentView + `NATIVEPHP_START_URL`)
+    /// has been kicked off.
+    var interactiveBootStarted: Bool { lock.withLock { _interactiveBootStarted } }
+
+    /// The payload `System.GetExecutionContext` returns to PHP. Keys are
+    /// snake_case to match the rest of the bridge vocabulary.
+    func snapshot() -> [String: Any] {
+        lock.withLock {
+            [
+                "launch": _launch.rawValue,
+                "state": _state.rawValue,
+                "foreground": _state != .background,
+                "active": _state == .active,
+                "has_become_active": _hasBecomeActive,
+                "headless": _launch == .background && !_hasBecomeActive,
+                "protected_data_available": _protectedDataAvailable,
+                "interactive_boot_started": _interactiveBootStarted,
+            ]
+        }
+    }
+
+    // MARK: - Lifecycle wiring
+
+    /// Capture how the process started and begin mirroring lifecycle changes.
+    /// Called from `AppDelegate.application(_:didFinishLaunchingWithOptions:)`,
+    /// which runs before any scene connects — so the launch reason is recorded
+    /// before anything can boot off it. Idempotent.
+    @MainActor
+    func start(launchState: UIApplication.State) {
+        let alreadyStarted: Bool = lock.withLock {
+            defer { started = true }
+            return started
+        }
+        guard !alreadyStarted else { return }
+
+        let run = RunState(launchState)
+        lock.withLock {
+            _launch = run == .background ? .background : .foreground
+            _state = run
+            _hasBecomeActive = run == .active
+            _protectedDataAvailable = UIApplication.shared.isProtectedDataAvailable
+        }
+
+        NSLog("[ExecutionContext] launch=\(launch.rawValue) state=\(run.rawValue) protectedData=\(isProtectedDataAvailable)")
+
+        observe(UIApplication.didBecomeActiveNotification) { $0.didBecomeActive() }
+        observe(UIApplication.willResignActiveNotification) { $0.set(state: .inactive) }
+        observe(UIApplication.willEnterForegroundNotification) { $0.set(state: .inactive) }
+        observe(UIApplication.didEnterBackgroundNotification) { $0.set(state: .background) }
+        observe(UIApplication.protectedDataDidBecomeAvailableNotification) {
+            $0.set(protectedDataAvailable: true)
+        }
+        observe(UIApplication.protectedDataWillBecomeUnavailableNotification) {
+            $0.set(protectedDataAvailable: false)
+        }
+    }
+
+    private func observe(_ name: Notification.Name, _ handler: @escaping (ExecutionContext) -> Void) {
+        NotificationCenter.default.addObserver(
+            forName: name,
+            object: nil,
+            queue: .main
+        ) { _ in handler(ExecutionContext.shared) }
+    }
+
+    private func set(state: RunState) {
+        lock.withLock { _state = state }
+    }
+
+    private func set(protectedDataAvailable: Bool) {
+        lock.withLock { _protectedDataAvailable = protectedDataAvailable }
+        NSLog("[ExecutionContext] protectedDataAvailable=\(protectedDataAvailable)")
+    }
+
+    private func didBecomeActive() {
+        let parked: [() -> Void] = lock.withLock {
+            _state = .active
+            _hasBecomeActive = true
+            defer { pendingInteractive.removeAll() }
+            return pendingInteractive
+        }
+
+        guard !parked.isEmpty else { return }
+
+        NSLog("[ExecutionContext] became active — running \(parked.count) deferred interactive task(s)")
+
+        // One block, so the parked closures keep their registration order —
+        // and off main, because this fires from a lifecycle notification and
+        // the work behind it reads files before it touches any UI state.
+        DispatchQueue.global(qos: .userInitiated).async {
+            parked.forEach { $0() }
+        }
+    }
+
+    // MARK: - Gating
+
+    /// Run `block` once the app is on screen — either because the work
+    /// touches the UI, or because it costs resources a headless background
+    /// wake never asked for (the queue worker's second PHP context).
+    ///
+    /// Runs immediately when the app is already on screen (a foreground launch
+    /// that hasn't been backgrounded, or any launch that has reached
+    /// `.active`). A headless background launch parks the block until the app
+    /// is actually opened — so a BGTaskScheduler wake never boots the
+    /// interactive route.
+    ///
+    /// Blocks run in registration order, always on a background queue; each is
+    /// responsible for hopping to main for anything UIKit or `@MainActor`.
+    func whenInteractive(_ block: @escaping () -> Void) {
+        let runNow: Bool = lock.withLock {
+            guard _state != .background else { return false }
+            // A foreground launch is on its way to `.active` by definition;
+            // waiting for the notification would stall the normal boot.
+            return _launch == .foreground || _hasBecomeActive
+        }
+
+        guard runNow else {
+            lock.withLock { pendingInteractive.append(block) }
+            NSLog("[ExecutionContext] deferring interactive work until the app becomes active")
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async(execute: block)
+    }
+
+    /// Claim the one-shot interactive boot. Returns false if it already ran,
+    /// so a deferred boot can't double-fire against a foreground re-entry.
+    func claimInteractiveBoot() -> Bool {
+        lock.withLock {
+            guard !_interactiveBootStarted else { return false }
+            _interactiveBootStarted = true
+            return true
+        }
+    }
+}

--- a/resources/xcode/NativePHP/Lifecycle/NativePHPBootstrap.swift
+++ b/resources/xcode/NativePHP/Lifecycle/NativePHPBootstrap.swift
@@ -1,0 +1,272 @@
+import Foundation
+
+/// Owns the app's boot sequence, split into two phases that are gated
+/// independently:
+///
+///  * **Runtime phase** — PHP environment, bundle extraction, the persistent
+///    Laravel runtime, plugin callbacks, hot reload. Headless and safe to run
+///    whenever the process starts, including a background cold launch on a
+///    locked device.
+///  * **Interactive phase** — the boot transport (`NATIVEPHP_START_URL` is
+///    dispatched, `ContentView` is rendered, a WKWebView may be created), plus
+///    the queue worker, whose second PHP context is memory a background wake
+///    never asked for. Held behind `ExecutionContext.whenInteractive` until
+///    the app is actually on screen.
+///
+/// Splitting them is what makes a BGTaskScheduler wake safe: iOS cold-launches
+/// the whole SwiftUI app to run one scheduled command, and without the gate
+/// the start route would run its middleware, mount components and start
+/// polling while the process is backgrounded and the device is locked.
+///
+/// Two entry points call `start()` — `SplashView.onAppear` for a normal
+/// launch, and `AppDelegate` for a background launch (which has no scene, so
+/// no `onAppear` fires and nothing else would boot the runtime the background
+/// work needs). `start()` is idempotent; whichever fires first wins.
+final class NativePHPBootstrap: @unchecked Sendable {
+    static let shared = NativePHPBootstrap()
+
+    private let lock = NSLock()
+    private var started = false
+
+    private init() {}
+
+    /// Kick off the boot sequence on a background thread. Safe to call more
+    /// than once and from any thread — only the first call does work.
+    func start() {
+        let alreadyStarted: Bool = lock.withLock {
+            defer { started = true }
+            return started
+        }
+
+        guard !alreadyStarted else {
+            NSLog("[NativePHP] Bootstrap already started — ignoring duplicate start()")
+            return
+        }
+
+        DispatchQueue.global(qos: .userInitiated).async { [self] in
+            bootRuntime()
+        }
+    }
+
+    // MARK: - Runtime phase (headless-safe)
+
+    /// Performs heavy initialization work after the splash view is visible.
+    /// This runs on a background thread to avoid blocking the main thread.
+    private func bootRuntime() {
+        NSLog("[NativePHP] Deferred initialization starting (headless=\(ExecutionContext.shared.isHeadless))")
+
+        // 1. Initialize PHP environment (env vars, php.ini, database)
+        NSLog("[NativePHP] preparePhpEnvironment START")
+        _ = NativePHPApp.preparePhpEnvironment()
+        NSLog("[NativePHP] preparePhpEnvironment DONE")
+
+        // 2. Ensure app is extracted from bundle if needed
+        NSLog("[NativePHP] ensureAppExists START")
+        let didExtract = AppUpdateManager.shared.ensureAppExists()
+        NSLog("[NativePHP] ensureAppExists DONE (didExtract=\(didExtract))")
+
+        // 3. Boot persistent PHP runtime (one-time Laravel boot) — unless classic mode
+        let runtimeMode = NativePHPApp.getRuntimeMode()
+        NSLog("[NativePHP] Runtime mode: \(runtimeMode)")
+
+        let booted: Bool
+        if runtimeMode == "classic" {
+            NSLog("[NativePHP] Classic mode configured — skipping persistent runtime boot")
+            booted = false
+            NativePHPApp.createStorageLink()
+        } else {
+            NSLog("[NativePHP] PersistentPHPRuntime.boot() START")
+            booted = PersistentPHPRuntime.shared.boot()
+            NSLog("[NativePHP] PersistentPHPRuntime.boot() DONE, booted=\(booted)")
+
+            if booted {
+                // Only run artisan commands when app was extracted or updated
+                if didExtract {
+                    NSLog("[NativePHP] artisan migrate START (post-extraction)")
+                    _ = PersistentPHPRuntime.shared.artisan(command: "migrate --force")
+                    NSLog("[NativePHP] artisan migrate DONE")
+
+                    NSLog("[NativePHP] artisan storage:link START")
+                    _ = PersistentPHPRuntime.shared.artisan(command: "storage:link")
+                    NSLog("[NativePHP] artisan storage:link DONE")
+                } else {
+                    NSLog("[NativePHP] Skipping artisan commands — no extraction needed")
+                }
+
+                // Execute plugin post-boot callbacks. Background-task plugins
+                // register their handlers here, so this must NOT be gated on
+                // the app being interactive — a background launch exists
+                // precisely to give them a runtime to run in.
+                NativePHPPluginRegistry.shared.executeOnAppReady()
+            } else {
+                NSLog("[NativePHP] persistent boot failed, falling back to classic mode")
+                NativePHPApp.createStorageLink()
+            }
+        }
+
+        // 4. The runtime is up. Hand the first screen over to the interactive
+        // phase — which only runs once there is a user to show it to. On a
+        // headless background cold launch this parks until the app is opened.
+        ExecutionContext.shared.whenInteractive { [self] in
+            startInteractiveBoot()
+        }
+
+        // 5. Execute plugin initialization callbacks (on main thread)
+        DispatchQueue.main.async {
+            NativePHPPluginRegistry.shared.executeOnAppLaunch()
+        }
+
+        // 6. Reload handling + hot reload server. The coordinator must be
+        // registered before anything can post reloadWebViewNotification —
+        // HotReloadServer triggers (DEBUG) or AppUpdateManager after an OTA
+        // update (production) — and independently of the WebView, which a
+        // native-direct boot never mounts.
+        HotReloadCoordinator.shared.activate()
+        #if DEBUG
+        HotReloadServer.shared.start()
+        #endif
+
+        // 7. OTA check commented out — parity with Android, where the boot-time
+        // Bifrost request was disabled for its network latency on cold boot.
+        // TODO: Re-enable on BOTH platforms together when OTA is ready for
+        // production, as an async check after first content — never on the
+        // boot path.
+        // NSLog("[NativePHP] checkForUpdates START")
+        // AppUpdateManager.shared.checkForUpdates()
+
+        // 8. Defer queue worker boot — start AFTER the critical path completes
+        //    so it doesn't compete for CPU/memory during first page render,
+        //    and only once the app is on screen. The worker boots a SECOND PHP
+        //    TSRM context; spending that memory during a headless background
+        //    wake is what gets the process jetsammed mid-task, and the wake
+        //    never asked for it. Jobs dispatched by background work still
+        //    queue normally — they're picked up when the app is next opened.
+        if booted {
+            ExecutionContext.shared.whenInteractive {
+                NSLog("[NativePHP] PHPQueueWorker.start() (deferred)")
+                PHPQueueWorker.shared.start()
+            }
+        } else {
+            NSLog("[NativePHP] Queue worker NOT started — persistent runtime boot failed")
+        }
+
+        NSLog("[NativePHP] Deferred initialization completed")
+    }
+
+    // MARK: - Interactive phase (app on screen)
+
+    /// Decide the boot transport (native-first) and start the first screen.
+    ///
+    /// NATIVE_DIRECT: dispatch the start route straight into the persistent
+    /// runtime — no WKWebView, no WebContent/Networking processes — and let
+    /// the first published native tree dismiss the splash (honest first
+    /// content; ContentView flips it via onChange(isActive)). WEB_LEGACY:
+    /// byte-identical to the old flow.
+    ///
+    /// Runs at most once per process: a launch that deferred this until
+    /// `didBecomeActive` must not re-run it on every later foreground.
+    /// Called on a background queue — only the state mutations hop to main.
+    private func startInteractiveBoot() {
+        guard ExecutionContext.shared.claimInteractiveBoot() else {
+            NSLog("[NativePHP] Interactive boot already ran — skipping")
+            return
+        }
+
+        // Resolved here rather than during the runtime phase so a deep link
+        // that arrived while the app sat backgrounded is still honoured.
+        let startPath = NativePHPApp.getStartURL()
+        let hasPendingDeepLink = DeepLinkRouter.shared.hasPendingURL()
+        let plan: BootPlanner.Entry = hasPendingDeepLink
+            ? .webLegacy // cold deep links keep the proven WebView path for now
+            : BootPlanner.plan(startPath: startPath)
+
+        switch plan {
+        case .nativeDirect:
+            DispatchQueue.main.async {
+                NSLog("TRACE[15]: native-direct boot — WebView withheld")
+                BootState.shared.webViewAllowed = false
+                DeepLinkRouter.shared.markPhpReady()
+                AppState.shared.markReadyToLoad()
+                // markInitialized deliberately NOT called here — the splash
+                // dismisses on first native content, or via the watchdog.
+            }
+            startNativeSession(startPath)
+            startFirstContentWatchdog()
+        case .webLegacy:
+            DispatchQueue.main.async {
+                NSLog("TRACE[15]: markPhpReady + markReadyToLoad + markInitialized on main thread")
+                DeepLinkRouter.shared.markPhpReady()
+                AppState.shared.markReadyToLoad()
+                AppState.shared.markInitialized()
+            }
+        }
+    }
+
+    /// Native-first boot: dispatch the start route directly into the
+    /// persistent runtime (same entry hot reload uses — the iOS analog of
+    /// Android's executeNativeRoute). The dispatch blocks its queue for the
+    /// life of the native session; the eventual response is the session's
+    /// exit envelope: 3xx+Location = EXIT_WEB, 204 = hot-restart, else the
+    /// stack emptied.
+    private func startNativeSession(_ uri: String) {
+        DispatchQueue.global(qos: .userInitiated).async { [self] in
+            NSLog("[NativeBoot] 🚀 Direct native dispatch: \(uri)")
+            let request = RequestData(
+                method: "GET",
+                uri: uri,
+                data: nil,
+                query: nil,
+                headers: [:]
+            )
+            let raw = PersistentPHPRuntime.shared.dispatch(request: request)
+            handleNativeSessionExit(raw)
+        }
+    }
+
+    private func handleNativeSessionExit(_ rawResponse: String) {
+        let head = rawResponse.components(separatedBy: "\r\n\r\n").first ?? rawResponse
+        let lines = head.components(separatedBy: "\r\n")
+        let status = lines.first?
+            .components(separatedBy: " ")
+            .dropFirst().first.flatMap { Int($0) } ?? 200
+        let location = lines
+            .first { $0.lowercased().hasPrefix("location:") }?
+            .components(separatedBy: ":").dropFirst().joined(separator: ":")
+            .trimmingCharacters(in: .whitespaces)
+
+        NSLog("[NativeBoot] Native session exited: status=\(status) location=\(location ?? "nil")")
+
+        if (300...399).contains(status), let location, !location.isEmpty {
+            let path = location.hasPrefix("http") || location.hasPrefix("php:")
+                ? (URL(string: location)?.path ?? "/")
+                : location
+            DispatchQueue.main.async {
+                NSLog("[NativeBoot] ⇄ EXIT_WEB → \(path)")
+                BootState.shared.allowWebView(loading: path)
+                // Drop the native branch explicitly. The usual clearers can't
+                // run here: didCommit needs the WebView to load, but the
+                // WebView only MOUNTS once the native branch unmounts — and
+                // the region teardown may be preserve-tree'd. Without this
+                // the exit deadlocks on a frozen native screen.
+                NativeUIBridge.shared.isActive = false
+                AppState.shared.markInitialized()
+            }
+        }
+        // 204 = hot restart in flight (the reload path re-dispatches);
+        // anything else = the native stack emptied — iOS apps can't finish()
+        // themselves, so the splash-free native background simply remains.
+    }
+
+    /// A broken PHP boot in native-direct mode would otherwise wedge on the
+    /// splash forever (no WebView error page to fall back on). After 10s
+    /// without content, fall back to the legacy WebView path.
+    private func startFirstContentWatchdog() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
+            if !AppState.shared.isInitialized {
+                NSLog("[NativeBoot] ⏰ No content 10s after native boot — falling back to WebView")
+                BootState.shared.allowWebView(loading: nil)
+                AppState.shared.markInitialized()
+            }
+        }
+    }
+}

--- a/resources/xcode/NativePHP/NativePHPApp.swift
+++ b/resources/xcode/NativePHP/NativePHPApp.swift
@@ -33,193 +33,6 @@ struct NativePHPApp: App {
         DebugLogger.shared.log("📱 NativePHPApp.init() completed (minimal)")
     }
 
-    /// Performs heavy initialization work after the splash view is visible.
-    /// This runs on a background thread to avoid blocking the main thread.
-    private func performDeferredInitialization() {
-        NSLog("[NativePHP] Deferred initialization starting")
-
-        // 1. Initialize PHP environment (env vars, php.ini, database)
-        NSLog("[NativePHP] preparePhpEnvironment START")
-        _ = preparePhpEnvironment()
-        NSLog("[NativePHP] preparePhpEnvironment DONE")
-
-        // 2. Ensure app is extracted from bundle if needed
-        NSLog("[NativePHP] ensureAppExists START")
-        let didExtract = AppUpdateManager.shared.ensureAppExists()
-        NSLog("[NativePHP] ensureAppExists DONE (didExtract=\(didExtract))")
-
-        // 3. Boot persistent PHP runtime (one-time Laravel boot) — unless classic mode
-        let runtimeMode = Self.getRuntimeMode()
-        NSLog("[NativePHP] Runtime mode: \(runtimeMode)")
-
-        let booted: Bool
-        if runtimeMode == "classic" {
-            NSLog("[NativePHP] Classic mode configured — skipping persistent runtime boot")
-            booted = false
-            createStorageLink()
-        } else {
-            NSLog("[NativePHP] PersistentPHPRuntime.boot() START")
-            booted = PersistentPHPRuntime.shared.boot()
-            NSLog("[NativePHP] PersistentPHPRuntime.boot() DONE, booted=\(booted)")
-
-            if booted {
-                // Only run artisan commands when app was extracted or updated
-                if didExtract {
-                    NSLog("[NativePHP] artisan migrate START (post-extraction)")
-                    _ = PersistentPHPRuntime.shared.artisan(command: "migrate --force")
-                    NSLog("[NativePHP] artisan migrate DONE")
-
-                    NSLog("[NativePHP] artisan storage:link START")
-                    _ = PersistentPHPRuntime.shared.artisan(command: "storage:link")
-                    NSLog("[NativePHP] artisan storage:link DONE")
-                } else {
-                    NSLog("[NativePHP] Skipping artisan commands — no extraction needed")
-                }
-
-                // Execute plugin post-boot callbacks
-                NativePHPPluginRegistry.shared.executeOnAppReady()
-            } else {
-                NSLog("[NativePHP] persistent boot failed, falling back to classic mode")
-                createStorageLink()
-            }
-        }
-
-        // 4. Now that PHP is booted, decide the boot transport (native-first).
-        // NATIVE_DIRECT: dispatch the start route straight into the persistent
-        // runtime — no WKWebView, no WebContent/Networking processes — and let
-        // the first published native tree dismiss the splash (honest first
-        // content; ContentView flips it via onChange(isActive)). WEB_LEGACY:
-        // byte-identical to the old flow.
-        let startPath = NativePHPApp.getStartURL()
-        let hasPendingDeepLink = DeepLinkRouter.shared.hasPendingURL()
-        let plan: BootPlanner.Entry = hasPendingDeepLink
-            ? .webLegacy // cold deep links keep the proven WebView path for now
-            : BootPlanner.plan(startPath: startPath)
-
-        switch plan {
-        case .nativeDirect:
-            DispatchQueue.main.async {
-                NSLog("TRACE[15]: native-direct boot — WebView withheld")
-                BootState.shared.webViewAllowed = false
-                DeepLinkRouter.shared.markPhpReady()
-                AppState.shared.markReadyToLoad()
-                // markInitialized deliberately NOT called here — the splash
-                // dismisses on first native content, or via the watchdog.
-            }
-            startNativeSession(startPath)
-            startFirstContentWatchdog()
-        case .webLegacy:
-            DispatchQueue.main.async {
-                NSLog("TRACE[15]: markPhpReady + markReadyToLoad + markInitialized on main thread")
-                DeepLinkRouter.shared.markPhpReady()
-                AppState.shared.markReadyToLoad()
-                AppState.shared.markInitialized()
-            }
-        }
-
-        // 5. Execute plugin initialization callbacks (on main thread)
-        DispatchQueue.main.async {
-            NativePHPPluginRegistry.shared.executeOnAppLaunch()
-        }
-
-        // 6. Reload handling + hot reload server. The coordinator must be
-        // registered before anything can post reloadWebViewNotification —
-        // HotReloadServer triggers (DEBUG) or AppUpdateManager after an OTA
-        // update (production) — and independently of the WebView, which a
-        // native-direct boot never mounts.
-        HotReloadCoordinator.shared.activate()
-        #if DEBUG
-        HotReloadServer.shared.start()
-        #endif
-
-        // 7. OTA check commented out — parity with Android, where the boot-time
-        // Bifrost request was disabled for its network latency on cold boot.
-        // TODO: Re-enable on BOTH platforms together when OTA is ready for
-        // production, as an async check after first content — never on the
-        // boot path.
-        // NSLog("[NativePHP] checkForUpdates START")
-        // AppUpdateManager.shared.checkForUpdates()
-
-        // 8. Defer queue worker boot — start AFTER critical path completes
-        //    so it doesn't compete for CPU/memory during first page render
-        if booted {
-            NSLog("[NativePHP] PHPQueueWorker.start() (deferred)")
-            PHPQueueWorker.shared.start()
-        } else {
-            NSLog("[NativePHP] Queue worker NOT started — persistent runtime boot failed")
-        }
-
-        NSLog("[NativePHP] Deferred initialization completed")
-    }
-
-    /// Native-first boot: dispatch the start route directly into the
-    /// persistent runtime (same entry hot reload uses — the iOS analog of
-    /// Android's executeNativeRoute). The dispatch blocks its queue for the
-    /// life of the native session; the eventual response is the session's
-    /// exit envelope: 3xx+Location = EXIT_WEB, 204 = hot-restart, else the
-    /// stack emptied.
-    private func startNativeSession(_ uri: String) {
-        DispatchQueue.global(qos: .userInitiated).async {
-            NSLog("[NativeBoot] 🚀 Direct native dispatch: \(uri)")
-            let request = RequestData(
-                method: "GET",
-                uri: uri,
-                data: nil,
-                query: nil,
-                headers: [:]
-            )
-            let raw = PersistentPHPRuntime.shared.dispatch(request: request)
-            handleNativeSessionExit(raw)
-        }
-    }
-
-    private func handleNativeSessionExit(_ rawResponse: String) {
-        let head = rawResponse.components(separatedBy: "\r\n\r\n").first ?? rawResponse
-        let lines = head.components(separatedBy: "\r\n")
-        let status = lines.first?
-            .components(separatedBy: " ")
-            .dropFirst().first.flatMap { Int($0) } ?? 200
-        let location = lines
-            .first { $0.lowercased().hasPrefix("location:") }?
-            .components(separatedBy: ":").dropFirst().joined(separator: ":")
-            .trimmingCharacters(in: .whitespaces)
-
-        NSLog("[NativeBoot] Native session exited: status=\(status) location=\(location ?? "nil")")
-
-        if (300...399).contains(status), let location, !location.isEmpty {
-            let path = location.hasPrefix("http") || location.hasPrefix("php:")
-                ? (URL(string: location)?.path ?? "/")
-                : location
-            DispatchQueue.main.async {
-                NSLog("[NativeBoot] ⇄ EXIT_WEB → \(path)")
-                BootState.shared.allowWebView(loading: path)
-                // Drop the native branch explicitly. The usual clearers can't
-                // run here: didCommit needs the WebView to load, but the
-                // WebView only MOUNTS once the native branch unmounts — and
-                // the region teardown may be preserve-tree'd. Without this
-                // the exit deadlocks on a frozen native screen.
-                NativeUIBridge.shared.isActive = false
-                AppState.shared.markInitialized()
-            }
-        }
-        // 204 = hot restart in flight (the reload path re-dispatches);
-        // anything else = the native stack emptied — iOS apps can't finish()
-        // themselves, so the splash-free native background simply remains.
-    }
-
-    /// A broken PHP boot in native-direct mode would otherwise wedge on the
-    /// splash forever (no WebView error page to fall back on). After 10s
-    /// without content, fall back to the legacy WebView path.
-    private func startFirstContentWatchdog() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 10) {
-            if !AppState.shared.isInitialized {
-                NSLog("[NativeBoot] ⏰ No content 10s after native boot — falling back to WebView")
-                BootState.shared.allowWebView(loading: nil)
-                AppState.shared.markInitialized()
-            }
-        }
-    }
-
     var body: some Scene {
         WindowGroup {
             ZStack {
@@ -235,10 +48,10 @@ struct NativePHPApp: App {
                         .transition(.opacity)
                         .onAppear {
                             // Phase 1: Start deferred initialization on a background thread
-                            // This runs AFTER the splash view is visible, avoiding watchdog timeout
-                            DispatchQueue.global(qos: .userInitiated).async {
-                                performDeferredInitialization()
-                            }
+                            // This runs AFTER the splash view is visible, avoiding watchdog timeout.
+                            // Idempotent — a headless background launch may already
+                            // have booted the runtime from AppDelegate.
+                            NativePHPBootstrap.shared.start()
                         }
                 }
             }
@@ -267,7 +80,7 @@ struct NativePHPApp: App {
         }
     }
 
-    private func getAppSupportDir(dir: String) -> String {
+    private static func getAppSupportDir(dir: String) -> String {
         // Get the URL for the Library directory in the user domain
         let appSupportURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
 
@@ -333,7 +146,7 @@ struct NativePHPApp: App {
         return "/"
     }
 
-    private func createPhpIni() -> String {
+    private static func createPhpIni() -> String {
         let caPath = Bundle.main.path(forResource: "cacert", ofType: "pem") ?? "Path not found"
 
         let phpIni = """
@@ -355,7 +168,7 @@ struct NativePHPApp: App {
         return supportDir.appendingPathComponent("php.ini").path(percentEncoded: false)
     }
 
-    private func createDatabase() {
+    private static func createDatabase() {
         let fileManager = FileManager.default
 
         let databaseFileURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
@@ -371,19 +184,19 @@ struct NativePHPApp: App {
         }
     }
 
-    private func migrateDatabase() {
+    private static func migrateDatabase() {
         _ = artisan(additionalArgs: ["migrate", "--force"])
     }
 
-    private func clearCaches() {
+    private static func clearCaches() {
         _ = artisan(additionalArgs: ["view:clear"])
     }
 
-    private func createStorageLink() {
+    static func createStorageLink() {
         _ = artisan(additionalArgs: ["storage:link"])
     }
 
-    private func preparePhpEnvironment() -> String {
+    static func preparePhpEnvironment() -> String {
         let phpIniPath = createPhpIni()
 
         setenv("PHPRC", phpIniPath, 1)
@@ -495,7 +308,7 @@ struct NativePHPApp: App {
         return output
     }
 
-    private func setupEnvironment() {
+    private static func setupEnvironment() {
         let storageDir = getAppSupportDir(dir: "storage")
         let viewCacheDir = getAppSupportDir(dir: "storage/framework/views")
         let databaseDir = getAppSupportDir(dir: "database")
@@ -521,7 +334,7 @@ struct NativePHPApp: App {
     }
 
     /// Retrieves APP_KEY from Keychain or generates a new one on first launch
-    private func getOrGenerateAppKey() -> String? {
+    private static func getOrGenerateAppKey() -> String? {
         let service = Bundle.main.bundleIdentifier ?? "com.nativephp.app"
         let account = "APP_KEY"
 
@@ -577,7 +390,7 @@ struct NativePHPApp: App {
     }
 
     /// Generates a new Laravel-compatible APP_KEY (base64:...)
-    private func generateAppKey() -> String? {
+    private static func generateAppKey() -> String? {
         var keyData = Data(count: 32)
         let result = keyData.withUnsafeMutableBytes {
             SecRandomCopyBytes(kSecRandomDefault, 32, $0.baseAddress!)
@@ -592,7 +405,7 @@ struct NativePHPApp: App {
         return "base64:\(base64Key)"
     }
 
-    func artisan(additionalArgs: [String] = []) -> String {
+    static func artisan(additionalArgs: [String] = []) -> String {
         print("Running `php artisan \(additionalArgs.joined())`...")
 
         output = ""

--- a/src/ExecutionContext.php
+++ b/src/ExecutionContext.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Native\Mobile;
+
+/**
+ * Where the app is running right now, and why the process started.
+ *
+ * iOS cold-launches an app straight into the background to run scheduled work
+ * — a BGTaskScheduler task, a silent push, background fetch — routinely while
+ * the device is locked. The process is fully booted, Laravel is up and your
+ * scheduled command runs, but there is no user, no screen, and Data Protection
+ * may have sealed the keychain and protected files.
+ *
+ * NativePHP holds the interactive boot back for exactly that case (the start
+ * route is not dispatched, no screen is mounted, no WebView is created), and
+ * this is how your app asks the same questions:
+ *
+ *     if (ExecutionContext::isHeadless()) {
+ *         // Woken for background work — do the job, don't touch the UI.
+ *         return;
+ *     }
+ *
+ *     if (! ExecutionContext::isProtectedDataAvailable()) {
+ *         // Device locked: keychain items and protected files are unreadable.
+ *         return;
+ *     }
+ *
+ * Android's runtime is started by its Activity, so it always reports a
+ * foreground launch; `isProtectedDataAvailable()` maps to the direct-boot
+ * user-unlocked state there. Off the device (desktop `php artisan`, tests, web
+ * preview) every read reports an ordinary interactive process.
+ *
+ * @see \Native\Mobile\Facades\ExecutionContext
+ */
+class ExecutionContext
+{
+    /**
+     * What to report when there is no native bridge to ask — an ordinary
+     * interactive process, the shape every existing code path assumes. Also
+     * the fallback for a native shell built before `System.GetExecutionContext`
+     * existed, so upgrading the PHP package alone never flips an app into
+     * thinking it is headless.
+     */
+    private const DEFAULTS = [
+        'launch' => 'foreground',
+        'state' => 'active',
+        'foreground' => true,
+        'active' => true,
+        'has_become_active' => true,
+        'headless' => false,
+        'protected_data_available' => true,
+        'interactive_boot_started' => true,
+    ];
+
+    /**
+     * The full context as reported by the platform.
+     *
+     * Deliberately un-cached. A native screen's PHP request blocks for the
+     * whole life of that screen, so a value captured once would still claim
+     * "active" long after the user backgrounded the app. The bridge call is an
+     * in-process hop into Swift/Kotlin, not IPC.
+     *
+     * @return array{
+     *     launch: string,
+     *     state: string,
+     *     foreground: bool,
+     *     active: bool,
+     *     has_become_active: bool,
+     *     headless: bool,
+     *     protected_data_available: bool,
+     *     interactive_boot_started: bool,
+     * }
+     */
+    public function all(): array
+    {
+        if (! function_exists('nativephp_call')) {
+            return self::DEFAULTS;
+        }
+
+        $decoded = json_decode(nativephp_call('System.GetExecutionContext', '{}') ?: '{}', true);
+
+        if (! is_array($decoded) || $decoded === []) {
+            return self::DEFAULTS;
+        }
+
+        // Union fills anything the native side didn't report, so a newer PHP
+        // package against an older native shell degrades key by key.
+        return $decoded + self::DEFAULTS;
+    }
+
+    /**
+     * 'active'     — frontmost and receiving events
+     * 'inactive'   — on screen but not receiving events (app switcher,
+     *                incoming call banner, a system permission alert)
+     * 'background' — not on screen
+     */
+    public function state(): string
+    {
+        return (string) $this->all()['state'];
+    }
+
+    /** Why the process started: 'foreground' (a user opened it) or 'background'. */
+    public function launch(): string
+    {
+        return (string) $this->all()['launch'];
+    }
+
+    /** Frontmost and receiving events. */
+    public function isActive(): bool
+    {
+        return (bool) $this->all()['active'];
+    }
+
+    /** On screen — covers both 'active' and the transient 'inactive'. */
+    public function isForeground(): bool
+    {
+        return (bool) $this->all()['foreground'];
+    }
+
+    /** Not on screen. */
+    public function isBackground(): bool
+    {
+        return ! $this->isForeground();
+    }
+
+    /** The system cold-launched this process for background work. */
+    public function launchedInBackground(): bool
+    {
+        return $this->launch() === 'background';
+    }
+
+    /** The app has been on screen at least once in this process. */
+    public function hasBecomeActive(): bool
+    {
+        return (bool) $this->all()['has_become_active'];
+    }
+
+    /**
+     * A background launch that has never been on screen — the state scheduled
+     * Artisan commands and queued jobs run in when iOS wakes the app for them.
+     * Nothing here should touch the UI, navigate, or start polling.
+     */
+    public function isHeadless(): bool
+    {
+        return (bool) $this->all()['headless'];
+    }
+
+    /**
+     * Whether protected files and keychain items can be read. False on iOS
+     * while the device is locked with Data Protection engaged; on Android,
+     * false before the user's first unlock after boot.
+     */
+    public function isProtectedDataAvailable(): bool
+    {
+        return (bool) $this->all()['protected_data_available'];
+    }
+
+    /**
+     * Whether the interactive boot has run — the point at which
+     * `NATIVEPHP_START_URL` was dispatched and the first screen was created.
+     * False throughout a headless background launch.
+     */
+    public function interactiveBootStarted(): bool
+    {
+        return (bool) $this->all()['interactive_boot_started'];
+    }
+}

--- a/src/Facades/ExecutionContext.php
+++ b/src/Facades/ExecutionContext.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Native\Mobile\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static array all()
+ * @method static string state()
+ * @method static string launch()
+ * @method static bool isActive()
+ * @method static bool isForeground()
+ * @method static bool isBackground()
+ * @method static bool launchedInBackground()
+ * @method static bool hasBecomeActive()
+ * @method static bool isHeadless()
+ * @method static bool isProtectedDataAvailable()
+ * @method static bool interactiveBootStarted()
+ *
+ * @see \Native\Mobile\ExecutionContext
+ */
+class ExecutionContext extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return \Native\Mobile\ExecutionContext::class;
+    }
+}

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -157,6 +157,7 @@ class NativeServiceProvider extends PackageServiceProvider
         $this->app->singleton(System::class, fn () => new System);
         $this->app->singleton(Dialog::class, fn () => new Dialog);
         $this->app->singleton(File::class, fn () => new File);
+        $this->app->singleton(ExecutionContext::class, fn () => new ExecutionContext);
     }
 
     protected function registerPluginServices(): void

--- a/tests/Feature/ExecutionContextTest.php
+++ b/tests/Feature/ExecutionContextTest.php
@@ -1,0 +1,148 @@
+<?php
+
+use Native\Mobile\ExecutionContext;
+use Native\Mobile\Facades\ExecutionContext as ExecutionContextFacade;
+use Native\Mobile\Testing\FakeBridge;
+
+// A headless iOS background cold launch — iOS woke the process for a
+// BGTaskScheduler task while the device sat locked.
+function headlessSnapshot(array $overrides = []): array
+{
+    return array_merge([
+        'launch' => 'background',
+        'state' => 'background',
+        'foreground' => false,
+        'active' => false,
+        'has_become_active' => false,
+        'headless' => true,
+        'protected_data_available' => false,
+        'interactive_boot_started' => false,
+    ], $overrides);
+}
+
+// ── Reading the native state ────────────────────────
+
+it('reports a headless background launch from the bridge', function () {
+    FakeBridge::enable()->respondTo('System.GetExecutionContext', headlessSnapshot());
+
+    $context = new ExecutionContext;
+
+    expect($context->isHeadless())->toBeTrue()
+        ->and($context->launchedInBackground())->toBeTrue()
+        ->and($context->isBackground())->toBeTrue()
+        ->and($context->isForeground())->toBeFalse()
+        ->and($context->isActive())->toBeFalse()
+        ->and($context->hasBecomeActive())->toBeFalse()
+        ->and($context->state())->toBe('background')
+        ->and($context->launch())->toBe('background');
+});
+
+it('reports protected data as unavailable while the device is locked', function () {
+    FakeBridge::enable()->respondTo('System.GetExecutionContext', headlessSnapshot());
+
+    expect((new ExecutionContext)->isProtectedDataAvailable())->toBeFalse();
+});
+
+it('reports the interactive boot as withheld during a headless launch', function () {
+    FakeBridge::enable()->respondTo('System.GetExecutionContext', headlessSnapshot());
+
+    expect((new ExecutionContext)->interactiveBootStarted())->toBeFalse();
+});
+
+it('reports an ordinary foreground app as interactive', function () {
+    FakeBridge::enable()->respondTo('System.GetExecutionContext', [
+        'launch' => 'foreground',
+        'state' => 'active',
+        'foreground' => true,
+        'active' => true,
+        'has_become_active' => true,
+        'headless' => false,
+        'protected_data_available' => true,
+        'interactive_boot_started' => true,
+    ]);
+
+    $context = new ExecutionContext;
+
+    expect($context->isHeadless())->toBeFalse()
+        ->and($context->isActive())->toBeTrue()
+        ->and($context->isForeground())->toBeTrue()
+        ->and($context->isBackground())->toBeFalse()
+        ->and($context->launchedInBackground())->toBeFalse()
+        ->and($context->isProtectedDataAvailable())->toBeTrue();
+});
+
+it('treats a foregrounded-but-inactive app as still on screen', function () {
+    FakeBridge::enable()->respondTo('System.GetExecutionContext', headlessSnapshot([
+        'state' => 'inactive',
+        'foreground' => true,
+        'has_become_active' => true,
+        'headless' => false,
+    ]));
+
+    $context = new ExecutionContext;
+
+    expect($context->isForeground())->toBeTrue()
+        ->and($context->isBackground())->toBeFalse()
+        ->and($context->isActive())->toBeFalse();
+});
+
+// ── Degrading safely ────────────────────────────────
+
+it('reports an interactive process when the bridge has no answer', function () {
+    // A native shell built before System.GetExecutionContext existed: the
+    // call goes out but comes back empty. Upgrading the PHP package alone
+    // must never flip an app into believing it is headless.
+    FakeBridge::enable();
+
+    $context = new ExecutionContext;
+
+    expect($context->isHeadless())->toBeFalse()
+        ->and($context->isForeground())->toBeTrue()
+        ->and($context->isActive())->toBeTrue()
+        ->and($context->isProtectedDataAvailable())->toBeTrue()
+        ->and($context->interactiveBootStarted())->toBeTrue()
+        ->and($context->state())->toBe('active')
+        ->and($context->launch())->toBe('foreground');
+});
+
+it('fills keys the native side did not report', function () {
+    FakeBridge::enable()->respondTo('System.GetExecutionContext', [
+        'headless' => true,
+        'protected_data_available' => false,
+    ]);
+
+    $context = new ExecutionContext;
+
+    expect($context->isHeadless())->toBeTrue()
+        ->and($context->isProtectedDataAvailable())->toBeFalse()
+        // Unreported keys fall back to the interactive defaults.
+        ->and($context->state())->toBe('active');
+});
+
+// ── Wiring ──────────────────────────────────────────
+
+it('resolves through the facade', function () {
+    FakeBridge::enable()->respondTo('System.GetExecutionContext', headlessSnapshot());
+
+    expect(ExecutionContextFacade::isHeadless())->toBeTrue()
+        ->and(ExecutionContextFacade::all())->toBe(headlessSnapshot());
+});
+
+it('re-reads the bridge on every call so a long-lived screen never goes stale', function () {
+    $bridge = FakeBridge::enable();
+    $bridge->respondTo('System.GetExecutionContext', headlessSnapshot());
+
+    $context = new ExecutionContext;
+    expect($context->isForeground())->toBeFalse();
+
+    $bridge->respondTo('System.GetExecutionContext', headlessSnapshot([
+        'state' => 'active',
+        'foreground' => true,
+        'active' => true,
+        'has_become_active' => true,
+        'headless' => false,
+    ]));
+
+    expect($context->isForeground())->toBeTrue()
+        ->and($context->isHeadless())->toBeFalse();
+});


### PR DESCRIPTION
## The problem

iOS cold-launches the whole app into the background to run scheduled work: a BGTaskScheduler task, a silent push, a background fetch. That usually happens while the phone is locked.

The boot sequence ran straight through, so a background wake dispatched `NATIVEPHP_START_URL`, mounted `ContentView` and started polling. Auth middleware, component mounts and navigation all ran with nobody watching and the keychain sealed.

Reported against `dev-element` with `nativephp/mobile-background-tasks`.

## What changed

The boot is now two phases, in the new `NativePHPBootstrap`.

The runtime phase runs on every launch: PHP environment, bundle extraction, the persistent Laravel runtime, plugin `onAppReady` callbacks, hot reload. Scheduled work needs all of that.

The interactive phase waits until the app is on screen. That is the boot transport, the start URL, `ContentView` and the WKWebView. It runs at most once per process, so a launch that parks it does not re-run it on every later foreground.

`AppDelegate` also starts the bootstrap directly on a background launch. No scene connects, so `SplashView.onAppear` cannot be relied on to boot the runtime the work needs. `start()` is idempotent, so whichever entry point fires first wins.

`ExecutionContext` is the gate. It records why the process started, then mirrors the lifecycle and protected-data notifications under a lock. Bridge functions read that mirror rather than hopping to main, which would deadlock whenever main is already waiting on PHP.

## Behaviour change worth arguing about

The queue worker and the async task pool are now behind the same gate. Between them they boot five PHP contexts on top of the persistent runtime, one for the worker and four for the pool, each a full Laravel boot. Paying for that during a background wake is how the process gets jetsammed mid-task.

The cost: jobs dispatched from background work sit in the queue until the app is next opened, and `AsyncTask::dispatch()` returns false while the pool is down. The false return is honest, since the async completion callback wakes the UI runloop and a headless launch has not got one. But if you would rather the async pool always boot, say so and I will pull that half out.

## New API

`System.GetExecutionContext` on both platforms, behind `Native\Mobile\Facades\ExecutionContext`:

```php
if (ExecutionContext::isHeadless()) return;                 // woken for background work
if (! ExecutionContext::isProtectedDataAvailable()) return; // device locked
```

Plus `state()`, `launch()`, `isActive()`, `isForeground()`, `isBackground()`, `launchedInBackground()`, `hasBecomeActive()`, `interactiveBootStarted()`, `all()`.

Reads are not cached. A native screen's request stays open for the life of the screen, so a captured value would still say "active" long after the app went away.

Android reports `headless: false` and `launch: "foreground"`, because its runtime starts from the Activity and there is no equivalent launch. `protected_data_available` maps to the direct-boot unlocked state. One PHP code path either way.

## Backwards compatibility

An empty or missing bridge response falls back to an ordinary interactive process, so a newer PHP package against an older native shell cannot flip an app into thinking it is headless. Missing keys fill individually from the defaults.

`NativePHPApp`'s boot helpers are now static so the bootstrap can call them without `NativePHPApp.shared`. The App-init versus AppDelegate ordering is not guaranteed, and main now calls `runMigrationsAndClearCaches()` from inside `ensureAppExists()`, which would silently skip migrations if that reference were nil. `AppUpdateManager` and `HotReloadServer` call `NativePHPApp.artisan(...)` directly now.

## What to watch for in review

Run against the super-native demo app on an iPhone 17 Pro simulator (iOS 26.2) and a Medium_Phone_API_35 emulator. Both build, launch and render the native start route. `ExecutionContext` reads correctly from PHP on both: `launch=foreground`, `state=active`, `isHeadless()=false`, `protectedDataAvailable()=true`.

That run caught a bug the compiler could not. The original detection read `UIApplication.applicationState` synchronously inside `didFinishLaunchingWithOptions`, which is the documented approach but is wrong for scene-based SwiftUI apps: no scene has connected at that point, so it returns `.background` for every launch. Measured `.background` with zero scenes at t=0, `.inactive` with one connected scene at +160ms, `.active` at +500ms. Every ordinary launch was being classified headless, and `launchedInBackground()` latched that for the life of the process. Classification now happens on the next main-runloop turn, after UIKit has connected the scene, and the gate no longer consults it at all. Fixed in ca106b0 and re-verified on both simulators.

A real BGTaskScheduler cold launch on a locked phone is still not covered. Simulators cannot trigger one, so the headless branch itself is reasoned and compiled but not executed. That is the main thing left to check by hand.

Nothing in CI compiles the iOS Swift. I typechecked all 61 files of the target together against the real iOS SDK, stubbing the three non-SDK modules (PHP, Bridge, ZIPFoundation).

Commits 2 to 6 are fixes to problems in commit 1, found while reviewing and then while running it:

- `whenInteractive()` decided and then parked in two separate critical sections. A `didBecomeActive` landing in the gap drains an empty queue and orphans the block, leaving the app on the splash for the rest of the process with no watchdog to recover.
- The gate dispatched to a background queue even when running immediately, which reordered the boot so the extra PHP runtimes could start competing for CPU during first render.
- `registerBridgeFunctions()` was only called from `NativePHPApp.init()`. A headless launch may never build the App value, so PHP could boot with no bridge and every `nativephp_call()` would fail, including the one behind `ExecutionContext` itself.
- The launch classification bug above.

## A trap for anyone testing the headless path

`NATIVEPHP_APP_VERSION=DEBUG` is what `native:run` ships, and `shouldUpdateWithVersion()` treats it as "always re-extract". So every cold start unpacks the whole Laravel bundle again:

```
📦 An app bundle has already been extracted
🚧 DEBUG version detected, updating from bundle
📦 Extracting bundled app to documents directory...
```

A `BGAppRefreshTask` gets 30 seconds in total. On a debug build a headless wake will spend most or all of that re-extracting and may never reach the scheduled command — and if iOS kills it mid-extraction, `AppUpdateManager` deletes the app directory to self-heal, which sets the next attempt up to do the same thing.

This is pre-existing behaviour and not something this branch changes, but it makes the headless path effectively untestable on a debug build. Set a real `NATIVEPHP_APP_VERSION` when testing background tasks. Possibly worth skipping the debug re-extract when `NATIVEPHP_BACKGROUND_TASK` is set, as a separate change.

## Checks

Pint, PHPStan and 1174 Pest tests pass, including 9 new ones. Rebased onto main.

Docs are in a companion PR on nativephp.com: a new Execution Context page next to Lifecycle Hooks, and an update to the Queues page, whose "starts automatically when your app boots" line this change makes untrue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


