### PR TITLE
Use destructive theme color for native errors

### DIFF
--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -436,11 +436,13 @@ class NativeServiceProvider extends PackageServiceProvider
             return "<?php
                 \$__nativeErrorArgs = [{$expression}];
                 \$__nativeErrorField = \$__nativeErrorArgs[0];
-                \$__nativeErrorColor = \$__nativeErrorArgs[1] ?? theme('destructive', '#FF0000');
+                \$__nativeErrorColor = \$__nativeErrorArgs[1] ?? config('native-ui.theme.light.destructive', '#FF0000');
+                \$__nativeErrorDarkColor = isset(\$__nativeErrorArgs[1]) ? null : config('native-ui.theme.dark.destructive');
                 if (isset(\$errors) && is_array(\$errors) && !empty(\$errors[\$__nativeErrorField])) {
                     \\Native\\Mobile\\Edge\\NativeElementCollector::leaf('text', [
                         'text' => \$errors[\$__nativeErrorField],
                         'color' => \$__nativeErrorColor,
+                        'dark' => ['color' => \$__nativeErrorDarkColor],
                         'fontSize' => 12,
                     ]);
                 }

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -436,7 +436,7 @@ class NativeServiceProvider extends PackageServiceProvider
             return "<?php
                 \$__nativeErrorArgs = [{$expression}];
                 \$__nativeErrorField = \$__nativeErrorArgs[0];
-                \$__nativeErrorColor = \$__nativeErrorArgs[1] ?? '#FF0000';
+                \$__nativeErrorColor = \$__nativeErrorArgs[1] ?? theme('destructive', '#FF0000');
                 if (isset(\$errors) && is_array(\$errors) && !empty(\$errors[\$__nativeErrorField])) {
                     \\Native\\Mobile\\Edge\\NativeElementCollector::leaf('text', [
                         'text' => \$errors[\$__nativeErrorField],

--- a/tests/Feature/Edge/BladeNativeRenderingTest.php
+++ b/tests/Feature/Edge/BladeNativeRenderingTest.php
@@ -354,7 +354,7 @@ BLADE);
 it('uses the destructive theme color for errors by default', function () {
     config([
         'native-ui.theme.light.destructive' => '#B42318',
-        'native-ui.theme.dark.destructive' => '#B42318',
+        'native-ui.theme.dark.destructive' => '#F87171',
     ]);
 
     $viewPath = __DIR__.'/views/test-error-themed.blade.php';
@@ -368,7 +368,9 @@ BLADE);
     view('test-error-themed', ['errors' => ['email' => 'Invalid email']])->render();
     $tree = NativeElementCollector::collect()->toArray(new CallbackRegistry);
 
-    expect($tree['children'][0]['props']['color'])->toBe('#B42318');
+    expect($tree['children'][0]['props'])
+        ->color->toBe('#B42318')
+        ->dark_color->toBe('#F87171');
 });
 
 it('renders error text with custom color', function () {
@@ -391,5 +393,6 @@ BLADE);
     expect($errorNode['type'])->toBe('text');
     expect($errorNode['props']['text'])->toBe('Invalid email');
     expect($errorNode['props']['color'])->toBe('#E91E63');
+    expect($errorNode['props'])->not->toHaveKey('dark_color');
     expect($errorNode['props']['font_size'])->toBe(12.0);
 });

--- a/tests/Feature/Edge/BladeNativeRenderingTest.php
+++ b/tests/Feature/Edge/BladeNativeRenderingTest.php
@@ -351,6 +351,26 @@ BLADE);
     expect($errorNode['props']['font_size'])->toBe(12.0);
 });
 
+it('uses the destructive theme color for errors by default', function () {
+    config([
+        'native-ui.theme.light.destructive' => '#B42318',
+        'native-ui.theme.dark.destructive' => '#B42318',
+    ]);
+
+    $viewPath = __DIR__.'/views/test-error-themed.blade.php';
+    file_put_contents($viewPath, <<<'BLADE'
+<native:column>
+    @nativeError('email')
+</native:column>
+BLADE);
+
+    NativeElementCollector::reset();
+    view('test-error-themed', ['errors' => ['email' => 'Invalid email']])->render();
+    $tree = NativeElementCollector::collect()->toArray(new CallbackRegistry);
+
+    expect($tree['children'][0]['props']['color'])->toBe('#B42318');
+});
+
 it('renders error text with custom color', function () {
     $viewPath = __DIR__.'/views/test-error-custom-color.blade.php';
     file_put_contents($viewPath, <<<'BLADE'


### PR DESCRIPTION
## Summary

- resolve `@nativeError`'s default color from the appearance-aware `destructive` theme token
- preserve explicit color overrides and the existing fallback when the token is unavailable
- add Blade rendering regression coverage

## Why

The directive hardcoded `#FF0000`, so default validation errors ignored each app's light and dark palettes.

## Test plan

- `php -d error_reporting=8191 vendor/bin/pest --compact`
- `vendor/bin/phpstan analyse --no-progress`
- `vendor/bin/pint --test src/NativeServiceProvider.php tests/Feature/Edge/BladeNativeRenderingTest.php`
