### PR TITLE
Fix native:check-build-number for iOS

### DIFF
--- a/src/Commands/CheckBuildNumberCommand.php
+++ b/src/Commands/CheckBuildNumberCommand.php
@@ -19,6 +19,9 @@ class CheckBuildNumberCommand extends Command
         {platform : The platform to check (android/a, ios/i, or both)}
         {--google-service-key= : Path to Google Service Account JSON key file (Android)}
         {--api-key= : Path to App Store Connect API key file (iOS)}
+        {--api-key-path= : Path to App Store Connect API key file (.p8) - same as --api-key}
+        {--api-key-id= : App Store Connect API key ID}
+        {--api-issuer-id= : App Store Connect API issuer ID}
         {--update : Update local build number to store latest + 1}
         {--jump-by= : Add extra number to the suggested version (e.g. --jump-by=10 to skip ahead)}';
 
@@ -98,8 +101,21 @@ class CheckBuildNumberCommand extends Command
     {
         $this->info('🍎 Checking iOS (App Store Connect)...');
 
-        $latestBuildNumber = $this->getLatestBuildNumberFromStore('ios');
         $currentLocal = env('NATIVEPHP_APP_VERSION_CODE');
+
+        // Suggesting a number without having reached Apple is worse than not
+        // answering: "1" looks like a fresh app rather than a failed lookup.
+        if (! $this->hasAppStoreConnectCredentials()) {
+            $this->line('📱 App Store: not checked - no API credentials');
+            $this->line('💻 Local current: '.($currentLocal ?: 'not set'));
+            $this->line('🔑 Provide --api-key-path, --api-key-id and --api-issuer-id, or set');
+            $this->line('   APP_STORE_API_KEY, APP_STORE_API_KEY_ID and APP_STORE_API_ISSUER_ID');
+            $this->newLine();
+
+            return;
+        }
+
+        $latestBuildNumber = $this->getLatestBuildNumberFromStore('ios');
 
         if ($latestBuildNumber !== null) {
             $this->line("📱 App Store latest: {$latestBuildNumber}");
@@ -113,7 +129,10 @@ class CheckBuildNumberCommand extends Command
                 $this->line('🔧 To update: add --update flag');
             }
         } else {
-            $this->line('📱 App Store: No releases found or check not implemented');
+            // Reached Apple, found nothing. Build numbers only have to be unique
+            // within one version string, so a new version really does start at 1.
+            $version = config('nativephp.version');
+            $this->line("📱 App Store: no builds yet for version {$version}");
             $this->line('💻 Local current: '.($currentLocal ?: 'not set'));
             $this->line('💡 Suggested next: 1');
         }

--- a/src/Concerns/ChecksLatestBuildNumber.php
+++ b/src/Concerns/ChecksLatestBuildNumber.php
@@ -105,14 +105,47 @@ trait ChecksLatestBuildNumber
 
     private function getApiKeyPath(): ?string
     {
-        // Check for API key file path - try flags first, then environment variables
-        $apiKeyPath = $this->option('api-key-path') ?? $this->option('api-key') ?? env('APP_STORE_API_KEY_PATH');
+        // Check for API key file path - try flags first, then environment variables,
+        // then the config that `app_store_connect` publishes (APP_STORE_API_KEY).
+        $apiKeyPath = $this->option('api-key-path')
+            ?: $this->option('api-key')
+            ?: env('APP_STORE_API_KEY_PATH')
+            ?: config('nativephp.app_store_connect.api_key');
 
         if ($apiKeyPath && file_exists($apiKeyPath)) {
             return $apiKeyPath;
         }
 
         return null;
+    }
+
+    /**
+     * Whether an App Store Connect lookup can even be attempted.
+     *
+     * Without this, a missing credential is indistinguishable from a version
+     * that genuinely has no builds yet - both end up as null.
+     */
+    protected function hasAppStoreConnectCredentials(): bool
+    {
+        return $this->getApiKeyPath() !== null
+            && $this->getApiKeyId() !== null
+            && $this->getApiIssuerId() !== null;
+    }
+
+    private function getApiKeyId(): ?string
+    {
+        return $this->option('api-key-id')
+            ?: env('APP_STORE_API_KEY_ID')
+            ?: config('nativephp.app_store_connect.api_key_id')
+            ?: null;
+    }
+
+    private function getApiIssuerId(): ?string
+    {
+        return $this->option('api-issuer-id')
+            ?: env('APP_STORE_API_ISSUER_ID')
+            ?: config('nativephp.app_store_connect.api_issuer_id')
+            ?: null;
     }
 
     public function updateBuildNumberFromStore(string $platform, int $jumpBy = 0): bool
