### PR TITLE
fix(android): stop mangling keystore passwords containing special characters

### DIFF
--- a/src/Concerns/CreatesAndroidCredentials.php
+++ b/src/Concerns/CreatesAndroidCredentials.php
@@ -3,6 +3,7 @@
 namespace Native\Mobile\Concerns;
 
 use Illuminate\Support\Facades\Process;
+use Native\Mobile\Support\EnvValue;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\password;
@@ -82,6 +83,11 @@ trait CreatesAndroidCredentials
 
         if (empty($keyPassword)) {
             $keyPassword = $password;
+        }
+
+        $this->warnIfPasswordNeedsQuoting($password);
+        if ($keyPassword !== $password) {
+            $this->warnIfPasswordNeedsQuoting($keyPassword);
         }
 
         // Collect certificate information
@@ -246,6 +252,8 @@ trait CreatesAndroidCredentials
 
         // Use same password for key password (standard for upload keystores)
         $keyPassword = $password;
+
+        $this->warnIfPasswordNeedsQuoting($password);
 
         // Collect certificate information
         $this->info('📋 Certificate information:');
@@ -427,7 +435,7 @@ trait CreatesAndroidCredentials
                 if (empty($addedVars)) {
                     $envContent .= PHP_EOL.'# Android Keystore Configuration'.PHP_EOL;
                 }
-                $envContent .= "{$key}={$value}".PHP_EOL;
+                $envContent .= "{$key}=".EnvValue::quote($value).PHP_EOL;
                 $addedVars[] = $key;
             }
         }
@@ -447,7 +455,44 @@ trait CreatesAndroidCredentials
             foreach ($existingVars as $var) {
                 $this->line("  - {$var}");
             }
+
+            $untouchedPasswordVars = array_values(array_intersect(
+                $existingVars,
+                ['ANDROID_KEYSTORE_PASSWORD', 'ANDROID_KEY_PASSWORD']
+            ));
+
+            if ($untouchedPasswordVars !== []) {
+                $this->newLine();
+                $verb = count($untouchedPasswordVars) > 1 ? 'were' : 'was';
+                $this->warn('⚠️  '.implode(' and ', $untouchedPasswordVars)." {$verb} not overwritten. If your");
+                $this->line('   password contains special characters, make sure the existing value is');
+                $this->line('   wrapped in double quotes:');
+                $this->line('       ANDROID_KEYSTORE_PASSWORD="your#password"');
+                $this->line('   An unquoted # is treated as the start of a comment and silently');
+                $this->line('   truncates the password, which fails keystore signing at package time.');
+            }
         }
+    }
+
+    /**
+     * Warn at entry time when a chosen password will need quoting — the
+     * value is written to .env double quoted (safe), but the same password
+     * passed via --keystore-password / --key-password goes through the
+     * shell, which mangles it unless single quoted.
+     */
+    private function warnIfPasswordNeedsQuoting(string $password): void
+    {
+        if (! EnvValue::needsQuoting($password)) {
+            return;
+        }
+
+        $this->newLine();
+        $this->warn('⚠️  That password contains characters that need quoting.');
+        $this->line('   It will be written to .env double quoted, which is safe, but if you');
+        $this->line('   ever pass it via --keystore-password or --key-password, wrap it in');
+        $this->line('   single quotes so your shell does not alter it before PHP sees it.');
+        $this->line('   An alphanumeric password avoids the issue entirely.');
+        $this->newLine();
     }
 
     private function addCredentialsToGitignore(): void

--- a/src/Concerns/CreatesIosCredentials.php
+++ b/src/Concerns/CreatesIosCredentials.php
@@ -3,6 +3,7 @@
 namespace Native\Mobile\Concerns;
 
 use Illuminate\Support\Facades\Process;
+use Native\Mobile\Support\EnvValue;
 
 use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\password;
@@ -276,7 +277,7 @@ trait CreatesIosCredentials
             return;
         }
 
-        if (preg_match('/[#\s"\'\\\\$!`]/', $p12Password)) {
+        if (EnvValue::needsQuoting($p12Password)) {
             $this->newLine();
             $this->warn('⚠️  That password contains characters that need quoting.');
             $this->line('   It will be written to .env double quoted, which is safe, but if you');
@@ -427,7 +428,7 @@ trait CreatesIosCredentials
                 if (empty($addedVars)) {
                     $envContent .= PHP_EOL.'# iOS Certificate Configuration (File Path)'.PHP_EOL;
                 }
-                $envContent .= "{$key}={$this->quoteEnvValue($value)}".PHP_EOL;
+                $envContent .= "{$key}=".EnvValue::quote($value).PHP_EOL;
                 $addedVars[] = $key;
             }
         }
@@ -461,17 +462,5 @@ trait CreatesIosCredentials
                 $this->line('   truncates the password, which fails the keychain import at build time.');
             }
         }
-    }
-
-    /**
-     * Quote a value for safe storage in .env.
-     *
-     * Unquoted values break on '#' (treated as a comment) and on whitespace
-     * (parse error), so every value is double quoted with the characters that
-     * are special inside a double-quoted dotenv string escaped.
-     */
-    private function quoteEnvValue(string $value): string
-    {
-        return '"'.str_replace(['\\', '"', '$'], ['\\\\', '\\"', '\\$'], $value).'"';
     }
 }

