### PR TITLE
Give the splash screen plugins a named patch marker to anchor to

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
@@ -95,6 +95,11 @@ class MainActivity : FragmentActivity(), WebViewProvider {
     // Last appearance pushed to PHP, so onConfigurationChanged (which also fires
     // on rotation) only emits AppearanceChanged when the theme actually flips.
     private var lastAppearance: String? = null
+    // Splash-screen plugins replace core's splash with their own by patching
+    // this file, which they can only do by matching its source exactly. The
+    // four `nativephp:splash-*` markers below name the sites they patch, and
+    // are a stable contract for this major version: each marker, the statement
+    // beneath it, and that statement's indentation.
     private var showSplash by mutableStateOf(true)
     // Gates composition of the heavy MainScreen tree (Scaffold + WebView)
     // until the runtime is booted and the WebView is ready. Until then the first
@@ -121,6 +126,7 @@ class MainActivity : FragmentActivity(), WebViewProvider {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // nativephp:splash-install — installSplashScreen() goes here, above super
         super.onCreate(savedInstanceState)
         instance = this
 
@@ -181,6 +187,7 @@ class MainActivity : FragmentActivity(), WebViewProvider {
                     // Lives here — NOT inside the showContent gate — so it paints on the
                     // first frame and covers the boot; MainScreen composes beneath it.
                     AnimatedVisibility(
+                        // nativephp:splash-visibility
                         visible = showSplash,
                         exit = fadeOut(animationSpec = tween(300))
                     ) {
@@ -402,9 +409,7 @@ class MainActivity : FragmentActivity(), WebViewProvider {
         firstContentReported = true
         Log.d("MainActivity", "🎨 First content ($source)")
 
-                // The two lines below keep their original 12-space indent: splash-screen
-                // plugins (s2br/nativephp-mobile-splashscreen) patch them via exact-string
-                // match including that indentation. Do not re-indent.
+            // nativephp:splash-release
             // Hide splash screen after URL is loaded
             showSplash = false
 
@@ -1418,6 +1423,7 @@ class MainActivity : FragmentActivity(), WebViewProvider {
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                // nativephp:splash-backdrop
                 .background(Color.Black),
             contentAlignment = Alignment.Center
         ) {

--- a/src/Plugins/Commands/NativePluginHookCommand.php
+++ b/src/Plugins/Commands/NativePluginHookCommand.php
@@ -94,6 +94,42 @@ abstract class NativePluginHookCommand extends Command
     }
 
     /**
+     * Get the path to NativePHP's own template sources — the tree the native
+     * project is installed from.
+     *
+     * A plugin that replaces a file core installs verbatim reads its original
+     * from here, so restoring one never reinstates a pre-upgrade version.
+     *
+     * @param  string  $path  Relative path within resources/ (e.g. 'xcode/NativePHP/SplashView.swift')
+     */
+    protected function coreTemplatePath(string $path = ''): string
+    {
+        $resources = dirname(__DIR__, 3).'/resources';
+
+        return $path === '' ? $resources : $resources.'/'.ltrim($path, '/');
+    }
+
+    /**
+     * Get the path to a file in the iOS template sources
+     *
+     * @param  string  $path  Relative path within resources/xcode/ (e.g. 'NativePHP/LaunchScreen.storyboard')
+     */
+    protected function iosTemplatePath(string $path = ''): string
+    {
+        return $this->coreTemplatePath('xcode'.($path === '' ? '' : '/'.ltrim($path, '/')));
+    }
+
+    /**
+     * Get the path to a file in the Android template sources
+     *
+     * @param  string  $path  Relative path within resources/androidstudio/ (e.g. 'app/src/main/AndroidManifest.xml')
+     */
+    protected function androidTemplatePath(string $path = ''): string
+    {
+        return $this->coreTemplatePath('androidstudio'.($path === '' ? '' : '/'.ltrim($path, '/')));
+    }
+
+    /**
      * Get the build configuration array
      */
     protected function config(): array

--- a/tests/Unit/Plugins/HookCommandTemplatePathTest.php
+++ b/tests/Unit/Plugins/HookCommandTemplatePathTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Native\Mobile\Plugins\Commands\NativePluginHookCommand;
+
+/**
+ * Plugins that replace a file core installs verbatim restore it by reading
+ * core's own copy. These cover the accessors that locate that copy, so a
+ * plugin never has to hardcode a path into another package's vendor tree.
+ */
+function hookCommand(): NativePluginHookCommand
+{
+    return new class extends NativePluginHookCommand
+    {
+        protected $signature = 'nativephp:test:hook';
+
+        public function templatePath(string $path = ''): string
+        {
+            return $this->coreTemplatePath($path);
+        }
+
+        public function ios(string $path = ''): string
+        {
+            return $this->iosTemplatePath($path);
+        }
+
+        public function android(string $path = ''): string
+        {
+            return $this->androidTemplatePath($path);
+        }
+    };
+}
+
+it('resolves the package template root', function () {
+    expect(hookCommand()->templatePath())
+        ->toBe(realpath(__DIR__.'/../../../resources'))
+        ->and(is_dir(hookCommand()->templatePath()))->toBeTrue();
+});
+
+it('resolves files core installs verbatim', function () {
+    expect(hookCommand()->ios('NativePHP/LaunchScreen.storyboard'))
+        ->toEndWith('/resources/xcode/NativePHP/LaunchScreen.storyboard')
+        ->and(file_exists(hookCommand()->ios('NativePHP/LaunchScreen.storyboard')))->toBeTrue()
+        ->and(file_exists(hookCommand()->android('app/src/main/AndroidManifest.xml')))->toBeTrue();
+});
+
+/**
+ * The path is appended, so a caller may write it with or without the
+ * separator core already adds.
+ */
+it('takes a relative path either way', function () {
+    expect(hookCommand()->ios('/NativePHP'))->toBe(hookCommand()->ios('NativePHP'))
+        ->and(hookCommand()->android())->toEndWith('/resources/androidstudio');
+});


### PR DESCRIPTION
Follow-up to #159, which was closed with:

> We're going to leave this functionality to Plugins rather than adding more complexity to the core. If there's some aspect of core that would make it easier for you to build a plugin for this feature, we would welcome it.

The splash behavior is a plugin now: [unlocnl/nativephp-enhanced-splash](https://github.com/unlocnl/nativephp-enhanced-splash). Building it turned up three things in core that made it harder than it had to be. This is the first, and the only one that affects every splash plugin rather than just that one.

No behavior change, no config, no dependency — comments and three path accessors.

## The contract already exists

`MainActivity.kt` currently carries this in `onFirstContent()`:

```kotlin
// The two lines below keep their original 12-space indent: splash-screen
// plugins (s2br/nativephp-mobile-splashscreen) patch them via exact-string
// match including that indentation. Do not re-indent.
```

Core is already maintaining a whitespace contract for a third-party plugin. There is now more than one splash plugin doing this, and between them they anchor on four sites in this file — an insertion point above `super.onCreate()`,
`visible = showSplash,`, `showSplash = false`, and `.background(Color.Black),`. All four are incidental details of the source that no release note would ever mention changing.

## What this does

Replaces the convention with named markers at the same four sites:

- `nativephp:splash-install` — where `installSplashScreen()` goes, above `super.onCreate()`
- `nativephp:splash-visibility` — the overlay's `visible` argument
- `nativephp:splash-release` — where `showSplash` is cleared on first content
- `nativephp:splash-backdrop` — the overlay's backdrop color

The contract is stated once, next to `showSplash`: each marker, the statement beneath it, and that statement's indentation are stable for the major version. That is cheap to keep, survives reformatting, and covers cases core never
anticipated.

The existing 12-space indentation is untouched, so the plugin the old comment was written for keeps working.

## Why markers rather than something better

The root cause is that the native project is copied from `resources/androidstudio` only at `native:install`, never per build, so a plugin cannot rely on starting from core's own source — it has to undo its own previous patch first, by exact
string. Re-emitting template-derived files each build would remove the need to patch at all, but it would also discard hand edits to the native project, which seems like the wrong trade. Markers are the cheap version.

## Also included

`NativePluginHookCommand` gains `coreTemplatePath()`, `iosTemplatePath()` and `androidTemplatePath()`.

A plugin that replaces a file core installs verbatim — `LaunchScreen.storyboard`, `SplashView.swift` — restores it by copying core's own copy back, so a core upgrade is never silently undone. Today that means hardcoding
`base_path('vendor/nativephp/mobile/resources/xcode/NativePHP/…')` into the plugin, which breaks under a custom vendor dir or a path repository. The accessors resolve it from the package's own location instead.

## Testing

`tests/Unit/Plugins/HookCommandTemplatePathTest.php` covers the accessors. The Kotlin change is comments only.
