### PR TITLE
[Masterclass] Dismiss the keyboard on tap for screens with native chrome

### DIFF
--- a/resources/xcode/NativePHP/NativeRender/NativeRootStackRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeRootStackRenderer.swift
@@ -259,6 +259,11 @@ struct NativeRootStackRenderer: View {
             // and the press transition renders as a visible flicker
             // behind the touched element. iOS 26+ only.
             NodeView(node: node)
+                // Tapping outside a focused field dismisses the keyboard, the
+                // same as on a chrome-less screen. Attached per-screen because
+                // the NavigationStack root itself is deliberately left unwrapped
+                // (mobile-air #308).
+                .dismissesKeyboardOnTap()
                 .withGlassContainer()
                 // NavigationStack hosts screens on its own container
                 // background (systemBackground — white in light mode) and

--- a/resources/xcode/NativePHP/NativeRender/NativeRootTabsRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeRootTabsRenderer.swift
@@ -563,6 +563,12 @@ private struct PerTabContent: View {
         }
         if let content {
             NodeView(node: content)
+                // Tapping outside a focused field dismisses the keyboard, the
+                // same as on a chrome-less screen. Attached to the screen
+                // content, not the TabView — a tap on the tab bar is the bar's
+                // business, and wrapping the TabView risks iOS 26's search
+                // capsule (mobile-air #308).
+                .dismissesKeyboardOnTap()
         } else {
             Color.clear
         }

--- a/resources/xcode/NativePHP/NativeRender/SwiftUINodeRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/SwiftUINodeRenderer.swift
@@ -87,11 +87,7 @@ struct NativeTreeRenderer: View {
                     .environment(\.availableHeight, geo.size.height)
             }
             .ignoresSafeArea(.container, edges: .all)
-            .simultaneousGesture(
-                TapGesture().onEnded {
-                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-                }
-            )
+            .dismissesKeyboardOnTap()
         }
     }
 
@@ -102,6 +98,42 @@ struct NativeTreeRenderer: View {
             return (0, 0)
         }
         return (insets.top, insets.bottom)
+    }
+}
+
+// MARK: - Tap-to-dismiss Keyboard
+
+extension View {
+    /// Dismiss the keyboard when the user taps anywhere in this subtree.
+    ///
+    /// Applied to the screen CONTENT on every kind of screen — chrome-less
+    /// roots here, plus the stack and tabs renderers, which host their screens
+    /// separately and so never inherited the gesture. Before that, tapping
+    /// outside a field dismissed the keyboard on a plain screen but did
+    /// nothing on any screen inside a tab or stack layout (mobile-air #308).
+    ///
+    /// Deliberately attached to the screen content rather than to the
+    /// TabView / NavigationStack root: `rootContent` bypasses NodeView's
+    /// wrappers for those sentinels because cumulative wrapping breaks iOS 26's
+    /// `Tab(role: .search)` capsule activation, and adding a gesture recognizer
+    /// spanning the tab bar risks the same class of problem. Screen content is
+    /// also the correct scope — a tap on the tab bar or a toolbar button is
+    /// that control's business, not a dismiss.
+    ///
+    /// `simultaneousGesture` rather than `onTapGesture` so it runs ALONGSIDE
+    /// whatever it lands on: buttons, pressables and list rows underneath keep
+    /// receiving their own taps instead of having them swallowed.
+    func dismissesKeyboardOnTap() -> some View {
+        simultaneousGesture(
+            TapGesture().onEnded {
+                UIApplication.shared.sendAction(
+                    #selector(UIResponder.resignFirstResponder),
+                    to: nil,
+                    from: nil,
+                    for: nil
+                )
+            }
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #308. cc @shrutibalasawebdev

Independent of #313 / #314 — touches no files they do, so it can merge in any order.

Demos: `/masterclass/keyboard-dismiss` (native chrome — the failing case) and `/masterclass/keyboard-dismiss-plain` (no chrome — the control), in the super-native demo app.

---

## Cause

@shrutibalasawebdev's note called it exactly: *"the tap-to-dismiss gesture appears to only be attached on chrome-less screens, so any screen presented inside a tab or stack layout never gets it."*

`SwiftUINodeRenderer.rootContent` switches three ways on the root node type, and the gesture was attached to only **one** of them — the `else` branch that renders a plain root. The `native_root_tabs` and `native_root_stack` branches return their renderers directly and never picked it up, so every screen inside a tab or stack layout was born without it.

Dragging still dismissed because that's SwiftUI's own `scrollDismissesKeyboard`, which is unrelated and was never part of the bug. It just made the failure look intermittent rather than total.

## Fix

Extracted the gesture as `View.dismissesKeyboardOnTap()` and attached it in all three places.

**On the two chrome renderers it goes on the screen CONTENT, not on the `TabView` / `NavigationStack` root.** Two reasons:

1. `rootContent` deliberately bypasses NodeView's wrappers for those sentinels — the comment there records that cumulative wrapping breaks iOS 26's `Tab(role: .search)` capsule activation. A gesture recognizer spanning the tab bar is the same class of risk, and this fix isn't worth trading for that regression.
2. It's the correct scope anyway. A tap on the tab bar or a toolbar button is that control's business, not a dismiss.

Kept as `simultaneousGesture` rather than `onTapGesture` so it runs **alongside** whatever it lands on — buttons, pressables and list rows keep receiving their own taps instead of having them swallowed. A dismiss that broke every button would be a worse bug than the one being fixed, so section 2 of the demo checks it explicitly: with the keyboard up, the button must **both** dismiss and increment.

I checked the other `NodeView` call sites in both chrome renderers — they're toolbar title views, not screen content — so these two insertion points cover it.

## Android needs no change

Its equivalent lives on the root `BoxWithConstraints` in `NativeUIRenderer.kt`:

```kotlin
BoxWithConstraints(
    modifier = Modifier.fillMaxSize().imePadding().clickable(...) {
        focusManager.clearFocus()
    }
)
```

That wraps the whole render — the `AnimatedContent` inside it renders `NodeView(node: t.root)`, and that root is whatever the tree says, chrome sentinels included. So the gesture sits above everything and always covered every screen. That's the structural difference: Android put it at the true root, iOS put it in one branch of a three-way switch.

## Testing

Full suite green: **881 passed**. No PHP surface changed, so there's nothing new to unit-test here — this is a pure SwiftUI view-tree fix, verified by the two demo screens.

⚠️ **Compile-unverified** — no iOS build has been run against this yet.

Worth checking on device beyond the demo: the **SyncUp Native chat screen**, which is a text field inside a *tab* layout — the exact shape this was filed from, and the path the demo screens don't exercise (they cover the stack renderer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
