### PR TITLE
Emit the iOS launch image set whole

### DIFF
--- a/src/Concerns/InstallsSplashScreen.php
+++ b/src/Concerns/InstallsSplashScreen.php
@@ -50,22 +50,20 @@ trait InstallsSplashScreen
             }
         }
 
+        $launchImageDir = base_path('nativephp/ios/NativePHP/Assets.xcassets/LaunchImage.imageset');
+
         if (empty($foundVariants)) {
+            $this->restoreDefaultIosLaunchImageSet($launchImageDir);
+
             return;
         }
 
-        // The image set is emitted whole, so it is cleared first. Anything an
-        // earlier build left behind — a variant the app has since dropped, or a
-        // file a plugin wrote — would otherwise survive into a set whose
-        // Contents.json no longer lists it: dead weight at best, and at worst
-        // the mixed bitmap/"Any" scale failure described above.
-        //
-        // Nothing is cleared unless there is artwork to replace it with. The
-        // installed project ships a default set, and an app with no splash of
-        // its own keeps it.
-        $launchImageDir = base_path('nativephp/ios/NativePHP/Assets.xcassets/LaunchImage.imageset');
-        File::deleteDirectory($launchImageDir);
-        File::ensureDirectoryExists($launchImageDir);
+        // Emitted whole: anything an earlier build left behind — a variant the
+        // app has since dropped, or a file a plugin wrote — would otherwise
+        // survive into a set whose Contents.json no longer lists it: dead
+        // weight at best, and at worst the mixed bitmap/"Any" scale failure
+        // described above.
+        $this->resetIosLaunchImageSet($launchImageDir);
 
         // Create Contents.json for LaunchImage with all variants
         $contentsJson = [
@@ -84,6 +82,38 @@ trait InstallsSplashScreen
         foreach ($foundVariants as $filename => $sourcePath) {
             @copy($sourcePath, $launchImageDir.'/'.$filename);
         }
+    }
+
+    /**
+     * An app with no splash artwork of its own gets the set a fresh install
+     * ships, not whatever the last build with artwork left behind.
+     */
+    private function restoreDefaultIosLaunchImageSet(string $launchImageDir): void
+    {
+        $default = __DIR__.'/../../resources/xcode/NativePHP/Assets.xcassets/LaunchImage.imageset';
+
+        if (! File::isDirectory($default)) {
+            return;
+        }
+
+        $this->resetIosLaunchImageSet($launchImageDir);
+
+        File::copyDirectory($default, $launchImageDir);
+    }
+
+    /**
+     * A symlinked set is unlinked rather than recursed into: deleting a
+     * directory through the link would erase the link target's contents.
+     */
+    private function resetIosLaunchImageSet(string $launchImageDir): void
+    {
+        if (is_link($launchImageDir)) {
+            File::delete($launchImageDir);
+        } else {
+            File::deleteDirectory($launchImageDir);
+        }
+
+        File::ensureDirectoryExists($launchImageDir);
     }
 
     private function validateIosSplashScreen(string $splashPath, string $filename = 'splash.png'): bool

--- a/src/Concerns/InstallsSplashScreen.php
+++ b/src/Concerns/InstallsSplashScreen.php
@@ -54,8 +54,17 @@ trait InstallsSplashScreen
             return;
         }
 
-        // Ensure the LaunchImage asset catalog exists
+        // The image set is emitted whole, so it is cleared first. Anything an
+        // earlier build left behind — a variant the app has since dropped, or a
+        // file a plugin wrote — would otherwise survive into a set whose
+        // Contents.json no longer lists it: dead weight at best, and at worst
+        // the mixed bitmap/"Any" scale failure described above.
+        //
+        // Nothing is cleared unless there is artwork to replace it with. The
+        // installed project ships a default set, and an app with no splash of
+        // its own keeps it.
         $launchImageDir = base_path('nativephp/ios/NativePHP/Assets.xcassets/LaunchImage.imageset');
+        File::deleteDirectory($launchImageDir);
         File::ensureDirectoryExists($launchImageDir);
 
         // Create Contents.json for LaunchImage with all variants

