### PR TITLE
Add Tailwind aliases and unsupported class warnings

### DIFF
--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -1296,11 +1296,16 @@ abstract class NativeComponent
         // returns a View. We need the View to access its engine + path.
         $view = view($name, $data);
         $engine = $view->getEngine();
+        TailwindParser::beginViewDiagnostics($view->getName());
 
         if (! $engine instanceof CompilerEngine) {
             // Non-blade engine — fall back to the standard render path.
             // $this won't be bound, but at least the view still runs.
-            $view->render();
+            try {
+                $view->render();
+            } finally {
+                TailwindParser::endViewDiagnostics();
+            }
 
             return;
         }
@@ -1373,6 +1378,7 @@ abstract class NativeComponent
             $factory->flushStateIfDoneRendering();
         } finally {
             NativeTagPrecompiler::setActive($wasActive);
+            TailwindParser::endViewDiagnostics();
         }
     }
 

--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -2,6 +2,7 @@
 
 namespace Native\Mobile\Edge;
 
+use Illuminate\Support\Facades\Log;
 use Native\Mobile\Edge\Enums\AlignItems;
 use Native\Mobile\Edge\Enums\AlignSelf;
 use Native\Mobile\Edge\Enums\JustifyContent;
@@ -11,6 +12,15 @@ use Native\Mobile\Platform;
 class TailwindParser
 {
     private static array $cache = [];
+
+    /** @var array<string, list<string>> */
+    private static array $unsupportedCache = [];
+
+    /** @var list<array{view: string, enabled: bool, classes: array<string, true>}> */
+    private static array $diagnosticScopes = [];
+
+    /** @var array<string, array<string, true>> */
+    private static array $reportedUnsupportedByView = [];
 
     /**
      * Plugin-provided resolver for `bg-theme-*` / `text-theme-*` classes —
@@ -35,13 +45,13 @@ class TailwindParser
     public static function setThemeResolver(?callable $resolver): void
     {
         static::$themeResolver = $resolver;
-        static::$cache = [];
+        static::clearCache();
     }
 
     public static function setThemeDarkResolver(?callable $resolver): void
     {
         static::$themeDarkResolver = $resolver;
-        static::$cache = [];
+        static::clearCache();
     }
 
     /**
@@ -52,7 +62,7 @@ class TailwindParser
     public static function setPlatform(?string $platform): void
     {
         Platform::set($platform);
-        static::$cache = [];
+        static::clearCache();
     }
 
     private static function currentPlatform(): ?string
@@ -211,15 +221,22 @@ class TailwindParser
     public static function parse(string $classString): array
     {
         if (isset(self::$cache[$classString])) {
+            self::recordUnsupported(self::$unsupportedCache[$classString] ?? []);
+
             return self::$cache[$classString];
         }
 
         $result = [];
+        $unsupported = [];
         $classes = preg_split('/\s+/', trim($classString), -1, PREG_SPLIT_NO_EMPTY);
 
         foreach ($classes as $class) {
             $parsed = self::parseClass($class);
             if ($parsed === null) {
+                if (! self::isInactivePlatformVariant($class)) {
+                    $unsupported[$class] = true;
+                }
+
                 continue;
             }
             // Merge dark companion separately so a class that contributes BOTH
@@ -245,6 +262,8 @@ class TailwindParser
         }
 
         self::$cache[$classString] = $result;
+        self::$unsupportedCache[$classString] = array_keys($unsupported);
+        self::recordUnsupported(self::$unsupportedCache[$classString]);
 
         return $result;
     }
@@ -252,6 +271,75 @@ class TailwindParser
     public static function clearCache(): void
     {
         self::$cache = [];
+        self::$unsupportedCache = [];
+    }
+
+    /**
+     * Group unsupported utility diagnostics under the Blade view currently
+     * being rendered. Scopes nest for child components and partials, so each
+     * warning points back to the view that authored the dropped classes.
+     */
+    public static function beginViewDiagnostics(string $view): void
+    {
+        self::$diagnosticScopes[] = [
+            'view' => $view,
+            'enabled' => (bool) config('app.debug', false),
+            'classes' => [],
+        ];
+    }
+
+    public static function endViewDiagnostics(): void
+    {
+        $scope = array_pop(self::$diagnosticScopes);
+
+        if ($scope === null || ! $scope['enabled'] || $scope['classes'] === []) {
+            return;
+        }
+
+        $reported = self::$reportedUnsupportedByView[$scope['view']] ?? [];
+        $classes = array_values(array_filter(
+            array_keys($scope['classes']),
+            fn (string $class): bool => ! isset($reported[$class])
+        ));
+
+        if ($classes === []) {
+            return;
+        }
+
+        foreach ($classes as $class) {
+            self::$reportedUnsupportedByView[$scope['view']][$class] = true;
+        }
+
+        Log::warning('NativePHP EDGE dropped unsupported Tailwind classes.', [
+            'view' => $scope['view'],
+            'classes' => $classes,
+        ]);
+    }
+
+    /** @param  list<string>  $classes */
+    private static function recordUnsupported(array $classes): void
+    {
+        $scopeIndex = array_key_last(self::$diagnosticScopes);
+
+        if ($scopeIndex === null || ! self::$diagnosticScopes[$scopeIndex]['enabled']) {
+            return;
+        }
+
+        foreach ($classes as $class) {
+            self::$diagnosticScopes[$scopeIndex]['classes'][$class] = true;
+        }
+    }
+
+    /**
+     * Platform variants that target another platform are intentional no-ops,
+     * not unsupported utilities. A malformed class containing both platform
+     * targets is still reported when one target matches the current platform.
+     */
+    private static function isInactivePlatformVariant(string $class): bool
+    {
+        $targets = array_values(array_intersect(explode(':', $class), ['ios', 'android']));
+
+        return $targets !== [] && ! in_array(self::currentPlatform(), $targets, true);
     }
 
     /**
@@ -385,10 +473,10 @@ class TailwindParser
             $class === 'flex-row', $class === 'flex-row-reverse' => ['flexDirection' => 1],
             $class === 'flex-col', $class === 'flex-col-reverse' => ['flexDirection' => 0],
             $class === 'flex-1' => ['flexGrow' => 1, 'flexShrink' => 1, 'flexBasis' => 0],
-            $class === 'flex-grow' => ['flexGrow' => 1],
-            $class === 'flex-grow-0' => ['flexGrow' => 0],
-            $class === 'flex-shrink' => ['flexShrink' => 1],
-            $class === 'flex-shrink-0' => ['flexShrink' => 0],
+            $class === 'flex-grow', $class === 'grow' => ['flexGrow' => 1],
+            $class === 'flex-grow-0', $class === 'grow-0' => ['flexGrow' => 0],
+            $class === 'flex-shrink', $class === 'shrink' => ['flexShrink' => 1],
+            $class === 'flex-shrink-0', $class === 'shrink-0' => ['flexShrink' => 0],
             $class === 'flex-wrap' => ['flexWrap' => 1],
             $class === 'flex-nowrap' => ['flexWrap' => 0],
             $class === 'flex-wrap-reverse' => ['flexWrap' => 2],

--- a/tests/Feature/Edge/TailwindParserWarningsTest.php
+++ b/tests/Feature/Edge/TailwindParserWarningsTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Edge\TailwindParser;
+use Native\Mobile\Testing\Native;
+
+final class FirstTailwindWarningScreen extends NativeComponent
+{
+    public function render(): View
+    {
+        return view('tailwind-warning-first');
+    }
+}
+
+final class SecondTailwindWarningScreen extends NativeComponent
+{
+    public function render(): View
+    {
+        return view('tailwind-warning-second');
+    }
+}
+
+beforeEach(function () {
+    $viewPath = __DIR__.'/views';
+    app('view')->addLocation($viewPath);
+
+    file_put_contents(
+        $viewPath.'/tailwind-warning-first.blade.php',
+        '<native:column class="p-4 truncate animate-pulse ios:bg-red-500"><native:text class="truncate">First</native:text></native:column>'
+    );
+    file_put_contents(
+        $viewPath.'/tailwind-warning-second.blade.php',
+        '<native:column class="animate-pulse truncate ios:bg-red-500"><native:text>Second</native:text></native:column>'
+    );
+
+    TailwindParser::clearCache();
+});
+
+afterEach(function () {
+    TailwindParser::setPlatform(null);
+    TailwindParser::clearCache();
+
+    @unlink(__DIR__.'/views/tailwind-warning-first.blade.php');
+    @unlink(__DIR__.'/views/tailwind-warning-second.blade.php');
+});
+
+it('warns once per view with the unique unsupported classes in debug mode', function () {
+    config()->set('app.debug', true);
+    Log::spy();
+
+    Native::test(FirstTailwindWarningScreen::class, platform: 'android');
+    Native::test(FirstTailwindWarningScreen::class, platform: 'android');
+    Native::test(SecondTailwindWarningScreen::class, platform: 'android');
+
+    Log::shouldHaveReceived('warning')
+        ->with('NativePHP EDGE dropped unsupported Tailwind classes.', [
+            'view' => 'tailwind-warning-first',
+            'classes' => ['truncate', 'animate-pulse'],
+        ])
+        ->once();
+
+    Log::shouldHaveReceived('warning')
+        ->with('NativePHP EDGE dropped unsupported Tailwind classes.', [
+            'view' => 'tailwind-warning-second',
+            'classes' => ['animate-pulse', 'truncate'],
+        ])
+        ->once();
+});
+
+it('does not warn about unsupported classes when debug mode is disabled', function () {
+    config()->set('app.debug', false);
+    Log::spy();
+
+    Native::test(FirstTailwindWarningScreen::class, platform: 'android');
+
+    Log::shouldNotHaveReceived('warning');
+});
+
+it('attributes cached unsupported classes to every view that uses them', function () {
+    config()->set('app.debug', true);
+    Log::spy();
+
+    TailwindParser::beginViewDiagnostics('cached-tailwind-first');
+    TailwindParser::parse('truncate');
+    TailwindParser::endViewDiagnostics();
+
+    TailwindParser::beginViewDiagnostics('cached-tailwind-second');
+    TailwindParser::parse('truncate');
+    TailwindParser::endViewDiagnostics();
+
+    Log::shouldHaveReceived('warning')
+        ->with('NativePHP EDGE dropped unsupported Tailwind classes.', [
+            'view' => 'cached-tailwind-first',
+            'classes' => ['truncate'],
+        ])
+        ->once();
+
+    Log::shouldHaveReceived('warning')
+        ->with('NativePHP EDGE dropped unsupported Tailwind classes.', [
+            'view' => 'cached-tailwind-second',
+            'classes' => ['truncate'],
+        ])
+        ->once();
+});

--- a/tests/Feature/Edge/TailwindParserWarningsTest.php
+++ b/tests/Feature/Edge/TailwindParserWarningsTest.php
@@ -24,6 +24,9 @@ final class SecondTailwindWarningScreen extends NativeComponent
 
 beforeEach(function () {
     $viewPath = __DIR__.'/views';
+    if (! is_dir($viewPath)) {
+        mkdir($viewPath, 0755, true);
+    }
     app('view')->addLocation($viewPath);
 
     file_put_contents(

--- a/tests/Unit/Edge/TailwindParserTest.php
+++ b/tests/Unit/Edge/TailwindParserTest.php
@@ -96,6 +96,13 @@ it('parses flex utilities', function () {
     expect(TailwindParser::parse('flex-shrink-0'))->toBe(['flexShrink' => 0]);
 });
 
+it('parses the current Tailwind grow and shrink aliases', function () {
+    expect(TailwindParser::parse('grow'))->toBe(['flexGrow' => 1]);
+    expect(TailwindParser::parse('grow-0'))->toBe(['flexGrow' => 0]);
+    expect(TailwindParser::parse('shrink'))->toBe(['flexShrink' => 1]);
+    expect(TailwindParser::parse('shrink-0'))->toBe(['flexShrink' => 0]);
+});
+
 it('parses items alignment', function () {
     expect(TailwindParser::parse('items-start'))->toBe(['alignItems' => 0]);
     expect(TailwindParser::parse('items-center'))->toBe(['alignItems' => 1]);


### PR DESCRIPTION
## Summary

- support Tailwind's current `grow`, `grow-0`, `shrink`, and `shrink-0` utilities
- warn once per Blade view in debug mode when unsupported classes are dropped
- preserve diagnostics across parser cache hits and ignore inactive platform variants

Unsupported classes currently return no parsed attributes and are skipped silently, making migration layout regressions difficult to trace.

## Test plan

- `php -d error_reporting=8191 vendor/bin/pest --compact`
- `composer analyse -- --no-progress`
- `vendor/bin/pint --test`
- `git diff --check`
