### PR TITLE
Allow the surface-aware tree hook to be undefined when linking iOS

### DIFF
--- a/resources/xcode/NativePHP.xcodeproj/project.pbxproj
+++ b/resources/xcode/NativePHP.xcodeproj/project.pbxproj
@@ -2041,6 +2041,7 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lresolv",
+					"-Wl,-U,_NativeElement_PostTreeUpdateForSurface",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.nativephp.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2093,6 +2094,7 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lresolv",
+					"-Wl,-U,_NativeElement_PostTreeUpdateForSurface",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.nativephp.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2265,6 +2267,7 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lresolv",
+					"-Wl,-U,_NativeElement_PostTreeUpdateForSurface",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.nativephp.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2318,6 +2321,7 @@
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lresolv",
+					"-Wl,-U,_NativeElement_PostTreeUpdateForSurface",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.nativephp.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
Linking an iOS app against a `php-bin-mobile` build that carries the multi-surface runtime fails:

```
Undefined symbols for architecture arm64:
  "_NativeElement_PostTreeUpdateForSurface", referenced from:
      _nphp_element_publish_surface in libphp.a[391](nphp_element.o)
      _zif_nphp_frame_end in libphp.a[391](nphp_element.o)
ld: symbol(s) not found for architecture arm64
```

## Why the extension is not at fault

It declares the hook weak and guards every call, precisely so a reader that does not implement surfaces can link without it:

```c
extern void NativeElement_PostTreeUpdateForSurface(uint32_t surface_id) __attribute__((weak));
...
if (NativeElement_PostTreeUpdateForSurface) {
    NativeElement_PostTreeUpdateForSurface(surface_id);
} else if (is_primary) {
    NativeElement_PostTreeUpdate();          // legacy reader, primary surface only
}
```

That is the right C, and it is not sufficient on Apple platforms. `ld` will not produce an executable containing a symbol that is defined nowhere, regardless of the attribute. Tested against a minimal case, symbol defined nowhere, `clang -arch arm64`:

| declaration | result |
| --- | --- |
| `__attribute__((weak))` | **fails** with this same error |
| `__attribute__((weak_import))` | **fails** with this same error |
| either, plus `-Wl,-U,_Hook` | **links**; resolves to null, guard skips the call |

The attribute governs how the reference is emitted, not whether the link may leave it unresolved. `-U` is the part that says this one may stay undefined.

The desktop shell never hit this because its Swift defines the hook. Mobile defines only the legacy `NativeElement_PostTreeUpdate` (`BridgeRouter.swift:301`), so on iOS the reference is genuinely unresolved.

## The change

`-Wl,-U,_NativeElement_PostTreeUpdateForSurface` added to `OTHER_LDFLAGS` in both configurations of both application targets (`NativePHP` and `NativePHP-simulator`), since both link `libphp`.

It costs nothing on builds whose binaries predate the surface API: the symbol is not referenced, and an unused `-U` is inert. So this can merge ahead of any php-bin release.

## Why not a Swift no-op

Defining `@_cdecl("NativeElement_PostTreeUpdateForSurface")` as an empty function would also make it link, and would be wrong. The C falls back to the legacy hook **only when the symbol is absent**, so any definition — including an empty one — makes `if (NativeElement_PostTreeUpdateForSurface)` true and swallows every tree update.

The app would boot, run, and never render anything, with no error anywhere. That is a considerably worse failure than a link error, and a much harder one to trace back to this decision.

## Verified

Building the workspace for a device target against a `libphp.a` that references the symbol:

```
xcodebuild -workspace NativePHP.xcworkspace -scheme NativePHP \
  -configuration Debug -sdk iphoneos -destination 'generic/platform=iOS'
** BUILD SUCCEEDED **
```

The same build failed to link beforehand with the error above. The patched `project.pbxproj` here is byte-identical to the one that linked, and `plutil -lint` passes.

Android is unaffected — it resolves bridge symbols through `dlsym`, so an absent hook is a lookup returning null rather than a link error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)