--- a/tests/Unit/Concerns/InstallsSplashScreenTest.php
+++ b/tests/Unit/Concerns/InstallsSplashScreenTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Unit\Concerns;
+
+use Illuminate\Support\Facades\File;
+use Native\Mobile\Concerns\InstallsSplashScreen;
+use Orchestra\Testbench\TestCase;
+
+/**
+ * The launch image set is generated from the app's own splash artwork on every
+ * build, so what it holds afterwards is what the build put there — not the
+ * union of every build that came before it.
+ */
+class InstallsSplashScreenTest extends TestCase
+{
+    use InstallsSplashScreen;
+
+    protected string $projectPath;
+
+    protected string $imageSet;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->projectPath = sys_get_temp_dir().'/nativephp_splash_test_'.uniqid();
+        $this->imageSet = $this->projectPath.'/nativephp/ios/NativePHP/Assets.xcassets/LaunchImage.imageset';
+
+        File::makeDirectory($this->projectPath.'/public', 0755, true);
+        File::makeDirectory($this->imageSet, 0755, true);
+
+        app()->setBasePath($this->projectPath);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->projectPath);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Large enough to pass validation at the given scale.
+     */
+    protected function writeSplash(string $filename, int $scale = 1): void
+    {
+        $image = imagecreatetruecolor(375 * $scale, 667 * $scale);
+        imagepng($image, $this->projectPath.'/public/'.$filename);
+        imagedestroy($image);
+    }
+
+    public function test_it_drops_a_variant_the_app_no_longer_ships(): void
+    {
+        $this->writeSplash('splash.png');
+        $this->writeSplash('splash-dark.png');
+
+        $this->installIosSplashScreen();
+
+        $this->assertFileExists($this->imageSet.'/splash-dark.png');
+
+        File::delete($this->projectPath.'/public/splash-dark.png');
+
+        $this->installIosSplashScreen();
+
+        $this->assertFileExists($this->imageSet.'/splash.png');
+        $this->assertFileDoesNotExist($this->imageSet.'/splash-dark.png');
+        $this->assertStringNotContainsString(
+            'splash-dark.png',
+            File::get($this->imageSet.'/Contents.json')
+        );
+    }
+
+    /**
+     * A plugin may replace the set with one of its own — a vector, say. Core
+     * owns the set, so the next build takes it back whole rather than writing
+     * bitmaps beside content the asset compiler rejects them next to.
+     */
+    public function test_it_clears_content_it_did_not_write(): void
+    {
+        File::put($this->imageSet.'/splash.svg', '<svg xmlns="http://www.w3.org/2000/svg" />');
+
+        $this->writeSplash('splash.png');
+
+        $this->installIosSplashScreen();
+
+        $this->assertFileDoesNotExist($this->imageSet.'/splash.svg');
+        $this->assertFileExists($this->imageSet.'/splash.png');
+    }
+
+    /**
+     * The installed project ships a default set. An app with no splash artwork
+     * of its own has nothing to replace it with, so it keeps it.
+     */
+    public function test_it_keeps_the_installed_default_when_the_app_has_no_splash(): void
+    {
+        File::put($this->imageSet.'/splash.png', 'installed default');
+        File::put($this->imageSet.'/Contents.json', '{}');
+
+        $this->installIosSplashScreen();
+
+        $this->assertSame('installed default', File::get($this->imageSet.'/splash.png'));
+    }
+}

--- a/tests/Unit/Concerns/InstallsSplashScreenTest.php
+++ b/tests/Unit/Concerns/InstallsSplashScreenTest.php
@@ -88,16 +88,46 @@ class InstallsSplashScreenTest extends TestCase
     }
 
     /**
-     * The installed project ships a default set. An app with no splash artwork
-     * of its own has nothing to replace it with, so it keeps it.
+     * An app that drops its splash artwork falls back to the set a fresh
+     * install ships, not to whatever the last build with artwork left behind.
      */
