### PR TITLE
[Masterclass] Support per-corner and per-side border radius classes

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/ComposeFlexLayout.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/ComposeFlexLayout.kt
@@ -10,12 +10,15 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 // MARK: - Flex Enums (match PHP/binary protocol values)
@@ -35,10 +38,25 @@ object JustifyContent {
 }
 
 object AlignItems {
-    const val START = 0
+    /**
+     * No `items-*` / `self-*` class was authored — PHP omits `align_items`
+     * entirely, so it arrives as 0 and each renderer applies its own default.
+     * On Android that default is content-sizing (this file never adds
+     * `fillMaxWidth()` for it), which is unchanged by #309.
+     */
+    const val UNSET = 0
     const val CENTER = 1
     const val END = 2
     const val STRETCH = 3
+
+    /**
+     * Explicitly authored `items-start` / `self-start`. Deliberately NOT 0:
+     * while Android renders START and UNSET identically, iOS does not, and a
+     * shared wire value meant iOS could not fix `items-start` without also
+     * flipping every unclassed container (mobile-air #309). Android behaviour
+     * is untouched — 4 falls through the same `else` branches 0 always did.
+     */
+    const val START = 4
 }
 
 object PositionType {
@@ -159,7 +177,7 @@ private fun FlexColumn(
     val alignment = when (align) {
         AlignItems.CENTER -> Alignment.CenterHorizontally
         AlignItems.END -> Alignment.End
-        else -> Alignment.Start // START and STRETCH both start-align; STRETCH handled per-child
+        else -> Alignment.Start // UNSET, START and STRETCH all start-align; STRETCH fills per-child
     }
 
     Column(
@@ -237,6 +255,38 @@ private fun FlexRow(
 }
 
 /**
+ * Apply `min_width` / `max_width` / `min_height` / `max_height` from the packed
+ * node as Compose constraint bounds.
+ *
+ * A bound of 0 is "unset" on the wire, so it maps to [Dp.Unspecified] rather
+ * than to a literal 0.dp — `widthIn(max = 0.dp)` would collapse the node.
+ *
+ * Shared by [buildChildModifier] and `NodeView`'s no-parent fallback so the
+ * constraints apply whether or not the node sits inside a flex container.
+ */
+fun Modifier.applySizeConstraints(layout: NodeLayout?): Modifier {
+    if (layout == null) return this
+
+    var mod = this
+
+    if (layout.minWidth > 0f || layout.maxWidth > 0f) {
+        mod = mod.widthIn(
+            min = if (layout.minWidth > 0f) layout.minWidth.dp else Dp.Unspecified,
+            max = if (layout.maxWidth > 0f) layout.maxWidth.dp else Dp.Unspecified
+        )
+    }
+
+    if (layout.minHeight > 0f || layout.maxHeight > 0f) {
+        mod = mod.heightIn(
+            min = if (layout.minHeight > 0f) layout.minHeight.dp else Dp.Unspecified,
+            max = if (layout.maxHeight > 0f) layout.maxHeight.dp else Dp.Unspecified
+        )
+    }
+
+    return mod
+}
+
+/**
  * Build per-child modifier for flex properties (weight, fill, fixed size, margin).
  */
 @Composable
@@ -273,6 +323,17 @@ private fun buildChildModifier(
             mod = mod.offset(x = negX.dp, y = negY.dp)
         }
     }
+
+    // Min/max size constraints (`max-w-*`, `min-h-*`, …).
+    //
+    // Applied BEFORE the fill/fixed/weight modifiers below so that a combo
+    // like `w-full max-w-[280px]` fills *within* the 280dp bound instead of
+    // filling the parent and being clamped after the fact. Compose narrows
+    // constraints outer→inner, so ordering here is the whole behaviour.
+    //
+    // 0 means "unset" on the wire (the packed node has no companion size
+    // mode for min/max), which is why each bound is gated on `> 0f`.
+    mod = mod.applySizeConstraints(layout)
 
     // Main axis: flex_grow or fill → weight
     val flexGrow = layout?.flexGrow ?: 0f

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/ComposeFlexLayout.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/ComposeFlexLayout.kt
@@ -335,6 +335,40 @@ private fun buildChildModifier(
     // mode for min/max), which is why each bound is gated on `> 0f`.
     mod = mod.applySizeConstraints(layout)
 
+    // Cross axis: per-child `self-*` PLACEMENT.
+    //
+    // The container's Column/Row alignment parameter applies to every child
+    // uniformly, so an individual child can only move via `Modifier.align()`
+    // inside the layout scope. Without this, `self-center` / `self-end` only
+    // affected whether the child FILLED (via the width branch below) and never
+    // where it sat — a `self-end` child hugged its content but stayed on the
+    // leading edge. iOS honours align_self in FlexContainer's placement switch,
+    // so this was a platform divergence.
+    //
+    // 0 = unset (inherit the container's align-items) and STRETCH needs no
+    // placement — it's expressed as fillMaxWidth/Height below — so both fall
+    // through untouched.
+    val alignSelf = layout?.alignSelf ?: 0
+    if (alignSelf > 0 && alignSelf != AlignItems.STRETCH) {
+        mod = if (isRow && scope is RowScope) {
+            with(scope) {
+                when (alignSelf) {
+                    AlignItems.CENTER -> mod.align(Alignment.CenterVertically)
+                    AlignItems.END -> mod.align(Alignment.Bottom)
+                    else -> mod.align(Alignment.Top)
+                }
+            }
+        } else if (!isRow && scope is ColumnScope) {
+            with(scope) {
+                when (alignSelf) {
+                    AlignItems.CENTER -> mod.align(Alignment.CenterHorizontally)
+                    AlignItems.END -> mod.align(Alignment.End)
+                    else -> mod.align(Alignment.Start)
+                }
+            }
+        } else mod
+    }
+
     // Main axis: flex_grow or fill → weight
     val flexGrow = layout?.flexGrow ?: 0f
     val mainFill = if (isRow) {

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeModifiers.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeModifiers.kt
@@ -95,6 +95,35 @@ fun argbToComposeColor(argb: Int): Color {
  * Handles background color, corner radius, border, shadow, opacity,
  * and dark mode overrides from dark_* props.
  */
+/**
+ * The node's outline: per-corner when `rounded-<side>-*` was authored,
+ * otherwise the uniform `border_radius`.
+ *
+ * Per-corner radii ride the props bag because the packed binary node carries
+ * a single `border_radius` float with no room for four. PHP emits all four
+ * whenever ANY corner is authored, each already resolved against the uniform
+ * radius — so `radius_tl` being present is the whole switch, and there is no
+ * per-corner defaulting to do here.
+ *
+ * Compose names corners start/end, which flip under RTL, while the Tailwind
+ * spellings we accept are physical (`tl` = top-LEFT). Start is mapped to left
+ * to match the rest of this renderer, which has no RTL handling either; the
+ * parser rejects Tailwind's logical `rounded-s-*` spellings for that reason.
+ */
+fun nodeShape(radius: Float, props: GenericProps): RoundedCornerShape =
+    if (props.has("radius_tl")) {
+        RoundedCornerShape(
+            topStart = props.getFloat("radius_tl", 0f).dp,
+            topEnd = props.getFloat("radius_tr", 0f).dp,
+            bottomEnd = props.getFloat("radius_br", 0f).dp,
+            bottomStart = props.getFloat("radius_bl", 0f).dp
+        )
+    } else if (radius > 0f) {
+        RoundedCornerShape(radius.dp)
+    } else {
+        RoundedCornerShape(0.dp)
+    }
+
 fun Modifier.nodeStyle(style: NodeStyle?, props: GenericProps, isDarkMode: Boolean): Modifier {
     if (style == null) return this
 
@@ -127,7 +156,7 @@ fun Modifier.nodeStyle(style: NodeStyle?, props: GenericProps, isDarkMode: Boole
     // Background color (with dark mode override)
     val darkBg = if (isDarkMode) props.getColor("dark_bg_color", 0) else 0
     val bgArgb = if (darkBg != 0) darkBg else style.bgColor
-    val shape = if (radius > 0f) RoundedCornerShape(radius.dp) else RoundedCornerShape(0.dp)
+    val shape = nodeShape(radius, props)
 
     // Shadow — must come before background. Compose shadow requires a shape
     // to cast from; the background provides the visual fill.
@@ -163,7 +192,6 @@ fun Modifier.nodeStyle(style: NodeStyle?, props: GenericProps, isDarkMode: Boole
         if (borderArgb != 0) {
             val borderColor = argbToComposeColor(borderArgb)
             if (borderColor != Color.Transparent) {
-                val shape = if (radius > 0f) RoundedCornerShape(radius.dp) else RoundedCornerShape(0.dp)
                 mod = mod.border(style.borderWidth.dp, borderColor, shape)
             }
         }

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeView.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeView.kt
@@ -61,6 +61,10 @@ fun NodeView(node: NativeUINode, overrideModifier: Modifier? = null) {
             var mod: Modifier = Modifier
             val layout = node.layout
             if (layout != null) {
+                // Constraint bounds first, so a `w-full max-w-*` node fills
+                // within its bound rather than being clamped afterwards —
+                // same ordering rule as `buildChildModifier`.
+                mod = mod.applySizeConstraints(layout)
                 when (layout.widthMode) {
                     SizeMode.FILL -> mod = mod.fillMaxWidth()
                     SizeMode.FIXED -> if (layout.width > 0f) mod = mod.width(layout.width.dp)

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeView.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeView.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.runtime.Composable
@@ -94,14 +93,16 @@ fun NodeView(node: NativeUINode, overrideModifier: Modifier? = null) {
         // (rounded tappable surfaces) → click region (nodeGestures) →
         // inset children (nodeLayout).
         //
-        // The conditional `.clip(RoundedCornerShape)` is the reason
+        // The conditional `.clip(nodeShape(...))` is the reason
         // ripples stay inside the pill / rounded-button shape instead
         // of bleeding past the corners. It applies ONLY when both
         // conditions hold:
         //   - the node has a press / long-press handler (so ripple
         //     will actually be drawn — clipping a non-tappable surface
         //     wouldn't do anything useful)
-        //   - the node has a non-zero border radius
+        //   - the node has a non-zero uniform radius, OR per-corner
+        //     radii from `rounded-<side>-*` (which can be asymmetric
+        //     with a zero uniform radius — a squared-off chat bubble)
         // Non-tappable rounded surfaces (cards, chips with overflowing
         // avatars, etc.) intentionally skip the clip — the existing
         // policy in NodeModifiers.kt explains why we don't clip
@@ -280,8 +281,11 @@ fun NodeView(node: NativeUINode, overrideModifier: Modifier? = null) {
 
         modifier = modifier.nodeStyle(node.style, node.props, isDarkMode)
 
-        if (hasPress && radius > 0f) {
-            modifier = modifier.clip(RoundedCornerShape(radius.dp))
+        // Per-corner radii also count as "has a radius" here — otherwise a
+        // tappable bubble squared off with `rounded-br-none` would fall to the
+        // un-clipped branch and its ripple would bleed past the rounded corners.
+        if (hasPress && (radius > 0f || node.props.has("radius_tl"))) {
+            modifier = modifier.clip(nodeShape(radius, node.props))
         }
         modifier = modifier
             .nodeGestures(node, interactionSource)

--- a/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
+++ b/resources/xcode/NativePHP/NativeRender/FlexContainer.swift
@@ -35,10 +35,17 @@ enum JustifyContent {
 }
 
 enum AlignItems {
-    static let start = 0
+    /// No `items-*` / `self-*` class was authored. PHP omits `align_items`
+    /// entirely in that case, so it arrives as 0 and we apply the container
+    /// default (stretch — the CSS default, and what this renderer has always
+    /// done). Distinct from `start`, which the author asked for explicitly.
+    static let unset = 0
     static let center = 1
     static let end = 2
     static let stretch = 3
+    /// Explicitly authored `items-start` / `self-start`. Deliberately NOT 0 —
+    /// see the note on the PHP `AlignItems` enum (mobile-air #309).
+    static let start = 4
 }
 
 enum PositionType {
@@ -644,8 +651,12 @@ struct FlexContainer: Layout {
                     : ProposedViewSize(width: nil, height: childMain)
 
                 switch effectiveAlign {
-                case AlignItems.stretch:
-                    // No FILL: use natural size, align to start (like Android).
+                case AlignItems.start:
+                    // Explicitly authored `items-start` / `self-start`: the
+                    // child hugs its own content and sits at the leading edge,
+                    // matching ComposeFlexLayout (which simply omits
+                    // `fillMaxWidth()`).
+                    //
                     // We can't reuse childCrosses[i] from Phase 3 here — Phase 3
                     // proposes crossAvail, which makes container children (e.g.
                     // a flex column) fill the cross axis and report container
@@ -666,8 +677,19 @@ struct FlexContainer: Layout {
                     finalCross = min(natural, containerCross - crossMargin(info))
                     crossPos = (isRow ? bounds.minY : bounds.minX) + containerCross - finalCross - crossMarginBefore(info)
 
-                default: // start
-                    // Start: use measured cross size (from Phase 3), align to start
+                default: // unset (0) and stretch (3)
+                    // Both take the container's cross extent. Phase 3 already
+                    // measured every child against `crossAvail`, so
+                    // `childCrosses[i]` IS the stretched size: a container child
+                    // reports the full cross axis, while a child with its own
+                    // explicit cross size reports that instead — which is what
+                    // CSS stretch does too.
+                    //
+                    // Unset lands here because stretch is the CSS default for
+                    // `align-items`, and it is what this renderer has always
+                    // done for an unclassed container. Keeping the two together
+                    // is what lets `items-start` be fixed without moving every
+                    // existing layout (mobile-air #309).
                     finalCross = childCrosses[i]
                     crossPos = (isRow ? bounds.minY : bounds.minX) + crossMarginBefore(info)
                 }

--- a/resources/xcode/NativePHP/NativeRender/NodeLayoutModifier.swift
+++ b/resources/xcode/NativePHP/NativeRender/NodeLayoutModifier.swift
@@ -63,27 +63,40 @@ struct NodeLayoutModifier: ViewModifier {
     /// SwiftUI's ideal-size discovery sensible at the root, but nested w-full
     /// elements no longer overflow when their parent is narrower than the screen.
     private var resolvedMaxWidth: CGFloat {
-        if let l = layout {
-            if l.widthMode == SizeMode.fill { return .infinity }
-            if l.widthMode == SizeMode.percent, l.width > 0 {
-                return availableWidth * CGFloat(l.width) / 100
-            }
-            if l.widthMode == SizeMode.fixed, l.width > 0 { return CGFloat(l.width) }
-            if l.maxWidth > 0 { return CGFloat(l.maxWidth) }
+        guard let l = layout else { return .infinity }
+
+        let base: CGFloat
+        if l.widthMode == SizeMode.fill {
+            base = .infinity
+        } else if l.widthMode == SizeMode.percent, l.width > 0 {
+            base = availableWidth * CGFloat(l.width) / 100
+        } else if l.widthMode == SizeMode.fixed, l.width > 0 {
+            base = CGFloat(l.width)
+        } else {
+            base = .infinity
         }
-        return .infinity
+
+        // `max-w-*` clamps whatever the width mode resolved to rather than
+        // being an alternative to it — `w-full max-w-[280px]` has to fill up
+        // to 280, not fill unbounded. 0 means unset on the wire.
+        return l.maxWidth > 0 ? min(base, CGFloat(l.maxWidth)) : base
     }
 
     private var resolvedMaxHeight: CGFloat {
-        if let l = layout {
-            if l.heightMode == SizeMode.fill { return .infinity }
-            if l.heightMode == SizeMode.percent, l.height > 0 {
-                return availableHeight * CGFloat(l.height) / 100
-            }
-            if l.heightMode == SizeMode.fixed, l.height > 0 { return CGFloat(l.height) }
-            if l.maxHeight > 0 { return CGFloat(l.maxHeight) }
+        guard let l = layout else { return .infinity }
+
+        let base: CGFloat
+        if l.heightMode == SizeMode.fill {
+            base = .infinity
+        } else if l.heightMode == SizeMode.percent, l.height > 0 {
+            base = availableHeight * CGFloat(l.height) / 100
+        } else if l.heightMode == SizeMode.fixed, l.height > 0 {
+            base = CGFloat(l.height)
+        } else {
+            base = .infinity
         }
-        return .infinity
+
+        return l.maxHeight > 0 ? min(base, CGFloat(l.maxHeight)) : base
     }
 
     // MARK: - Size Resolution

--- a/resources/xcode/NativePHP/NativeRender/NodeStyleModifier.swift
+++ b/resources/xcode/NativePHP/NativeRender/NodeStyleModifier.swift
@@ -25,6 +25,7 @@ struct NodeStyleModifier: ViewModifier {
     func body(content: Content) -> some View {
         let dark = colorScheme == .dark
         let radius = cornerRadius
+        let radii = cornerRadii
         let glassFlags = props.getInt("glass", default: 0)
 
         // Defer opacity to `NodeAnimationModifier` when:
@@ -52,9 +53,10 @@ struct NodeStyleModifier: ViewModifier {
             // RoundedRectangle, no rounded → Rectangle).
             .modifier(GlassModifier(
                 flags: Self.glassHandledByRenderer.contains(nodeType) ? 0 : glassFlags,
-                cornerRadius: radius
+                cornerRadius: radius,
+                cornerRadii: radii
             ))
-            .modifier(ClipRadiusModifier(radius: radius))
+            .modifier(ClipRadiusModifier(radius: radius, radii: radii))
             .overlay(borderOverlay(dark: dark, radius: radius))
             .shadow(
                 color: shadowColor,
@@ -124,17 +126,54 @@ struct NodeStyleModifier: ViewModifier {
         return CGFloat(s.borderRadius)
     }
 
+    /// Per-corner radii (`rounded-br-none`, `rounded-t-2xl`, …), or nil when
+    /// the node uses only the uniform `rounded-*`.
+    ///
+    /// These ride the props bag rather than NodeStyle: the packed binary node
+    /// carries a single `border_radius` float with no room for four. PHP emits
+    /// all four whenever ANY corner is authored — each already resolved
+    /// against the uniform radius — so the presence of `radius_tl` alone is
+    /// the switch, and no per-corner defaulting is needed here.
+    ///
+    /// SwiftUI's `UnevenRoundedRectangle` names its corners leading/trailing,
+    /// which flip under RTL. The Tailwind spellings we accept are physical
+    /// (`tl` = top-LEFT), so leading is mapped to left. That matches the rest
+    /// of this renderer — FlexContainer places everything off `bounds.minX`
+    /// and has no RTL handling either — and is why the parser rejects
+    /// Tailwind's logical `rounded-s-*` / `rounded-ee-*` spellings outright
+    /// rather than pretending to honour them.
+    private var cornerRadii: RectangleCornerRadii? {
+        guard props.has("radius_tl") else { return nil }
+
+        return RectangleCornerRadii(
+            topLeading: CGFloat(props.getFloat("radius_tl", default: 0)),
+            bottomLeading: CGFloat(props.getFloat("radius_bl", default: 0)),
+            bottomTrailing: CGFloat(props.getFloat("radius_br", default: 0)),
+            topTrailing: CGFloat(props.getFloat("radius_tr", default: 0))
+        )
+    }
+
     // MARK: - Border
 
+    @ViewBuilder
     private func borderOverlay(dark: Bool, radius: CGFloat) -> some View {
         let width = CGFloat(style?.borderWidth ?? 0)
         let darkBorder = dark ? props.getColor("dark_border_color", default: 0) : 0
         let argb = darkBorder != 0 ? darkBorder : (style?.borderColor ?? 0)
         let color = colorFromARGB(argb)
 
-        return RoundedRectangle(cornerRadius: radius)
-            .strokeBorder(color, lineWidth: width)
-            .opacity(width > 0 ? 1 : 0)
+        // Both shapes are Insettable, so the border keeps drawing INSIDE the
+        // bounds via strokeBorder — plain `stroke` would straddle the edge and
+        // shift every existing border by half its width.
+        if let radii = cornerRadii {
+            UnevenRoundedRectangle(cornerRadii: radii)
+                .strokeBorder(color, lineWidth: width)
+                .opacity(width > 0 ? 1 : 0)
+        } else {
+            RoundedRectangle(cornerRadius: radius)
+                .strokeBorder(color, lineWidth: width)
+                .opacity(width > 0 ? 1 : 0)
+        }
     }
 
     // MARK: - Shadow
@@ -181,8 +220,15 @@ func colorFromARGB(_ argb: Int) -> Color {
 /// rectangle which cuts off content that slightly overflows (e.g. Toggle switches).
 private struct ClipRadiusModifier: ViewModifier {
     let radius: CGFloat
+    /// Per-corner radii, when the node used `rounded-<side>-*`. Wins over
+    /// `radius`, which PHP has already folded into each corner.
+    let radii: RectangleCornerRadii?
+
+    @ViewBuilder
     func body(content: Content) -> some View {
-        if radius > 0 {
+        if let radii {
+            content.clipShape(UnevenRoundedRectangle(cornerRadii: radii))
+        } else if radius > 0 {
             content.clipShape(RoundedRectangle(cornerRadius: radius))
         } else {
             content
@@ -211,6 +257,9 @@ private struct ClipRadiusModifier: ViewModifier {
 private struct GlassModifier: ViewModifier {
     let flags: Int
     let cornerRadius: CGFloat
+    /// Per-corner radii when `rounded-<side>-*` was used, so a glass surface
+    /// takes the same asymmetric outline as its clip and border.
+    let cornerRadii: RectangleCornerRadii?
 
     private var enabled: Bool      { (flags & 1) != 0 }
     private var interactive: Bool  { (flags & 4) != 0 }
@@ -240,7 +289,9 @@ private struct GlassModifier: ViewModifier {
     /// Tailwind parser maps `rounded-full` → 9999, `rounded-{xs..3xl}`
     /// → fixed pt values, no `rounded-*` → 0.
     private var glassShape: AnyShape {
-        if cornerRadius >= 9999 {
+        if let cornerRadii {
+            return AnyShape(UnevenRoundedRectangle(cornerRadii: cornerRadii))
+        } else if cornerRadius >= 9999 {
             return AnyShape(Capsule())
         } else if cornerRadius > 0 {
             return AnyShape(RoundedRectangle(cornerRadius: cornerRadius))

--- a/src/Edge/Enums/AlignItems.php
+++ b/src/Edge/Enums/AlignItems.php
@@ -7,13 +7,26 @@ use Native\Mobile\Edge\Enums\Concerns\ResolvesAlignmentValue;
 /**
  * Cross-axis alignment of a flex container's children (CSS `align-items`).
  * Wire values match the native `FlexContainer` (iOS) / `ComposeFlexLayout`
- * (Android) enums: 0 = start, 1 = center, 2 = end, 3 = stretch.
+ * (Android) enums: 1 = center, 2 = end, 3 = stretch, 4 = start.
+ *
+ * **0 is deliberately not a case — it means UNSET.** The layout array only
+ * carries `align_items` when the author actually asked for an alignment, so
+ * a node with no `items-*` class arrives as 0 and each renderer applies its
+ * own default. Start therefore cannot be 0: if it were, "no items-* class"
+ * and an explicit `items-start` would be the same byte on the wire, and the
+ * renderers could not honour one without also changing the other (mobile-air
+ * #309 — swapping iOS's transposed branches also flipped every unclassed
+ * container from fill to hug).
+ *
+ * `parse()` validates integers against the cases, so `align-items="0"` now
+ * resolves to null and leaves the native default in place — which is what
+ * "unset" should do anyway.
  */
 enum AlignItems: int
 {
     use ResolvesAlignmentValue;
 
-    case Start = 0;
+    case Start = 4;
 
     case Center = 1;
 

--- a/src/Edge/Enums/AlignSelf.php
+++ b/src/Edge/Enums/AlignSelf.php
@@ -6,13 +6,20 @@ use Native\Mobile\Edge\Enums\Concerns\ResolvesAlignmentValue;
 
 /**
  * Per-child cross-axis alignment override (CSS `align-self`). Same wire
- * domain as {@see AlignItems}: 0 = start, 1 = center, 2 = end, 3 = stretch.
+ * domain as {@see AlignItems}: 1 = center, 2 = end, 3 = stretch, 4 = start,
+ * and 0 = UNSET (inherit the container's `align-items`).
+ *
+ * Both renderers already treated 0 as "unset" here — they resolve the
+ * effective alignment with `alignSelf > 0 ? alignSelf : align`. That made
+ * `self-start` a silent no-op for as long as Start was 0, since it was
+ * indistinguishable from "no self-* class". Moving Start to 4 fixes that
+ * for free alongside {@see AlignItems}.
  */
 enum AlignSelf: int
 {
     use ResolvesAlignmentValue;
 
-    case Start = 0;
+    case Start = 4;
 
     case Center = 1;
 

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -532,6 +532,18 @@ class NativeElementCollector
         if (isset($attrs['height'])) {
             $layout['height'] = $attrs['height'];
         }
+        if (isset($attrs['minWidth'])) {
+            $layout['min_width'] = (float) $attrs['minWidth'];
+        }
+        if (isset($attrs['maxWidth'])) {
+            $layout['max_width'] = (float) $attrs['maxWidth'];
+        }
+        if (isset($attrs['minHeight'])) {
+            $layout['min_height'] = (float) $attrs['minHeight'];
+        }
+        if (isset($attrs['maxHeight'])) {
+            $layout['max_height'] = (float) $attrs['maxHeight'];
+        }
 
         // Padding
         $uniformPadding = isset($attrs['padding']) && ! is_array($attrs['padding']) ? (float) $attrs['padding'] : null;
@@ -1310,6 +1322,18 @@ class NativeElementCollector
         }
         if (isset($attrs['height'])) {
             $element->height($attrs['height']);
+        }
+        if (isset($attrs['minWidth'])) {
+            $element->minWidth((float) $attrs['minWidth']);
+        }
+        if (isset($attrs['maxWidth'])) {
+            $element->maxWidth((float) $attrs['maxWidth']);
+        }
+        if (isset($attrs['minHeight'])) {
+            $element->minHeight((float) $attrs['minHeight']);
+        }
+        if (isset($attrs['maxHeight'])) {
+            $element->maxHeight((float) $attrs['maxHeight']);
         }
         // Padding (uniform + directional from Tailwind classes)
         $uniformPadding = isset($attrs['padding']) && ! is_array($attrs['padding']) ? (float) $attrs['padding'] : null;

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -357,6 +357,7 @@ class NativeElementCollector
             $style = static::buildStyleArray($attrs);
             $props = static::buildDarkProps($attrs)
                 + static::buildGradientProps($attrs)
+                + static::buildCornerRadiusProps($attrs)
                 + static::buildAnimationProps($attrs);
             $onPress = static::resolveOnPress($attrs);
             $onLongPress = static::resolveOnLongPress($attrs);
@@ -404,7 +405,9 @@ class NativeElementCollector
             $layout = $element->getLayout();
             $style = $element->getStyle();
             $props = $element->getResolvedProps(static::$callbacks);
-            $darkProps = static::buildDarkProps($attrs) + static::buildGradientProps($attrs);
+            $darkProps = static::buildDarkProps($attrs)
+                + static::buildGradientProps($attrs)
+                + static::buildCornerRadiusProps($attrs);
             if (! empty($darkProps)) {
                 $props = array_merge($props ?? [], $darkProps);
             }
@@ -449,6 +452,7 @@ class NativeElementCollector
             $style = static::buildStyleArray($attrs);
             $props = static::buildDarkProps($attrs)
                 + static::buildGradientProps($attrs)
+                + static::buildCornerRadiusProps($attrs)
                 + static::buildAnimationProps($attrs);
             $onPress = static::resolveOnPress($attrs);
             $onLongPress = static::resolveOnLongPress($attrs);
@@ -491,7 +495,9 @@ class NativeElementCollector
             $layout = $element->getLayout();
             $style = $element->getStyle();
             $props = $element->getResolvedProps(static::$callbacks);
-            $darkProps = static::buildDarkProps($attrs) + static::buildGradientProps($attrs);
+            $darkProps = static::buildDarkProps($attrs)
+                + static::buildGradientProps($attrs)
+                + static::buildCornerRadiusProps($attrs);
             if (! empty($darkProps)) {
                 $props = array_merge($props ?? [], $darkProps);
             }
@@ -795,6 +801,52 @@ class NativeElementCollector
             // native side splits it. Two or three `#AARRGGBB` entries.
             'gradient_stops' => implode(',', $stops),
         ];
+    }
+
+    /**
+     * Per-corner border radius (`rounded-br-none`, `rounded-t-2xl`, …).
+     *
+     * The packed node carries a single `border_radius` float at offset 134
+     * with no room for four, so the corners ride the generic prop bag
+     * instead — no wire format bump, and old renderers simply ignore props
+     * they don't know.
+     *
+     * All four corners are emitted whenever ANY is authored, each resolving
+     * to the per-corner value if given and the uniform `rounded-*` otherwise.
+     * That means the native side needs no per-corner presence checks — the
+     * existence of `radius_tl` alone says "use the corner props" — and it is
+     * what makes `rounded-2xl rounded-br-none` square off exactly one corner
+     * while the other three keep 16.
+     *
+     * Returns [] when no per-corner class was used, leaving the plain
+     * `border_radius` style field to do its job unchanged.
+     */
+    public static function buildCornerRadiusProps(array $attrs): array
+    {
+        $corners = [
+            'radius_tl' => 'borderRadiusTopLeft',
+            'radius_tr' => 'borderRadiusTopRight',
+            'radius_br' => 'borderRadiusBottomRight',
+            'radius_bl' => 'borderRadiusBottomLeft',
+        ];
+
+        $authored = array_filter(
+            $corners,
+            fn (string $attr): bool => isset($attrs[$attr])
+        );
+
+        if ($authored === []) {
+            return [];
+        }
+
+        $uniform = isset($attrs['borderRadius']) ? (float) $attrs['borderRadius'] : 0.0;
+
+        $props = [];
+        foreach ($corners as $prop => $attr) {
+            $props[$prop] = isset($attrs[$attr]) ? (float) $attrs[$attr] : $uniform;
+        }
+
+        return $props;
     }
 
     /**
@@ -1289,6 +1341,12 @@ class NativeElementCollector
         // (column/row/stack/etc.) pick up `animate-duration`,
         // `animate-easing`, etc. without needing per-element wiring.
         foreach (static::buildAnimationProps($attrs) as $key => $value) {
+            $element->setProp($key, $value);
+        }
+
+        // Per-corner radius rides the prop bag for the same reason — the
+        // packed node has only one `border_radius` float.
+        foreach (static::buildCornerRadiusProps($attrs) as $key => $value) {
             $element->setProp($key, $value);
         }
 

--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -207,6 +207,29 @@ class TailwindParser
         'xl' => 12, '2xl' => 16, '3xl' => 24, 'full' => 9999,
     ];
 
+    /**
+     * Which corners each `rounded-<side>-*` suffix touches. Sides expand to
+     * their two corners, exactly as Tailwind's longhand does.
+     *
+     * Only the PHYSICAL spellings are here. Tailwind's logical variants
+     * (`rounded-s-*`, `rounded-ee-*`, …) resolve against the writing
+     * direction, and neither renderer flips corners for RTL yet — accepting
+     * them would silently render LTR geometry in an RTL layout, so they stay
+     * unparsed and land in the dropped-class diagnostics instead.
+     *
+     * @var array<string, list<string>>
+     */
+    private const BORDER_RADIUS_CORNERS = [
+        'tl' => ['borderRadiusTopLeft'],
+        'tr' => ['borderRadiusTopRight'],
+        'br' => ['borderRadiusBottomRight'],
+        'bl' => ['borderRadiusBottomLeft'],
+        't' => ['borderRadiusTopLeft', 'borderRadiusTopRight'],
+        'r' => ['borderRadiusTopRight', 'borderRadiusBottomRight'],
+        'b' => ['borderRadiusBottomRight', 'borderRadiusBottomLeft'],
+        'l' => ['borderRadiusTopLeft', 'borderRadiusBottomLeft'],
+    ];
+
     private const SHADOW = [
         'sm' => 1, 'md' => 6, 'lg' => 8, 'xl' => 12, '2xl' => 16, 'none' => 0,
     ];
@@ -1182,13 +1205,54 @@ class TailwindParser
         return self::resolveColor($value, 'borderColor');
     }
 
+    /**
+     * `rounded-*` — uniform, per-side and per-corner.
+     *
+     * The scale keys carry no dashes, so a dash unambiguously separates a
+     * side from its size: `2xl` is uniform, `br-none` is one corner.
+     * A bare side (`rounded-t`) takes Tailwind's default 4pt radius, the
+     * same as a bare `rounded`.
+     *
+     * Per-corner keys are emitted ALONGSIDE any uniform `borderRadius` rather
+     * than merged into it, so `rounded-2xl rounded-br-none` keeps both and the
+     * collector resolves the precedence. That makes the result independent of
+     * the order the classes appear in — which matches Tailwind, where the
+     * longhand always follows the shorthand in the generated stylesheet
+     * regardless of how the author ordered the attribute.
+     */
     private static function parseRounded(string $value): ?array
     {
         if (isset(self::BORDER_RADIUS[$value])) {
             return ['borderRadius' => self::BORDER_RADIUS[$value]];
         }
 
-        return null;
+        [$side, $size] = array_pad(explode('-', $value, 2), 2, null);
+
+        $corners = self::BORDER_RADIUS_CORNERS[$side] ?? null;
+        if ($corners === null) {
+            return null;
+        }
+
+        // Bare side (`rounded-b`) → the same default `rounded` uses.
+        $radius = $size === null ? 4 : (self::BORDER_RADIUS[$size] ?? null);
+        if ($radius === null) {
+            return null;
+        }
+
+        return array_fill_keys($corners, $radius);
+    }
+
+    /**
+     * Arbitrary per-corner radius — `rounded-br-[4px]`, `rounded-t-[12]`.
+     * The uniform `rounded-[N]` form is handled inline in parseArbitrary.
+     *
+     * @return array<string, float>|null
+     */
+    private static function parseArbitraryRounded(string $side, string $value): ?array
+    {
+        $corners = self::BORDER_RADIUS_CORNERS[$side] ?? null;
+
+        return $corners === null ? null : array_fill_keys($corners, (float) $value);
     }
 
     private static function parseShadow(string $value): ?array
@@ -1259,6 +1323,10 @@ class TailwindParser
             'bg' => $isColor ? self::arbitraryColor('bg', $value) : null,
             'text' => $isColor ? self::arbitraryColor('color', $value) : ['fontSize' => (float) $value],
             'rounded' => ['borderRadius' => (float) $value],
+            // `rounded-br-[4px]` etc. The arbitrary regex is non-greedy up to
+            // the final `-[`, so the whole `rounded-<side>` arrives as prefix.
+            'rounded-tl', 'rounded-tr', 'rounded-br', 'rounded-bl',
+            'rounded-t', 'rounded-r', 'rounded-b', 'rounded-l' => self::parseArbitraryRounded(substr($prefix, 8), $value),
             'border' => $isColor ? self::arbitraryColor('borderColor', $value) : ['borderWidth' => (float) $value],
             'opacity' => ['opacity' => (float) $value],
             'aspect' => ['aspectRatio' => self::parseRatio($value)],

--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -211,6 +211,18 @@ class TailwindParser
         'sm' => 1, 'md' => 6, 'lg' => 8, 'xl' => 12, '2xl' => 16, 'none' => 0,
     ];
 
+    /**
+     * Tailwind's container scale, used by `max-w-*` (and, in v4, `min-w-*`).
+     * Values are the rem sizes converted at the 16px root Tailwind assumes.
+     * Most are far wider than a phone, but they're what authors type and a
+     * constraint that never binds is still better than a dropped class.
+     */
+    private const CONTAINER_SIZES = [
+        '3xs' => 256, '2xs' => 288, 'xs' => 320, 'sm' => 384, 'md' => 448,
+        'lg' => 512, 'xl' => 576, '2xl' => 672, '3xl' => 768, '4xl' => 896,
+        '5xl' => 1024, '6xl' => 1152, '7xl' => 1280,
+    ];
+
     private const WIDTH_FRACTIONS = [
         '1/2' => '50%', '1/3' => '33%', '2/3' => '67%',
         '1/4' => '25%', '2/4' => '50%', '3/4' => '75%',
@@ -538,8 +550,17 @@ class TailwindParser
             str_starts_with($class, 'ml-') => self::parseSpacingSide('marginLeft', substr($class, 3)),
             str_starts_with($class, 'm-') => self::parseSpacingUniform('margin', substr($class, 2)),
 
-            // Gap, dimensions
+            // Gap, dimensions.
+            //
+            // The min-/max- constraints MUST precede the bare `w-`/`h-`
+            // branches only for readability — they don't actually collide
+            // (`max-w-4` doesn't start with `w-`) — but grouping them keeps
+            // the sizing rules together.
             str_starts_with($class, 'gap-') => self::parseSpacingUniform('gap', substr($class, 4)),
+            str_starts_with($class, 'min-w-') => self::parseSizeConstraint('minWidth', substr($class, 6)),
+            str_starts_with($class, 'max-w-') => self::parseSizeConstraint('maxWidth', substr($class, 6)),
+            str_starts_with($class, 'min-h-') => self::parseSizeConstraint('minHeight', substr($class, 6)),
+            str_starts_with($class, 'max-h-') => self::parseSizeConstraint('maxHeight', substr($class, 6)),
             str_starts_with($class, 'w-') => self::parseWidth(substr($class, 2)),
             str_starts_with($class, 'h-') => self::parseHeight(substr($class, 2)),
             // Inset shorthands. `inset-x-`/`inset-y-` MUST precede the bare
@@ -867,6 +888,36 @@ class TailwindParser
     {
         if (isset(self::SPACING[$value])) {
             return ['height' => self::SPACING[$value]];
+        }
+
+        return null;
+    }
+
+    /**
+     * `max-w-*` / `min-w-*` / `max-h-*` / `min-h-*`.
+     *
+     * Accepts the spacing scale (`max-w-64`), the container scale that only
+     * max-width has in Tailwind (`max-w-sm`), and `none` (an explicit "no
+     * constraint", which is what the wire's 0 already means).
+     *
+     * The `full` / `screen*` / `min` / `max` / `fit` keywords are deliberately
+     * NOT accepted: the packed node carries min/max as bare floats with no
+     * companion size mode, so there is nowhere to put "100% of the parent".
+     * Leaving them unparsed lands them in the dropped-class diagnostics
+     * instead of silently doing nothing.
+     */
+    private static function parseSizeConstraint(string $key, string $value): ?array
+    {
+        if ($value === 'none') {
+            return [$key => 0];
+        }
+
+        if (isset(self::SPACING[$value])) {
+            return [$key => self::SPACING[$value]];
+        }
+
+        if (($key === 'maxWidth' || $key === 'minWidth') && isset(self::CONTAINER_SIZES[$value])) {
+            return [$key => self::CONTAINER_SIZES[$value]];
         }
 
         return null;
@@ -1201,6 +1252,10 @@ class TailwindParser
             'gap' => ['gap' => (float) $value],
             'w' => ['width' => (float) $value],
             'h' => ['height' => (float) $value],
+            'min-w' => ['minWidth' => (float) $value],
+            'max-w' => ['maxWidth' => (float) $value],
+            'min-h' => ['minHeight' => (float) $value],
+            'max-h' => ['maxHeight' => (float) $value],
             'bg' => $isColor ? self::arbitraryColor('bg', $value) : null,
             'text' => $isColor ? self::arbitraryColor('color', $value) : ['fontSize' => (float) $value],
             'rounded' => ['borderRadius' => (float) $value],

--- a/tests/Unit/Edge/AlignmentEnumsTest.php
+++ b/tests/Unit/Edge/AlignmentEnumsTest.php
@@ -28,15 +28,24 @@ it('pins the alignment wire values to the native protocol', function () {
     expect([TextAlign::Left->value, TextAlign::Center->value, TextAlign::Right->value])
         ->toBe([0, 1, 2]);
 
+    // Start is 4, NOT 0. 0 is reserved for "unset" — the layout array omits
+    // `align_items` when no items-*/self-* class was authored, and the
+    // renderers apply their own default for it. Collapsing Start onto 0 is
+    // what made iOS unable to fix `items-start` without also flipping every
+    // unclassed container (mobile-air #309).
     expect([
         AlignItems::Start->value, AlignItems::Center->value,
         AlignItems::End->value, AlignItems::Stretch->value,
-    ])->toBe([0, 1, 2, 3]);
+    ])->toBe([4, 1, 2, 3]);
 
     expect([
         AlignSelf::Start->value, AlignSelf::Center->value,
         AlignSelf::End->value, AlignSelf::Stretch->value,
-    ])->toBe([0, 1, 2, 3]);
+    ])->toBe([4, 1, 2, 3]);
+
+    // 0 must not resolve to any case, or the "unset" slot leaks back.
+    expect(AlignItems::tryFrom(0))->toBeNull()
+        ->and(AlignSelf::tryFrom(0))->toBeNull();
 
     expect([
         JustifyContent::Start->value, JustifyContent::Center->value,
@@ -157,16 +166,22 @@ it('keeps Tailwind alignment classes mapping to the same wire values', function 
 it('rejects integers outside the enum instead of passing them to the wire', function () {
     // The native renderers switch on this value and silently fall back to
     // their own default for anything unknown, so an out-of-range int must not
-    // reach them — that just moves the failure somewhere harder to see. This
-    // is why the old `Align::BASELINE = 4` was removed.
-    expect(AlignItems::parse(4))->toBeNull();
+    // reach them — that just moves the failure somewhere harder to see. The
+    // old `Align::BASELINE = 4` was removed for this reason; 4 has since been
+    // reassigned to Start (#309) and no renderer still reads it as baseline.
+    expect(AlignItems::parse(5))->toBeNull();
     expect(AlignItems::parse(-1))->toBeNull();
     expect(JustifyContent::parse(6))->toBeNull();
     expect(TextAlign::parse(3))->toBeNull();
 
+    // 0 is the "unset" slot and is not a case, so it must not resolve either —
+    // an explicit `alignItems="0"` leaves the native default in place, which
+    // is exactly what unset should do.
+    expect(AlignItems::parse(0))->toBeNull();
+
     // ...and the setter leaves the native default in place rather than
     // writing a value the renderer can't read.
-    $el = Column::make()->alignItems(4)->toArray(new CallbackRegistry);
+    $el = Column::make()->alignItems(5)->toArray(new CallbackRegistry);
     expect($el['layout'] ?? [])->not->toHaveKey('align_items');
 });
 

--- a/tests/Unit/Edge/TailwindParserTest.php
+++ b/tests/Unit/Edge/TailwindParserTest.php
@@ -78,6 +78,50 @@ it('parses height from spacing scale', function () {
     expect(TailwindParser::parse('h-32'))->toBe(['height' => 128]);
 });
 
+// ── Min/max size constraints (#310) ─────────────────
+
+it('parses min/max size constraints from the spacing scale', function () {
+    expect(TailwindParser::parse('max-w-64'))->toBe(['maxWidth' => 256]);
+    expect(TailwindParser::parse('min-w-4'))->toBe(['minWidth' => 16]);
+    expect(TailwindParser::parse('max-h-96'))->toBe(['maxHeight' => 384]);
+    expect(TailwindParser::parse('min-h-8'))->toBe(['minHeight' => 32]);
+});
+
+it('parses max-w from the container scale', function () {
+    expect(TailwindParser::parse('max-w-xs'))->toBe(['maxWidth' => 320]);
+    expect(TailwindParser::parse('max-w-sm'))->toBe(['maxWidth' => 384]);
+    expect(TailwindParser::parse('max-w-2xl'))->toBe(['maxWidth' => 672]);
+});
+
+it('parses arbitrary min/max size constraints', function () {
+    expect(TailwindParser::parse('max-w-[280px]'))->toBe(['maxWidth' => 280.0]);
+    expect(TailwindParser::parse('min-h-[100px]'))->toBe(['minHeight' => 100.0]);
+});
+
+it('treats max-w-none as an explicit no-constraint', function () {
+    // 0 is what "unset" already means on the wire, so `none` round-trips to it.
+    expect(TailwindParser::parse('max-w-none'))->toBe(['maxWidth' => 0]);
+});
+
+it('combines a width mode with a max-width constraint', function () {
+    expect(TailwindParser::parse('w-full max-w-[280px]'))
+        ->toBe(['fillWidth' => true, 'maxWidth' => 280.0]);
+});
+
+it('drops max-w keywords the wire cannot express', function () {
+    // min/max ride the packed node as bare floats with no companion size
+    // mode, so there is nowhere to put "100% of the parent". Dropping them
+    // surfaces the class in the unsupported-class diagnostics instead of
+    // silently rendering nothing.
+    expect(TailwindParser::parse('max-w-full'))->toBe([]);
+    expect(TailwindParser::parse('max-w-screen'))->toBe([]);
+});
+
+it('does not let the margin branch swallow min/max classes', function () {
+    expect(TailwindParser::parse('m-4'))->toBe(['margin' => 16]);
+    expect(TailwindParser::parse('mx-2'))->toBe(['marginLeft' => 8, 'marginRight' => 8]);
+});
+
 // ── Flex & Alignment ────────────────────────────────
 
 it('parses flex direction', function () {
@@ -104,10 +148,26 @@ it('parses the current Tailwind grow and shrink aliases', function () {
 });
 
 it('parses items alignment', function () {
-    expect(TailwindParser::parse('items-start'))->toBe(['alignItems' => 0]);
+    // start is 4, not 0 — 0 is the "no items-* class" slot. See AlignItems.
+    expect(TailwindParser::parse('items-start'))->toBe(['alignItems' => 4]);
     expect(TailwindParser::parse('items-center'))->toBe(['alignItems' => 1]);
     expect(TailwindParser::parse('items-end'))->toBe(['alignItems' => 2]);
     expect(TailwindParser::parse('items-stretch'))->toBe(['alignItems' => 3]);
+});
+
+it('distinguishes an authored items-start from no alignment at all', function () {
+    // The whole point of moving Start off 0 (#309): these two must not
+    // produce the same wire value, or the renderers cannot tell them apart.
+    NativeElementCollector::reset();
+    NativeElementCollector::leaf('column', ['class' => 'items-start']);
+    $explicit = NativeElementCollector::collect()->toArray(new CallbackRegistry);
+
+    NativeElementCollector::reset();
+    NativeElementCollector::leaf('column', ['class' => 'p-4']);
+    $unset = NativeElementCollector::collect()->toArray(new CallbackRegistry);
+
+    expect($explicit['layout']['align_items'])->toBe(4)
+        ->and($unset['layout'])->not->toHaveKey('align_items');
 });
 
 it('parses justify content', function () {
@@ -120,7 +180,9 @@ it('parses justify content', function () {
 });
 
 it('parses self alignment', function () {
-    expect(TailwindParser::parse('self-start'))->toBe(['alignSelf' => 0]);
+    // Both renderers resolve `alignSelf > 0 ? alignSelf : align`, so while
+    // Start was 0 an authored `self-start` was a silent no-op. 4 fixes it.
+    expect(TailwindParser::parse('self-start'))->toBe(['alignSelf' => 4]);
     expect(TailwindParser::parse('self-center'))->toBe(['alignSelf' => 1]);
     expect(TailwindParser::parse('self-end'))->toBe(['alignSelf' => 2]);
     expect(TailwindParser::parse('self-stretch'))->toBe(['alignSelf' => 3]);
@@ -642,6 +704,20 @@ it('combines uniform and directional padding through collector', function () {
 
     // p-4 = 16 uniform, pt-8 = 32 top override
     expect($tree['layout']['padding'])->toBe([32.0, 16.0, 16.0, 16.0]);
+});
+
+it('carries min/max size constraints through the collector to the wire', function () {
+    NativeElementCollector::reset();
+    NativeElementCollector::leaf('column', [
+        'class' => 'w-full max-w-[280px] min-h-16',
+    ]);
+
+    $tree = NativeElementCollector::collect()->toArray(new CallbackRegistry);
+
+    expect($tree['layout']['max_width'])->toBe(280.0)
+        ->and($tree['layout']['min_height'])->toBe(64.0)
+        // `w-full` still sets the width mode — max-w clamps it, it doesn't replace it.
+        ->and($tree['layout']['width'])->toBe('fill');
 });
 
 it('explicit attrs override class attrs', function () {

--- a/tests/Unit/Edge/TailwindParserTest.php
+++ b/tests/Unit/Edge/TailwindParserTest.php
@@ -307,6 +307,100 @@ it('parses border radius', function () {
     expect(TailwindParser::parse('rounded-full'))->toBe(['borderRadius' => 9999]);
 });
 
+// ── Per-corner / per-side border radius (#311) ──────
+
+it('parses per-corner border radius', function () {
+    expect(TailwindParser::parse('rounded-tl-2xl'))->toBe(['borderRadiusTopLeft' => 16]);
+    expect(TailwindParser::parse('rounded-tr-lg'))->toBe(['borderRadiusTopRight' => 8]);
+    expect(TailwindParser::parse('rounded-br-none'))->toBe(['borderRadiusBottomRight' => 0]);
+    expect(TailwindParser::parse('rounded-bl-full'))->toBe(['borderRadiusBottomLeft' => 9999]);
+});
+
+it('expands per-side border radius to its two corners', function () {
+    expect(TailwindParser::parse('rounded-t-2xl'))
+        ->toBe(['borderRadiusTopLeft' => 16, 'borderRadiusTopRight' => 16]);
+    expect(TailwindParser::parse('rounded-b-lg'))
+        ->toBe(['borderRadiusBottomRight' => 8, 'borderRadiusBottomLeft' => 8]);
+    expect(TailwindParser::parse('rounded-l-md'))
+        ->toBe(['borderRadiusTopLeft' => 6, 'borderRadiusBottomLeft' => 6]);
+    expect(TailwindParser::parse('rounded-r-xl'))
+        ->toBe(['borderRadiusTopRight' => 12, 'borderRadiusBottomRight' => 12]);
+});
+
+it('gives a bare side the same default radius as a bare rounded', function () {
+    expect(TailwindParser::parse('rounded-b'))
+        ->toBe(['borderRadiusBottomRight' => 4, 'borderRadiusBottomLeft' => 4]);
+});
+
+it('parses arbitrary per-corner radius', function () {
+    expect(TailwindParser::parse('rounded-br-[4px]'))->toBe(['borderRadiusBottomRight' => 4.0]);
+    expect(TailwindParser::parse('rounded-t-[12]'))
+        ->toBe(['borderRadiusTopLeft' => 12.0, 'borderRadiusTopRight' => 12.0]);
+    // The uniform arbitrary form must keep working alongside them.
+    expect(TailwindParser::parse('rounded-[10]'))->toBe(['borderRadius' => 10.0]);
+});
+
+it('keeps uniform and per-corner radius as separate keys, order-independently', function () {
+    // Tailwind emits the shorthand before the longhand in its stylesheet, so
+    // the per-corner value wins no matter how the author orders the classes.
+    // Merging them here would make the result depend on class order.
+    $expected = ['borderRadius' => 16, 'borderRadiusBottomRight' => 0];
+
+    expect(TailwindParser::parse('rounded-2xl rounded-br-none'))->toBe($expected);
+    expect(TailwindParser::parse('rounded-br-none rounded-2xl'))
+        ->toBe(['borderRadiusBottomRight' => 0, 'borderRadius' => 16]);
+});
+
+it('rejects logical and malformed radius spellings', function () {
+    // Logical (writing-direction) corners aren't supported — neither renderer
+    // flips corners for RTL, so accepting these would render LTR geometry in
+    // an RTL layout. Dropping them surfaces the class in the diagnostics.
+    expect(TailwindParser::parse('rounded-s-lg'))->toBe([]);
+    expect(TailwindParser::parse('rounded-ee-lg'))->toBe([]);
+    expect(TailwindParser::parse('rounded-zz-lg'))->toBe([]);
+    expect(TailwindParser::parse('rounded-t-bogus'))->toBe([]);
+});
+
+it('resolves per-corner radius against the uniform radius on the wire', function () {
+    // All four corners are emitted whenever any is authored, each already
+    // resolved — so the native side needs no per-corner presence checks.
+    NativeElementCollector::reset();
+    NativeElementCollector::leaf('column', ['class' => 'rounded-2xl rounded-br-none']);
+    $tree = NativeElementCollector::collect()->toArray(new CallbackRegistry);
+
+    expect($tree['props'])->toMatchArray([
+        'radius_tl' => 16.0,
+        'radius_tr' => 16.0,
+        'radius_br' => 0.0,
+        'radius_bl' => 16.0,
+    ])
+        // The uniform field stays populated so renderers that ignore the
+        // corner props still draw something sane.
+        ->and($tree['style']['border_radius'])->toBe(16.0);
+});
+
+it('emits no corner props when only a uniform radius is used', function () {
+    NativeElementCollector::reset();
+    NativeElementCollector::leaf('column', ['class' => 'rounded-2xl']);
+    $tree = NativeElementCollector::collect()->toArray(new CallbackRegistry);
+
+    expect($tree['props'] ?? [])->not->toHaveKey('radius_tl')
+        ->and($tree['style']['border_radius'])->toBe(16.0);
+});
+
+it('defaults unauthored corners to zero when there is no uniform radius', function () {
+    NativeElementCollector::reset();
+    NativeElementCollector::leaf('column', ['class' => 'rounded-tl-2xl']);
+    $tree = NativeElementCollector::collect()->toArray(new CallbackRegistry);
+
+    expect($tree['props'])->toMatchArray([
+        'radius_tl' => 16.0,
+        'radius_tr' => 0.0,
+        'radius_br' => 0.0,
+        'radius_bl' => 0.0,
+    ]);
+});
+
 // ── Visual ──────────────────────────────────────────
 
 it('parses opacity', function () {


### PR DESCRIPTION
Fixes #311. cc @shrutibalasawebdev

> **Stacked on #313** — based on `fix/masterclass-issues` so the diff here is only the radius work. GitHub will retarget this to `main` automatically once #313 merges.

Demo: `/masterclass/corner-radius` in the super-native demo app, under the **Masterclass Fixes** group. Sections 1–5 are the issue's five blocks verbatim.

---

## The parser cause (mundane)

`TailwindParser::parseRounded` only ever looked its argument up in the `BORDER_RADIUS` scale. `rounded-br-none` arrived as the string `br-none`, missed, and returned `null`.

That's precisely why the class **neither applied its own radius nor overrode a uniform one** — @shrutibalasawebdev called that out as ruling out a precedence problem, and it was the right read: the class was being dropped before it reached the renderer, not mismapped. `rounded-br-[4px]` failed separately, in `parseArbitrary`, for want of a prefix.

## The wire (the interesting part)

The packed node carries a **single** `border_radius` float at offset 134, with no room for four. Widening it means bumping `NPHP_FORMAT_VERSION` in lockstep with the embedded PHP binary — far too much blast radius for a styling fix.

So the corners ride the **generic prop bag** instead (`radius_tl` … `radius_bl`) — the same escape hatch gradients already use for their variable-length stop list. No format bump, and renderers that don't know the props simply ignore them.

PHP resolves all four corners at collection time (per-corner value if authored → else the uniform `rounded-*` → else 0) and emits all four whenever **any** is authored. Two useful things fall out:

- the native side needs **no per-corner presence checks** — `radius_tl` existing *is* the switch
- the result is **independent of class order**

That second one matters. Tailwind's generated stylesheet always places the longhand after the shorthand, so `rounded-2xl rounded-br-none` and `rounded-br-none rounded-2xl` are identical in CSS. Keeping them as separate keys and resolving at collection time preserves that; merging in the parser would have made the outcome depend on attribute order. Section 6 of the demo asserts the two are pixel-identical.

Wire output:

```
rounded-2xl rounded-br-none  style={"border_radius":16}
                             props={"radius_tl":16,"radius_tr":16,"radius_br":0,"radius_bl":16}
rounded-2xl                  style={"border_radius":16}  props=[]
```

The uniform style field stays populated so nothing regresses for nodes that never use a corner class.

## Renderers

iOS `UnevenRoundedRectangle`, Android `RoundedCornerShape(topStart: …)` — available unconditionally at the iOS 18.2 deployment target.

Applied to the **clip, the border overlay _and_ the glass shape**. The border is drawn from a separate shape to the background, so a rounded stroke over a squared-off fill was a genuine way to get this half-right. `strokeBorder` is kept over `stroke` so existing borders don't shift by half a line width.

Android's ripple clip gated on `radius > 0`, which would have let a `rounded-br-none` bubble's ripple bleed past its corners — it now consults the corner props too.

## Deliberately not supported

Tailwind's **logical** spellings (`rounded-s-*`, `rounded-ee-*`, …) stay unparsed. They resolve against writing direction and neither renderer flips corners for RTL, so accepting them would quietly render LTR geometry in an RTL layout. They surface in the dropped-class diagnostics instead. Section 9 of the demo shows this.

Same reasoning behind one detail worth flagging: both `UnevenRoundedRectangle` and `RoundedCornerShape` name their corners *leading/trailing*, which flip under RTL, while the spellings we accept are physical (`tl` = top-**left**). Leading is mapped to left — consistent with the rest of the renderer, since `FlexContainer` places everything off `bounds.minX` and has no RTL handling either. Commented in both files so it's a decision rather than an accident.

## Testing

- Full suite green: **890 passed**, Pint clean
- 10 new tests: every side and corner spelling, the bare-side default (`rounded-b` → 4pt), arbitrary per-corner values, the order-independence pair, rejection of logical/malformed spellings, and wire-level assertions that corners resolve against the uniform radius
- Includes the negative case — a node using only `rounded-2xl` must emit **no** corner props, so the existing uniform path is untouched

⚠️ **The Swift and Kotlin changes are compile-unverified** — no iOS or Android build has been run against this yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
