### PR TITLE
EDGE: Laravel-style validation for components

### DIFF
--- a/src/Attributes/Validate.php
+++ b/src/Attributes/Validate.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Native\Mobile\Attributes;
+
+use Attribute;
+
+/**
+ * Declares validation rules for a public component property.
+ *
+ *     #[Validate('required|email')]
+ *     public string $email = '';
+ *
+ *     #[Validate(['required', 'min:8'])]
+ *     public string $password = '';
+ *
+ * Attribute rules are EAGER: they run automatically whenever the
+ * property syncs through `native:model` (validateOnly inside
+ * __syncProperty), and they're included in every $this->validate()
+ * call. Rules that should only run on demand belong in the component's
+ * rules() method instead — that's the opt-out lever, mirroring the
+ * attribute-vs-method split Livewire settled on.
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+class Validate
+{
+    public function __construct(
+        public string|array $rule,
+    ) {}
+}

--- a/src/Attributes/Validate.php
+++ b/src/Attributes/Validate.php
@@ -19,8 +19,18 @@ use Attribute;
  * call. Rules that should only run on demand belong in the component's
  * rules() method instead — that's the opt-out lever, mirroring the
  * attribute-vs-method split Livewire settled on.
+ *
+ * Repeatable — stacked attributes merge their rules:
+ *
+ *     #[Validate('required')]
+ *     #[Validate('min:3')]
+ *     public string $title = '';
+ *
+ * String rules are pipe-exploded when merging, so use the array form
+ * for rules that legitimately contain a pipe (regex:) — same caveat as
+ * Laravel's validator itself.
  */