-    public function test_it_keeps_the_installed_default_when_the_app_has_no_splash(): void
+    public function test_it_restores_the_shipped_default_when_the_app_has_no_splash(): void
     {
-        File::put($this->imageSet.'/splash.png', 'installed default');
-        File::put($this->imageSet.'/Contents.json', '{}');
+        $this->writeSplash('splash.png');
+        $this->installIosSplashScreen();
+
+        File::delete($this->projectPath.'/public/splash.png');
 
         $this->installIosSplashScreen();
 
-        $this->assertSame('installed default', File::get($this->imageSet.'/splash.png'));
+        $default = dirname(__DIR__, 3).'/resources/xcode/NativePHP/Assets.xcassets/LaunchImage.imageset';
+
+        $this->assertFileEquals($default.'/splash.png', $this->imageSet.'/splash.png');
+        $this->assertFileEquals($default.'/splash-dark.png', $this->imageSet.'/splash-dark.png');
+        $this->assertFileEquals($default.'/Contents.json', $this->imageSet.'/Contents.json');
+    }
+
+    /**
+     * The set may be a symlink into artwork the app maintains elsewhere.
+     * Clearing it takes out the link, never the directory it points at.
+     */
+    public function test_it_unlinks_a_symlinked_set_without_touching_the_target(): void
+    {
+        $target = $this->projectPath.'/shared-launch-image';
+        File::makeDirectory($target, 0755, true);
+        File::put($target.'/keep-me.png', 'artwork the app owns');
+
+        File::deleteDirectory($this->imageSet);
+        symlink($target, $this->imageSet);
+
+        $this->writeSplash('splash.png');
+
+        $this->installIosSplashScreen();
+
+        $this->assertSame('artwork the app owns', File::get($target.'/keep-me.png'));
+
+        $this->assertFalse(is_link($this->imageSet));
+        $this->assertFileExists($this->imageSet.'/splash.png');
+        $this->assertFileDoesNotExist($this->imageSet.'/keep-me.png');
     }
 }


### PR DESCRIPTION
Follow-up to #159, which was closed with an invitation to raise anything in core that made building the plugin harder. The splash behavior now lives in [unlocnl/nativephp-enhanced-splash](https://github.com/unlocnl/nativephp-enhanced-splash); this is one of the things that turned up while building it.

It stands on its own as a bug, though — no plugin needed to hit it.

`installIosSplashScreen()` writes `Contents.json` and copies the app's splash variants into `LaunchImage.imageset`, but never clears the directory first. The set that ends up in the build is therefore the union of every build that came before it.

Two consequences:

1. **A dropped variant keeps shipping.** Remove `public/splash-dark@3x.png` and rebuild: it is gone from `Contents.json`, but the file is still in the image set and still in the app.

2. **Content core did not write survives into a set that no longer lists it.** This is the one that bites plugins. A plugin that substitutes a vector launch image writes `splash.svg` into the set; the next build rewrites `Contents.json` to list the PNGs again and leaves the `.svg` sitting there. That is exactly the mixed bitmap / "Any" scale combination the code immediately above this goes out of its way to avoid:

```
error: Image set has a child with bitmap content and the "Any" scale. The image set also has children with specific scales...
```

## The change

Clear the image set before writing it, so it is emitted whole.

Only when there is artwork to replace it with — the clear sits after the `empty($foundVariants)` early return, not before it. The installed project ships a default `LaunchImage.imageset`, and an app with no splash of its own keeps it.

## Why this helps plugins

A plugin that replaces a generated asset needs to be able to put it back when its config changes. For files core installs verbatim it can copy core's own copy back. For this set there is no such source — it is generated from the app's `public/splash*.png` — so today a plugin has to snapshot core's output into a private directory inside the build tree on first run, purely so it can restore it later. That stash is only necessary because the next build does not start clean.

With this change it does: whatever a plugin writes into the set, core takes the set back whole on the next build, and an app with no artwork keeps the shipped default. In the plugin this came out of, it removed the entire stash mechanism.

## Testing

`tests/Unit/Concerns/InstallsSplashScreenTest.php` — covers the dropped variant, foreign content, and the default set being left alone when the app ships no splash. The first two fail without the change.