--- a/src/Support/EnvValue.php
+++ b/src/Support/EnvValue.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Native\Mobile\Support;
+
+/**
+ * Quoting for values written to .env files.
+ *
+ * phpdotenv mangles unquoted values two ways: everything from an unquoted
+ * '#' onwards is parsed as a comment (silently truncating the value), and
+ * an unquoted space is a parse error that aborts bootstrap before any
+ * artisan command runs. Credential passwords are user-chosen, so both are
+ * reachable — every value goes out double quoted, with the characters that
+ * are special inside a double-quoted dotenv string escaped.
+ */
+class EnvValue
+{
+    public static function quote(string $value): string
+    {
+        return '"'.str_replace(['\\', '"', '$'], ['\\\\', '\\"', '\\$'], $value).'"';
+    }
+
+    /**
+     * Whether the value contains characters that an unquoted .env entry or
+     * an unquoted shell argument would mangle — used to warn at entry time.
+     */
+    public static function needsQuoting(string $value): bool
+    {
+        return (bool) preg_match('/[#\s"\'\\\\$!`]/', $value);
+    }
+}

--- a/tests/Feature/AndroidCredentialsEnvTest.php
+++ b/tests/Feature/AndroidCredentialsEnvTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Native\Mobile\Concerns\CreatesAndroidCredentials;
+
+function makeAndroidEnvWriter(): object
+{
+    return new class
+    {
+        use CreatesAndroidCredentials;
+
+        public array $messages = [];
+
+        public function writeEnvVars(string $keystoreFile, string $keystorePassword, string $keyAlias, string $keyPassword): void
+        {
+            $this->updateAndroidEnvVars($keystoreFile, $keystorePassword, $keyAlias, $keyPassword);
+        }
+
+        protected function info(string $message): void
+        {
+            $this->messages[] = $message;
+        }
+
+        protected function line(string $message): void
+        {
+            $this->messages[] = $message;
+        }
+
+        protected function warn(string $message): void
+        {
+            $this->messages[] = $message;
+        }
+
+        protected function error(string $message): void
+        {
+            $this->messages[] = $message;
+        }
+
+        protected function newLine(): void {}
+    };
+}
+
+beforeEach(function () {
+    $this->envDir = sys_get_temp_dir().'/android-env-test-'.getmypid();
+    if (! is_dir($this->envDir)) {
+        mkdir($this->envDir, 0755, true);
+    }
+    $this->originalBasePath = $this->app->basePath();
+    $this->app->setBasePath($this->envDir);
+});
+
+afterEach(function () {
+    $this->app->setBasePath($this->originalBasePath);
+    @unlink($this->envDir.'/.env');
+    @rmdir($this->envDir);
+});
+
+it('writes keystore env vars double quoted so special characters survive dotenv', function () {
+    makeAndroidEnvWriter()->writeEnvVars('upload-keystore.jks', 'p@ss#w0rd', 'app-key', 'key pass$1');
+
+    $parsed = Dotenv\Dotenv::createArrayBacked($this->envDir)->load();
+
+    expect($parsed['ANDROID_KEYSTORE_FILE'])->toBe('upload-keystore.jks')
+        ->and($parsed['ANDROID_KEYSTORE_PASSWORD'])->toBe('p@ss#w0rd')
+        ->and($parsed['ANDROID_KEY_ALIAS'])->toBe('app-key')
+        ->and($parsed['ANDROID_KEY_PASSWORD'])->toBe('key pass$1');
+});
+
+it('leaves existing password vars untouched and warns about unquoted values', function () {
+    file_put_contents($this->envDir.'/.env', 'ANDROID_KEYSTORE_PASSWORD=old#password'.PHP_EOL);
+
+    $writer = makeAndroidEnvWriter();
+    $writer->writeEnvVars('upload-keystore.jks', 'new-password', 'app-key', 'new-password');
+
+    // The pre-existing (broken, unquoted) value must not be overwritten...
+    $envContent = file_get_contents($this->envDir.'/.env');
+    expect($envContent)->toContain('ANDROID_KEYSTORE_PASSWORD=old#password');
+
+    // ...but the user must be told it was skipped and how to fix it.
+    $warning = collect($writer->messages)->first(
+        fn (string $m) => str_contains($m, 'ANDROID_KEYSTORE_PASSWORD') && str_contains($m, 'not overwritten')
+    );
+    expect($warning)->not->toBeNull();
+
+    // Vars that were missing are still added, quoted.
+    $parsed = Dotenv\Dotenv::createArrayBacked($this->envDir)->load();
+    expect($parsed['ANDROID_KEY_PASSWORD'])->toBe('new-password');
+});

