### PR TITLE
Durable fluent native callbacks: $this closures cross the process boundary + onSuccess()

### DIFF
--- a/src/Attributes/On.php
+++ b/src/Attributes/On.php
@@ -3,6 +3,7 @@
 namespace Native\Mobile\Attributes;
 
 use Attribute;
+use Illuminate\Support\Str;
 
 /**
  * Marks a NativeComponent method as a listener for a native event.
@@ -33,9 +34,8 @@ class On
     {
         // Idempotent prefixing: the bridge docs' older examples spell the
         // prefix out (#[On('native:Foo')]), and double-prefixing silently
-        // registers a listener no event name can ever match.
-        $this->event = str_starts_with($event, 'native:')
-            ? $event
-            : 'native:'.$event;
+        // registers a listener no event name can ever match. Str::start
+        // also collapses an already-doubled prefix.
+        $this->event = Str::start($event, 'native:');
     }
 }

--- a/src/Attributes/On.php
+++ b/src/Attributes/On.php
@@ -31,6 +31,11 @@ class On
 
     public function __construct(string $event)
     {
-        $this->event = 'native:'.$event;
+        // Idempotent prefixing: the bridge docs' older examples spell the
+        // prefix out (#[On('native:Foo')]), and double-prefixing silently
+        // registers a listener no event name can ever match.
+        $this->event = str_starts_with($event, 'native:')
+            ? $event
+            : 'native:'.$event;
     }
 }

--- a/src/Concerns/HandlesNativeCallbacks.php
+++ b/src/Concerns/HandlesNativeCallbacks.php
@@ -46,12 +46,28 @@ trait HandlesNativeCallbacks
     /**
      * Register a callback for the operation's SUCCESS event without naming
      * it — `->onSuccess(fn ($event) => …)` reads the same on every builder
-     * (photoTaken, mediaSelected, videoRecorded, …). Honors a custom
-     * ->event(Custom::class) override, since that replaces $eventClass.
+     * (photoTaken, mediaSelected, videoRecorded, …). A ->event(Custom::class)
+     * override is honored in EITHER order: event() re-keys registrations
+     * made under the previous success event (see retargetPendingCallbacks).
      */
     public function onSuccess(Closure|array|string $callback): static
     {
         return $this->on($this->eventClass, $callback);
+    }
+
+    /**
+     * Re-key callbacks registered under a previous success event class.
+     * Every builder's event() calls this before assigning the override,
+     * so ->onSuccess(...)->event(Custom::class) doesn't leave the
+     * callback stranded under the default event, silently never firing.
+     */
+    protected function retargetPendingCallbacks(?string $from, string $to): void
+    {
+        if ($from === null || $from === $to) {
+            return;
+        }
+
+        NativeCallbacks::retarget($this->getId(), $from, $to);
     }
 
     /**

--- a/src/Concerns/HandlesNativeCallbacks.php
+++ b/src/Concerns/HandlesNativeCallbacks.php
@@ -35,6 +35,10 @@ trait HandlesNativeCallbacks
     /**
      * Register a callback for a specific event class. Public escape hatch for
      * custom events; also the primitive every named method funnels through.
+     *
+     * Ordering: call ->id() BEFORE registering callbacks — registration
+     * keys on the id at call time, and only ->event() re-keys existing
+     * registrations (a later ->id() does not).
      */
     public function on(string $eventClass, Closure|array|string $callback): static
     {

--- a/src/Concerns/HandlesNativeCallbacks.php
+++ b/src/Concerns/HandlesNativeCallbacks.php
@@ -44,6 +44,17 @@ trait HandlesNativeCallbacks
     }
 
     /**
+     * Register a callback for the operation's SUCCESS event without naming
+     * it — `->onSuccess(fn ($event) => …)` reads the same on every builder
+     * (photoTaken, mediaSelected, videoRecorded, …). Honors a custom
+     * ->event(Custom::class) override, since that replaces $eventClass.
+     */
+    public function onSuccess(Closure|array|string $callback): static
+    {
+        return $this->on($this->eventClass, $callback);
+    }
+
+    /**
      * Event classes that get a named handler method. Defaults to the success
      * event plus any failure events; override to expose more.
      *

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -1922,8 +1922,24 @@ abstract class NativeComponent
             return;
         }
 
-        if (is_string($callback) && class_exists($callback)) {
-            $callback = app($callback);
+        if (is_string($callback)) {
+            if (class_exists($callback)) {
+                $callback = app($callback);
+            } elseif (method_exists($this, $callback)) {
+                // Method-name form — `->mediaSelected('onMediaSelected')`.
+                // Serializes into the durable tier trivially, so it's the
+                // fluent shape that survives both a process kill on device
+                // AND the stateless web target, where every request is a
+                // fresh process and closures registered last request are
+                // gone unless the durable tier carried them.
+                $method = $callback;
+                $callback = fn ($event) => $this->{$method}($event);
+            } else {
+                NativeRouter::debugLog("Native callback '{$callback}' is neither a class nor a method on ".static::class);
+                NativeCallbacks::forget($id, $eventClass);
+
+                return;
+            }
         }
 
         // Bind the closure to this live component so then()/catch() can use

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -1911,11 +1911,13 @@ abstract class NativeComponent
         // Exact correlation by id (camera). If that misses — either no id came
         // back (some native paths drop it across a lifecycle bounce, e.g. the
         // gallery picker) or it didn't match — fall back to the single in-flight
-        // callback for this event class.
-        $callback = ($id !== null) ? NativeCallbacks::resolve($id, $eventClass) : null;
+        // callback for this event class. `for: $this` lets the registry skip a
+        // durable entry that belongs to a DIFFERENT screen class (post-kill
+        // cold start lands on '/', not the screen that registered).
+        $callback = ($id !== null) ? NativeCallbacks::resolve($id, $eventClass, for: $this) : null;
 
         if ($callback === null) {
-            [$id, $callback] = NativeCallbacks::resolveByEvent($eventClass) ?? [null, null];
+            [$id, $callback] = NativeCallbacks::resolveByEvent($eventClass, for: $this) ?? [null, null];
         }
 
         if ($callback === null) {
@@ -1923,19 +1925,21 @@ abstract class NativeComponent
         }
 
         if (is_string($callback)) {
-            if (class_exists($callback)) {
-                $callback = app($callback);
-            } elseif (method_exists($this, $callback)) {
+            // Own method FIRST: class_exists() is case-insensitive and
+            // autoloading, so a handler named `error`, `log`, `view`, …
+            // would otherwise be hijacked into app() resolution of a PHP
+            // built-in or a facade alias. The component's own method is
+            // the more specific match.
+            if (method_exists($this, $callback)) {
                 // Method-name form — `->mediaSelected('onMediaSelected')`.
                 // Serializes into the durable tier trivially, so it's the
                 // fluent shape that survives both a process kill on device
-                // AND the stateless web target, where every request is a
-                // fresh process and closures registered last request are
-                // gone unless the durable tier carried them.
-                $method = $callback;
-                $callback = fn ($event) => $this->{$method}($event);
+                // AND the stateless web target.
+                $callback = [$this, $callback];
+            } elseif (class_exists($callback)) {
+                $callback = app($callback);
             } else {
-                NativeRouter::debugLog("Native callback '{$callback}' is neither a class nor a method on ".static::class);
+                NativeRouter::debugLog("Native callback '{$callback}' is neither a method on ".static::class.' nor a class');
                 NativeCallbacks::forget($id, $eventClass);
 
                 return;
@@ -1943,10 +1947,16 @@ abstract class NativeComponent
         }
 
         // Bind the closure to this live component so then()/catch() can use
-        // $this (e.g. $this->images[] = ...). Static closures can't be bound, so
-        // they keep running without $this.
-        if ($callback instanceof \Closure && ! (new \ReflectionFunction($callback))->isStatic()) {
-            $callback = \Closure::bind($callback, $this, static::class);
+        // $this (e.g. $this->images[] = ...). Static closures can't be bound,
+        // and FAKE closures (first-class callables — $this->onPicked(...))
+        // must not be: bind() on those returns null. Both keep their own
+        // binding; ?? guards any other null from bind().
+        if ($callback instanceof \Closure) {
+            $reflection = new \ReflectionFunction($callback);
+
+            if (! $reflection->isStatic() && $reflection->isAnonymous()) {
+                $callback = \Closure::bind($callback, $this, static::class) ?? $callback;
+            }
         }
 
         try {

--- a/src/Http/Controllers/DispatchEventFromAppController.php
+++ b/src/Http/Controllers/DispatchEventFromAppController.php
@@ -4,6 +4,7 @@ namespace Native\Mobile\Http\Controllers;
 
 use Closure;
 use Illuminate\Http\Request;
+use Native\Mobile\Edge\NativeComponent;
 use Native\Mobile\Support\NativeCallbacks;
 use ReflectionFunction;
 
@@ -81,6 +82,12 @@ class DispatchEventFromAppController
         // a component method can share the name. The durable owner tag
         // settles it: recorded owner means component-owned, Edge-only.
         if (is_string($peek) && NativeCallbacks::ownerOf($id, $eventClass) !== null) {
+            return false;
+        }
+
+        // [$component, 'method'] arrays are component-owned like
+        // $this-closures — firing here would run against a dead instance.
+        if (is_array($peek) && ($peek[0] ?? null) instanceof NativeComponent) {
             return false;
         }
 

--- a/src/Http/Controllers/DispatchEventFromAppController.php
+++ b/src/Http/Controllers/DispatchEventFromAppController.php
@@ -66,11 +66,14 @@ class DispatchEventFromAppController
             return false;
         }
 
-        // Method-name strings (->mediaSelected('onPicked')) name a method on
-        // the OWNING COMPONENT — like $this-closures, only the Edge loop can
-        // fire them. Peek-and-bail BEFORE consuming, or the durable copy is
-        // destroyed here and the Edge loop finds nothing.
-        if (is_string($peek) && ! class_exists($peek)) {
+        // The ONLY string shape this controller can fire is an invokable
+        // class. Everything else — method-name strings like 'onPicked',
+        // but also method names that happen to shadow a loadable class
+        // ('error', 'log', any materialized facade alias) — names a method
+        // on the OWNING COMPONENT, which only the Edge loop can fire.
+        // Peek-and-bail BEFORE consuming, or the durable copy is destroyed
+        // here and the Edge loop finds nothing.
+        if (is_string($peek) && (! class_exists($peek) || ! method_exists($peek, '__invoke'))) {
             return false;
         }
 

--- a/src/Http/Controllers/DispatchEventFromAppController.php
+++ b/src/Http/Controllers/DispatchEventFromAppController.php
@@ -66,6 +66,14 @@ class DispatchEventFromAppController
             return false;
         }
 
+        // Method-name strings (->mediaSelected('onPicked')) name a method on
+        // the OWNING COMPONENT — like $this-closures, only the Edge loop can
+        // fire them. Peek-and-bail BEFORE consuming, or the durable copy is
+        // destroyed here and the Edge loop finds nothing.
+        if (is_string($peek) && ! class_exists($peek)) {
+            return false;
+        }
+
         $callback = NativeCallbacks::resolve($id, $eventClass);
 
         // Normalise an invokable class-string into a resolved instance so it can
@@ -75,10 +83,13 @@ class DispatchEventFromAppController
             $callback = app($callback);
         }
 
-        call_user_func($callback, $event);
-
-        // One outcome per capture — drop the success/cancel/denied siblings too.
-        NativeCallbacks::forget($id, $eventClass);
+        // One outcome per capture, even when the callback throws — drop the
+        // success/cancel/denied siblings too.
+        try {
+            call_user_func($callback, $event);
+        } finally {
+            NativeCallbacks::forget($id, $eventClass);
+        }
 
         return true;
     }

--- a/src/Http/Controllers/DispatchEventFromAppController.php
+++ b/src/Http/Controllers/DispatchEventFromAppController.php
@@ -77,6 +77,13 @@ class DispatchEventFromAppController
             return false;
         }
 
+        // A string that DOES name an invokable class is still ambiguous —
+        // a component method can share the name. The durable owner tag
+        // settles it: recorded owner means component-owned, Edge-only.
+        if (is_string($peek) && NativeCallbacks::ownerOf($id, $eventClass) !== null) {
+            return false;
+        }
+
         $callback = NativeCallbacks::resolve($id, $eventClass);
 
         // Normalise an invokable class-string into a resolved instance so it can

--- a/src/PendingAlert.php
+++ b/src/PendingAlert.php
@@ -93,6 +93,8 @@ class PendingAlert
             throw new InvalidArgumentException("Event class {$eventClass} does not exist");
         }
 
+        $this->retargetPendingCallbacks($this->eventClass, $eventClass);
+
         $this->eventClass = $eventClass;
 
         return $this;

--- a/src/PendingBiometric.php
+++ b/src/PendingBiometric.php
@@ -56,6 +56,8 @@ class PendingBiometric
             throw new InvalidArgumentException("Event class {$eventClass} does not exist");
         }
 
+        $this->retargetPendingCallbacks($this->eventClass, $eventClass);
+
         $this->eventClass = $eventClass;
 
         return $this;

--- a/src/PendingGeolocation.php
+++ b/src/PendingGeolocation.php
@@ -76,6 +76,8 @@ class PendingGeolocation
             throw new InvalidArgumentException("Event class {$eventClass} does not exist");
         }
 
+        $this->retargetPendingCallbacks($this->eventClass, $eventClass);
+
         $this->eventClass = $eventClass;
 
         return $this;

--- a/src/PendingLocationWatch.php
+++ b/src/PendingLocationWatch.php
@@ -105,6 +105,8 @@ class PendingLocationWatch
             throw new InvalidArgumentException("Event class {$eventClass} does not exist");
         }
 
+        $this->retargetPendingCallbacks($this->eventClass, $eventClass);
+
         $this->eventClass = $eventClass;
 
         return $this;

--- a/src/PendingLocationWatch.php
+++ b/src/PendingLocationWatch.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use LogicException;
 use Native\Mobile\Edge\NativeComponent;
 use Native\Mobile\Events\Geolocation\LocationUpdated;
+use Native\Mobile\Support\CallStack;
 use ReflectionFunction;
 
 /**
@@ -105,8 +106,9 @@ class PendingLocationWatch
             throw new InvalidArgumentException("Event class {$eventClass} does not exist");
         }
 
-        $this->retargetPendingCallbacks($this->eventClass, $eventClass);
-
+        // No retargetPendingCallbacks() here, unlike the other builders:
+        // this class doesn't use HandlesNativeCallbacks — its handlers are
+        // persistent component listeners, not one-shot registry entries.
         $this->eventClass = $eventClass;
 
         return $this;
@@ -230,17 +232,7 @@ class PendingLocationWatch
      */
     private function detectComponent(): ?NativeComponent
     {
-        if (! class_exists(NativeComponent::class)) {
-            return null;
-        }
-
-        foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 20) as $frame) {
-            if (($frame['object'] ?? null) instanceof NativeComponent) {
-                return $frame['object'];
-            }
-        }
-
-        return null;
+        return CallStack::component(20);
     }
 
     /**

--- a/src/PendingMediaPicker.php
+++ b/src/PendingMediaPicker.php
@@ -65,6 +65,8 @@ class PendingMediaPicker
             throw new InvalidArgumentException("Event class {$eventClass} does not exist");
         }
 
+        $this->retargetPendingCallbacks($this->eventClass, $eventClass);
+
         $this->eventClass = $eventClass;
 
         return $this;

--- a/src/PendingMicrophone.php
+++ b/src/PendingMicrophone.php
@@ -68,6 +68,8 @@ class PendingMicrophone
             throw new InvalidArgumentException("Event class {$eventClass} does not exist");
         }
 
+        $this->retargetPendingCallbacks($this->eventClass, $eventClass);
+
         $this->eventClass = $eventClass;
 
         return $this;

--- a/src/PendingPhotoCapture.php
+++ b/src/PendingPhotoCapture.php
@@ -63,6 +63,8 @@ class PendingPhotoCapture
             throw new InvalidArgumentException("Event class {$eventClass} does not exist");
         }
 
+        $this->retargetPendingCallbacks($this->eventClass, $eventClass);
+
         $this->eventClass = $eventClass;
 
         return $this;

--- a/src/PendingPushNotificationEnrollment.php
+++ b/src/PendingPushNotificationEnrollment.php
@@ -58,6 +58,8 @@ class PendingPushNotificationEnrollment
             throw new InvalidArgumentException("Event class {$eventClass} does not exist");
         }
 
+        $this->retargetPendingCallbacks($this->eventClass, $eventClass);
+
         $this->eventClass = $eventClass;
 
         return $this;

--- a/src/PendingVideoRecorder.php
+++ b/src/PendingVideoRecorder.php
@@ -73,6 +73,8 @@ class PendingVideoRecorder
             throw new InvalidArgumentException("Event class {$eventClass} does not exist");
         }
 
+        $this->retargetPendingCallbacks($this->eventClass, $eventClass);
+
         $this->eventClass = $eventClass;
 
         return $this;

--- a/src/Support/CallStack.php
+++ b/src/Support/CallStack.php
@@ -17,7 +17,9 @@ class CallStack
             return null;
         }
 
-        foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, $limit) as $frame) {
+        // +1: this helper adds a frame of its own — callers' limits mean
+        // "frames of YOUR stack", not "minus one for the messenger".
+        foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, $limit + 1) as $frame) {
             if (($frame['object'] ?? null) instanceof NativeComponent) {
                 return $frame['object'];
             }

--- a/src/Support/CallStack.php
+++ b/src/Support/CallStack.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Native\Mobile\Support;
+
+use Native\Mobile\Edge\NativeComponent;
+
+/**
+ * The one shared walk-the-backtrace-for-a-component loop. Used wherever
+ * an API needs to know which component invoked it without receiving a
+ * reference (fluent builders, callback registration).
+ */
+class CallStack
+{
+    public static function component(int $limit = 25): ?NativeComponent
+    {
+        if (! class_exists(NativeComponent::class)) {
+            return null;
+        }
+
+        foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, $limit) as $frame) {
+            if (($frame['object'] ?? null) instanceof NativeComponent) {
+                return $frame['object'];
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Support/NativeCallbacks.php
+++ b/src/Support/NativeCallbacks.php
@@ -90,7 +90,13 @@ class NativeCallbacks
             // the registering call stack.
             $ownerClass = null;
 
-            if (is_string($callback) && ! class_exists($callback)) {
+            if (is_string($callback)) {
+                // ALL strings, including ones that shadow (or genuinely
+                // name) loadable classes: 'error' must carry its owner so
+                // a post-kill wrong-screen resolve skips it, and a real
+                // invokable registered inside a component is still fired
+                // by the Edge loop — the owner tag just routes it away
+                // from the WebView controller.
                 $ownerClass = static::callingComponentClass();
             } elseif (is_array($callback) && ($callback[0] ?? null) instanceof NativeComponent) {
                 $ownerClass = get_class($callback[0]);
@@ -126,7 +132,13 @@ class NativeCallbacks
                     $line = $reflection->getFileName().':'.$reflection->getStartLine();
                     $existing = static::$closureLines[$line] ?? null;
 
-                    if ($existing !== null && $existing !== [$id, $eventClass] && static::has(...$existing)) {
+                    // Pendingness is judged by the DURABLE tier only: the
+                    // conflation hazard is about durable code extraction,
+                    // and memory entries never expire — an abandoned
+                    // capture (picker dismissed by the OS, no result)
+                    // would otherwise re-latch the permanent kill. The
+                    // cache's 5-minute TTL bounds the block.
+                    if ($existing !== null && $existing !== [$id, $eventClass] && Cache::has(static::key(...$existing))) {
                         [$otherId, $otherEvent] = $existing;
                         Cache::forget(static::key($otherId, $otherEvent));
                         NativeRouter::debugLog("NativeCallbacks: two pending closures share {$line} — durable copies dropped for both (split the chain across lines to restore durability)");
@@ -256,6 +268,27 @@ class NativeCallbacks
     }
 
     /**
+     * The owner component class recorded on a durable entry, without
+     * consuming it — the WebView controller's signal that a string
+     * callback is component-owned (Edge-loop-only) even when its name
+     * collides with an invokable class.
+     */
+    public static function ownerOf(string $id, string $eventClass): ?string
+    {
+        $serialized = Cache::get(static::key($id, $eventClass));
+
+        if ($serialized === null) {
+            return null;
+        }
+
+        $restored = unserialize($serialized);
+
+        return is_array($restored) && array_key_exists('c', $restored)
+            ? ($restored['o'] ?? null)
+            : null;
+    }
+
+    /**
      * Re-key a pending registration to a different event class — the
      * ->event(Custom::class) override arriving AFTER onSuccess() already
      * registered under the builder's default event.
@@ -366,27 +399,45 @@ class NativeCallbacks
     }
 
     /**
-     * Whether a closure's captured use-variables contain a raw resource
+     * Whether a closure's captured use-variables contain a resource
      * (serialize() silently corrupts those into ints — no exception, just
-     * a TypeError detonating after the process kill). Scans arrays AND
+     * a TypeError detonating after the process kill). Scans arrays,
      * object properties ((array)-cast exposes private/protected too),
-     * with a depth limit and a cycle guard.
+     * nested closures' own captures, and closed resources (which evade
+     * is_resource() but serialize just as corruptly).
+     *
+     * FAILS CLOSED at the depth cap: a walk too deep to finish reports
+     * "may contain a resource", costing durability instead of risking a
+     * poisoned copy — which also makes the cycle guard order-safe (a
+     * truncated visit bubbles true rather than memoizing an unscanned
+     * subtree).
      */
     protected static function capturesResources(\ReflectionFunction $reflection): bool
     {
         $seen = new \SplObjectStorage;
 
         $scan = function ($value, int $depth) use (&$scan, $seen): bool {
-            if (is_resource($value)) {
+            if (is_resource($value) || gettype($value) === 'resource (closed)') {
                 return true;
             }
 
-            if ($depth >= 4) {
+            if (! is_array($value) && ! is_object($value)) {
                 return false;
             }
 
-            if (is_object($value)) {
-                if ($seen->contains($value) || $value instanceof Closure) {
+            if ($depth >= 5) {
+                return true; // fail closed — see docblock
+            }
+
+            if ($value instanceof Closure) {
+                if ($seen->contains($value)) {
+                    return false;
+                }
+                $seen->attach($value);
+
+                $value = (new \ReflectionFunction($value))->getStaticVariables();
+            } elseif (is_object($value)) {
+                if ($seen->contains($value)) {
                     return false;
                 }
                 $seen->attach($value);
@@ -394,11 +445,9 @@ class NativeCallbacks
                 $value = (array) $value;
             }
 
-            if (is_array($value)) {
-                foreach ($value as $item) {
-                    if ($scan($item, $depth + 1)) {
-                        return true;
-                    }
+            foreach ($value as $item) {
+                if ($scan($item, $depth + 1)) {
+                    return true;
                 }
             }
 
@@ -421,12 +470,8 @@ class NativeCallbacks
      */
     protected static function callingComponentClass(): ?string
     {
-        foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 25) as $frame) {
-            if (($frame['object'] ?? null) instanceof NativeComponent) {
-                return get_class($frame['object']);
-            }
-        }
+        $component = CallStack::component();
 
-        return null;
+        return $component === null ? null : get_class($component);
     }
 }

--- a/src/Support/NativeCallbacks.php
+++ b/src/Support/NativeCallbacks.php
@@ -58,12 +58,17 @@ class NativeCallbacks
     protected static array $memory = [];
 
     /**
-     * file:line => [id, eventClass] for durably-stored closures, used to
-     * detect same-line registrations (see class docblock). Per-process,
-     * which is sufficient: the colliding registrations of a one-line
-     * chain always happen in one request.
+     * file:line => [id, eventClass, registeredAt] for closures that went
+     * through the same-line check, used to detect same-line registrations
+     * (see class docblock). Per-process, which is sufficient: the
+     * colliding registrations of a one-line chain always happen in one
+     * request. The timestamp bounds detection: an entry is a conflation
+     * suspect while its durable copy exists OR while it is younger than
+     * the TTL — so a line-mate whose durable copy is ABSENT (size-capped,
+     * or forgotten by an earlier collision) is still detected, while an
+     * abandoned capture stops blocking the line once the TTL passes.
      *
-     * @var array<string, array{0: string, 1: string}>
+     * @var array<string, array{0: string, 1: string, 2: int}>
      */
     protected static array $closureLines = [];
 
@@ -112,9 +117,11 @@ class NativeCallbacks
 
                 // Captured resources don't make serialize() throw — they
                 // silently become ints, poisoning the durable copy with a
-                // TypeError that only detonates after a process kill.
-                if (static::capturesResources($reflection)) {
-                    NativeRouter::debugLog("NativeCallbacks: '{$eventClass}' closure captures a resource — durable copy skipped");
+                // TypeError that only detonates after a process kill. A
+                // capture graph too big to verify also skips durability
+                // (fail closed), with an honest log for each case.
+                if (($blocker = static::durabilityBlocker($reflection)) !== null) {
+                    NativeRouter::debugLog("NativeCallbacks: '{$eventClass}' {$blocker} — durable copy skipped");
 
                     return;
                 }
@@ -132,21 +139,25 @@ class NativeCallbacks
                     $line = $reflection->getFileName().':'.$reflection->getStartLine();
                     $existing = static::$closureLines[$line] ?? null;
 
-                    // Pendingness is judged by the DURABLE tier only: the
-                    // conflation hazard is about durable code extraction,
-                    // and memory entries never expire — an abandoned
-                    // capture (picker dismissed by the OS, no result)
-                    // would otherwise re-latch the permanent kill. The
-                    // cache's 5-minute TTL bounds the block.
-                    if ($existing !== null && $existing !== [$id, $eventClass] && Cache::has(static::key(...$existing))) {
-                        [$otherId, $otherEvent] = $existing;
-                        Cache::forget(static::key($otherId, $otherEvent));
-                        NativeRouter::debugLog("NativeCallbacks: two pending closures share {$line} — durable copies dropped for both (split the chain across lines to restore durability)");
+                    // A line-mate is a conflation suspect while its durable
+                    // copy exists OR while its registration is younger than
+                    // the TTL — the timestamp half catches mates whose
+                    // durable copy is absent (size-capped, or forgotten by
+                    // an earlier collision on the same line). Completed
+                    // captures are pruned by forget(); abandoned ones age
+                    // out with the TTL instead of blocking forever.
+                    if ($existing !== null && [$existing[0], $existing[1]] !== [$id, $eventClass]) {
+                        [$otherId, $otherEvent, $registeredAt] = $existing;
 
-                        return;
+                        if (Cache::has(static::key($otherId, $otherEvent)) || (now()->getTimestamp() - $registeredAt) < static::$ttlMinutes * 60) {
+                            Cache::forget(static::key($otherId, $otherEvent));
+                            NativeRouter::debugLog("NativeCallbacks: two pending closures share {$line} — durable copies dropped for both (split the chain across lines to restore durability)");
+
+                            return;
+                        }
                     }
 
-                    static::$closureLines[$line] = [$id, $eventClass];
+                    static::$closureLines[$line] = [$id, $eventClass, now()->getTimestamp()];
 
                     if ($boundThis !== null) {
                         // The binding never needs to survive — fire-time
@@ -211,13 +222,7 @@ class NativeCallbacks
             return null;
         }
 
-        $restored = unserialize($serialized);
-
-        $ownerClass = null;
-        if (is_array($restored) && array_key_exists('c', $restored)) {
-            $ownerClass = $restored['o'] ?? null;
-            $restored = $restored['c'];
-        }
+        [$ownerClass, $restored] = static::readEntry($serialized);
 
         if ($ownerClass !== null && $for !== null && ! $for instanceof $ownerClass) {
             NativeRouter::debugLog("NativeCallbacks: durable callback for '{$eventClass}' belongs to {$ownerClass}, live screen is ".get_class($for).' — skipped');
@@ -229,6 +234,23 @@ class NativeCallbacks
         return $restored instanceof SerializableClosure
             ? $restored->getClosure()
             : $restored;
+    }
+
+    /**
+     * THE decoder for durable entries — resolve() and ownerOf() both go
+     * through it, so the envelope shape can't drift between them.
+     *
+     * @return array{0: ?string, 1: mixed} [ownerClass, callback]
+     */
+    protected static function readEntry(string $serialized): array
+    {
+        $restored = unserialize($serialized);
+
+        if (is_array($restored) && array_key_exists('c', $restored)) {
+            return [$restored['o'] ?? null, $restored['c']];
+        }
+
+        return [null, $restored];
     }
 
     /**
@@ -277,15 +299,7 @@ class NativeCallbacks
     {
         $serialized = Cache::get(static::key($id, $eventClass));
 
-        if ($serialized === null) {
-            return null;
-        }
-
-        $restored = unserialize($serialized);
-
-        return is_array($restored) && array_key_exists('c', $restored)
-            ? ($restored['o'] ?? null)
-            : null;
+        return $serialized === null ? null : static::readEntry($serialized)[0];
     }
 
     /**
@@ -315,8 +329,8 @@ class NativeCallbacks
         // collision handler would forget a dead key and leave the real
         // conflation-suspect durable copy intact.
         foreach (static::$closureLines as $line => $entry) {
-            if ($entry === [$id, $fromEvent]) {
-                static::$closureLines[$line] = [$id, $toEvent];
+            if ([$entry[0], $entry[1]] === [$id, $fromEvent]) {
+                static::$closureLines[$line] = [$id, $toEvent, $entry[2]];
             }
         }
     }
@@ -399,24 +413,26 @@ class NativeCallbacks
     }
 
     /**
-     * Whether a closure's captured use-variables contain a resource
-     * (serialize() silently corrupts those into ints — no exception, just
-     * a TypeError detonating after the process kill). Scans arrays,
-     * object properties ((array)-cast exposes private/protected too),
-     * nested closures' own captures, and closed resources (which evade
-     * is_resource() but serialize just as corruptly).
+     * Why a closure's captures can't be trusted in the durable tier, or
+     * null when they can. Resources — open OR closed — serialize silently
+     * into ints (no exception, just a TypeError detonating after the
+     * process kill), so the scan walks arrays, object properties
+     * ((array)-cast exposes private/protected too), and nested closures'
+     * own captures.
      *
-     * FAILS CLOSED at the depth cap: a walk too deep to finish reports
-     * "may contain a resource", costing durability instead of risking a
-     * poisoned copy — which also makes the cycle guard order-safe (a
-     * truncated visit bubbles true rather than memoizing an unscanned
-     * subtree).
+     * FAILS CLOSED when the walk is truncated (depth cap, or the visited-
+     * node budget for wide graphs like loaded Eloquent relations): an
+     * unverifiable graph costs durability instead of risking a poisoned
+     * copy — which also makes the cycle guard order-safe. Each outcome
+     * gets its own honest reason string for the log.
      */
-    protected static function capturesResources(\ReflectionFunction $reflection): bool
+    protected static function durabilityBlocker(\ReflectionFunction $reflection): ?string
     {
         $seen = new \SplObjectStorage;
+        $budget = 500;
+        $truncated = false;
 
-        $scan = function ($value, int $depth) use (&$scan, $seen): bool {
+        $scan = function ($value, int $depth) use (&$scan, &$budget, &$truncated, $seen): bool {
             if (is_resource($value) || gettype($value) === 'resource (closed)') {
                 return true;
             }
@@ -425,8 +441,10 @@ class NativeCallbacks
                 return false;
             }
 
-            if ($depth >= 5) {
-                return true; // fail closed — see docblock
+            if ($depth >= 8 || --$budget <= 0) {
+                $truncated = true;
+
+                return false; // the caller fails closed on $truncated
             }
 
             if ($value instanceof Closure) {
@@ -456,11 +474,13 @@ class NativeCallbacks
 
         foreach ($reflection->getStaticVariables() as $value) {
             if ($scan($value, 0)) {
-                return true;
+                return 'closure captures a resource';
             }
         }
 
-        return false;
+        return $truncated
+            ? 'capture graph too deep/large to verify for resources'
+            : null;
     }
 
     /**

--- a/src/Support/NativeCallbacks.php
+++ b/src/Support/NativeCallbacks.php
@@ -49,13 +49,19 @@ class NativeCallbacks
             $serializable = $callback;
 
             if ($serializable instanceof Closure) {
-                // A closure bound to an instance (e.g. one defined in a component
-                // method that uses $this) can't be serialized: PHP won't let us
-                // unbind $this, and the bound object isn't serializable. Such
-                // callbacks are in-memory only — skip the durable copy quietly.
-                // Use `static fn` for a callback that must survive an app kill.
+                // A closure bound to a component instance (one that uses
+                // $this) can't serialize as-is: the component isn't
+                // serializable. But the binding doesn't need to survive —
+                // fireNativeCallback rebinds every non-static closure to
+                // the LIVE component (full class scope, so private access
+                // is restored) at fire time. Only the code + captured
+                // `use` vars must cross the boundary, so rebind to a
+                // throwaway serializable carrier first. This is what lets
+                // `->onSuccess(function ($e) { $this->… })` fire on the
+                // stateless web target (fresh process per request) and
+                // survive an OS kill on device.
                 if ((new \ReflectionFunction($serializable))->getClosureThis() !== null) {
-                    return;
+                    $serializable = Closure::bind($serializable, new \stdClass);
                 }
 
                 $serializable = new SerializableClosure($serializable);

--- a/src/Support/NativeCallbacks.php
+++ b/src/Support/NativeCallbacks.php
@@ -81,7 +81,20 @@ class NativeCallbacks
         // Tier 2: best-effort durable copy so the callback survives a process kill.
         try {
             $serializable = $callback;
+
+            // Owner class rides the durable entry so a post-kill cold
+            // start on a DIFFERENT screen skips it (resolve(for:)). For
+            // closures it comes from the binding; for method-name strings
+            // and [$component, 'method'] arrays — which would otherwise
+            // fire a same-named method on whatever screen is live — from
+            // the registering call stack.
             $ownerClass = null;
+
+            if (is_string($callback) && ! class_exists($callback)) {
+                $ownerClass = static::callingComponentClass();
+            } elseif (is_array($callback) && ($callback[0] ?? null) instanceof NativeComponent) {
+                $ownerClass = get_class($callback[0]);
+            }
 
             if ($serializable instanceof Closure) {
                 $reflection = new \ReflectionFunction($serializable);
@@ -104,13 +117,19 @@ class NativeCallbacks
                     // serializable-closure extracts code by START LINE, so
                     // two anonymous closures registered from one line get
                     // the SAME body durably — running the success body on
-                    // cancel after a kill. Drop durability for both.
+                    // cancel after a kill. Drop durability for both — but
+                    // ONLY while the other registration is still pending:
+                    // builders default to fresh UUID ids, so a completed
+                    // capture's mapping is stale, not a conflation, and
+                    // treating it as one would permanently kill durability
+                    // for that code line after its first use.
                     $line = $reflection->getFileName().':'.$reflection->getStartLine();
+                    $existing = static::$closureLines[$line] ?? null;
 
-                    if (isset(static::$closureLines[$line]) && static::$closureLines[$line] !== [$id, $eventClass]) {
-                        [$otherId, $otherEvent] = static::$closureLines[$line];
+                    if ($existing !== null && $existing !== [$id, $eventClass] && static::has(...$existing)) {
+                        [$otherId, $otherEvent] = $existing;
                         Cache::forget(static::key($otherId, $otherEvent));
-                        NativeRouter::debugLog("NativeCallbacks: two closures share {$line} — durable copies dropped for both (split the chain across lines to restore durability)");
+                        NativeRouter::debugLog("NativeCallbacks: two pending closures share {$line} — durable copies dropped for both (split the chain across lines to restore durability)");
 
                         return;
                     }
@@ -258,6 +277,15 @@ class NativeCallbacks
             Cache::put(static::key($id, $toEvent), $durable, now()->addMinutes(static::$ttlMinutes));
             Cache::put(static::latestKey($toEvent), $id, now()->addMinutes(static::$ttlMinutes));
         }
+
+        // Keep the same-line bookkeeping pointing at the LIVE key, or the
+        // collision handler would forget a dead key and leave the real
+        // conflation-suspect durable copy intact.
+        foreach (static::$closureLines as $line => $entry) {
+            if ($entry === [$id, $fromEvent]) {
+                static::$closureLines[$line] = [$id, $toEvent];
+            }
+        }
     }
 
     /**
@@ -277,6 +305,14 @@ class NativeCallbacks
         }
 
         unset(static::$memory[$id]);
+
+        // Prune same-line bookkeeping: a completed capture's mapping must
+        // not poison durability for the next capture from that line.
+        foreach (static::$closureLines as $line => $entry) {
+            if ($entry[0] === $id) {
+                unset(static::$closureLines[$line]);
+            }
+        }
     }
 
     public static function has(string $id, string $eventClass): bool
@@ -329,15 +365,36 @@ class NativeCallbacks
         }
     }
 
-    /** Whether a closure's captured use-variables contain a raw resource. */
+    /**
+     * Whether a closure's captured use-variables contain a raw resource
+     * (serialize() silently corrupts those into ints — no exception, just
+     * a TypeError detonating after the process kill). Scans arrays AND
+     * object properties ((array)-cast exposes private/protected too),
+     * with a depth limit and a cycle guard.
+     */
     protected static function capturesResources(\ReflectionFunction $reflection): bool
     {
-        $scan = function ($value, int $depth) use (&$scan): bool {
+        $seen = new \SplObjectStorage;
+
+        $scan = function ($value, int $depth) use (&$scan, $seen): bool {
             if (is_resource($value)) {
                 return true;
             }
 
-            if (is_array($value) && $depth < 3) {
+            if ($depth >= 4) {
+                return false;
+            }
+
+            if (is_object($value)) {
+                if ($seen->contains($value) || $value instanceof Closure) {
+                    return false;
+                }
+                $seen->attach($value);
+
+                $value = (array) $value;
+            }
+
+            if (is_array($value)) {
                 foreach ($value as $item) {
                     if ($scan($item, $depth + 1)) {
                         return true;
@@ -355,5 +412,21 @@ class NativeCallbacks
         }
 
         return false;
+    }
+
+    /**
+     * The component class on the registering call stack, if any — the
+     * owner signal for method-name and [$component, 'method'] callbacks,
+     * whose shapes carry no binding of their own.
+     */
+    protected static function callingComponentClass(): ?string
+    {
+        foreach (debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT | DEBUG_BACKTRACE_IGNORE_ARGS, 25) as $frame) {
+            if (($frame['object'] ?? null) instanceof NativeComponent) {
+                return get_class($frame['object']);
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Support/NativeCallbacks.php
+++ b/src/Support/NativeCallbacks.php
@@ -5,6 +5,8 @@ namespace Native\Mobile\Support;
 use Closure;
 use Illuminate\Support\Facades\Cache;
 use Laravel\SerializableClosure\SerializableClosure;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Edge\NativeRouter;
 use Throwable;
 
 /**
@@ -16,16 +18,35 @@ use Throwable;
  * Two storage tiers:
  *
  *   1. In-memory static — survives the request boundary for free because the
- *      persistent PHP interpreter keeps statics alive between requests. Closures
- *      can capture anything. Lost if the OS kills the app (e.g. Android while the
- *      camera Activity is foregrounded).
+ *      persistent PHP interpreter keeps statics alive between requests.
+ *      Closures can capture anything. Lost if the OS kills the app.
  *
- *   2. Serialized cache (SQLite-backed by default) — survives process death.
- *      Requires the closure to be serializable; if it isn't we fall back to
- *      tier 1 only and report the exception so the tradeoff is visible.
+ *   2. Serialized cache — survives process death. $this-bound closures are
+ *      rebound to a throwaway carrier before serializing (fire-time rebinds
+ *      to the live component anyway), so the dominant fluent shape survives
+ *      a kill too. Durable entries carry the registering component's class
+ *      so a cold-started app on a different screen skips them instead of
+ *      firing them against the wrong component.
  *
- * Callbacks are correlated by the `id` the Pending* builder already passes to
- * native and that comes back on the result event.
+ * Durability is best-effort with explicit bail-outs (each debug-logged, not
+ * report()-spammed): unserializable or resource-carrying captures, payloads
+ * over the size cap, and two closures registered from the same file:line —
+ * serializable-closure extracts code by start line, so one-line chains like
+ * `->photoTaken(fn () => a())->photoCancelled(fn () => b())` would serialize
+ * BOTH with the first closure's body; running a() on cancel after a process
+ * kill is strictly worse than losing durability.
+ *
+ * Cache keys are session-scoped off-device: the stateless web target shares
+ * one app-wide cache across users, and the documented fixed-id API
+ * (->id('avatar')) would otherwise collide across sessions — user B's
+ * registration overwriting user A's closure (with B's captured values) is
+ * both a correctness bug and a data-leak vector. On device there is one
+ * user; keys stay unscoped.
+ *
+ * Callbacks are correlated by the `id` the Pending* builder passes to
+ * native. Some native paths drop the id across a lifecycle bounce, so
+ * register() also maintains a per-event "latest id" index — the durable
+ * tier's stand-in for scanning the (empty, post-kill) memory tier.
  */
 class NativeCallbacks
 {
@@ -36,8 +57,21 @@ class NativeCallbacks
      */
     protected static array $memory = [];
 
+    /**
+     * file:line => [id, eventClass] for durably-stored closures, used to
+     * detect same-line registrations (see class docblock). Per-process,
+     * which is sufficient: the colliding registrations of a one-line
+     * chain always happen in one request.
+     *
+     * @var array<string, array{0: string, 1: string}>
+     */
+    protected static array $closureLines = [];
+
     /** How long a pending callback may wait for its result before it's considered abandoned. */
     protected static int $ttlMinutes = 5;
+
+    /** Serialized payloads above this skip the durable tier (memory still fires). */
+    protected static int $maxDurableBytes = 131072;
 
     public static function register(string $id, string $eventClass, Closure|array|string $callback): void
     {
@@ -47,35 +81,77 @@ class NativeCallbacks
         // Tier 2: best-effort durable copy so the callback survives a process kill.
         try {
             $serializable = $callback;
+            $ownerClass = null;
 
             if ($serializable instanceof Closure) {
-                // A closure bound to a component instance (one that uses
-                // $this) can't serialize as-is: the component isn't
-                // serializable. But the binding doesn't need to survive —
-                // fireNativeCallback rebinds every non-static closure to
-                // the LIVE component (full class scope, so private access
-                // is restored) at fire time. Only the code + captured
-                // `use` vars must cross the boundary, so rebind to a
-                // throwaway serializable carrier first. This is what lets
-                // `->onSuccess(function ($e) { $this->… })` fire on the
-                // stateless web target (fresh process per request) and
-                // survive an OS kill on device.
-                if ((new \ReflectionFunction($serializable))->getClosureThis() !== null) {
-                    $serializable = Closure::bind($serializable, new \stdClass);
+                $reflection = new \ReflectionFunction($serializable);
+                $boundThis = $reflection->getClosureThis();
+
+                if ($boundThis instanceof NativeComponent) {
+                    $ownerClass = get_class($boundThis);
                 }
+
+                // Captured resources don't make serialize() throw — they
+                // silently become ints, poisoning the durable copy with a
+                // TypeError that only detonates after a process kill.
+                if (static::capturesResources($reflection)) {
+                    NativeRouter::debugLog("NativeCallbacks: '{$eventClass}' closure captures a resource — durable copy skipped");
+
+                    return;
+                }
+
+                if ($reflection->isAnonymous()) {
+                    // serializable-closure extracts code by START LINE, so
+                    // two anonymous closures registered from one line get
+                    // the SAME body durably — running the success body on
+                    // cancel after a kill. Drop durability for both.
+                    $line = $reflection->getFileName().':'.$reflection->getStartLine();
+
+                    if (isset(static::$closureLines[$line]) && static::$closureLines[$line] !== [$id, $eventClass]) {
+                        [$otherId, $otherEvent] = static::$closureLines[$line];
+                        Cache::forget(static::key($otherId, $otherEvent));
+                        NativeRouter::debugLog("NativeCallbacks: two closures share {$line} — durable copies dropped for both (split the chain across lines to restore durability)");
+
+                        return;
+                    }
+
+                    static::$closureLines[$line] = [$id, $eventClass];
+
+                    if ($boundThis !== null) {
+                        // The binding never needs to survive — fire-time
+                        // rebinds to the live component. Rebind to a
+                        // serializable carrier so only code + use-vars
+                        // must cross.
+                        $serializable = Closure::bind($serializable, new \stdClass);
+                    }
+                }
+                // First-class callables ($this->onPicked(...)) are FAKE
+                // closures: Closure::bind() on them returns null, but
+                // serializable-closure stores them as a method reference,
+                // so they serialize fine as-is — no carrier needed.
 
                 $serializable = new SerializableClosure($serializable);
             }
 
-            Cache::put(
-                static::key($id, $eventClass),
-                serialize($serializable),
-                now()->addMinutes(static::$ttlMinutes),
-            );
+            $payload = serialize(['o' => $ownerClass, 'c' => $serializable]);
+
+            if (strlen($payload) > static::$maxDurableBytes) {
+                NativeRouter::debugLog("NativeCallbacks: '{$eventClass}' durable payload is ".strlen($payload).' bytes (cap '.static::$maxDurableBytes.') — skipped; callback fires from memory only');
+
+                return;
+            }
+
+            Cache::put(static::key($id, $eventClass), $payload, now()->addMinutes(static::$ttlMinutes));
+
+            // Per-event latest-id index: after a kill the memory tier is
+            // empty AND some native paths lose the id, so this is the only
+            // way an id-less result event can find its durable copy.
+            Cache::put(static::latestKey($eventClass), $id, now()->addMinutes(static::$ttlMinutes));
         } catch (Throwable $e) {
-            // Closure captured something else unserializable (a resource, a PDO
-            // handle, ...). Keep the in-memory copy; just won't survive a kill.
-            report($e);
+            // Closure captured something unserializable (a PDO handle, ...).
+            // Keep the in-memory copy; just won't survive a kill. debugLog,
+            // not report(): this fires per registration on hot paths.
+            NativeRouter::debugLog("NativeCallbacks: '{$eventClass}' durable copy failed (".$e->getMessage().') — callback fires from memory only');
         }
     }
 
@@ -84,8 +160,14 @@ class NativeCallbacks
      * copy. When $consume is true (default) the durable copy is removed (pull);
      * pass false to peek without consuming (the in-memory copy is never removed
      * here either way — call forget() for that).
+     *
+     * $for: the live component about to fire the callback. A durable entry
+     * registered by a DIFFERENT component class is skipped (forgotten +
+     * logged) instead of being rebound to the wrong screen — after a real
+     * OS kill the app cold-starts at '/', and firing ScreenA's closure
+     * against the home screen writes silent dynamic properties at best.
      */
-    public static function resolve(string $id, string $eventClass, bool $consume = true): Closure|array|string|null
+    public static function resolve(string $id, string $eventClass, bool $consume = true, ?object $for = null): Closure|array|string|null
     {
         if (isset(static::$memory[$id][$eventClass])) {
             return static::$memory[$id][$eventClass];
@@ -100,6 +182,19 @@ class NativeCallbacks
 
         $restored = unserialize($serialized);
 
+        $ownerClass = null;
+        if (is_array($restored) && array_key_exists('c', $restored)) {
+            $ownerClass = $restored['o'] ?? null;
+            $restored = $restored['c'];
+        }
+
+        if ($ownerClass !== null && $for !== null && ! $for instanceof $ownerClass) {
+            NativeRouter::debugLog("NativeCallbacks: durable callback for '{$eventClass}' belongs to {$ownerClass}, live screen is ".get_class($for).' — skipped');
+            static::forget($id, $eventClass);
+
+            return null;
+        }
+
         return $restored instanceof SerializableClosure
             ? $restored->getClosure()
             : $restored;
@@ -110,12 +205,14 @@ class NativeCallbacks
      * when no usable id came back from native (some platforms drop it across a
      * lifecycle bounce). A given native operation — a photo, a gallery pick — is
      * modal and single-in-flight, so one pending callback for the event class is
-     * unambiguous. Returns [id, callback] or null when there are zero matches.
-     * If several are somehow pending, the most recent wins.
+     * unambiguous. Checks the in-memory tier first, then the durable
+     * latest-id index (the memory tier is empty precisely in the
+     * process-death case this fallback exists for). Returns [id, callback]
+     * or null when there are zero matches.
      *
      * @return array{0: string, 1: Closure|array|string}|null
      */
-    public static function resolveByEvent(string $eventClass): ?array
+    public static function resolveByEvent(string $eventClass, ?object $for = null): ?array
     {
         $matchId = null;
         foreach (static::$memory as $id => $byEvent) {
@@ -124,11 +221,43 @@ class NativeCallbacks
             }
         }
 
-        if ($matchId === null) {
+        if ($matchId !== null) {
+            return [$matchId, static::$memory[$matchId][$eventClass]];
+        }
+
+        $latestId = Cache::get(static::latestKey($eventClass));
+
+        if (! is_string($latestId) || $latestId === '') {
             return null;
         }
 
-        return [$matchId, static::$memory[$matchId][$eventClass]];
+        $callback = static::resolve($latestId, $eventClass, consume: false, for: $for);
+
+        return $callback === null ? null : [$latestId, $callback];
+    }
+
+    /**
+     * Re-key a pending registration to a different event class — the
+     * ->event(Custom::class) override arriving AFTER onSuccess() already
+     * registered under the builder's default event.
+     */
+    public static function retarget(string $id, string $fromEvent, string $toEvent): void
+    {
+        if ($fromEvent === $toEvent) {
+            return;
+        }
+
+        if (isset(static::$memory[$id][$fromEvent])) {
+            static::$memory[$id][$toEvent] = static::$memory[$id][$fromEvent];
+            unset(static::$memory[$id][$fromEvent]);
+        }
+
+        $durable = Cache::pull(static::key($id, $fromEvent));
+
+        if ($durable !== null) {
+            Cache::put(static::key($id, $toEvent), $durable, now()->addMinutes(static::$ttlMinutes));
+            Cache::put(static::latestKey($toEvent), $id, now()->addMinutes(static::$ttlMinutes));
+        }
     }
 
     /**
@@ -165,10 +294,66 @@ class NativeCallbacks
     public static function flush(): void
     {
         static::$memory = [];
+        static::$closureLines = [];
     }
 
     protected static function key(string $id, string $eventClass): string
     {
-        return 'native_cb:'.$id.':'.$eventClass;
+        return 'native_cb:'.static::scope().$id.':'.$eventClass;
+    }
+
+    /** Per-event latest-id index key (see register()). */
+    protected static function latestKey(string $eventClass): string
+    {
+        return 'native_cb_latest:'.static::scope().$eventClass;
+    }
+
+    /**
+     * Session discriminator for cache keys OFF-DEVICE only. On device the
+     * cache belongs to one user; on the stateless web target it's shared
+     * app-wide, and unscoped keys would let one user's fixed-id
+     * registration overwrite (and leak into) another's.
+     */
+    protected static function scope(): string
+    {
+        if (config('nativephp-internal.running')) {
+            return '';
+        }
+
+        try {
+            $sessionId = session()->getId();
+
+            return is_string($sessionId) && $sessionId !== '' ? $sessionId.':' : '';
+        } catch (Throwable) {
+            return ''; // console / no session bound
+        }
+    }
+
+    /** Whether a closure's captured use-variables contain a raw resource. */
+    protected static function capturesResources(\ReflectionFunction $reflection): bool
+    {
+        $scan = function ($value, int $depth) use (&$scan): bool {
+            if (is_resource($value)) {
+                return true;
+            }
+
+            if (is_array($value) && $depth < 3) {
+                foreach ($value as $item) {
+                    if ($scan($item, $depth + 1)) {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        };
+
+        foreach ($reflection->getStaticVariables() as $value) {
+            if ($scan($value, 0)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Feature/DurableNativeCallbacksTest.php
+++ b/tests/Feature/DurableNativeCallbacksTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Native\Mobile\Events\Camera\PermissionDenied;
 use Native\Mobile\Events\Camera\PhotoCancelled;
 use Native\Mobile\Events\Camera\PhotoTaken;
 use Native\Mobile\Events\Gallery\MediaSelected;
@@ -335,9 +336,11 @@ it('records the owner for class-shadowing method names too', function () {
 it('does not let an abandoned capture re-latch the same-line kill', function () {
     $screen = Native::test(PickerScreen::class)->call('startUuidPicker');
 
-    // Abandon it: no result ever arrives, durable copy expires (simulated
-    // by clearing the cache) while the memory entry lives forever.
+    // Abandon it: no result ever arrives. The durable copy expires
+    // (simulated by clearing the cache) and the TTL window passes —
+    // within the window the line stays conservatively blocked.
     cache()->flush();
+    $this->travelTo(now()->addMinutes(6));
 
     // A later capture from the same line must regain durability.
     $screen->set('status', 'idle');
@@ -373,4 +376,53 @@ it('fails closed when the resource scan hits its depth cap', function () {
 
     // Truncated walk costs durability, never risks a poisoned copy.
     expect(NativeCallbacks::has('deep-pick', MediaSelected::class))->toBeFalse();
+});
+
+// ── Review round five ───────────────────────────────
+
+it('catches the THIRD closure of a one-line chain', function () {
+    // reg2's collision forgets reg1's durable copy; reg3 must still be
+    // detected via the line timestamp, not slip through because the
+    // cache entry is gone.
+    Native::test(PickerScreen::class)->call('startTripleLine');
+
+    NativeCallbacks::flush();
+
+    expect(NativeCallbacks::has('triple-pick', PhotoTaken::class))->toBeFalse()
+        ->and(NativeCallbacks::has('triple-pick', PhotoCancelled::class))->toBeFalse()
+        ->and(NativeCallbacks::has('triple-pick', PermissionDenied::class))->toBeFalse();
+});
+
+it('catches a line-mate whose durable copy was size-capped away', function () {
+    // reg1 never wrote a cache entry (size cap) — reg2 on the same line
+    // must still be treated as a conflation suspect.
+    Native::test(PickerScreen::class)->call('startHugeThenSmallLine');
+
+    NativeCallbacks::flush();
+
+    expect(NativeCallbacks::has('hts-pick', PhotoCancelled::class))->toBeFalse();
+});
+
+it('keeps ordinary deep captures durable under the raised cap', function () {
+    // Six levels of plain arrays — the shape of a model with a loaded
+    // relation — must NOT lose the durable tier.
+    $screen = Native::test(PickerScreen::class)->call('startDeepClean');
+
+    NativeCallbacks::flush();
+
+    $screen->emitNative(MediaSelected::class, ['success' => true, 'files' => [], 'count' => 1, 'id' => 'deepclean-pick'])
+        ->assertSet('status', 'deepclean:1');
+});
+
+it('controller bails on component-bound array callables', function () {
+    Native::test(PickerScreen::class)->call('startArrayCallback');
+
+    $controller = new DispatchEventFromAppController;
+    $fire = new ReflectionMethod($controller, 'fireCallback');
+    $fire->setAccessible(true);
+
+    $handled = $fire->invoke($controller, MediaSelected::class, ['id' => 'array-pick'], new MediaSelected(true));
+
+    expect($handled)->toBeFalse()
+        ->and(NativeCallbacks::has('array-pick', MediaSelected::class))->toBeTrue();
 });

--- a/tests/Feature/DurableNativeCallbacksTest.php
+++ b/tests/Feature/DurableNativeCallbacksTest.php
@@ -1,0 +1,106 @@
+<?php
+
+use Native\Mobile\Events\Gallery\MediaSelected;
+use Native\Mobile\Support\NativeCallbacks;
+use Native\Mobile\Testing\Native;
+use Tests\Fixtures\Edge\PickerScreen;
+
+/**
+ * Fluent native callbacks across a process boundary. The in-memory tier
+ * dies with the process (OS kill on device, next request on web);
+ * NativeCallbacks::flush() simulates exactly that between registering a
+ * callback and delivering its result event, so every passing test here
+ * proves the DURABLE tier alone can fire the callback on a live
+ * component.
+ */
+beforeEach(function () {
+    NativeCallbacks::flush();
+});
+
+afterEach(function () {
+    NativeCallbacks::flush();
+});
+
+// ── $this-bound closures (the carrier trick) ────────
+
+it('fires a $this-bound closure from the durable tier after a process death', function () {
+    $screen = Native::test(PickerScreen::class)
+        ->call('startClosure')
+        ->assertAwaitingNativeEvent(MediaSelected::class);
+
+    NativeCallbacks::flush(); // "process died" — memory tier gone
+
+    $screen->emitNative(MediaSelected::class, [
+        'success' => true,
+        'files' => [['path' => '/tmp/photo.jpg']],
+        'count' => 1,
+        'id' => 'closure-pick',
+    ])->assertSee('Picked: /tmp/photo.jpg!'); // private $secretSuffix appended
+});
+
+it('restores private-member access when the woken closure rebinds', function () {
+    // Covered by the assertion above ('!' comes from a private prop), but
+    // assert the state directly too so a rendering change can't mask it.
+    $screen = Native::test(PickerScreen::class)->call('startClosure');
+
+    NativeCallbacks::flush();
+
+    $screen->emitNative(MediaSelected::class, [
+        'success' => true, 'files' => [['path' => '/a.png']], 'count' => 1, 'id' => 'closure-pick',
+    ])->assertSet('picked', '/a.png!');
+});
+
+it('still fires the warm in-memory copy without any process death', function () {
+    Native::test(PickerScreen::class)
+        ->call('startClosure')
+        ->emitNative(MediaSelected::class, [
+            'success' => true, 'files' => [['path' => '/warm.png']], 'count' => 1, 'id' => 'closure-pick',
+        ])
+        ->assertSet('picked', '/warm.png!');
+});
+
+it('consumes the callback after firing (one outcome per capture)', function () {
+    $screen = Native::test(PickerScreen::class)
+        ->call('startClosure')
+        ->emitNative(MediaSelected::class, [
+            'success' => true, 'files' => [['path' => '/first.png']], 'count' => 1, 'id' => 'closure-pick',
+        ]);
+
+    expect(NativeCallbacks::has('closure-pick', MediaSelected::class))->toBeFalse();
+
+    // A duplicate delivery is a no-op, not a double mutation.
+    $screen->emitNative(MediaSelected::class, [
+        'success' => true, 'files' => [['path' => '/second.png']], 'count' => 1, 'id' => 'closure-pick',
+    ])->assertSet('picked', '/first.png!');
+});
+
+// ── Method-name strings ─────────────────────────────
+
+it('fires a method-name callback on the live component after a process death', function () {
+    $screen = Native::test(PickerScreen::class)->call('startMethodName');
+
+    NativeCallbacks::flush();
+
+    $screen->emitNative(MediaSelected::class, [
+        'success' => true, 'files' => [], 'count' => 3, 'id' => 'method-pick',
+    ])->assertSet('status', 'picked:3')
+        ->assertSee('Status: picked:3');
+});
+
+it('drops an unknown method-name string without crashing and forgets it', function () {
+    $screen = Native::test(PickerScreen::class)->call('startBogusMethod');
+
+    $screen->emitNative(MediaSelected::class, [
+        'success' => true, 'files' => [], 'count' => 1, 'id' => 'bogus-pick',
+    ])->assertSet('status', 'idle'); // nothing fired, nothing exploded
+
+    expect(NativeCallbacks::has('bogus-pick', MediaSelected::class))->toBeFalse();
+});
+
+// ── onSuccess() sugar ───────────────────────────────
+
+it('onSuccess registers for the builder success event', function () {
+    Native::test(PickerScreen::class)->call('startClosure');
+
+    expect(NativeCallbacks::has('closure-pick', MediaSelected::class))->toBeTrue();
+});

--- a/tests/Feature/DurableNativeCallbacksTest.php
+++ b/tests/Feature/DurableNativeCallbacksTest.php
@@ -9,6 +9,7 @@ use Native\Mobile\Testing\Native;
 use Tests\Fixtures\Edge\CounterScreen;
 use Tests\Fixtures\Edge\CustomPickEvent;
 use Tests\Fixtures\Edge\PickerScreen;
+use Tests\Fixtures\Edge\WrongPickScreen;
 
 /**
  * Fluent native callbacks across a process boundary. The in-memory tier
@@ -247,4 +248,66 @@ it('scopes durable keys by session off-device', function () {
     } finally {
         session()->setId($original);
     }
+});
+
+// ── Review round three: fixes-of-fixes ──────────────
+
+it('keeps durability alive for repeat captures from the same source line', function () {
+    // Builders default to fresh UUID ids: the same code line registering
+    // again after the previous capture COMPLETED is normal reuse, not a
+    // conflation — a stale same-line mapping must not kill durability
+    // for every capture after the first.
+    $screen = Native::test(PickerScreen::class)->call('startUuidPicker');
+
+    // First capture completes (id-less delivery consumes + forgets).
+    $screen->emitNative(MediaSelected::class, ['success' => true, 'files' => [], 'count' => 1])
+        ->assertSet('status', 'uuid-picked');
+
+    // Second capture from the SAME line, then the process dies.
+    $screen->call('startUuidPicker');
+    NativeCallbacks::flush();
+
+    $screen->emitNative(MediaSelected::class, ['success' => true, 'files' => [], 'count' => 1])
+        ->assertSet('status', 'uuid-picked'); // durable copy fired
+});
+
+it('controller bails on method names that shadow loadable classes', function () {
+    // 'error' passes class_exists() — the previous !class_exists guard
+    // consumed it, crashed, and destroyed the registration.
+    Native::test(PickerScreen::class)->call('startClassNamedMethod');
+
+    $controller = new DispatchEventFromAppController;
+    $fire = new ReflectionMethod($controller, 'fireCallback');
+    $fire->setAccessible(true);
+
+    $handled = $fire->invoke($controller, MediaSelected::class, ['id' => 'named-pick'], new MediaSelected(true));
+
+    expect($handled)->toBeFalse()
+        ->and(NativeCallbacks::has('named-pick', MediaSelected::class))->toBeTrue();
+});
+
+it('skips a durable method-name callback owned by a different screen', function () {
+    // The string carries no binding; the owner comes from the registering
+    // call stack. Post-kill, a screen with a same-named method must NOT
+    // fire it.
+    Native::test(PickerScreen::class)->call('startMethodName');
+
+    NativeCallbacks::flush();
+
+    Native::test(WrongPickScreen::class)
+        ->emitNative(MediaSelected::class, ['success' => true, 'files' => [], 'count' => 1, 'id' => 'method-pick'])
+        ->assertSet('status', 'idle'); // NOT 'WRONGLY-FIRED'
+
+    expect(NativeCallbacks::has('method-pick', MediaSelected::class))->toBeFalse();
+});
+
+it('skips durability when a captured object holds a resource', function () {
+    $screen = Native::test(PickerScreen::class)->call('startDtoResource');
+
+    expect(NativeCallbacks::has('dto-pick', MediaSelected::class))->toBeTrue(); // warm fine
+
+    NativeCallbacks::flush();
+
+    $screen->emitNative(MediaSelected::class, ['success' => true, 'files' => [], 'count' => 1, 'id' => 'dto-pick'])
+        ->assertSet('status', 'idle'); // no poisoned durable copy fired
 });

--- a/tests/Feature/DurableNativeCallbacksTest.php
+++ b/tests/Feature/DurableNativeCallbacksTest.php
@@ -263,6 +263,10 @@ it('keeps durability alive for repeat captures from the same source line', funct
     $screen->emitNative(MediaSelected::class, ['success' => true, 'files' => [], 'count' => 1])
         ->assertSet('status', 'uuid-picked');
 
+    // Reset so the final assertion can't be satisfied by stale state —
+    // with the guard bug reintroduced, this test MUST fail.
+    $screen->set('status', 'idle');
+
     // Second capture from the SAME line, then the process dies.
     $screen->call('startUuidPicker');
     NativeCallbacks::flush();
@@ -310,4 +314,63 @@ it('skips durability when a captured object holds a resource', function () {
 
     $screen->emitNative(MediaSelected::class, ['success' => true, 'files' => [], 'count' => 1, 'id' => 'dto-pick'])
         ->assertSet('status', 'idle'); // no poisoned durable copy fired
+});
+
+// ── Review round four ───────────────────────────────
+
+it('records the owner for class-shadowing method names too', function () {
+    // 'error' passes class_exists — pre-fix the owner tag was skipped
+    // for it, so a wrong screen with an error() method fired it.
+    Native::test(PickerScreen::class)->call('startClassNamedMethod');
+
+    NativeCallbacks::flush();
+
+    Native::test(WrongPickScreen::class)
+        ->emitNative(MediaSelected::class, ['success' => true, 'files' => [], 'count' => 1, 'id' => 'named-pick'])
+        ->assertSet('status', 'idle'); // NOT 'WRONGLY-FIRED-ERROR'
+
+    expect(NativeCallbacks::has('named-pick', MediaSelected::class))->toBeFalse();
+});
+
+it('does not let an abandoned capture re-latch the same-line kill', function () {
+    $screen = Native::test(PickerScreen::class)->call('startUuidPicker');
+
+    // Abandon it: no result ever arrives, durable copy expires (simulated
+    // by clearing the cache) while the memory entry lives forever.
+    cache()->flush();
+
+    // A later capture from the same line must regain durability.
+    $screen->set('status', 'idle');
+    $screen->call('startUuidPicker');
+    NativeCallbacks::flush();
+
+    $screen->emitNative(MediaSelected::class, ['success' => true, 'files' => [], 'count' => 1])
+        ->assertSet('status', 'uuid-picked');
+});
+
+it('catches a resource captured by a NESTED closure', function () {
+    $screen = Native::test(PickerScreen::class)->call('startNestedResource');
+
+    NativeCallbacks::flush();
+
+    $screen->emitNative(MediaSelected::class, ['success' => true, 'files' => [], 'count' => 1, 'id' => 'nested-pick'])
+        ->assertSet('status', 'idle'); // durability was skipped, not poisoned
+});
+
+it('catches a CLOSED resource capture', function () {
+    $screen = Native::test(PickerScreen::class)->call('startClosedResource');
+
+    NativeCallbacks::flush();
+
+    $screen->emitNative(MediaSelected::class, ['success' => true, 'files' => [], 'count' => 1, 'id' => 'closed-pick'])
+        ->assertSet('status', 'idle');
+});
+
+it('fails closed when the resource scan hits its depth cap', function () {
+    Native::test(PickerScreen::class)->call('startDeepResource');
+
+    NativeCallbacks::flush();
+
+    // Truncated walk costs durability, never risks a poisoned copy.
+    expect(NativeCallbacks::has('deep-pick', MediaSelected::class))->toBeFalse();
 });

--- a/tests/Feature/DurableNativeCallbacksTest.php
+++ b/tests/Feature/DurableNativeCallbacksTest.php
@@ -1,8 +1,13 @@
 <?php
 
+use Native\Mobile\Events\Camera\PhotoCancelled;
+use Native\Mobile\Events\Camera\PhotoTaken;
 use Native\Mobile\Events\Gallery\MediaSelected;
+use Native\Mobile\Http\Controllers\DispatchEventFromAppController;
 use Native\Mobile\Support\NativeCallbacks;
 use Native\Mobile\Testing\Native;
+use Tests\Fixtures\Edge\CounterScreen;
+use Tests\Fixtures\Edge\CustomPickEvent;
 use Tests\Fixtures\Edge\PickerScreen;
 
 /**
@@ -113,4 +118,133 @@ it('normalizes an already-prefixed #[On] event name instead of double-prefixing'
 
     expect($bare->event)->toBe('native:'.MediaSelected::class)
         ->and($prefixed->event)->toBe('native:'.MediaSelected::class);
+});
+
+// ── Review round two: registry hardening ────────────
+
+it('fires an id-less result event from the durable tier via the latest-id index', function () {
+    // The headline kill scenario: Android drops the id across the
+    // lifecycle bounce AND the memory tier died with the process.
+    $screen = Native::test(PickerScreen::class)->call('startClosure');
+
+    NativeCallbacks::flush();
+
+    $screen->emitNative(MediaSelected::class, [
+        'success' => true, 'files' => [['path' => '/idless.png']], 'count' => 1,
+        // no 'id' key at all
+    ])->assertSet('picked', '/idless.png!');
+});
+
+it('skips a durable closure whose owning screen class is not the live one', function () {
+    Native::test(PickerScreen::class)->call('startClosure');
+
+    NativeCallbacks::flush();
+
+    // Cold start lands on a different screen; ScreenA's closure must not
+    // be rebound to it.
+    Native::test(CounterScreen::class)
+        ->emitNative(MediaSelected::class, [
+            'success' => true, 'files' => [['path' => '/wrong.png']], 'count' => 1, 'id' => 'closure-pick',
+        ]);
+
+    expect(NativeCallbacks::has('closure-pick', MediaSelected::class))->toBeFalse();
+});
+
+it('drops durability for both closures of a one-line chain', function () {
+    Native::test(PickerScreen::class)->call('startOneLineChain');
+
+    NativeCallbacks::flush(); // memory gone — only durable copies could fire
+
+    expect(NativeCallbacks::has('oneline-pick', PhotoTaken::class))->toBeFalse()
+        ->and(NativeCallbacks::has('oneline-pick', PhotoCancelled::class))->toBeFalse();
+});
+
+it('keeps first-class callables durable without the carrier', function () {
+    $screen = Native::test(PickerScreen::class)->call('startFirstClass');
+
+    NativeCallbacks::flush();
+
+    $screen->emitNative(MediaSelected::class, [
+        'success' => true, 'files' => [], 'count' => 7, 'id' => 'fc-pick',
+    ])->assertSet('status', 'picked:7');
+});
+
+it('skips durability for resource-capturing closures instead of poisoning them', function () {
+    $screen = Native::test(PickerScreen::class)->call('startResourceClosure');
+
+    // Warm copy still fires…
+    expect(NativeCallbacks::has('resource-pick', MediaSelected::class))->toBeTrue();
+
+    NativeCallbacks::flush();
+
+    // …but no durable copy was written (a poisoned one would TypeError here).
+    $screen->emitNative(MediaSelected::class, [
+        'success' => true, 'files' => [], 'count' => 1, 'id' => 'resource-pick',
+    ])->assertSet('status', 'idle');
+});
+
+it('skips durability above the payload size cap', function () {
+    Native::test(PickerScreen::class)->call('startHuge');
+
+    NativeCallbacks::flush();
+
+    expect(NativeCallbacks::has('huge-pick', MediaSelected::class))->toBeFalse();
+});
+
+it('prefers a component method over a same-named loadable class', function () {
+    // class_exists('error') is true (PHP built-in, case-insensitively) —
+    // the component's own method must win.
+    Native::test(PickerScreen::class)
+        ->call('startClassNamedMethod')
+        ->emitNative(MediaSelected::class, [
+            'success' => true, 'files' => [], 'count' => 1, 'id' => 'named-pick',
+        ])
+        ->assertSet('status', 'component-error-method');
+});
+
+it('honors ->event() declared AFTER onSuccess()', function () {
+    $screen = Native::test(PickerScreen::class)->call('startCustomEvent');
+
+    // The registration must have moved off the default MediaSelected key…
+    expect(NativeCallbacks::has('custom-pick', MediaSelected::class))->toBeFalse()
+        ->and(NativeCallbacks::has('custom-pick', CustomPickEvent::class))->toBeTrue();
+
+    // …and fire under the override, durable tier included.
+    NativeCallbacks::flush();
+
+    $screen->emitNative(CustomPickEvent::class, [
+        'success' => true, 'count' => 5, 'id' => 'custom-pick',
+    ])->assertSet('status', 'custom:5');
+});
+
+it('leaves component-owned callbacks alone in the app-event controller', function () {
+    Native::test(PickerScreen::class)->call('startMethodName');
+
+    $controller = new DispatchEventFromAppController;
+    $fire = new ReflectionMethod($controller, 'fireCallback');
+    $fire->setAccessible(true);
+
+    $handled = $fire->invoke($controller, MediaSelected::class, ['id' => 'method-pick'], new MediaSelected(true));
+
+    // Bailed without consuming: the Edge loop still owns the callback.
+    expect($handled)->toBeFalse()
+        ->and(NativeCallbacks::has('method-pick', MediaSelected::class))->toBeTrue();
+});
+
+it('scopes durable keys by session off-device', function () {
+    Native::test(PickerScreen::class)->call('startClosure');
+    NativeCallbacks::flush();
+
+    // Same session still finds the durable copy…
+    expect(NativeCallbacks::has('closure-pick', MediaSelected::class))->toBeTrue();
+
+    // …a different session must not.
+    $original = session()->getId();
+    session()->setId(str_repeat('b', 40));
+
+    try {
+        expect(NativeCallbacks::has('closure-pick', MediaSelected::class))->toBeFalse();
+    } finally {
+        session()->setId($original);
+    }
 });

--- a/tests/Feature/DurableNativeCallbacksTest.php
+++ b/tests/Feature/DurableNativeCallbacksTest.php
@@ -104,3 +104,13 @@ it('onSuccess registers for the builder success event', function () {
 
     expect(NativeCallbacks::has('closure-pick', MediaSelected::class))->toBeTrue();
 });
+
+// ── #[On] prefix idempotence ────────────────────────
+
+it('normalizes an already-prefixed #[On] event name instead of double-prefixing', function () {
+    $bare = new \Native\Mobile\Attributes\On(MediaSelected::class);
+    $prefixed = new \Native\Mobile\Attributes\On('native:'.MediaSelected::class);
+
+    expect($bare->event)->toBe('native:'.MediaSelected::class)
+        ->and($prefixed->event)->toBe('native:'.MediaSelected::class);
+});

--- a/tests/Fixtures/Edge/CustomPickEvent.php
+++ b/tests/Fixtures/Edge/CustomPickEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/** Custom outcome event for the ->event(Custom::class) override tests. */
+class CustomPickEvent
+{
+    use Dispatchable;
+
+    public function __construct(
+        public bool $success = false,
+        public int $count = 0,
+        public ?string $id = null,
+    ) {}
+}

--- a/tests/Fixtures/Edge/PickerScreen.php
+++ b/tests/Fixtures/Edge/PickerScreen.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Events\Gallery\MediaSelected;
+use Native\Mobile\PendingMediaPicker;
+
+/**
+ * Fixture for the durable-callbacks suite: every fluent callback shape
+ * the media picker supports, plus a private member so the carrier
+ * round-trip proves class scope is restored on rebind.
+ */
+class PickerScreen extends NativeComponent
+{
+    public ?string $picked = null;
+
+    public string $status = 'idle';
+
+    private string $secretSuffix = '!';
+
+    public function startClosure(): void
+    {
+        (new PendingMediaPicker)->id('closure-pick')->onSuccess(function (MediaSelected $media) {
+            // Captures $this AND touches a private member — the hardest
+            // shape to move across a process boundary.
+            $this->picked = ($media->files[0]['path'] ?? '?').$this->secretSuffix;
+        });
+    }
+
+    public function startMethodName(): void
+    {
+        (new PendingMediaPicker)->id('method-pick')->mediaSelected('onPicked');
+    }
+
+    public function startBogusMethod(): void
+    {
+        (new PendingMediaPicker)->id('bogus-pick')->mediaSelected('noSuchMethod');
+    }
+
+    public function onPicked(MediaSelected $media): void
+    {
+        $this->status = 'picked:'.$media->count;
+    }
+
+    public function render(): Element
+    {
+        return Column::make(
+            Text::make('Picked: '.($this->picked ?? 'nothing')),
+            Text::make('Status: '.$this->status),
+        );
+    }
+}

--- a/tests/Fixtures/Edge/PickerScreen.php
+++ b/tests/Fixtures/Edge/PickerScreen.php
@@ -118,6 +118,39 @@ class PickerScreen extends NativeComponent
             ->event(CustomPickEvent::class);
     }
 
+    public function startNestedResource(): void
+    {
+        $handle = fopen('php://memory', 'r');
+        $inner = function () use ($handle) {
+            return $handle;
+        };
+
+        (new PendingMediaPicker)->id('nested-pick')->onSuccess(function () use ($inner) {
+            $this->status = 'nested:'.get_debug_type($inner());
+        });
+    }
+
+    public function startClosedResource(): void
+    {
+        $handle = fopen('php://memory', 'r');
+        fclose($handle);
+
+        (new PendingMediaPicker)->id('closed-pick')->onSuccess(function () use ($handle) {
+            $this->status = 'closed:'.get_debug_type($handle);
+        });
+    }
+
+    public function startDeepResource(): void
+    {
+        $deep = ['a' => ['b' => ['c' => ['d' => ['e' => ['f' => fopen('php://memory', 'r')]]]]]];
+
+        // The body must USE the capture, or Pint's lambda_not_used_import
+        // fixer strips `use ($deep)` and silently defuses the fixture.
+        (new PendingMediaPicker)->id('deep-pick')->onSuccess(function () use ($deep) {
+            $this->status = 'deep:'.count($deep);
+        });
+    }
+
     public function render(): Element
     {
         return Column::make(

--- a/tests/Fixtures/Edge/PickerScreen.php
+++ b/tests/Fixtures/Edge/PickerScreen.php
@@ -140,6 +140,35 @@ class PickerScreen extends NativeComponent
         });
     }
 
+    /** THREE closures on one line — the collision path must catch the third too. */
+    public function startTripleLine(): void
+    {
+        (new PendingPhotoCapture)->id('triple-pick')->photoTaken(fn () => $this->status = 't1')->photoCancelled(fn () => $this->status = 't2')->permissionDenied(fn () => $this->status = 't3');
+    }
+
+    /** Huge capture then small on ONE line: reg1 size-caps (no cache entry), reg2 must still be caught. */
+    public function startHugeThenSmallLine(): void
+    {
+        $blob = str_repeat('x', 200 * 1024);
+
+        (new PendingPhotoCapture)->id('hts-pick')->photoTaken(fn () => $this->status = 'huge:'.strlen($blob))->photoCancelled(fn () => $this->status = 'small');
+    }
+
+    /** Deep but ORDINARY capture (no resource) — must stay durable under the cap. */
+    public function startDeepClean(): void
+    {
+        $deep = ['a' => ['b' => ['c' => ['d' => ['e' => ['f' => 'leaf']]]]]];
+
+        (new PendingMediaPicker)->id('deepclean-pick')->onSuccess(function () use ($deep) {
+            $this->status = 'deepclean:'.count($deep);
+        });
+    }
+
+    public function startArrayCallback(): void
+    {
+        (new PendingMediaPicker)->id('array-pick')->onSuccess([$this, 'onPicked']);
+    }
+
     public function startDeepResource(): void
     {
         $deep = ['a' => ['b' => ['c' => ['d' => ['e' => ['f' => fopen('php://memory', 'r')]]]]]];

--- a/tests/Fixtures/Edge/PickerScreen.php
+++ b/tests/Fixtures/Edge/PickerScreen.php
@@ -8,6 +8,7 @@ use Native\Mobile\Edge\Elements\Text;
 use Native\Mobile\Edge\NativeComponent;
 use Native\Mobile\Events\Gallery\MediaSelected;
 use Native\Mobile\PendingMediaPicker;
+use Native\Mobile\PendingPhotoCapture;
 
 /**
  * Fixture for the durable-callbacks suite: every fluent callback shape
@@ -44,6 +45,61 @@ class PickerScreen extends NativeComponent
     public function onPicked(MediaSelected $media): void
     {
         $this->status = 'picked:'.$media->count;
+    }
+
+    /**
+     * Both callbacks DELIBERATELY on one line — the same-line durability
+     * hazard (serializable-closure extracts code by start line). Arrow
+     * functions on purpose: Pint keeps them inline, where it would
+     * expand `function () {}` bodies onto separate lines and silently
+     * defuse this fixture.
+     */
+    public function startOneLineChain(): void
+    {
+        (new PendingPhotoCapture)->id('oneline-pick')->photoTaken(fn () => $this->status = 'taken')->photoCancelled(fn () => $this->status = 'cancelled');
+    }
+
+    public function startFirstClass(): void
+    {
+        (new PendingMediaPicker)->id('fc-pick')->onSuccess($this->onPicked(...));
+    }
+
+    public function startResourceClosure(): void
+    {
+        $handle = fopen('php://memory', 'r');
+
+        (new PendingMediaPicker)->id('resource-pick')->onSuccess(function () use ($handle) {
+            $this->status = 'resource:'.get_debug_type($handle);
+        });
+    }
+
+    public function startHuge(): void
+    {
+        $blob = str_repeat('x', 200 * 1024);
+
+        (new PendingMediaPicker)->id('huge-pick')->onSuccess(function () use ($blob) {
+            $this->status = 'huge:'.strlen($blob);
+        });
+    }
+
+    /** Method named after a loadable class — the class_exists hijack bait. */
+    public function startClassNamedMethod(): void
+    {
+        (new PendingMediaPicker)->id('named-pick')->mediaSelected('error');
+    }
+
+    public function error(MediaSelected $media): void
+    {
+        $this->status = 'component-error-method';
+    }
+
+    public function startCustomEvent(): void
+    {
+        (new PendingMediaPicker)->id('custom-pick')
+            ->onSuccess(function (CustomPickEvent $event) {
+                $this->status = 'custom:'.$event->count;
+            })
+            ->event(CustomPickEvent::class);
     }
 
     public function render(): Element

--- a/tests/Fixtures/Edge/PickerScreen.php
+++ b/tests/Fixtures/Edge/PickerScreen.php
@@ -64,6 +64,22 @@ class PickerScreen extends NativeComponent
         (new PendingMediaPicker)->id('fc-pick')->onSuccess($this->onPicked(...));
     }
 
+    /** Auto-UUID id, fixed source line — the stale same-line-mapping case. */
+    public function startUuidPicker(): void
+    {
+        (new PendingMediaPicker)->onSuccess(fn () => $this->status = 'uuid-picked');
+    }
+
+    public function startDtoResource(): void
+    {
+        $dto = new \stdClass;
+        $dto->handle = fopen('php://memory', 'r');
+
+        (new PendingMediaPicker)->id('dto-pick')->onSuccess(function () use ($dto) {
+            $this->status = 'dto:'.get_debug_type($dto->handle);
+        });
+    }
+
     public function startResourceClosure(): void
     {
         $handle = fopen('php://memory', 'r');

--- a/tests/Fixtures/Edge/WrongPickScreen.php
+++ b/tests/Fixtures/Edge/WrongPickScreen.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Events\Gallery\MediaSelected;
+
+/**
+ * A DIFFERENT screen with a method named identically to PickerScreen's
+ * callback target — the cold-start-on-the-wrong-screen hazard for
+ * method-name string callbacks.
+ */
+class WrongPickScreen extends NativeComponent
+{
+    public string $status = 'idle';
+
+    public function onPicked(MediaSelected $media): void
+    {
+        $this->status = 'WRONGLY-FIRED';
+    }
+
+    public function render(): Element
+    {
+        return Column::make(Text::make('Status: '.$this->status));
+    }
+}

--- a/tests/Fixtures/Edge/WrongPickScreen.php
+++ b/tests/Fixtures/Edge/WrongPickScreen.php
@@ -22,6 +22,12 @@ class WrongPickScreen extends NativeComponent
         $this->status = 'WRONGLY-FIRED';
     }
 
+    /** Same name as PickerScreen's class-shadowing 'error' callback target. */
+    public function error(MediaSelected $media): void
+    {
+        $this->status = 'WRONGLY-FIRED-ERROR';
+    }
+
     public function render(): Element
     {
         return Column::make(Text::make('Status: '.$this->status));


### PR DESCRIPTION
## Summary

`Camera::pickImages('image')->onSuccess(function ($media) { $this->attachedImage = …; })` now fires even when the registering process is gone — an OS kill on device, or the next request on the stateless web target.

- **The insight:** `fireNativeCallback` already rebinds every non-static closure to the *live* component (full class scope) at fire time, so the closure's `$this` binding never needs to survive serialization — only its code and captured `use` vars do. `NativeCallbacks::register()` now rebinds `$this`-bound closures to a throwaway `stdClass` carrier and stores them in the existing durable cache tier via `SerializableClosure` (previously such closures skipped the durable tier entirely).
- `onSuccess()` sugar on `HandlesNativeCallbacks`: names the builder's success event generically (photoTaken / mediaSelected / videoRecorded all read the same); honors `->event()` overrides.
- `fireNativeCallback` also resolves **method-name strings** (`->mediaSelected('onMediaSelected')`) against the live component — a fluent form with zero serialization constraints. Unknown strings are logged and dropped instead of fataling.

Constraints (documented in the code): captured `use` vars must serialize; closures in eval'd code can't round-trip (SerializableClosure extracts source text); the durable tier needs a persistent cache store.

Independent of #301 — applies cleanly to main; the two compose without conflict.

## Verification

Carrier round-trip proven in isolation (serialize → fresh process → rebind: private-property access restored, captures intact), then end-to-end via the mobile-web target against a demo app: closure registered in one HTTP request, fired in a later request on a rebuilt component instance. Package-level tests to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)