-#[Attribute(Attribute::TARGET_PROPERTY)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::IS_REPEATABLE)]
 class Validate
 {
     public function __construct(

--- a/src/Edge/Concerns/ValidatesProps.php
+++ b/src/Edge/Concerns/ValidatesProps.php
@@ -109,12 +109,26 @@ trait ValidatesProps
         $validator = $this->makePropValidator($rules, $messages, $attributes);
 
         if ($validator->fails()) {
-            $this->nativeErrorBag = new MessageBag($validator->errors()->messages());
+            // Failure refreshes exactly the keys THIS validation ran
+            // (wildcard-aware) and leaves the rest of the bag alone —
+            // never a whole-bag replace. With per-tier event guards,
+            // multiple listeners in one delivery can each fail; a
+            // replace here would erase an earlier tier's recorded
+            // errors (the second failing ->on() sibling wiping the
+            // first). Scoped-refresh also means validate(['bio' => …])
+            // failing doesn't clear an unrelated on-screen title error
+            // it never re-checked.
+            $this->forgetErrors(array_keys($rules));
+            foreach ($validator->errors()->messages() as $key => $keyMessages) {
+                foreach ($keyMessages as $message) {
+                    $this->getErrorBag()->add($key, $message);
+                }
+            }
 
             throw new RecordedValidationException($validator);
         }
 
-        // A full pass supersedes everything previously recorded,
+        // A full PASS still supersedes everything previously recorded,
         // including addError() entries — same as Livewire.
         $this->nativeErrorBag = new MessageBag;
 

--- a/src/Edge/Concerns/ValidatesProps.php
+++ b/src/Edge/Concerns/ValidatesProps.php
@@ -3,6 +3,7 @@
 namespace Native\Mobile\Edge\Concerns;
 
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
+use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\ViewErrorBag;
@@ -36,12 +37,22 @@ trait ValidatesProps
     protected ?MessageBag $nativeErrorBag = null;
 
     /**
-     * True while a ValidationException thrown by validate()/validateOnly()
-     * has already been recorded in the bag — tells runGuarded() not to
-     * fold the exception's messages in a second time (its per-key merge
-     * would otherwise resurrect keys a later validate() had cleared).
+     * Exceptions whose messages have already been recorded in SOME
+     * component's bag. Keyed on the exception INSTANCE (not an instance
+     * flag) because guards nest across components: a child's guard can
+     * catch an exception a parent's validate() already recorded (emit()
+     * listeners, nested dispatch), and an instance flag on the catcher
+     * would wrongly fold the parent's errors into the child's bag — or,
+     * left stale, wrongly swallow a fresh author-thrown exception.
+     *
+     * @var \WeakMap<ValidationException, true>
      */
-    private bool $validationRecorded = false;
+    private static ?\WeakMap $recordedValidationExceptions = null;
+
+    private static function recordedExceptions(): \WeakMap
+    {
+        return self::$recordedValidationExceptions ??= new \WeakMap;
+    }
 
     // ── Bag access ──────────────────────────────────
 
@@ -115,9 +126,11 @@ trait ValidatesProps
 
         if ($validator->fails()) {
             $this->nativeErrorBag = new MessageBag($validator->errors()->messages());
-            $this->validationRecorded = true;
 
-            throw new ValidationException($validator);
+            $exception = new ValidationException($validator);
+            self::recordedExceptions()[$exception] = true;
+
+            throw $exception;
         }
 
         // A full pass supersedes everything previously recorded,
@@ -129,43 +142,64 @@ trait ValidatesProps
 
     /**
      * Validate a single property (wildcard-aware: validateOnly('tags.0')
-     * matches a 'tags.*' rule). Only that property's errors are replaced
-     * or cleared; the rest of the bag is untouched. Throws on failure
-     * like validate().
+     * matches a 'tags.*' rule). Only THAT property's errors are replaced
+     * or cleared — a wildcard rule may validate sibling entries as a
+     * side effect of running, but their bag entries are never touched
+     * (editing tags.1 must not conjure an error onto untouched tags.0).
+     * Throws on failure like validate().
+     *
+     * $rules narrows the rule source (defaults to every declared rule);
+     * the eager sync path passes attributeValidationRules() so
+     * rules()-tier rules never run per keystroke — even when the two
+     * tiers declare the same key.
      */
-    public function validateOnly(string $prop, array $messages = [], array $attributes = []): array
+    public function validateOnly(string $prop, array $messages = [], array $attributes = [], ?array $rules = null): array
     {
-        $rules = [];
+        $matched = [];
 
-        foreach ($this->allValidationRules() as $key => $rule) {
+        foreach ($rules ?? $this->allValidationRules() as $key => $rule) {
             if ($key === $prop || $this->wildcardCovers($key, $prop)) {
-                $rules[$key] = $rule;
+                $matched[$key] = $rule;
             }
         }
 
-        if ($rules === []) {
+        if ($matched === []) {
             return [];
         }
 
-        $validator = $this->makePropValidator($rules, $messages, $attributes);
+        $covers = fn (string $key): bool => $key === $prop || $this->wildcardCovers($prop, $key);
+
+        $validator = $this->makePropValidator($matched, $messages, $attributes);
 
         if ($validator->fails()) {
-            $failed = $validator->errors()->messages();
+            // A wildcard rule validates sibling entries as a side effect;
+            // only failures on the TARGET prop count here. Sibling-only
+            // failures mean the edited prop is fine: no throw, no bag
+            // changes for entries the author didn't touch.
+            $covered = array_filter(
+                $validator->errors()->messages(),
+                $covers,
+                ARRAY_FILTER_USE_KEY,
+            );
 
-            $this->forgetErrors(array_keys($rules));
-            foreach ($failed as $key => $keyMessages) {
-                foreach ($keyMessages as $message) {
-                    $this->getErrorBag()->add($key, $message);
+            if ($covered !== []) {
+                $this->forgetErrors([$prop]);
+                foreach ($covered as $key => $keyMessages) {
+                    foreach ($keyMessages as $message) {
+                        $this->getErrorBag()->add($key, $message);
+                    }
                 }
-            }
-            $this->validationRecorded = true;
 
-            throw new ValidationException($validator);
+                $exception = new ValidationException($validator);
+                self::recordedExceptions()[$exception] = true;
+
+                throw $exception;
+            }
         }
 
-        $this->forgetErrors(array_keys($rules));
+        $this->forgetErrors([$prop]);
 
-        return $validator->validated();
+        return $validator->fails() ? [] : $validator->validated();
     }
 
     // ── Dispatch guard ──────────────────────────────
@@ -178,14 +212,16 @@ trait ValidatesProps
      */
     protected function runGuarded(callable $fn): mixed
     {
-        $this->validationRecorded = false;
-
         try {
             return $fn();
         } catch (ValidationException $e) {
-            if (! $this->validationRecorded) {
+            if (! isset(self::recordedExceptions()[$e])) {
                 // Author-thrown (ValidationException::withMessages or a
-                // bare Validator) — fold in per key.
+                // bare Validator) — fold into THIS component's bag, and
+                // mark the exception so an enclosing guard on another
+                // component doesn't fold it into its bag too.
+                self::recordedExceptions()[$e] = true;
+
                 foreach ($e->errors() as $key => $messages) {
                     $this->forgetErrors([$key]);
                     foreach ($messages as $message) {
@@ -195,8 +231,6 @@ trait ValidatesProps
             }
 
             return null;
-        } finally {
-            $this->validationRecorded = false;
         }
     }
 
@@ -208,16 +242,28 @@ trait ValidatesProps
      * subset — the request is never "handled", just read. Caller-passed
      * messages/attributes win over the request's own.
      *
+     * Scope caveat: the DATA under validation is the component's public
+     * props, not an HTTP payload. Rules for request-only fields behave
+     * as they would for an absent field (implicit rules like `required`
+     * fail; non-implicit ones pass) and never appear in validated() —
+     * share a FormRequest only when its fields map onto props.
+     *
      * @return array{0: array, 1: array, 2: array} [rules, messages, attributes]
      */
     protected function harvestFormRequest(string $class, array $messages, array $attributes): array
     {
-        if (! is_subclass_of($class, \Illuminate\Foundation\Http\FormRequest::class)) {
+        if (! is_subclass_of($class, FormRequest::class)) {
             throw new \InvalidArgumentException(
                 "validate({$class}) expects a FormRequest class-string or an array of rules."
             );
         }
 
+        // Bare instantiation on purpose: resolving a FormRequest THROUGH
+        // the container triggers Laravel's ValidatesWhenResolved hook,
+        // which would attempt full HTTP-style validation with no request.
+        // rules() itself goes through the container so method-injected
+        // dependencies (rules(SomeService $svc)) resolve like they do in
+        // a controller-bound request.
         $request = new $class;
 
         if (! method_exists($request, 'rules')) {
@@ -225,7 +271,7 @@ trait ValidatesProps
         }
 
         return [
-            (array) $request->rules(),
+            (array) app()->call([$request, 'rules']),
             array_merge((array) $request->messages(), $messages),
             array_merge((array) $request->attributes(), $attributes),
         ];

--- a/src/Edge/Concerns/ValidatesProps.php
+++ b/src/Edge/Concerns/ValidatesProps.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace Native\Mobile\Edge\Concerns;
+
+use Illuminate\Contracts\Validation\Validator as ValidatorContract;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\MessageBag;
+use Illuminate\Support\ViewErrorBag;
+use Illuminate\Validation\ValidationException;
+use Native\Mobile\Attributes\Validate;
+
+/**
+ * Laravel-style validation for EDGE components, identical on every
+ * render target (device run loop and web update cycle both route event
+ * dispatch through runGuarded()).
+ *
+ * Rule sources, merged in order (later wins per key):
+ *   1. #[Validate('...')] attributes on public props (EAGER — they also
+ *      auto-run on native:model sync, see NativeComponent::__syncProperty)
+ *   2. the component's rules() method (on-demand only)
+ *   3. the $rules argument passed to validate() (validates ONLY those)
+ *
+ * Failure semantics: validate()/validateOnly() update the error bag and
+ * throw Laravel's own ValidationException. The dispatch-cycle guard
+ * (runGuarded) swallows it — the handler aborts at the validate() line,
+ * component state stays, and the frame renders with $errors set.
+ * Author-thrown ValidationException::withMessages(...) is also honored:
+ * the guard folds its messages into the bag per key.
+ *
+ * The bag is INTERNAL state, not a public prop — it never rides the
+ * generic snapshot path. The web target carries it explicitly in the
+ * sealed snapshot; on device the persistent instance simply keeps it.
+ */
+trait ValidatesProps
+{
+    protected ?MessageBag $nativeErrorBag = null;
+
+    /**
+     * True while a ValidationException thrown by validate()/validateOnly()
+     * has already been recorded in the bag — tells runGuarded() not to
+     * fold the exception's messages in a second time (its per-key merge
+     * would otherwise resurrect keys a later validate() had cleared).
+     */
+    private bool $validationRecorded = false;
+
+    // ── Bag access ──────────────────────────────────
+
+    public function getErrorBag(): MessageBag
+    {
+        return $this->nativeErrorBag ??= new MessageBag;
+    }
+
+    /** Replace the whole bag — used by targets that rehydrate state (web snapshot). */
+    public function setErrorBag(array $messages): void
+    {
+        $this->nativeErrorBag = new MessageBag($messages);
+    }
+
+    public function addError(string $key, string $message): void
+    {
+        $this->getErrorBag()->add($key, $message);
+    }
+
+    /** Clear one key's errors, or the whole bag when no key is given. */
+    public function resetValidation(?string $key = null): void
+    {
+        if ($key === null) {
+            $this->nativeErrorBag = new MessageBag;
+
+            return;
+        }
+
+        $this->forgetErrors([$key]);
+    }
+
+    /** The bag as Blade sees it: a ViewErrorBag so @error / $errors->first() work. */
+    protected function errorBagForViews(): ViewErrorBag
+    {
+        return (new ViewErrorBag)->put('default', $this->getErrorBag());
+    }
+
+    // ── Validation ──────────────────────────────────
+
+    /**
+     * Validate the component's public properties. With no arguments,
+     * every declared rule runs (#[Validate] attributes + rules()).
+     * Passing $rules validates only those rules. Returns the validated
+     * data; throws ValidationException on failure (after recording the
+     * errors — the dispatch guard turns the throw into "abort handler,
+     * render with errors").
+     *
+     * $rules also accepts a FormRequest class-string — its rules(),
+     * messages() and attributes() are harvested so HTTP controllers and
+     * screens can share one definition:
+     *
+     *     $this->validate(StorePostRequest::class);
+     *
+     * Harvesting only: the request is instantiated bare (no HTTP
+     * context), so authorize() is NOT called and rules() must not read
+     * $this->input()/route()/user(). Something Livewire doesn't offer.
+     */
+    public function validate(array|string|null $rules = null, array $messages = [], array $attributes = []): array
+    {
+        if (is_string($rules)) {
+            [$rules, $messages, $attributes] = $this->harvestFormRequest($rules, $messages, $attributes);
+        }
+
+        $rules ??= $this->allValidationRules();
+
+        if ($rules === []) {
+            return [];
+        }
+
+        $validator = $this->makePropValidator($rules, $messages, $attributes);
+
+        if ($validator->fails()) {
+            $this->nativeErrorBag = new MessageBag($validator->errors()->messages());
+            $this->validationRecorded = true;
+
+            throw new ValidationException($validator);
+        }
+
+        // A full pass supersedes everything previously recorded,
+        // including addError() entries — same as Livewire.
+        $this->nativeErrorBag = new MessageBag;
+
+        return $validator->validated();
+    }
+
+    /**
+     * Validate a single property (wildcard-aware: validateOnly('tags.0')
+     * matches a 'tags.*' rule). Only that property's errors are replaced
+     * or cleared; the rest of the bag is untouched. Throws on failure
+     * like validate().
+     */
+    public function validateOnly(string $prop, array $messages = [], array $attributes = []): array
+    {
+        $rules = [];
+
+        foreach ($this->allValidationRules() as $key => $rule) {
+            if ($key === $prop || $this->wildcardCovers($key, $prop)) {
+                $rules[$key] = $rule;
+            }
+        }
+
+        if ($rules === []) {
+            return [];
+        }
+
+        $validator = $this->makePropValidator($rules, $messages, $attributes);
+
+        if ($validator->fails()) {
+            $failed = $validator->errors()->messages();
+
+            $this->forgetErrors(array_keys($rules));
+            foreach ($failed as $key => $keyMessages) {
+                foreach ($keyMessages as $message) {
+                    $this->getErrorBag()->add($key, $message);
+                }
+            }
+            $this->validationRecorded = true;
+
+            throw new ValidationException($validator);
+        }
+
+        $this->forgetErrors(array_keys($rules));
+
+        return $validator->validated();
+    }
+
+    // ── Dispatch guard ──────────────────────────────
+
+    /**
+     * Run an event handler with validation-abort semantics. Every event
+     * entry point (device bridge events, web update dispatch) routes
+     * through here so a ValidationException means the same thing
+     * everywhere: stop the handler, keep state, render with errors.
+     */
+    protected function runGuarded(callable $fn): mixed
+    {
+        $this->validationRecorded = false;
+
+        try {
+            return $fn();
+        } catch (ValidationException $e) {
+            if (! $this->validationRecorded) {
+                // Author-thrown (ValidationException::withMessages or a
+                // bare Validator) — fold in per key.
+                foreach ($e->errors() as $key => $messages) {
+                    $this->forgetErrors([$key]);
+                    foreach ($messages as $message) {
+                        $this->getErrorBag()->add($key, $message);
+                    }
+                }
+            }
+
+            return null;
+        } finally {
+            $this->validationRecorded = false;
+        }
+    }
+
+    /**
+     * Harvest rules/messages/attributes from a FormRequest class so an
+     * HTTP controller and a screen can share one definition. Livewire
+     * deliberately rejected full FormRequest integration (authorize()
+     * and input sources are HTTP-coupled); this is the uncontroversial
+     * subset — the request is never "handled", just read. Caller-passed
+     * messages/attributes win over the request's own.
+     *
+     * @return array{0: array, 1: array, 2: array} [rules, messages, attributes]
+     */
+    protected function harvestFormRequest(string $class, array $messages, array $attributes): array
+    {
+        if (! is_subclass_of($class, \Illuminate\Foundation\Http\FormRequest::class)) {
+            throw new \InvalidArgumentException(
+                "validate({$class}) expects a FormRequest class-string or an array of rules."
+            );
+        }
+
+        $request = new $class;
+
+        if (! method_exists($request, 'rules')) {
+            throw new \InvalidArgumentException("{$class} declares no rules() method.");
+        }
+
+        return [
+            (array) $request->rules(),
+            array_merge((array) $request->messages(), $messages),
+            array_merge((array) $request->attributes(), $attributes),
+        ];
+    }
+
+    // ── Rule sources ────────────────────────────────
+
+    /** #[Validate] attribute rules merged under rules() (method wins per key). */
+    protected function allValidationRules(): array
+    {
+        $methodRules = method_exists($this, 'rules') ? (array) $this->rules() : [];
+
+        return array_merge($this->attributeValidationRules(), $methodRules);
+    }
+
+    /** Rules declared via #[Validate] on public props, cached per class. */
+    protected function attributeValidationRules(): array
+    {
+        static $cache = [];
+
+        return $cache[static::class] ??= (function () {
+            $rules = [];
+
+            foreach ((new \ReflectionClass($this))->getProperties(\ReflectionProperty::IS_PUBLIC) as $prop) {
+                if ($prop->isStatic()) {
+                    continue;
+                }
+
+                foreach ($prop->getAttributes(Validate::class) as $attribute) {
+                    $rules[$prop->getName()] = $attribute->newInstance()->rule;
+                }
+            }
+
+            return $rules;
+        })();
+    }
+
+    /** Whether a #[Validate]-declared (eager) rule exists for this prop. */
+    protected function hasEagerValidationRule(string $prop): bool
+    {
+        $rules = $this->attributeValidationRules();
+
+        if (isset($rules[$prop])) {
+            return true;
+        }
+
+        foreach (array_keys($rules) as $key) {
+            if ($this->wildcardCovers($key, $prop)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // ── Internals ───────────────────────────────────
+
+    protected function makePropValidator(array $rules, array $messages, array $attributes): ValidatorContract
+    {
+        return Validator::make(
+            $this->getPublicProperties(),
+            $rules,
+            array_merge(method_exists($this, 'messages') ? (array) $this->messages() : [], $messages),
+            array_merge(method_exists($this, 'validationAttributes') ? (array) $this->validationAttributes() : [], $attributes),
+        );
+    }
+
+    /** Drop bag entries for the given rule keys (wildcards clear their matches). */
+    private function forgetErrors(array $ruleKeys): void
+    {
+        $bag = $this->getErrorBag();
+        $kept = [];
+
+        foreach ($bag->messages() as $key => $messages) {
+            $covered = false;
+            foreach ($ruleKeys as $ruleKey) {
+                if ($key === $ruleKey || $this->wildcardCovers($ruleKey, $key)) {
+                    $covered = true;
+                    break;
+                }
+            }
+            if (! $covered) {
+                $kept[$key] = $messages;
+            }
+        }
+
+        $this->nativeErrorBag = new MessageBag($kept);
+    }
+
+    /** Whether a wildcard rule key ('tags.*') covers a concrete key ('tags.0'). */
+    private function wildcardCovers(string $ruleKey, string $concrete): bool
+    {
+        if (! str_contains($ruleKey, '*')) {
+            return false;
+        }
+
+        $pattern = '/^'.str_replace('\*', '[^.]+', preg_quote($ruleKey, '/')).'$/';
+
+        return preg_match($pattern, $concrete) === 1;
+    }
+}

--- a/src/Edge/Concerns/ValidatesProps.php
+++ b/src/Edge/Concerns/ValidatesProps.php
@@ -4,11 +4,13 @@ namespace Native\Mobile\Edge\Concerns;
 
 use Illuminate\Contracts\Validation\Validator as ValidatorContract;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\MessageBag;
 use Illuminate\Support\ViewErrorBag;
 use Illuminate\Validation\ValidationException;
 use Native\Mobile\Attributes\Validate;
+use Native\Mobile\Edge\Exceptions\RecordedValidationException;
 
 /**
  * Laravel-style validation for EDGE components, identical on every
@@ -35,24 +37,6 @@ use Native\Mobile\Attributes\Validate;
 trait ValidatesProps
 {
     protected ?MessageBag $nativeErrorBag = null;
-
-    /**
-     * Exceptions whose messages have already been recorded in SOME
-     * component's bag. Keyed on the exception INSTANCE (not an instance
-     * flag) because guards nest across components: a child's guard can
-     * catch an exception a parent's validate() already recorded (emit()
-     * listeners, nested dispatch), and an instance flag on the catcher
-     * would wrongly fold the parent's errors into the child's bag — or,
-     * left stale, wrongly swallow a fresh author-thrown exception.
-     *
-     * @var \WeakMap<ValidationException, true>
-     */
-    private static ?\WeakMap $recordedValidationExceptions = null;
-
-    private static function recordedExceptions(): \WeakMap
-    {
-        return self::$recordedValidationExceptions ??= new \WeakMap;
-    }
 
     // ── Bag access ──────────────────────────────────
 
@@ -127,10 +111,7 @@ trait ValidatesProps
         if ($validator->fails()) {
             $this->nativeErrorBag = new MessageBag($validator->errors()->messages());
 
-            $exception = new ValidationException($validator);
-            self::recordedExceptions()[$exception] = true;
-
-            throw $exception;
+            throw new RecordedValidationException($validator);
         }
 
         // A full pass supersedes everything previously recorded,
@@ -171,35 +152,44 @@ trait ValidatesProps
 
         $validator = $this->makePropValidator($matched, $messages, $attributes);
 
-        if ($validator->fails()) {
-            // A wildcard rule validates sibling entries as a side effect;
-            // only failures on the TARGET prop count here. Sibling-only
-            // failures mean the edited prop is fine: no throw, no bag
-            // changes for entries the author didn't touch.
-            $covered = array_filter(
-                $validator->errors()->messages(),
-                $covers,
-                ARRAY_FILTER_USE_KEY,
-            );
+        // fails() executes the rules — call it ONCE. This is the eager
+        // per-keystroke path, and rules can be expensive (unique:) or
+        // time-dependent; a second run is waste at best, disagreement at
+        // worst.
+        if (! $validator->fails()) {
+            $this->forgetErrors([$prop]);
 
-            if ($covered !== []) {
-                $this->forgetErrors([$prop]);
-                foreach ($covered as $key => $keyMessages) {
-                    foreach ($keyMessages as $message) {
-                        $this->getErrorBag()->add($key, $message);
-                    }
-                }
-
-                $exception = new ValidationException($validator);
-                self::recordedExceptions()[$exception] = true;
-
-                throw $exception;
-            }
+            return $validator->validated();
         }
 
+        // A wildcard rule validates sibling entries as a side effect;
+        // only failures on the TARGET prop count here.
+        $covered = array_filter(
+            $validator->errors()->messages(),
+            $covers,
+            ARRAY_FILTER_USE_KEY,
+        );
+
+        if ($covered !== []) {
+            $this->forgetErrors([$prop]);
+            foreach ($covered as $key => $keyMessages) {
+                foreach ($keyMessages as $message) {
+                    $this->getErrorBag()->add($key, $message);
+                }
+            }
+
+            throw new RecordedValidationException($validator);
+        }
+
+        // Sibling-only failure: the TARGET passed. No throw, no bag
+        // changes for entries the author didn't touch — and the caller
+        // still gets the target's data (validated() would throw here).
         $this->forgetErrors([$prop]);
 
-        return $validator->fails() ? [] : $validator->validated();
+        $out = [];
+        Arr::set($out, $prop, data_get($this->getPublicProperties(), $prop));
+
+        return $out;
     }
 
     // ── Dispatch guard ──────────────────────────────
@@ -215,13 +205,13 @@ trait ValidatesProps
         try {
             return $fn();
         } catch (ValidationException $e) {
-            if (! isset(self::recordedExceptions()[$e])) {
+            if (! $e instanceof RecordedValidationException) {
                 // Author-thrown (ValidationException::withMessages or a
-                // bare Validator) — fold into THIS component's bag, and
-                // mark the exception so an enclosing guard on another
-                // component doesn't fold it into its bag too.
-                self::recordedExceptions()[$e] = true;
-
+                // bare Validator) — fold into THIS component's bag. A
+                // RecordedValidationException already lives on its
+                // thrower's bag; since guards never rethrow, each
+                // exception meets at most one guard, so recordedness on
+                // the instance is all the bookkeeping needed.
                 foreach ($e->errors() as $key => $messages) {
                     $this->forgetErrors([$key]);
                     foreach ($messages as $message) {
@@ -287,7 +277,13 @@ trait ValidatesProps
         return array_merge($this->attributeValidationRules(), $methodRules);
     }
 
-    /** Rules declared via #[Validate] on public props, cached per class. */
+    /**
+     * Rules declared via #[Validate] on public props, cached per class.
+     * The attribute is repeatable; stacked declarations MERGE (string
+     * rules pipe-exploded, array rules taken as-is — the regex: caveat
+     * matches Laravel's own string-rule parsing). A single declaration
+     * keeps its raw shape untouched.
+     */
     protected function attributeValidationRules(): array
     {
         static $cache = [];
@@ -300,9 +296,25 @@ trait ValidatesProps
                     continue;
                 }
 
-                foreach ($prop->getAttributes(Validate::class) as $attribute) {
-                    $rules[$prop->getName()] = $attribute->newInstance()->rule;
+                $declared = $prop->getAttributes(Validate::class);
+
+                if ($declared === []) {
+                    continue;
                 }
+
+                if (count($declared) === 1) {
+                    $rules[$prop->getName()] = $declared[0]->newInstance()->rule;
+
+                    continue;
+                }
+
+                $merged = [];
+                foreach ($declared as $attribute) {
+                    $rule = $attribute->newInstance()->rule;
+                    $merged = array_merge($merged, is_array($rule) ? $rule : explode('|', $rule));
+                }
+
+                $rules[$prop->getName()] = $merged;
             }
 
             return $rules;

--- a/src/Edge/Exceptions/RecordedValidationException.php
+++ b/src/Edge/Exceptions/RecordedValidationException.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Native\Mobile\Edge\Exceptions;
+
+use Illuminate\Validation\ValidationException;
+
+/**
+ * A ValidationException whose messages validate()/validateOnly() already
+ * recorded on the throwing component's error bag. runGuarded() folds the
+ * messages of any OTHER ValidationException (author-thrown withMessages,
+ * a bare validator) into the catching component's bag — this subclass is
+ * how it knows not to double-record, without any shared state: each
+ * exception instance carries its own recordedness, so nested guards
+ * across components (emit() listeners) can never mis-attribute errors.
+ *
+ * Author code catching ValidationException catches this transparently.
+ */
+class RecordedValidationException extends ValidationException {}

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -36,6 +36,8 @@ use Symfony\Component\VarDumper\VarDumper;
 
 abstract class NativeComponent
 {
+    use Concerns\ValidatesProps;
+
     const EVENT_HOT_RELOAD = 15;
 
     /**
@@ -292,7 +294,7 @@ abstract class NativeComponent
 
     protected function view(string $name, array $data = []): Element
     {
-        $viewData = array_merge($this->getPublicProperties(), $data);
+        $viewData = array_merge($this->getPublicProperties(), ['errors' => $this->errorBagForViews()], $data);
 
         // Rendering as a nested child component: the parent's tree is live
         // in the collector, so emit in place — no reset, no chrome, and no
@@ -334,7 +336,7 @@ abstract class NativeComponent
      */
     protected function partial(string $name, array $data = []): Element
     {
-        $viewData = array_merge($this->getPublicProperties(), $data);
+        $viewData = array_merge($this->getPublicProperties(), ['errors' => $this->errorBagForViews()], $data);
 
         // Inside a child component's render the hard reset below would wipe
         // the parent's live tree — capture() collects the detached subtree
@@ -371,7 +373,7 @@ abstract class NativeComponent
      */
     protected function fromView(View $view): Element
     {
-        $viewData = array_merge($this->getPublicProperties(), $view->getData());
+        $viewData = array_merge($this->getPublicProperties(), ['errors' => $this->errorBagForViews()], $view->getData());
 
         // Nested child render — same in-place emission as view() above.
         if (NativeElementCollector::inComponentScope()) {
@@ -408,7 +410,7 @@ abstract class NativeComponent
      */
     protected function fromViewPartial(View $view): Element
     {
-        $viewData = array_merge($this->getPublicProperties(), $view->getData());
+        $viewData = array_merge($this->getPublicProperties(), ['errors' => $this->errorBagForViews()], $view->getData());
 
         // Same child-scope safety as partial() — never hard-reset the
         // parent's live tree from inside a nested component render.
@@ -1388,7 +1390,7 @@ abstract class NativeComponent
      */
     protected function streamView(string $name, array $data = []): void
     {
-        $viewData = array_merge($this->getPublicProperties(), $data);
+        $viewData = array_merge($this->getPublicProperties(), ['errors' => $this->errorBagForViews()], $data);
 
         NativeElementCollector::setCallbacks($this->nativeCallbacks);
         NativeElementCollector::setOwner($this);
@@ -1734,8 +1736,15 @@ abstract class NativeComponent
 
     /**
      * Handle a native event (type 20) by looking up #[OnNative] listeners.
+     * Guarded like dispatch(): a ValidationException in a listener
+     * records errors and aborts that listener instead of crashing.
      */
     protected function dispatchNativeEvent(array $event): void
+    {
+        $this->runGuarded(fn () => $this->dispatchNativeEventUnguarded($event));
+    }
+
+    protected function dispatchNativeEventUnguarded(array $event): void
     {
         $eventName = $event['event'] ?? '';
         $payload = $event['payload'] ?? [];
@@ -3030,6 +3039,17 @@ abstract class NativeComponent
         if (method_exists($this, $hook)) {
             $this->{$hook}($value);
         }
+
+        // #[Validate] rules are eager: re-validate this property on every
+        // sync (after the updated hook, so a hook that normalizes the
+        // value validates the normalized form). Runs inside the dispatch
+        // guard, so a failure records errors and aborts cleanly. The
+        // author's native:model modifier (.live/.blur/.debounce) is the
+        // cadence control. rules()-method rules deliberately do NOT run
+        // here — that's the on-demand tier.
+        if ($this->hasEagerValidationRule($property)) {
+            $this->validateOnly($property);
+        }
     }
 
     // ── Child components (nested <native:*> component tags) ──
@@ -3340,7 +3360,19 @@ abstract class NativeComponent
 
     // ── Event dispatch ──────────────────────────────
 
+    /**
+     * Guarded entry: a ValidationException thrown anywhere in a handler
+     * (a validate() call, sync auto-validation, an author-thrown
+     * withMessages) aborts the handler, records the errors on the bag,
+     * and lets the frame render — identical on device and web, because
+     * both route event dispatch through this method.
+     */
     protected function dispatch(array $event): void
+    {
+        $this->runGuarded(fn () => $this->dispatchUnguarded($event));
+    }
+
+    protected function dispatchUnguarded(array $event): void
     {
         $callbackId = (int) ($event['callback_id'] ?? 0);
 

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -292,9 +292,39 @@ abstract class NativeComponent
         return false;
     }
 
+    /**
+     * The data envelope every Blade render path shares: public props +
+     * the validation `$errors` ViewErrorBag + caller data (later wins).
+     * ONE home, so a new render path can't forget the bag and the
+     * legacy-$errors policy lives in code instead of merge precedence.
+     */
+    protected function nativeViewData(array $data = []): array
+    {
+        $props = $this->getPublicProperties();
+
+        if (array_key_exists('errors', $props)) {
+            // v3 escape hatch, explicit: a component-declared $errors
+            // prop wins over the injected bag — which also means it
+            // SHADOWS it, so $this->validate() output can't reach Blade
+            // on such a component. Deprecated for exactly that footgun.
+            static $warned = [];
+            if (! isset($warned[static::class])) {
+                $warned[static::class] = true;
+                trigger_error(
+                    static::class.' declares public $errors, shadowing the validation ViewErrorBag — rename it, or drop it and use $this->validate() with @error/@nativeError.',
+                    E_USER_DEPRECATED,
+                );
+            }
+        } else {
+            $props['errors'] = $this->errorBagForViews();
+        }
+
+        return array_merge($props, $data);
+    }
+
     protected function view(string $name, array $data = []): Element
     {
-        $viewData = array_merge(['errors' => $this->errorBagForViews()], $this->getPublicProperties(), $data);
+        $viewData = $this->nativeViewData($data);
 
         // Rendering as a nested child component: the parent's tree is live
         // in the collector, so emit in place — no reset, no chrome, and no
@@ -336,7 +366,7 @@ abstract class NativeComponent
      */
     protected function partial(string $name, array $data = []): Element
     {
-        $viewData = array_merge(['errors' => $this->errorBagForViews()], $this->getPublicProperties(), $data);
+        $viewData = $this->nativeViewData($data);
 
         // Inside a child component's render the hard reset below would wipe
         // the parent's live tree — capture() collects the detached subtree
@@ -373,7 +403,7 @@ abstract class NativeComponent
      */
     protected function fromView(View $view): Element
     {
-        $viewData = array_merge(['errors' => $this->errorBagForViews()], $this->getPublicProperties(), $view->getData());
+        $viewData = $this->nativeViewData($view->getData());
 
         // Nested child render — same in-place emission as view() above.
         if (NativeElementCollector::inComponentScope()) {
@@ -410,7 +440,7 @@ abstract class NativeComponent
      */
     protected function fromViewPartial(View $view): Element
     {
-        $viewData = array_merge(['errors' => $this->errorBagForViews()], $this->getPublicProperties(), $view->getData());
+        $viewData = $this->nativeViewData($view->getData());
 
         // Same child-scope safety as partial() — never hard-reset the
         // parent's live tree from inside a nested component render.
@@ -1390,7 +1420,7 @@ abstract class NativeComponent
      */
     protected function streamView(string $name, array $data = []): void
     {
-        $viewData = array_merge(['errors' => $this->errorBagForViews()], $this->getPublicProperties(), $data);
+        $viewData = $this->nativeViewData($data);
 
         NativeElementCollector::setCallbacks($this->nativeCallbacks);
         NativeElementCollector::setOwner($this);
@@ -1748,15 +1778,16 @@ abstract class NativeComponent
 
     /**
      * Handle a native event (type 20) by looking up #[OnNative] listeners.
-     * Guarded like dispatch(): a ValidationException in a listener
-     * records errors and aborts that listener instead of crashing.
+     *
+     * Delivery has four independent tiers — fluent then()/catch()
+     * callbacks, ->on() closure listeners, the global Laravel event()
+     * broadcast, and the #[On] method — each guarded SEPARATELY: a
+     * ValidationException in one listener records errors and aborts
+     * that listener only, and the remaining tiers still receive the
+     * event. One guard around the whole method would turn a tier-1
+     * validation failure into silent partial delivery.
      */
     protected function dispatchNativeEvent(array $event): void
-    {
-        $this->runGuarded(fn () => $this->dispatchNativeEventUnguarded($event));
-    }
-
-    protected function dispatchNativeEventUnguarded(array $event): void
     {
         $eventName = $event['event'] ?? '';
         $payload = $event['payload'] ?? [];
@@ -1781,7 +1812,7 @@ abstract class NativeComponent
         // Fire any fluent callback registered for this event
         // (e.g. Camera::getPhoto()->photoTaken(...)). Independent of #[On] — it must
         // run even when the component declares no listener for this event.
-        $this->fireNativeCallback($eventName, is_array($payload) ? $payload : []);
+        $this->runGuarded(fn () => $this->fireNativeCallback($eventName, is_array($payload) ? $payload : []));
 
         // Fluent closure listeners registered via ->on('Event', fn) — persistent
         // and keyed by event name, so they fire every time the event arrives
@@ -1797,7 +1828,9 @@ abstract class NativeComponent
                 $bound = ($closure instanceof \Closure && ! (new \ReflectionFunction($closure))->isStatic())
                     ? \Closure::bind($closure, $this, static::class)
                     : $closure;
-                $bound($eventObject);
+                // Per-closure guard: one failing listener must not
+                // starve its siblings of the event.
+                $this->runGuarded(fn () => $bound($eventObject));
             }
         }
 
@@ -1806,7 +1839,7 @@ abstract class NativeComponent
         // this component's #[On] handlers. Runs before the (early-returning)
         // #[On] lookup below so it fires even when this component declares no
         // listener for the event.
-        $this->dispatchGloballyIfMarked($eventName, is_array($payload) ? $payload : []);
+        $this->runGuarded(fn () => $this->dispatchGloballyIfMarked($eventName, is_array($payload) ? $payload : []));
 
         $method = $this->nativeEventListeners[$eventName]
             ?? $this->nativeEventListeners['native:'.$eventName]
@@ -1841,9 +1874,9 @@ abstract class NativeComponent
                     $args[] = $param->getDefaultValue();
                 }
             }
-            $this->$method(...$args);
+            $this->runGuarded(fn () => $this->$method(...$args));
         } else {
-            $this->$method($payload);
+            $this->runGuarded(fn () => $this->$method($payload));
         }
     }
 

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -294,7 +294,7 @@ abstract class NativeComponent
 
     protected function view(string $name, array $data = []): Element
     {
-        $viewData = array_merge($this->getPublicProperties(), ['errors' => $this->errorBagForViews()], $data);
+        $viewData = array_merge(['errors' => $this->errorBagForViews()], $this->getPublicProperties(), $data);
 
         // Rendering as a nested child component: the parent's tree is live
         // in the collector, so emit in place — no reset, no chrome, and no
@@ -336,7 +336,7 @@ abstract class NativeComponent
      */
     protected function partial(string $name, array $data = []): Element
     {
-        $viewData = array_merge($this->getPublicProperties(), ['errors' => $this->errorBagForViews()], $data);
+        $viewData = array_merge(['errors' => $this->errorBagForViews()], $this->getPublicProperties(), $data);
 
         // Inside a child component's render the hard reset below would wipe
         // the parent's live tree — capture() collects the detached subtree
@@ -373,7 +373,7 @@ abstract class NativeComponent
      */
     protected function fromView(View $view): Element
     {
-        $viewData = array_merge($this->getPublicProperties(), ['errors' => $this->errorBagForViews()], $view->getData());
+        $viewData = array_merge(['errors' => $this->errorBagForViews()], $this->getPublicProperties(), $view->getData());
 
         // Nested child render — same in-place emission as view() above.
         if (NativeElementCollector::inComponentScope()) {
@@ -410,7 +410,7 @@ abstract class NativeComponent
      */
     protected function fromViewPartial(View $view): Element
     {
-        $viewData = array_merge($this->getPublicProperties(), ['errors' => $this->errorBagForViews()], $view->getData());
+        $viewData = array_merge(['errors' => $this->errorBagForViews()], $this->getPublicProperties(), $view->getData());
 
         // Same child-scope safety as partial() — never hard-reset the
         // parent's live tree from inside a nested component render.
@@ -1390,7 +1390,7 @@ abstract class NativeComponent
      */
     protected function streamView(string $name, array $data = []): void
     {
-        $viewData = array_merge($this->getPublicProperties(), ['errors' => $this->errorBagForViews()], $data);
+        $viewData = array_merge(['errors' => $this->errorBagForViews()], $this->getPublicProperties(), $data);
 
         NativeElementCollector::setCallbacks($this->nativeCallbacks);
         NativeElementCollector::setOwner($this);
@@ -1420,13 +1420,25 @@ abstract class NativeComponent
 
     private function getPublicProperties(): array
     {
-        $reflect = new \ReflectionClass($this);
+        // Names are cached per class: this runs on every render AND every
+        // eager-validation keystroke, and the declared-prop list can't
+        // change at runtime. Values are read fresh each call.
+        static $names = [];
+
+        if (! isset($names[static::class])) {
+            $names[static::class] = [];
+
+            foreach ((new \ReflectionClass($this))->getProperties(\ReflectionProperty::IS_PUBLIC) as $prop) {
+                if (! $prop->isStatic()) {
+                    $names[static::class][] = $prop->getName();
+                }
+            }
+        }
+
         $props = [];
 
-        foreach ($reflect->getProperties(\ReflectionProperty::IS_PUBLIC) as $prop) {
-            if (! $prop->isStatic()) {
-                $props[$prop->getName()] = $prop->getValue($this);
-            }
+        foreach ($names[static::class] as $name) {
+            $props[$name] = $this->{$name};
         }
 
         return $props;
@@ -3045,10 +3057,13 @@ abstract class NativeComponent
         // value validates the normalized form). Runs inside the dispatch
         // guard, so a failure records errors and aborts cleanly. The
         // author's native:model modifier (.live/.blur/.debounce) is the
-        // cadence control. rules()-method rules deliberately do NOT run
-        // here — that's the on-demand tier.
+        // cadence control. Passing the ATTRIBUTE rules explicitly is what
+        // keeps the promise that rules()-method rules never run here —
+        // with the default (merged) source, a same-key rules() entry
+        // would replace the attribute entry and its potentially expensive
+        // rules (unique:, exists:) would fire per keystroke.
         if ($this->hasEagerValidationRule($property)) {
-            $this->validateOnly($property);
+            $this->validateOnly($property, rules: $this->attributeValidationRules());
         }
     }
 
@@ -3333,7 +3348,11 @@ abstract class NativeComponent
             $binding = CallbackRegistry::parse($this->nativeChildEventBindings[$event]);
 
             if (method_exists($parent, $binding['method'])) {
-                $parent->{$binding['method']}(...[...$binding['args'], ...$args]);
+                // Guarded by the OWNER: a validate() failure in the
+                // parent's handler must record on the PARENT's bag and
+                // stop there — unwinding into the emitting child's guard
+                // would fold the parent's errors into the child's bag.
+                $parent->runGuarded(fn () => $parent->{$binding['method']}(...[...$binding['args'], ...$args]));
             }
         }
 
@@ -3354,7 +3373,10 @@ abstract class NativeComponent
             ?? null;
 
         if ($method !== null && method_exists($this, $method)) {
-            $this->{$method}(...$args);
+            // Own-guarded for the same reason as emit()'s binding call:
+            // this listener belongs to $this, so its validation failures
+            // record here, not in whichever component emitted.
+            $this->runGuarded(fn () => $this->{$method}(...$args));
         }
     }
 

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -1236,6 +1236,23 @@ class NativeElementCollector
             unset($attrs[$attribute]);
         }
 
+        // Validation auto-wiring: a `native:model`-bound element whose
+        // property has errors gets `is_error` + the first message as
+        // `supporting` — injected via extraProps, which the toArray()
+        // merge ranks BELOW subclass-resolved props, so an author's
+        // explicit error/supporting attributes always win. Elements
+        // without those slots carry the props inert on the wire.
+        $modelProp = $attrs['model-prop'] ?? null;
+        if ($modelProp !== null) {
+            unset($attrs['model-prop']);
+
+            $bag = static::$owner?->getErrorBag();
+            if ($bag !== null && $bag->has($modelProp)) {
+                $element->setProp('is_error', true);
+                $element->setProp('supporting', (string) $bag->first($modelProp));
+            }
+        }
+
         // Let plugin elements apply their own attributes
         $element->applyAttributes($attrs);
 

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -1236,22 +1236,13 @@ class NativeElementCollector
             unset($attrs[$attribute]);
         }
 
-        // Validation auto-wiring: a `native:model`-bound element whose
-        // property has errors gets `is_error` + the first message as
-        // `supporting` — injected via extraProps, which the toArray()
-        // merge ranks BELOW subclass-resolved props, so an author's
-        // explicit error/supporting attributes always win. Elements
-        // without those slots carry the props inert on the wire.
-        $modelProp = $attrs['model-prop'] ?? null;
-        if ($modelProp !== null) {
-            unset($attrs['model-prop']);
-
-            $bag = static::$owner?->getErrorBag();
-            if ($bag !== null && $bag->has($modelProp)) {
-                $element->setProp('is_error', true);
-                $element->setProp('supporting', (string) $bag->first($modelProp));
-            }
-        }
+        // `model-prop` (emitted by compileNativeModel) is metadata about
+        // the bound property, not an element attribute — strip it before
+        // the element sees the attrs. Deliberately NOT used to auto-wire
+        // validation errors onto the element: error display is the
+        // author's explicit call (@error / @nativeError in Blade, or
+        // error/supporting attributes), matching Livewire's semantics.
+        unset($attrs['model-prop']);
 
         // Let plugin elements apply their own attributes
         $element->applyAttributes($attrs);

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -1236,14 +1236,6 @@ class NativeElementCollector
             unset($attrs[$attribute]);
         }
 
-        // `model-prop` (emitted by compileNativeModel) is metadata about
-        // the bound property, not an element attribute — strip it before
-        // the element sees the attrs. Deliberately NOT used to auto-wire
-        // validation errors onto the element: error display is the
-        // author's explicit call (@error / @nativeError in Blade, or
-        // error/supporting attributes), matching Livewire's semantics.
-        unset($attrs['model-prop']);
-
         // Let plugin elements apply their own attributes
         $element->applyAttributes($attrs);
 

--- a/src/Edge/NativeTagPrecompiler.php
+++ b/src/Edge/NativeTagPrecompiler.php
@@ -387,9 +387,11 @@ class NativeTagPrecompiler
         }
 
         // `model-prop` carries the bound property name into the collector
-        // so validation errors auto-wire onto the element (is_error +
-        // supporting injection in createElement) — and it's generally
-        // useful metadata (devtools, future targets).
+        // as metadata (stripped there before the element sees attrs) —
+        // useful for devtools/future targets. It deliberately does NOT
+        // drive any automatic error display; errors render only where
+        // the author writes @error/@nativeError or sets error/supporting
+        // attributes, matching Livewire.
         $out = ':value="$'.$prop.'" _change="__syncProperty(\''.$prop.'\')" model-prop="'.$prop.'" sync-mode="'.$syncMode.'"';
         if ($debounceMs > 0) {
             $out .= ' debounce-ms="'.$debounceMs.'"';

--- a/src/Edge/NativeTagPrecompiler.php
+++ b/src/Edge/NativeTagPrecompiler.php
@@ -195,7 +195,7 @@ class NativeTagPrecompiler
         // Kept for backwards compatibility; prefer `native:model` going forward.
         $value = preg_replace_callback(
             '/@model=["\']([^"\']+)["\']/',
-            fn ($m) => ':value="$'.$m[1].'" _change="__syncProperty(\''.$m[1].'\')" model-prop="'.$m[1].'" sync-mode="live"',
+            fn ($m) => ':value="$'.$m[1].'" _change="__syncProperty(\''.$m[1].'\')" sync-mode="live"',
             $value
         );
 
@@ -386,13 +386,12 @@ class NativeTagPrecompiler
             // `.live` or anything unknown falls through to syncMode=live.
         }
 
-        // `model-prop` carries the bound property name into the collector
-        // as metadata (stripped there before the element sees attrs) —
-        // useful for devtools/future targets. It deliberately does NOT
-        // drive any automatic error display; errors render only where
-        // the author writes @error/@nativeError or sets error/supporting
-        // attributes, matching Livewire.
-        $out = ':value="$'.$prop.'" _change="__syncProperty(\''.$prop.'\')" model-prop="'.$prop.'" sync-mode="'.$syncMode.'"';
+        // No metadata attribute for the bound prop name: anything that
+        // needs it (the test harness does) derives it from the
+        // `__syncProperty('prop')` change expression, and an extra attr
+        // would have to be stripped at every attr funnel (element,
+        // streaming, child-component props) to avoid leaking.
+        $out = ':value="$'.$prop.'" _change="__syncProperty(\''.$prop.'\')" sync-mode="'.$syncMode.'"';
         if ($debounceMs > 0) {
             $out .= ' debounce-ms="'.$debounceMs.'"';
         }

--- a/src/Edge/NativeTagPrecompiler.php
+++ b/src/Edge/NativeTagPrecompiler.php
@@ -195,7 +195,7 @@ class NativeTagPrecompiler
         // Kept for backwards compatibility; prefer `native:model` going forward.
         $value = preg_replace_callback(
             '/@model=["\']([^"\']+)["\']/',
-            fn ($m) => ':value="$'.$m[1].'" _change="__syncProperty(\''.$m[1].'\')" sync-mode="live"',
+            fn ($m) => ':value="$'.$m[1].'" _change="__syncProperty(\''.$m[1].'\')" model-prop="'.$m[1].'" sync-mode="live"',
             $value
         );
 
@@ -386,7 +386,11 @@ class NativeTagPrecompiler
             // `.live` or anything unknown falls through to syncMode=live.
         }
 
-        $out = ':value="$'.$prop.'" _change="__syncProperty(\''.$prop.'\')" sync-mode="'.$syncMode.'"';
+        // `model-prop` carries the bound property name into the collector
+        // so validation errors auto-wire onto the element (is_error +
+        // supporting injection in createElement) — and it's generally
+        // useful metadata (devtools, future targets).
+        $out = ':value="$'.$prop.'" _change="__syncProperty(\''.$prop.'\')" model-prop="'.$prop.'" sync-mode="'.$syncMode.'"';
         if ($debounceMs > 0) {
             $out .= ' debounce-ms="'.$debounceMs.'"';
         }

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -443,8 +443,13 @@ class NativeServiceProvider extends PackageServiceProvider
                 \$__nativeErrorMessage = null;
                 if (isset(\$errors)) {
                     if (\$errors instanceof \\Illuminate\\Support\\ViewErrorBag) {
-                        \$__nativeErrorMessage = \$errors->first(\$__nativeErrorField) ?: null;
-                    } elseif (is_array(\$errors) && !empty(\$errors[\$__nativeErrorField])) {
+                        // has() not truthiness: a message of '0' is a message.
+                        \$__nativeErrorMessage = \$errors->has(\$__nativeErrorField)
+                            ? \$errors->first(\$__nativeErrorField)
+                            : null;
+                    } elseif (is_array(\$errors)
+                        && isset(\$errors[\$__nativeErrorField])
+                        && \$errors[\$__nativeErrorField] !== '') {
                         \$__nativeErrorMessage = \$errors[\$__nativeErrorField];
                     }
                 }

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -433,13 +433,24 @@ class NativeServiceProvider extends PackageServiceProvider
         });
 
         Blade::directive('nativeError', function ($expression) {
+            // $errors is a ViewErrorBag since ValidatesProps (every view-
+            // data merge injects it); the is_array branch keeps the older
+            // hand-rolled ['field' => 'message'] arrays working.
             return "<?php
                 \$__nativeErrorArgs = [{$expression}];
                 \$__nativeErrorField = \$__nativeErrorArgs[0];
                 \$__nativeErrorColor = \$__nativeErrorArgs[1] ?? '#FF0000';
-                if (isset(\$errors) && is_array(\$errors) && !empty(\$errors[\$__nativeErrorField])) {
+                \$__nativeErrorMessage = null;
+                if (isset(\$errors)) {
+                    if (\$errors instanceof \\Illuminate\\Support\\ViewErrorBag) {
+                        \$__nativeErrorMessage = \$errors->first(\$__nativeErrorField) ?: null;
+                    } elseif (is_array(\$errors) && !empty(\$errors[\$__nativeErrorField])) {
+                        \$__nativeErrorMessage = \$errors[\$__nativeErrorField];
+                    }
+                }
+                if (\$__nativeErrorMessage !== null) {
                     \\Native\\Mobile\\Edge\\NativeElementCollector::leaf('text', [
-                        'text' => \$errors[\$__nativeErrorField],
+                        'text' => \$__nativeErrorMessage,
                         'color' => \$__nativeErrorColor,
                         'fontSize' => 12,
                     ]);

--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -1364,7 +1364,16 @@ class TestableComponent
     protected function guard(\Closure $fn): mixed
     {
         try {
-            return $fn();
+            // Route through the component's validation guard so direct
+            // set()/call() interactions behave exactly like runtime
+            // dispatch: a ValidationException records errors on the bag
+            // and aborts the interaction (the next render shows $errors)
+            // instead of exploding the test. Device and web enter through
+            // dispatch(), which wraps the same guard.
+            return $this->scoped(function () use ($fn) {
+                /** @var \Native\Mobile\Edge\NativeComponent $this */
+                return $this->runGuarded($fn);
+            });
         } catch (NativeDumpException $e) {
             Assert::fail(
                 'Component called dd() at '.$e->getSourceFile().':'.$e->getSourceLine()."\n".$e->getFormattedDumps()

--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -243,7 +243,7 @@ class TestableComponent
             'Public property [$'.$property.'] does not exist on '.get_class($this->component).'.'
         );
 
-        $this->guard(fn () => $this->component->__syncProperty($property, $value));
+        $this->guardDispatch(fn () => $this->component->__syncProperty($property, $value));
 
         return $this->afterInteraction();
     }
@@ -258,7 +258,7 @@ class TestableComponent
             'Method ['.$method.'] does not exist on '.get_class($this->component).'.'
         );
 
-        $this->guard(fn () => $this->component->{$method}(...$args));
+        $this->guardDispatch(fn () => $this->component->{$method}(...$args));
 
         return $this->afterInteraction();
     }
@@ -1361,24 +1361,37 @@ class TestableComponent
      * Convert a component dd() into a readable test failure instead of a
      * raw exception (or a dead PHPUnit process).
      */
+    /**
+     * Dump-to-failure conversion ONLY. Deliberately does NOT swallow
+     * ValidationException: outside a dispatch, the device paints the
+     * error screen for one (mount(), a render frame), so in a test it
+     * must fail loudly — a guard here would quietly certify behavior
+     * the device doesn't have. Dispatch-path swallowing lives in core's
+     * dispatch()/dispatchNativeEvent() (which tap()/emitNative() go
+     * through) and in guardDispatch() for the direct set()/call() APIs.
+     */
     protected function guard(\Closure $fn): mixed
     {
         try {
-            // Route through the component's validation guard so direct
-            // set()/call() interactions behave exactly like runtime
-            // dispatch: a ValidationException records errors on the bag
-            // and aborts the interaction (the next render shows $errors)
-            // instead of exploding the test. Device and web enter through
-            // dispatch(), which wraps the same guard.
-            return $this->scoped(function () use ($fn) {
-                /** @var \Native\Mobile\Edge\NativeComponent $this */
-                return $this->runGuarded($fn);
-            });
+            return $fn();
         } catch (NativeDumpException $e) {
             Assert::fail(
                 'Component called dd() at '.$e->getSourceFile().':'.$e->getSourceLine()."\n".$e->getFormattedDumps()
             );
         }
+    }
+
+    /**
+     * guard() + the component's validation guard — for set()/call(),
+     * which emulate handler dispatch: a ValidationException records
+     * errors and aborts the interaction, exactly like a real event.
+     */
+    protected function guardDispatch(\Closure $fn): mixed
+    {
+        return $this->guard(fn () => $this->scoped(function () use ($fn) {
+            /** @var NativeComponent $this */
+            return $this->runGuarded($fn);
+        }));
     }
 
     protected function callbacks(): CallbackRegistry

--- a/tests/Feature/Edge/ValidationTest.php
+++ b/tests/Feature/Edge/ValidationTest.php
@@ -12,8 +12,9 @@ use Tests\Fixtures\Edge\ValidationScreen;
  * Component validation end to end through the real dispatch cycle:
  * validate()/validateOnly() abort handlers via the runGuarded seam,
  * $errors reaches Blade (@error and @nativeError), eager #[Validate]
- * rules fire on native:model sync, and the collector injects
- * is_error/supporting onto model-bound elements.
+ * rules fire on native:model sync — and error DISPLAY stays fully
+ * explicit (Livewire semantics): a failed validation never touches a
+ * bound element's props.
  */
 beforeEach(function () {
     NativeRouter::clearRoutes();
@@ -119,22 +120,25 @@ it('renders @nativeError from the injected ViewErrorBag', function () {
             && str_contains($node['props']['text'] ?? '', 'The bio field is required.'));
 });
 
-// ── is_error / supporting injection ─────────────────
+// ── No automatic error display (Livewire semantics) ─
 
-it('injects is_error and the first message into model-bound elements', function () {
+it('never injects error props into model-bound elements', function () {
+    // Error DISPLAY is the author's explicit call (@error/@nativeError
+    // or error/supporting attributes) — a failed validation must leave
+    // the bound element's props untouched.
     Native::test(ValidationScreen::class)
         ->tap('save-btn')
+        ->assertSee('TITLE-ERR') // the error exists…
         ->assertElement('text_input', fn (array $node) => ($node['ref'] ?? null) === 'title-input'
-            && ($node['props']['is_error'] ?? false) === true
-            && ($node['props']['supporting'] ?? null) === 'The title field is required.');
+            && ! isset($node['props']['is_error'])
+            && ! isset($node['props']['supporting'])); // …but the element is untouched
 });
 
-it('stops injecting once the error clears', function () {
+it('strips the model-prop metadata attribute before elements see it', function () {
     Native::test(ValidationScreen::class)
-        ->tap('save-btn')
-        ->input('title-input', 'A proper title')
         ->assertElement('text_input', fn (array $node) => ($node['ref'] ?? null) === 'title-input'
-            && ! isset($node['props']['is_error']));
+            && ! isset($node['props']['model-prop'])
+            && ! isset($node['props']['model_prop']));
 });
 
 // ── Child-component scoping ─────────────────────────
@@ -149,10 +153,7 @@ it('scopes validation errors to the child component that failed', function () {
         Native::test(\Tests\Fixtures\Edge\ValidationHostScreen::class)
             ->tap('child-save-btn')
             ->assertSee('CHILD-ERR The nickname field is required.')
-            ->assertDontSee('HOST-LEAKED') // parent bag untouched
-            ->assertElement('text_input', fn (array $node) => ($node['ref'] ?? null) === 'nickname-input'
-                && ($node['props']['is_error'] ?? false) === true
-                && ($node['props']['supporting'] ?? null) === 'The nickname field is required.');
+            ->assertDontSee('HOST-LEAKED'); // parent bag untouched
     } finally {
         \Native\Mobile\Edge\ComponentRegistry::reset();
     }
@@ -174,10 +175,10 @@ it('validates a child prop eagerly on the child input sync', function () {
     }
 });
 
-it('lets element-resolved props win over injected ones (merge order)', function () {
-    // The injection rides extraProps, which toArray() ranks BELOW the
-    // subclass's resolveProps — an element that resolves its own
-    // `supporting` (mobile-ui inputs with an explicit attr) always wins.
+it('lets element-resolved props win over setProp extras (merge order)', function () {
+    // Generic Element contract: extraProps rank BELOW the subclass's
+    // resolveProps in toArray(), so anything an element resolves from
+    // its own attributes beats a generic setProp() of the same key.
     $element = new class extends Element
     {
         protected string $type = 'probe';

--- a/tests/Feature/Edge/ValidationTest.php
+++ b/tests/Feature/Edge/ValidationTest.php
@@ -189,6 +189,44 @@ it('leaves untouched wildcard siblings alone in validateOnly', function () {
         ->assertDontSee('TAG0-ERR');
 });
 
+// ── Inline-review regressions (second pass) ─────────
+
+it('merges stacked #[Validate] attributes instead of fataling', function () {
+    // #[Validate('string')] + #[Validate('min:4')] on $handle: without
+    // IS_REPEATABLE this crashes on first render; without merging, one
+    // rule silently wins.
+    Native::test(ValidationScreen::class)
+        ->set('handle', 'abc')
+        ->assertSee('HANDLE-ERR The handle field must be at least 4 characters.')
+        ->set('handle', 'abcd')
+        ->assertDontSee('HANDLE-ERR');
+});
+
+it('delivers remaining native-event tiers after one listener fails validation', function () {
+    // The ->on() closure for 'probe' always fails validation; the #[On]
+    // method tier must still hear the event, and the closure's errors
+    // must still reach the bag.
+    Native::test(ValidationScreen::class)
+        ->emitNative('probe')
+        ->assertSet('probed', true)
+        ->assertSee('BIO-ERR The bio field is required.');
+});
+
+it('returns the target data when only wildcard siblings fail', function () {
+    Native::test(ValidationScreen::class)
+        ->set('tags', ['', 'ok'])
+        ->call('checkTagReturn') // validateOnly('tags.1') — tags.0 fails, target passes
+        ->assertSet('tagResult', ['tags' => [1 => 'ok']])
+        ->assertDontSee('TAG-ERR'); // and nothing was thrown or recorded
+});
+
+it('renders a falsy "0" message through @nativeError', function () {
+    Native::test(ValidationScreen::class)
+        ->call('zeroError') // addError('bio', '0')
+        ->assertElement('text', fn (array $node) => ($node['props']['text'] ?? null) === '0'
+            && ($node['props']['color'] ?? null) !== null);
+});
+
 // ── No automatic error display (Livewire semantics) ─
 
 it('never injects error props into model-bound elements', function () {

--- a/tests/Feature/Edge/ValidationTest.php
+++ b/tests/Feature/Edge/ValidationTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\ElementRegistry;
+use Native\Mobile\Edge\Elements\TextInput;
+use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Testing\Native;
+use Tests\Fixtures\Edge\ValidationScreen;
+
+/**
+ * Component validation end to end through the real dispatch cycle:
+ * validate()/validateOnly() abort handlers via the runGuarded seam,
+ * $errors reaches Blade (@error and @nativeError), eager #[Validate]
+ * rules fire on native:model sync, and the collector injects
+ * is_error/supporting onto model-bound elements.
+ */
+beforeEach(function () {
+    NativeRouter::clearRoutes();
+    app('view')->addLocation(__DIR__.'/../../Fixtures/views');
+
+    // text_input ships in the UI plugin; register it like the plugin would
+    // so `<native:text-input native:model=…>` compiles (same arrangement
+    // as NestedComponentsTest).
+    ElementRegistry::register('text_input', TextInput::class);
+});
+
+afterEach(function () {
+    NativeRouter::clearRoutes();
+});
+
+// ── validate() in handlers ──────────────────────────
+
+it('aborts the handler on failed validation and keeps state', function () {
+    Native::test(ValidationScreen::class)
+        ->tap('save-btn')
+        ->assertSet('saved', false)
+        ->assertSee('UNSAVED')
+        ->assertSee('TITLE-ERR The title field is required.')
+        ->assertSee('BIO-ERR The bio field is required.');
+});
+
+it('runs the handler to completion once validation passes', function () {
+    Native::test(ValidationScreen::class)
+        ->input('title-input', 'A proper title')
+        ->input('bio-input', 'short')
+        ->tap('save-btn')
+        ->assertSet('saved', true)
+        ->assertSee('SAVED')
+        ->assertDontSee('TITLE-ERR')
+        ->assertDontSee('BIO-ERR');
+});
+
+it('validates only the given rules when validate() gets an inline array', function () {
+    // saveInline() validates just `bio` — the empty (invalid) title must
+    // not block it once bio is set.
+    Native::test(ValidationScreen::class)
+        ->input('bio-input', 'hi')
+        ->call('saveInline')
+        ->assertSet('saved', true);
+});
+
+it('harvests rules and messages from a FormRequest class-string', function () {
+    Native::test(ValidationScreen::class)
+        ->call('saveViaRequest')
+        ->assertSet('saved', false)
+        ->assertSee('TITLE-ERR The request fixture insists on a title.');
+});
+
+it('records author-thrown ValidationException::withMessages and aborts', function () {
+    Native::test(ValidationScreen::class)
+        ->call('failManually')
+        ->assertSee('TITLE-ERR Custom problem');
+});
+
+// ── Eager #[Validate] rules on native:model sync ────
+
+it('validates eagerly on sync for #[Validate] props', function () {
+    Native::test(ValidationScreen::class)
+        ->input('title-input', 'ab') // min:3
+        ->assertSet('title', 'ab')   // the sync itself is never rolled back
+        ->assertSee('TITLE-ERR The title field must be at least 3 characters.');
+});
+
+it('clears the field error once an eager re-validation passes', function () {
+    Native::test(ValidationScreen::class)
+        ->input('title-input', 'ab')
+        ->assertSee('TITLE-ERR')
+        ->input('title-input', 'long enough now')
+        ->assertDontSee('TITLE-ERR');
+});
+
+it('does not run rules()-method rules on sync', function () {
+    // bio's rules live in rules() (on-demand tier): typing an over-limit
+    // value must not surface an error until a validate() call does.
+    Native::test(ValidationScreen::class)
+        ->input('bio-input', 'far too long for max five')
+        ->assertDontSee('BIO-ERR')
+        ->tap('save-btn')
+        ->assertSee('BIO-ERR');
+});
+
+// ── validateOnly + wildcards ────────────────────────
+
+it('validateOnly matches wildcard rules and scopes the bag to that field', function () {
+    Native::test(ValidationScreen::class)
+        ->set('tags', ['ok', ''])
+        ->call('checkTag') // validateOnly('tags.1') against 'tags.*'
+        ->assertSee('TAG-ERR')
+        ->assertDontSee('TITLE-ERR'); // untouched fields stay unvalidated
+});
+
+// ── Blade error display ─────────────────────────────
+
+it('renders @nativeError from the injected ViewErrorBag', function () {
+    Native::test(ValidationScreen::class)
+        ->tap('save-btn')
+        ->assertElement('text', fn (array $node) => ($node['props']['color'] ?? null) !== null
+            && str_contains($node['props']['text'] ?? '', 'The bio field is required.'));
+});
+
+// ── is_error / supporting injection ─────────────────
+
+it('injects is_error and the first message into model-bound elements', function () {
+    Native::test(ValidationScreen::class)
+        ->tap('save-btn')
+        ->assertElement('text_input', fn (array $node) => ($node['ref'] ?? null) === 'title-input'
+            && ($node['props']['is_error'] ?? false) === true
+            && ($node['props']['supporting'] ?? null) === 'The title field is required.');
+});
+
+it('stops injecting once the error clears', function () {
+    Native::test(ValidationScreen::class)
+        ->tap('save-btn')
+        ->input('title-input', 'A proper title')
+        ->assertElement('text_input', fn (array $node) => ($node['ref'] ?? null) === 'title-input'
+            && ! isset($node['props']['is_error']));
+});
+
+it('lets element-resolved props win over injected ones (merge order)', function () {
+    // The injection rides extraProps, which toArray() ranks BELOW the
+    // subclass's resolveProps — an element that resolves its own
+    // `supporting` (mobile-ui inputs with an explicit attr) always wins.
+    $element = new class extends Element
+    {
+        protected string $type = 'probe';
+
+        protected function resolveProps(CallbackRegistry $registry): array
+        {
+            return ['supporting' => 'author text'];
+        }
+    };
+
+    $element->setProp('supporting', 'injected message');
+    $element->setProp('is_error', true);
+
+    $nextId = 1;
+    $emitted = [];
+    $throwaway = [];
+    $node = $element->toArray(new CallbackRegistry, $nextId, '', 0, $emitted, $throwaway);
+
+    expect($node['props']['supporting'])->toBe('author text')
+        ->and($node['props']['is_error'])->toBeTrue(); // untouched key survives
+});

--- a/tests/Feature/Edge/ValidationTest.php
+++ b/tests/Feature/Edge/ValidationTest.php
@@ -1,11 +1,17 @@
 <?php
 
+use Illuminate\Validation\ValidationException;
 use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\ComponentRegistry;
 use Native\Mobile\Edge\Element;
 use Native\Mobile\Edge\ElementRegistry;
 use Native\Mobile\Edge\Elements\TextInput;
 use Native\Mobile\Edge\NativeRouter;
 use Native\Mobile\Testing\Native;
+use Tests\Fixtures\Edge\LegacyErrorsScreen;
+use Tests\Fixtures\Edge\MountValidationScreen;
+use Tests\Fixtures\Edge\ValidationChild;
+use Tests\Fixtures\Edge\ValidationHostScreen;
 use Tests\Fixtures\Edge\ValidationScreen;
 
 /**
@@ -120,6 +126,69 @@ it('renders @nativeError from the injected ViewErrorBag', function () {
             && str_contains($node['props']['text'] ?? '', 'The bio field is required.'));
 });
 
+// ── Review-driven regressions (PR #301 findings) ────
+
+it('eager sync uses attribute rules, never a same-key rules() entry', function () {
+    // rules() declares title => min:10; the attribute says min:3. A
+    // 5-char sync must PASS (attribute tier only) — the on-demand rule
+    // fires solely through validate() (finding 1).
+    Native::test(ValidationScreen::class)
+        ->input('title-input', 'abcde')
+        ->assertDontSee('TITLE-ERR')
+        ->input('bio-input', 'ok')
+        ->tap('save-btn')
+        ->assertSee('TITLE-ERR The title field must be at least 10 characters.');
+});
+
+it('keeps a parent validation failure out of the emitting child bag', function () {
+    ComponentRegistry::reset();
+    ComponentRegistry::components([
+        'validation-child' => ValidationChild::class,
+    ]);
+
+    try {
+        Native::test(ValidationHostScreen::class)
+            ->tap('ping-btn') // child emit('saved') → parent parentSave() fails
+            ->assertSee('HOST-ERR')      // parent's bag has it (finding 2)
+            ->assertDontSee('CHILD-LEAK'); // child's bag does NOT
+    } finally {
+        ComponentRegistry::reset();
+    }
+});
+
+it('records a manual throw after a caught validate() in the same dispatch', function () {
+    // A stale recorded-state would swallow the second exception (finding 4).
+    Native::test(ValidationScreen::class)
+        ->call('catchThenRethrow')
+        ->assertSee('TITLE-ERR The title field is required.')
+        ->assertSee('BIO-ERR Manual bio problem');
+});
+
+it('keeps the legacy public-array $errors pattern working', function () {
+    // The injected ViewErrorBag is a FALLBACK — a v3-style hand-rolled
+    // errors prop still reaches @nativeError untouched (finding 3).
+    Native::test(LegacyErrorsScreen::class)
+        ->assertSee('Legacy message');
+});
+
+it('bubbles a mount()-time validation failure like the device error screen', function () {
+    Native::test(MountValidationScreen::class);
+})->throws(ValidationException::class);
+
+it('bubbles a render-phase validation failure instead of keeping a stale frame', function () {
+    Native::test(ValidationScreen::class)->call('arm');
+})->throws(ValidationException::class);
+
+it('leaves untouched wildcard siblings alone in validateOnly', function () {
+    // Editing tags.1 must not conjure an error onto tags.0 even though
+    // the tags.* rule sweeps the whole array (finding 8).
+    Native::test(ValidationScreen::class)
+        ->set('tags', ['', ''])
+        ->call('checkTag') // validateOnly('tags.1')
+        ->assertSee('TAG-ERR')
+        ->assertDontSee('TAG0-ERR');
+});
+
 // ── No automatic error display (Livewire semantics) ─
 
 it('never injects error props into model-bound elements', function () {
@@ -144,34 +213,34 @@ it('strips the model-prop metadata attribute before elements see it', function (
 // ── Child-component scoping ─────────────────────────
 
 it('scopes validation errors to the child component that failed', function () {
-    \Native\Mobile\Edge\ComponentRegistry::reset();
-    \Native\Mobile\Edge\ComponentRegistry::components([
-        'validation-child' => \Tests\Fixtures\Edge\ValidationChild::class,
+    ComponentRegistry::reset();
+    ComponentRegistry::components([
+        'validation-child' => ValidationChild::class,
     ]);
 
     try {
-        Native::test(\Tests\Fixtures\Edge\ValidationHostScreen::class)
+        Native::test(ValidationHostScreen::class)
             ->tap('child-save-btn')
             ->assertSee('CHILD-ERR The nickname field is required.')
             ->assertDontSee('HOST-LEAKED'); // parent bag untouched
     } finally {
-        \Native\Mobile\Edge\ComponentRegistry::reset();
+        ComponentRegistry::reset();
     }
 });
 
 it('validates a child prop eagerly on the child input sync', function () {
-    \Native\Mobile\Edge\ComponentRegistry::reset();
-    \Native\Mobile\Edge\ComponentRegistry::components([
-        'validation-child' => \Tests\Fixtures\Edge\ValidationChild::class,
+    ComponentRegistry::reset();
+    ComponentRegistry::components([
+        'validation-child' => ValidationChild::class,
     ]);
 
     try {
-        Native::test(\Tests\Fixtures\Edge\ValidationHostScreen::class)
+        Native::test(ValidationHostScreen::class)
             ->input('nickname-input', 'x') // min:2
             ->assertSee('CHILD-ERR The nickname field must be at least 2 characters.')
             ->assertDontSee('HOST-LEAKED');
     } finally {
-        \Native\Mobile\Edge\ComponentRegistry::reset();
+        ComponentRegistry::reset();
     }
 });
 

--- a/tests/Feature/Edge/ValidationTest.php
+++ b/tests/Feature/Edge/ValidationTest.php
@@ -166,9 +166,13 @@ it('records a manual throw after a caught validate() in the same dispatch', func
 
 it('keeps the legacy public-array $errors pattern working', function () {
     // The injected ViewErrorBag is a FALLBACK — a v3-style hand-rolled
-    // errors prop still reaches @nativeError untouched (finding 3).
+    // errors prop still reaches @nativeError untouched (finding 3),
+    // including a falsy '0' message (the legacy branch of the falsy
+    // fix, pinned separately from the bag branch).
     Native::test(LegacyErrorsScreen::class)
-        ->assertSee('Legacy message');
+        ->assertSee('Legacy message')
+        ->assertElement('text', fn (array $node) => ($node['props']['text'] ?? null) === '0'
+            && ($node['props']['color'] ?? null) !== null);
 });
 
 it('bubbles a mount()-time validation failure like the device error screen', function () {
@@ -192,24 +196,27 @@ it('leaves untouched wildcard siblings alone in validateOnly', function () {
 // ── Inline-review regressions (second pass) ─────────
 
 it('merges stacked #[Validate] attributes instead of fataling', function () {
-    // #[Validate('string')] + #[Validate('min:4')] on $handle: without
-    // IS_REPEATABLE this crashes on first render; without merging, one
-    // rule silently wins.
+    // min:4 + starts_with:@ both fail on 'abc' — BOTH messages must
+    // appear, so a last-wins (or first-wins) merge regression can't
+    // hide behind a rule that never fails.
     Native::test(ValidationScreen::class)
         ->set('handle', 'abc')
         ->assertSee('HANDLE-ERR The handle field must be at least 4 characters.')
-        ->set('handle', 'abcd')
+        ->assertSee('HANDLE-ERR The handle field must start with')
+        ->set('handle', '@abcd')
         ->assertDontSee('HANDLE-ERR');
 });
 
 it('delivers remaining native-event tiers after one listener fails validation', function () {
-    // The ->on() closure for 'probe' always fails validation; the #[On]
-    // method tier must still hear the event, and the closure's errors
-    // must still reach the bag.
+    // The ->on() closure for 'probe' fails on bio; the #[On] method
+    // tier still hears the event AND fails on title. Both tiers'
+    // errors must coexist after one delivery — a failing validate()
+    // refreshes only its own keys, never the whole bag.
     Native::test(ValidationScreen::class)
         ->emitNative('probe')
         ->assertSet('probed', true)
-        ->assertSee('BIO-ERR The bio field is required.');
+        ->assertSee('BIO-ERR The bio field is required.')
+        ->assertSee('TITLE-ERR The title field is required.');
 });
 
 it('returns the target data when only wildcard siblings fail', function () {

--- a/tests/Feature/Edge/ValidationTest.php
+++ b/tests/Feature/Edge/ValidationTest.php
@@ -137,6 +137,43 @@ it('stops injecting once the error clears', function () {
             && ! isset($node['props']['is_error']));
 });
 
+// ── Child-component scoping ─────────────────────────
+
+it('scopes validation errors to the child component that failed', function () {
+    \Native\Mobile\Edge\ComponentRegistry::reset();
+    \Native\Mobile\Edge\ComponentRegistry::components([
+        'validation-child' => \Tests\Fixtures\Edge\ValidationChild::class,
+    ]);
+
+    try {
+        Native::test(\Tests\Fixtures\Edge\ValidationHostScreen::class)
+            ->tap('child-save-btn')
+            ->assertSee('CHILD-ERR The nickname field is required.')
+            ->assertDontSee('HOST-LEAKED') // parent bag untouched
+            ->assertElement('text_input', fn (array $node) => ($node['ref'] ?? null) === 'nickname-input'
+                && ($node['props']['is_error'] ?? false) === true
+                && ($node['props']['supporting'] ?? null) === 'The nickname field is required.');
+    } finally {
+        \Native\Mobile\Edge\ComponentRegistry::reset();
+    }
+});
+
+it('validates a child prop eagerly on the child input sync', function () {
+    \Native\Mobile\Edge\ComponentRegistry::reset();
+    \Native\Mobile\Edge\ComponentRegistry::components([
+        'validation-child' => \Tests\Fixtures\Edge\ValidationChild::class,
+    ]);
+
+    try {
+        Native::test(\Tests\Fixtures\Edge\ValidationHostScreen::class)
+            ->input('nickname-input', 'x') // min:2
+            ->assertSee('CHILD-ERR The nickname field must be at least 2 characters.')
+            ->assertDontSee('HOST-LEAKED');
+    } finally {
+        \Native\Mobile\Edge\ComponentRegistry::reset();
+    }
+});
+
 it('lets element-resolved props win over injected ones (merge order)', function () {
     // The injection rides extraProps, which toArray() ranks BELOW the
     // subclass's resolveProps — an element that resolves its own

--- a/tests/Fixtures/Edge/LegacyErrorsScreen.php
+++ b/tests/Fixtures/Edge/LegacyErrorsScreen.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Illuminate\View\View;
+use Native\Mobile\Edge\NativeComponent;
+
+/**
+ * The documented v3 pattern: a hand-rolled `public array $errors` prop
+ * consumed by @nativeError. The injected ViewErrorBag must be a
+ * FALLBACK that never clobbers it (regression: review finding 3).
+ */
+class LegacyErrorsScreen extends NativeComponent
+{
+    public array $errors = ['title' => 'Legacy message'];
+
+    public function render(): View
+    {
+        return view('legacy-errors');
+    }
+}

--- a/tests/Fixtures/Edge/LegacyErrorsScreen.php
+++ b/tests/Fixtures/Edge/LegacyErrorsScreen.php
@@ -12,7 +12,7 @@ use Native\Mobile\Edge\NativeComponent;
  */
 class LegacyErrorsScreen extends NativeComponent
 {
-    public array $errors = ['title' => 'Legacy message'];
+    public array $errors = ['title' => 'Legacy message', 'zero' => '0'];
 
     public function render(): View
     {

--- a/tests/Fixtures/Edge/MountValidationScreen.php
+++ b/tests/Fixtures/Edge/MountValidationScreen.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Illuminate\View\View;
+use Native\Mobile\Edge\NativeComponent;
+
+/**
+ * mount() fails validation. On device this paints the error screen (the
+ * runloop's plain catch), so in tests it must BUBBLE, never be silently
+ * recorded (regression: review finding 5).
+ */
+class MountValidationScreen extends NativeComponent
+{
+    public string $x = '';
+
+    public function mount(): void
+    {
+        $this->validate(['x' => 'required']);
+    }
+
+    public function render(): View
+    {
+        return view('validation-screen');
+    }
+}

--- a/tests/Fixtures/Edge/ValidationChild.php
+++ b/tests/Fixtures/Edge/ValidationChild.php
@@ -21,6 +21,11 @@ class ValidationChild extends NativeComponent
         $this->childSaved = true;
     }
 
+    public function pingParent(): void
+    {
+        $this->emit('saved');
+    }
+
     public function render(): View
     {
         return view('validation-child');

--- a/tests/Fixtures/Edge/ValidationChild.php
+++ b/tests/Fixtures/Edge/ValidationChild.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Illuminate\View\View;
+use Native\Mobile\Attributes\Validate;
+use Native\Mobile\Edge\NativeComponent;
+
+/** Child component with its own eager rule — bags must scope per instance. */
+class ValidationChild extends NativeComponent
+{
+    #[Validate('required|min:2')]
+    public string $nickname = '';
+
+    public bool $childSaved = false;
+
+    public function saveChild(): void
+    {
+        $this->validate();
+
+        $this->childSaved = true;
+    }
+
+    public function render(): View
+    {
+        return view('validation-child');
+    }
+}

--- a/tests/Fixtures/Edge/ValidationHostScreen.php
+++ b/tests/Fixtures/Edge/ValidationHostScreen.php
@@ -8,6 +8,14 @@ use Native\Mobile\Edge\NativeComponent;
 /** Host embedding ValidationChild — its own bag must stay untouched. */
 class ValidationHostScreen extends NativeComponent
 {
+    public string $hostField = '';
+
+    /** Invoked via the child's emit('saved') → @saved binding. */
+    public function parentSave(): void
+    {
+        $this->validate(['hostField' => 'required']);
+    }
+
     public function render(): View
     {
         return view('validation-host');

--- a/tests/Fixtures/Edge/ValidationHostScreen.php
+++ b/tests/Fixtures/Edge/ValidationHostScreen.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Illuminate\View\View;
+use Native\Mobile\Edge\NativeComponent;
+
+/** Host embedding ValidationChild — its own bag must stay untouched. */
+class ValidationHostScreen extends NativeComponent
+{
+    public function render(): View
+    {
+        return view('validation-host');
+    }
+}

--- a/tests/Fixtures/Edge/ValidationPostRequest.php
+++ b/tests/Fixtures/Edge/ValidationPostRequest.php
@@ -7,9 +7,10 @@ use Illuminate\Foundation\Http\FormRequest;
 /** FormRequest fixture for validate(ValidationPostRequest::class) harvesting. */
 class ValidationPostRequest extends FormRequest
 {
-    public function rules(): array
+    /** Method injection like a controller-bound request (finding 9). */
+    public function rules(ValidationRuleSource $source): array
     {
-        return ['title' => 'required|min:3'];
+        return ['title' => $source->titleRules()];
     }
 
     public function messages(): array

--- a/tests/Fixtures/Edge/ValidationPostRequest.php
+++ b/tests/Fixtures/Edge/ValidationPostRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/** FormRequest fixture for validate(ValidationPostRequest::class) harvesting. */
+class ValidationPostRequest extends FormRequest
+{
+    public function rules(): array
+    {
+        return ['title' => 'required|min:3'];
+    }
+
+    public function messages(): array
+    {
+        return ['title.required' => 'The request fixture insists on a title.'];
+    }
+}

--- a/tests/Fixtures/Edge/ValidationRuleSource.php
+++ b/tests/Fixtures/Edge/ValidationRuleSource.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+/** Injected into ValidationPostRequest::rules() to prove container method-injection works. */
+class ValidationRuleSource
+{
+    public function titleRules(): string
+    {
+        return 'required|min:3';
+    }
+}

--- a/tests/Fixtures/Edge/ValidationScreen.php
+++ b/tests/Fixtures/Edge/ValidationScreen.php
@@ -23,9 +23,15 @@ class ValidationScreen extends NativeComponent
 
     public bool $saved = false;
 
+    public bool $boom = false;
+
     protected function rules(): array
     {
         return [
+            // Same key as the #[Validate] attribute with a STRICTER rule:
+            // the eager sync tier must keep using the attribute's min:3,
+            // never this on-demand min:10 (regression: finding 1).
+            'title' => 'required|min:10',
             'bio' => 'required|max:5',
             'tags.*' => 'required|string',
         ];
@@ -62,8 +68,32 @@ class ValidationScreen extends NativeComponent
         $this->validateOnly('tags.1');
     }
 
+    public function catchThenRethrow(): void
+    {
+        try {
+            $this->validate(['title' => 'required']);
+        } catch (ValidationException) {
+            // swallowed on purpose — a later manual throw in the SAME
+            // dispatch must still reach the bag (regression: finding 4).
+        }
+
+        throw ValidationException::withMessages(['bio' => 'Manual bio problem']);
+    }
+
+    public function arm(): void
+    {
+        $this->boom = true;
+    }
+
     public function render(): View
     {
+        if ($this->boom) {
+            // Render-phase validation failure — must BUBBLE in tests
+            // (device paints the error screen), never silently keep a
+            // stale frame (regression: finding 6).
+            throw ValidationException::withMessages(['title' => 'Render-phase failure']);
+        }
+
         return view('validation-screen');
     }
 }

--- a/tests/Fixtures/Edge/ValidationScreen.php
+++ b/tests/Fixtures/Edge/ValidationScreen.php
@@ -23,7 +23,40 @@ class ValidationScreen extends NativeComponent
 
     public bool $saved = false;
 
+    #[Validate('string')]
+    #[Validate('min:4')]
+    public string $handle = '';
+
     public bool $boom = false;
+
+    public bool $probed = false;
+
+    public array $tagResult = [];
+
+    public function mount(): void
+    {
+        // Closure listener whose validation ALWAYS fails — the #[On]
+        // method tier below must still hear the same event.
+        $this->registerNativeEventListener('probe', function () {
+            $this->validate(['bio' => 'required']);
+        });
+    }
+
+    #[\Native\Mobile\Attributes\On('probe')]
+    public function probeHeard(): void
+    {
+        $this->probed = true;
+    }
+
+    public function checkTagReturn(): void
+    {
+        $this->tagResult = $this->validateOnly('tags.1');
+    }
+
+    public function zeroError(): void
+    {
+        $this->addError('bio', '0');
+    }
 
     protected function rules(): array
     {

--- a/tests/Fixtures/Edge/ValidationScreen.php
+++ b/tests/Fixtures/Edge/ValidationScreen.php
@@ -23,8 +23,11 @@ class ValidationScreen extends NativeComponent
 
     public bool $saved = false;
 
-    #[Validate('string')]
+    // Two INDEPENDENTLY falsifiable rules ('abc' fails both), so a
+    // last-wins regression in stacked-attribute merging can't hide
+    // behind a rule that never fails on a typed string prop.
     #[Validate('min:4')]
+    #[Validate('starts_with:@')]
     public string $handle = '';
 
     public bool $boom = false;
@@ -46,6 +49,11 @@ class ValidationScreen extends NativeComponent
     public function probeHeard(): void
     {
         $this->probed = true;
+
+        // This tier fails on a DIFFERENT key than the ->on() closure's
+        // bio failure — both errors must survive one event delivery
+        // (a whole-bag replace here would erase the closure's).
+        $this->validate(['title' => 'required']);
     }
 
     public function checkTagReturn(): void

--- a/tests/Fixtures/Edge/ValidationScreen.php
+++ b/tests/Fixtures/Edge/ValidationScreen.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Illuminate\Validation\ValidationException;
+use Illuminate\View\View;
+use Native\Mobile\Attributes\Validate;
+use Native\Mobile\Edge\NativeComponent;
+
+/**
+ * Fixture for the validation suite: one eager #[Validate] prop, one
+ * rules()-method (on-demand) prop, a wildcard rule, and handlers
+ * covering every validate() entry shape.
+ */
+class ValidationScreen extends NativeComponent
+{
+    #[Validate('required|min:3')]
+    public string $title = '';
+
+    public string $bio = '';
+
+    public array $tags = ['ok', 'go'];
+
+    public bool $saved = false;
+
+    protected function rules(): array
+    {
+        return [
+            'bio' => 'required|max:5',
+            'tags.*' => 'required|string',
+        ];
+    }
+
+    public function save(): void
+    {
+        $this->validate();
+
+        $this->saved = true;
+    }
+
+    public function saveInline(): void
+    {
+        $this->validate(['bio' => 'required']);
+
+        $this->saved = true;
+    }
+
+    public function saveViaRequest(): void
+    {
+        $this->validate(ValidationPostRequest::class);
+
+        $this->saved = true;
+    }
+
+    public function failManually(): void
+    {
+        throw ValidationException::withMessages(['title' => 'Custom problem']);
+    }
+
+    public function checkTag(): void
+    {
+        $this->validateOnly('tags.1');
+    }
+
+    public function render(): View
+    {
+        return view('validation-screen');
+    }
+}

--- a/tests/Fixtures/views/legacy-errors.blade.php
+++ b/tests/Fixtures/views/legacy-errors.blade.php
@@ -1,3 +1,4 @@
 <native:column>
     @nativeError('title')
+    @nativeError('zero')
 </native:column>

--- a/tests/Fixtures/views/legacy-errors.blade.php
+++ b/tests/Fixtures/views/legacy-errors.blade.php
@@ -1,0 +1,3 @@
+<native:column>
+    @nativeError('title')
+</native:column>

--- a/tests/Fixtures/views/validation-child.blade.php
+++ b/tests/Fixtures/views/validation-child.blade.php
@@ -1,5 +1,9 @@
 <native:column>
     <native:text-input native:model="nickname" ref="nickname-input" />
     <native:pressable @tap="saveChild" ref="child-save-btn"><native:text>Save child</native:text></native:pressable>
+    <native:pressable @tap="pingParent" ref="ping-btn"><native:text>Ping parent</native:text></native:pressable>
     @error('nickname')<native:text>CHILD-ERR {{ $message }}</native:text>@enderror
+    {{-- The PARENT's hostField errors must never reach this child's bag
+         when its emit() triggers a failing parent handler. --}}
+    @error('hostField')<native:text>CHILD-LEAK {{ $message }}</native:text>@enderror
 </native:column>

--- a/tests/Fixtures/views/validation-child.blade.php
+++ b/tests/Fixtures/views/validation-child.blade.php
@@ -1,0 +1,5 @@
+<native:column>
+    <native:text-input native:model="nickname" ref="nickname-input" />
+    <native:pressable @tap="saveChild" ref="child-save-btn"><native:text>Save child</native:text></native:pressable>
+    @error('nickname')<native:text>CHILD-ERR {{ $message }}</native:text>@enderror
+</native:column>

--- a/tests/Fixtures/views/validation-host.blade.php
+++ b/tests/Fixtures/views/validation-host.blade.php
@@ -1,7 +1,10 @@
 <native:column>
     <native:text>HOST</native:text>
-    <native:validation-child />
+    <native:validation-child @saved="parentSave" />
     {{-- The child's `nickname` errors belong to the CHILD's bag — this
          parent-side probe must never render. --}}
     @error('nickname')<native:text>HOST-LEAKED {{ $message }}</native:text>@enderror
+    {{-- The parent's own validation failure (triggered via the child's
+         emit) records HERE. --}}
+    @error('hostField')<native:text>HOST-ERR {{ $message }}</native:text>@enderror
 </native:column>

--- a/tests/Fixtures/views/validation-host.blade.php
+++ b/tests/Fixtures/views/validation-host.blade.php
@@ -1,0 +1,7 @@
+<native:column>
+    <native:text>HOST</native:text>
+    <native:validation-child />
+    {{-- The child's `nickname` errors belong to the CHILD's bag — this
+         parent-side probe must never render. --}}
+    @error('nickname')<native:text>HOST-LEAKED {{ $message }}</native:text>@enderror
+</native:column>

--- a/tests/Fixtures/views/validation-screen.blade.php
+++ b/tests/Fixtures/views/validation-screen.blade.php
@@ -12,3 +12,4 @@
 
     @nativeError('bio', '#AB12CD')
 </native:column>
+@error('tags.0')<native:text>TAG0-ERR {{ $message }}</native:text>@enderror

--- a/tests/Fixtures/views/validation-screen.blade.php
+++ b/tests/Fixtures/views/validation-screen.blade.php
@@ -1,0 +1,14 @@
+<native:column>
+    <native:text-input native:model="title" ref="title-input" />
+    <native:text-input native:model="bio" ref="bio-input" />
+
+    <native:pressable @tap="save" ref="save-btn"><native:text>Save</native:text></native:pressable>
+
+    <native:text>{{ $saved ? 'SAVED' : 'UNSAVED' }}</native:text>
+
+    @error('title')<native:text>TITLE-ERR {{ $message }}</native:text>@enderror
+    @error('bio')<native:text>BIO-ERR {{ $message }}</native:text>@enderror
+    @error('tags.1')<native:text>TAG-ERR {{ $message }}</native:text>@enderror
+
+    @nativeError('bio', '#AB12CD')
+</native:column>

--- a/tests/Fixtures/views/validation-screen.blade.php
+++ b/tests/Fixtures/views/validation-screen.blade.php
@@ -13,4 +13,4 @@
     @nativeError('bio', '#AB12CD')
 </native:column>
 @error('tags.0')<native:text>TAG0-ERR {{ $message }}</native:text>@enderror
-@error('handle')<native:text>HANDLE-ERR {{ $message }}</native:text>@enderror
+@foreach($errors->get('handle') as $handleMessage)<native:text>HANDLE-ERR {{ $handleMessage }}</native:text>@endforeach

--- a/tests/Fixtures/views/validation-screen.blade.php
+++ b/tests/Fixtures/views/validation-screen.blade.php
@@ -13,3 +13,4 @@
     @nativeError('bio', '#AB12CD')
 </native:column>
 @error('tags.0')<native:text>TAG0-ERR {{ $message }}</native:text>@enderror
+@error('handle')<native:text>HANDLE-ERR {{ $message }}</native:text>@enderror


### PR DESCRIPTION
## Summary

Adds first-class validation to `NativeComponent`, identical on device and web:

- `#[Validate('required|email')]` on public props + `$this->validate()` / `validateOnly()` in handlers. Rule sources merge: attributes → `rules()` method → inline argument. `validate(SomeFormRequest::class)` harvests a FormRequest's rules/messages/attributes (harvesting only — `authorize()` is never called).
- Failure throws Laravel's own `ValidationException`; `dispatch()` and `dispatchNativeEvent()` route through a `runGuarded()` wrapper that records errors on the component's bag and aborts the handler. Both device run loops and the web target enter through these two methods, so semantics are identical by construction.
- `$errors` (a `ViewErrorBag`) is injected into every view-data merge — `@error('field')` Blade muscle memory just works. The pre-existing `@nativeError` directive accepts the bag too (it previously required a hand-rolled array and silently rendered nothing otherwise).
- Attribute rules are **eager**: `__syncProperty()` runs `validateOnly()` after the `updated` hook, so `native:model`'s live/blur/debounce modifiers become the real-time validation cadence for free. `rules()`-method rules stay on-demand.
- **Error display is explicit-only (Livewire semantics)**: a failed validation records errors and exposes `$errors`, but nothing renders until the author writes `@error`/`@nativeError` or sets `error`/`supporting` attributes on an element. No automatic injection — devs own error presentation entirely. (`compileNativeModel()` emits a `model-prop` metadata attribute, stripped in the collector; it drives nothing.)

## Verification

15-case Pest suite driving the real dispatch cycle via `Native::test()`: handler abort with state kept, success path, inline-rule scoping, FormRequest harvesting with custom messages, author-thrown `withMessages`, eager sync validation (fires/clears/on-demand tier stays quiet), wildcard `validateOnly`, `@error` + `@nativeError` display, child-component bag scoping, and explicit-only display (failed validation leaves bound elements' props untouched). Also exercised end-to-end through the mobile-web target against a demo app.

`TestableComponent::guard()` routes `set()`/`call()` through `runGuarded` so harness interactions get the same validation-abort semantics as real dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)