--- a/tests/Unit/Support/EnvValueTest.php
+++ b/tests/Unit/Support/EnvValueTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use Native\Mobile\Support\EnvValue;
+
+/**
+ * Round-trip through the real phpdotenv parser — the same code path that
+ * reads .env at bootstrap. If phpdotenv's quoting rules ever change, this
+ * is the test that catches it.
+ */
+function parseEnvLine(string $line): array
+{
+    $dir = sys_get_temp_dir().'/env-value-test-'.getmypid();
+    if (! is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+    file_put_contents($dir.'/.env', $line.PHP_EOL);
+
+    try {
+        return Dotenv\Dotenv::createArrayBacked($dir)->load();
+    } finally {
+        unlink($dir.'/.env');
+        rmdir($dir);
+    }
+}
+
+it('round-trips adversarial values through real phpdotenv', function (string $value) {
+    $parsed = parseEnvLine('TEST_VALUE='.EnvValue::quote($value));
+
+    expect($parsed['TEST_VALUE'])->toBe($value);
+})->with(function () {
+    $values = [];
+
+    // Every ASCII punctuation character embedded in a password
+    foreach (str_split('!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~') as $char) {
+        $values["punctuation {$char}"] = "ab{$char}cd";
+    }
+
+    $values['interpolation braces'] = 'pre${HOME}post';
+    $values['interpolation bare'] = '$HOME';
+    $values['self-reference'] = '${ANDROID_KEYSTORE_PASSWORD}';
+    $values['backslash runs'] = 'a\\\\b\\c\\';
+    $values['mixed quotes'] = 'he said "hi" and \'bye\'';
+    $values['leading/trailing spaces'] = '  padded  ';
+    $values['hash heavy'] = '#a#b#c#';
+    $values['unicode'] = 'pässwörd→日本語';
+    $values['long mixed'] = str_repeat('aB3#$" \\', 25);
+    $values['original ios repro'] = 'p@ss#w0rd';
+    $values['plain alphanumeric'] = 'abc123XYZ';
+    $values['file path'] = 'credentials/upload-keystore.jks';
+
+    return $values;
+});
+
+it('flags values that need quoting', function () {
+    expect(EnvValue::needsQuoting('p@ss#w0rd'))->toBeTrue()
+        ->and(EnvValue::needsQuoting('has space'))->toBeTrue()
+        ->and(EnvValue::needsQuoting('dollar$sign'))->toBeTrue()
+        ->and(EnvValue::needsQuoting('back\\slash'))->toBeTrue()
+        ->and(EnvValue::needsQuoting('exclaim!'))->toBeTrue()
+        ->and(EnvValue::needsQuoting('abc123XYZ@%^&*()-_=+'))->toBeFalse();
+});


### PR DESCRIPTION
Android sibling of #210, closing the follow-up noted there.

## The bug

`native:credentials` wrote all four Android signing vars (`ANDROID_KEYSTORE_FILE`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, `ANDROID_KEY_PASSWORD`) to `.env` **unquoted** (`CreatesAndroidCredentials.php:430`). Both passwords are user-chosen via `Laravel\Prompts\password()`, so the same failure modes as the iOS bug apply:

| raw `.env` line | result |
|---|---|
| `PW=abc#123` | parses to `abc` — silently truncated |
| `PW=abc 123` | `Failed to parse dotenv file` — bootstrap aborts, no artisan command runs |

The truncated password then flows through `env('ANDROID_KEYSTORE_PASSWORD')` in `PackageCommand` into Gradle signing, failing with a keystore-password error that gives no hint the tool mangled its own output.

## Changes

1. **Shared helper** — `quoteEnvValue()` moves out of `CreatesIosCredentials` (where #210 added it as a private method) into `Native\Mobile\Support\EnvValue`, used by both platforms. `EnvValue::needsQuoting()` centralizes the warning heuristic too.
2. **`CreatesAndroidCredentials::updateAndroidEnvVars()`** — all four values written double quoted with `\`, `"`, `$` escaped.
3. **Entry-time warning parity** — both Android password prompt paths warn when the chosen password needs quoting (mentioning the `--keystore-password` / `--key-password` shell caveat), and the env writer warns when it leaves an existing password var untouched — it never overwrites, which is how a bad value survives a re-run.
4. **The round-trip verification is now a permanent test** — closing the nit left on #210. Every ASCII punctuation character, `${HOME}`, backslash runs, mixed quotes, padded spaces, unicode, and a 200-char mixed value round-trip byte-for-byte through the real vendored phpdotenv, as a Pest dataset in `tests/Unit/Support/EnvValueTest.php`.

New feature coverage: quoted writes parse back exactly via phpdotenv, existing vars are preserved with the skip-warning emitted, missing vars still get added quoted.

## Verification

- Full suite: 910 passed (main baseline + 47 new test cases), 4 risky / 3 skipped pre-existing.
- PHPStan: identical to main's 17-error baseline. Pint clean. `git diff --check` clean.

## Not fixed here (filed separately)

Two further mangling points downstream of `.env` remain — different file formats, different character classes; see the follow-up issue: `gradle.properties` writes the password raw (backslash is an escape char / trailing backslash is a line continuation in Java properties format), and the keytool validation in `applySigningConfiguration()` relies on `escapeshellarg`, which mangles `%` and `"` on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)