### PR TITLE
Restore push notification badge clearing

### DIFF
--- a/src/PushNotifications.php
+++ b/src/PushNotifications.php
@@ -64,4 +64,16 @@ class PushNotifications
 
         return null;
     }
+
+    /**
+     * Clear the app icon badge number
+     */
+    public function clearBadge(): void
+    {
+        if (! function_exists('nativephp_call')) {
+            return;
+        }
+
+        nativephp_call('PushNotification.ClearBadge', '{}');
+    }
 }

--- a/tests/Unit/PushNotificationsTest.php
+++ b/tests/Unit/PushNotificationsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Native\Mobile\Facades\PushNotifications;
+use Native\Mobile\Testing\FakeBridge;
+
+afterEach(fn () => FakeBridge::disable());
+
+it('clears the app badge through the native bridge', function () {
+    $bridge = FakeBridge::enable();
+
+    PushNotifications::clearBadge();
+
+    $bridge->assertCalled(
+        'PushNotification.ClearBadge',
+        fn (array $params) => $params === []
+    );
+});


### PR DESCRIPTION
## Summary

`PushNotifications::clearBadge()` was added in #82, then accidentally dropped by #111's large Jump merge while the facade's `@method clearBadge()` contract remained. Apps therefore still see the API advertised but hit an undefined method at runtime.

This restores the method and forwards it to the existing `PushNotification.ClearBadge` native bridge function, with a regression test for the bridge call and empty payload.

## Test plan

- `php84 vendor/bin/pest --colors=never` (860 passed, 2,932 assertions)
- `php84 vendor/bin/phpstan analyse --debug --no-progress`
- Targeted Pint check
- `nativephp-test-app`: booted against this branch; facade call captured as `PushNotification.ClearBadge` with empty params; smoke tests passed