@@ -153,8 +186,8 @@ trait ChecksLatestBuildNumber
     {
         try {
             $apiKeyPath = $this->getApiKeyPath();
-            $apiKeyId = $this->option('api-key-id') ?? env('APP_STORE_API_KEY_ID');
-            $apiIssuerId = $this->option('api-issuer-id') ?? env('APP_STORE_API_ISSUER_ID');
+            $apiKeyId = $this->getApiKeyId();
+            $apiIssuerId = $this->getApiIssuerId();
             $appId = config('nativephp.app_id');
 
             if (! $apiKeyPath || ! $apiKeyId || ! $apiIssuerId || ! $appId) {

--- a/tests/Feature/CheckBuildNumberIosCredentialsTest.php
+++ b/tests/Feature/CheckBuildNumberIosCredentialsTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\Feature;
+
+use Native\Mobile\Commands\CheckBuildNumberCommand;
+use Tests\TestCase;
+
+/**
+ * `native:check-build-number ios` read three options its signature never
+ * declared, so Symfony threw before the command reached Apple. The exception was
+ * swallowed and reported as "No releases found", which looks exactly like a new
+ * app - with "Suggested next: 1" underneath it.
+ */
+class CheckBuildNumberIosCredentialsTest extends TestCase
+{
+    /** The options ChecksLatestBuildNumber reads on the iOS path. */
+    private const REQUIRED_OPTIONS = ['api-key-path', 'api-key-id', 'api-issuer-id'];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (['APP_STORE_API_KEY', 'APP_STORE_API_KEY_PATH', 'APP_STORE_API_KEY_ID', 'APP_STORE_API_ISSUER_ID'] as $key) {
+            putenv($key);
+        }
+
+        config([
+            'nativephp.app_id' => 'com.example.app',
+            'nativephp.version' => '1.2.0',
+            'nativephp.app_store_connect' => ['api_key' => null, 'api_key_id' => null, 'api_issuer_id' => null],
+        ]);
+    }
+
+    public function test_the_command_declares_every_option_the_ios_check_reads(): void
+    {
+        $definition = (new CheckBuildNumberCommand)->getDefinition();
+
+        foreach (self::REQUIRED_OPTIONS as $option) {
+            $this->assertTrue(
+                $definition->hasOption($option),
+                "--{$option} is read on the iOS path but not declared, so Symfony throws before Apple is reached.",
+            );
+        }
+    }
+
+    public function test_it_reports_missing_credentials_instead_of_suggesting_one(): void
+    {
+        $this->artisan('native:check-build-number', ['platform' => 'ios'])
+            ->expectsOutputToContain('not checked - no API credentials')
+            ->doesntExpectOutputToContain('Suggested next: 1')
+            ->assertSuccessful();
+    }
+
+    public function test_it_does_not_touch_the_build_number_without_credentials(): void
+    {
+        // --update used to be unsafe to reach for: the output said 1, so it read
+        // as though the local build number was about to become 1.
+        putenv('NATIVEPHP_APP_VERSION_CODE=28');
+
+        $this->artisan('native:check-build-number', ['platform' => 'ios', '--update' => true])
+            ->expectsOutputToContain('Local current: 28')
+            ->assertSuccessful();
+
+        $this->assertSame('28', getenv('NATIVEPHP_APP_VERSION_CODE'));
+
+        putenv('NATIVEPHP_APP_VERSION_CODE');
+    }
+
+    public function test_it_finds_the_key_path_from_the_published_config(): void
+    {
+        // config/nativephp.php exposes it as app_store_connect.api_key, fed by
+        // APP_STORE_API_KEY - not the APP_STORE_API_KEY_PATH the concern used to
+        // be the only fallback for.
+        $key = tempnam(sys_get_temp_dir(), 'asc').'.p8';
+        file_put_contents($key, 'not a real key');
+
+        config([
+            'nativephp.app_store_connect' => [
+                'api_key' => $key,
+                'api_key_id' => 'ABC123',
+                'api_issuer_id' => '69a6de94-0000-0000-0000-000000000000',
+            ],
+        ]);
+
+        // Proof that the lookup was actually attempted: the version line is only
+        // printed once credential resolution has succeeded. The key is not a real
+        // one, so it gets no further than that - which is the point.
+        $this->artisan('native:check-build-number', ['platform' => 'ios'])
+            ->expectsOutputToContain('1.2.0')
+            ->doesntExpectOutputToContain('not checked - no API credentials')
+            ->assertSuccessful();
+
+        unlink($key);
+    }
+}


### PR DESCRIPTION
The iOS path reads --api-key-path, --api-key-id and --api-issuer-id, but CheckBuildNumberCommand only declares --api-key. Symfony therefore throws `The "api-key-path" option does not exist` inside getLatestIosBuildNumber(), where the catch-all turns it into a warning and returns null. The command then prints "No releases found or check not implemented" and "Suggested next: 1" — which is indistinguishable from a brand-new app, so the number cannot be trusted and the command is unusable for the one thing it exists to do.

PackageCommand and BuildIosAppCommand declare all three, which is why the same lookup works there.

Three changes:

- Declare the missing options, matching PackageCommand's wording.
- Resolve credentials from config('nativephp.app_store_connect.*') as a last fallback. getApiKeyPath() only fell back to APP_STORE_API_KEY_PATH, while the published config exposes the key as app_store_connect.api_key (APP_STORE_API_KEY), so a documented setup still found nothing.
- Say "not checked - no API credentials" instead of suggesting a number when the lookup cannot run. Suggesting 1 is worse than declining to answer. Once Apple has actually been asked, "no builds yet for version X" is correct and 1 really is the next build, since build numbers only have to be unique within a version.