### PR TITLE
Let plugins set attributes on the manifest nodes core declares

### DIFF
--- a/src/Exceptions/PluginConflictException.php
+++ b/src/Exceptions/PluginConflictException.php
@@ -17,6 +17,14 @@ class PluginConflictException extends RuntimeException
             $plugins = implode(' and ', $conflict['plugins']);
             if ($conflict['type'] === 'namespace') {
                 $messages[] = "Namespace '{$conflict['value']}' is used by both {$plugins}";
+            } elseif ($conflict['type'] === 'manifest_attribute') {
+                $values = [];
+                foreach ($conflict['values'] ?? [] as $plugin => $value) {
+                    $values[] = "    {$plugin} → {$value}";
+                }
+
+                $messages[] = "Manifest attribute {$conflict['value']} is set to different values by {$plugins}:\n".
+                    implode("\n", $values);
             } else {
                 $messages[] = "Bridge function '{$conflict['value']}' is registered by both {$plugins}";
             }

--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -12,6 +12,21 @@ use Native\Mobile\Support\Stub;
 
 class AndroidPluginCompiler
 {
+    /**
+     * Records which manifest attributes plugins are currently setting, so the
+     * next build knows what to hand back before applying its own.
+     */
+    protected const ATTRIBUTE_MARKER = 'NativePHP Plugin Attributes';
+
+    /**
+     * The opening tags a plugin may set attributes on, keyed by the target
+     * name it declares in nativephp.json.
+     */
+    protected const ATTRIBUTE_TARGETS = [
+        'application' => '/<application\b[^>]*>/',
+        'main_activity' => '/<activity\b[^>]*android:name="\.ui\.MainActivity"[^>]*>/',
+    ];
+
     protected string $androidProjectPath;
 
     /**
@@ -186,6 +201,10 @@ class AndroidPluginCompiler
         // Declare plugin-required Gradle plugins in the root build file (runs
         // even when the list is empty so a removed plugin's declaration is cleared).
         $this->injectGradlePlugins($allPlugins);
+
+        // Set attributes on the manifest nodes core declares itself (runs even
+        // when the list is empty so a removed plugin's attributes go back).
+        $this->injectManifestAttributes($allPlugins);
 
         if ($allPlugins->isEmpty()) {
             $this->generateEmptyRegistration();
@@ -898,6 +917,205 @@ class AndroidPluginCompiler
         $mainManifest = $this->injectApplicationEntries($mainManifest, $applicationEntries);
 
         $this->files->put($mainManifestPath, $mainManifest);
+    }
+
+    /**
+     * Apply `android.manifest_attributes` to the nodes core's own manifest
+     * declares.
+     *
+     * The manifest is installed once and edited in place from then on, so an
+     * attribute is only safely settable if it is also releasable: whatever the
+     * last build applied is put back first, from core's own template, before
+     * this build's declarations go on. A marker comment records what was
+     * applied, so a plugin that stops declaring an attribute — or is removed
+     * outright — gives it back rather than leaving it behind forever.
+     */
+    protected function injectManifestAttributes(Collection $plugins): void
+    {
+        $manifestPath = $this->androidProjectPath.'/app/src/main/AndroidManifest.xml';
+
+        if (! $this->files->exists($manifestPath)) {
+            return;
+        }
+
+        $this->files->put(
+            $manifestPath,
+            $this->mergeManifestAttributes($plugins, $this->files->get($manifestPath))
+        );
+    }
+
+    protected function mergeManifestAttributes(Collection $plugins, string $manifest): string
+    {
+        $declared = $this->collectManifestAttributes($plugins);
+
+        $manifest = $this->releaseManagedAttributes($manifest);
+
+        if (empty($declared)) {
+            return $manifest;
+        }
+
+        foreach ($declared as $target => $attributes) {
+            foreach ($attributes as $name => $attribute) {
+                $manifest = $this->setManifestAttribute($manifest, $target, $name, $attribute['value']);
+            }
+        }
+
+        return $this->writeManagedMarker($manifest, $declared);
+    }
+
+    /**
+     * Gather every plugin's declared attributes, keyed by target and name.
+     *
+     * Two plugins setting one attribute to different values is a genuine
+     * incompatibility: whichever won would depend on registration order, and
+     * the one that lost would fail somewhere that points nowhere near the
+     * cause. Agreeing on a value is not a conflict.
+     *
+     * @return array<string, array<string, array{value: string, plugin: string}>>
+     */
+    protected function collectManifestAttributes(Collection $plugins): array
+    {
+        $declared = [];
+        $conflicts = [];
+
+        foreach ($plugins as $plugin) {
+            foreach ($plugin->getAndroidManifestAttributes() as $target => $attributes) {
+                foreach ($attributes as $name => $value) {
+                    $value = $this->manifestAttributeValue($value);
+                    $existing = $declared[$target][$name] ?? null;
+
+                    if ($existing !== null && $existing['value'] !== $value) {
+                        $conflicts[] = [
+                            'type' => 'manifest_attribute',
+                            'value' => "{$name} on <{$target}>",
+                            'plugins' => [$existing['plugin'], $plugin->name],
+                            'values' => [$existing['plugin'] => $existing['value'], $plugin->name => $value],
+                        ];
+
+                        continue;
+                    }
+
+                    $declared[$target][$name] = ['value' => $value, 'plugin' => $plugin->name];
+                }
+            }
+        }
+
+        if (! empty($conflicts)) {
+            throw new PluginConflictException($conflicts);
+        }
+
+        return $declared;
+    }
+
+    /**
+     * Put back everything the last build applied: core's own value where the
+     * template has one, and removal where it has none.
+     */
+    protected function releaseManagedAttributes(string $manifest): string
+    {
+        if (! preg_match('/\s*<!-- '.self::ATTRIBUTE_MARKER.': ([^>]*) -->/', $manifest, $match)) {
+            return $manifest;
+        }
+
+        foreach (array_filter(explode(' ', trim($match[1]))) as $managed) {
+            [$target, $name] = array_pad(explode('/', $managed, 2), 2, '');
+
+            if ($name === '') {
+                continue;
+            }
+
+            $manifest = $this->setManifestAttribute(
+                $manifest,
+                $target,
+                $name,
+                $this->templateManifestAttribute($target, $name)
+            );
+        }
+
+        return str_replace($match[0], '', $manifest);
+    }
+
+    /**
+     * @param  array<string, array<string, array{value: string, plugin: string}>>  $declared
+     */
+    protected function writeManagedMarker(string $manifest, array $declared): string
+    {
+        $managed = [];
+
+        foreach ($declared as $target => $attributes) {
+            foreach (array_keys($attributes) as $name) {
+                $managed[] = "{$target}/{$name}";
+            }
+        }
+
+        return preg_replace(
+            '/(\s*<\/application>)/s',
+            "\n        <!-- ".self::ATTRIBUTE_MARKER.': '.implode(' ', $managed).' -->$1',
+            $manifest,
+            1
+        );
+    }
+
+    /**
+     * Set an attribute on a target node's opening tag, or remove it when the
+     * value is null.
+     */
+    protected function setManifestAttribute(string $manifest, string $target, string $name, ?string $value): string
+    {
+        $pattern = self::ATTRIBUTE_TARGETS[$target] ?? null;
+
+        if ($pattern === null) {
+            return $manifest;
+        }
+
+        return preg_replace_callback($pattern, function (array $match) use ($name, $value): string {
+            $tag = preg_replace('/\s+'.preg_quote($name, '/').'="[^"]*"/', '', $match[0]);
+
+            if ($value === null) {
+                return $tag;
+            }
+
+            $attribute = ' '.$name.'="'.htmlspecialchars($value, ENT_QUOTES | ENT_XML1).'"';
+
+            return preg_replace('/(\s*\/?>)$/', $attribute.'$1', $tag, 1);
+        }, $manifest, 1);
+    }
+
+    /**
+     * The value core's own template gives an attribute, or null when it
+     * declares none — which is what makes releasing one unambiguous.
+     */
+    protected function templateManifestAttribute(string $target, string $name): ?string
+    {
+        $template = dirname(__DIR__, 3).'/resources/androidstudio/app/src/main/AndroidManifest.xml';
+        $pattern = self::ATTRIBUTE_TARGETS[$target] ?? null;
+
+        if ($pattern === null || ! $this->files->exists($template)) {
+            return null;
+        }
+
+        if (! preg_match($pattern, $this->files->get($template), $node)) {
+            return null;
+        }
+
+        if (! preg_match('/\s'.preg_quote($name, '/').'="([^"]*)"/', $node[0], $attribute)) {
+            return null;
+        }
+
+        return htmlspecialchars_decode($attribute[1], ENT_QUOTES | ENT_XML1);
+    }
+
+    /**
+     * Manifest attribute values are always strings; a JSON boolean is the one
+     * shape a plain cast would not survive.
+     */
+    protected function manifestAttributeValue(string|bool|int $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return (string) $value;
     }
 
     /**

--- a/src/Plugins/Plugin.php
+++ b/src/Plugins/Plugin.php
@@ -181,6 +181,17 @@ class Plugin
         return $this->manifest->android['features'] ?? [];
     }
 
+    /**
+     * Attributes this plugin sets on nodes core's own manifest declares,
+     * from `android.manifest_attributes` in nativephp.json.
+     *
+     * @return array<string, array<string, string|bool|int>> Keyed by target
+     */
+    public function getAndroidManifestAttributes(): array
+    {
+        return $this->manifest->android['manifest_attributes'] ?? [];
+    }
+
     public function getIosRepositories(): array
     {
         return $this->manifest->ios['repositories'] ?? [];

--- a/src/Plugins/PluginManifest.php
+++ b/src/Plugins/PluginManifest.php
@@ -12,6 +12,11 @@ class PluginManifest implements JsonSerializable
      */
     public const PLATFORMS = ['android', 'ios'];
 
+    /**
+     * Nodes of core's own AndroidManifest.xml a plugin may set attributes on.
+     */
+    public const MANIFEST_ATTRIBUTE_TARGETS = ['application', 'main_activity'];
+
     public readonly string $namespace;
 
     /**
@@ -271,6 +276,54 @@ class PluginManifest implements JsonSerializable
                 throw new InvalidArgumentException(
                     "Component '{$component['type']}' missing platform renderer (android_renderer or ios_renderer)"
                 );
+            }
+        }
+
+        $this->validateManifestAttributes($data['android']['manifest_attributes'] ?? []);
+    }
+
+    /**
+     * Validate `android.manifest_attributes`, which sets attributes on the
+     * nodes core's own AndroidManifest.xml declares.
+     *
+     * The targets are a closed set on purpose: this exists so a plugin can
+     * configure the app's application and launcher activity, not so it can
+     * rewrite arbitrary XML.
+     */
+    protected function validateManifestAttributes(mixed $attributes): void
+    {
+        if (! is_array($attributes)) {
+            throw new InvalidArgumentException(
+                'android.manifest_attributes must be an object keyed by target'
+            );
+        }
+
+        foreach ($attributes as $target => $declared) {
+            if (! in_array($target, self::MANIFEST_ATTRIBUTE_TARGETS, true)) {
+                throw new InvalidArgumentException(
+                    "Unknown manifest attribute target '{$target}'. Valid targets: ".
+                    implode(', ', self::MANIFEST_ATTRIBUTE_TARGETS)
+                );
+            }
+
+            if (! is_array($declared) || $declared === []) {
+                throw new InvalidArgumentException(
+                    "Manifest attributes for '{$target}' must be a non-empty object of attribute => value"
+                );
+            }
+
+            foreach ($declared as $name => $value) {
+                if (! is_string($name) || ! preg_match('/^([a-zA-Z][\w.]*:)?[a-zA-Z][\w.]*$/', $name)) {
+                    throw new InvalidArgumentException(
+                        "Invalid manifest attribute name '{$name}' on '{$target}'"
+                    );
+                }
+
+                if (! is_string($value) && ! is_bool($value) && ! is_int($value)) {
+                    throw new InvalidArgumentException(
+                        "Manifest attribute '{$name}' on '{$target}' must be a string, bool or int"
+                    );
+                }
             }
         }
     }

--- a/tests/Feature/Plugins/AndroidManifestAttributesTest.php
+++ b/tests/Feature/Plugins/AndroidManifestAttributesTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Tests\Feature\Plugins;
+
+use Illuminate\Filesystem\Filesystem;
+use InvalidArgumentException;
+use Mockery;
+use Native\Mobile\Exceptions\PluginConflictException;
+use Native\Mobile\Plugins\Compilers\AndroidPluginCompiler;
+use Native\Mobile\Plugins\Plugin;
+use Native\Mobile\Plugins\PluginManifest;
+use Native\Mobile\Plugins\PluginRegistry;
+use Tests\TestCase;
+
+/**
+ * Plugins can add manifest nodes, but the app's own application and launcher
+ * activity are core's, and until now a plugin could only change them by
+ * patching the file. These cover `android.manifest_attributes`: applying an
+ * attribute, giving it back, and refusing to guess between two plugins that
+ * disagree.
+ */
+class AndroidManifestAttributesTest extends TestCase
+{
+    private AndroidPluginCompiler $compiler;
+
+    private Filesystem $files;
+
+    private string $testBasePath;
+
+    private string $manifestPath;
+
+    private $mockRegistry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = new Filesystem;
+        $this->testBasePath = sys_get_temp_dir().'/nativephp-manifest-attrs-'.uniqid();
+        $this->manifestPath = $this->testBasePath.'/android/app/src/main/AndroidManifest.xml';
+
+        $this->mockRegistry = Mockery::mock(PluginRegistry::class);
+        $this->mockRegistry->shouldReceive('detectConflicts')->andReturn([]);
+
+        $this->files->ensureDirectoryExists($this->testBasePath.'/android/app/src/main');
+
+        // The nodes core's own template declares, which is what a target names.
+        $this->files->put($this->manifestPath, <<<'XML'
+        <?xml version="1.0" encoding="utf-8"?>
+        <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:tools="http://schemas.android.com/tools">
+            <application
+                android:label="TestApp"
+                android:theme="@style/Theme.AndroidPHP"
+                tools:targetApi="31">
+                <activity
+                android:name=".ui.MainActivity"
+                    android:exported="true"
+                    android:launchMode="singleTop">
+                </activity>
+            </application>
+        </manifest>
+        XML);
+
+        $this->files->put($this->testBasePath.'/android/app/build.gradle.kts', "dependencies {\n}\n");
+
+        $this->compiler = new AndroidPluginCompiler(
+            $this->files,
+            $this->mockRegistry,
+            $this->testBasePath
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        $this->files->deleteDirectory($this->testBasePath);
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function test_it_sets_an_attribute_on_the_application(): void
+    {
+        $this->compileWith([$this->plugin('splash/plugin', [
+            'application' => ['android:theme' => '@style/Theme.Splash'],
+        ])]);
+
+        $this->assertStringContainsString('android:theme="@style/Theme.Splash"', $this->manifest());
+        $this->assertStringNotContainsString('android:theme="@style/Theme.AndroidPHP"', $this->manifest());
+        $this->assertStringContainsString('android:label="TestApp"', $this->manifest());
+    }
+
+    public function test_it_sets_an_attribute_the_template_does_not_declare(): void
+    {
+        $this->compileWith([$this->plugin('ml/plugin', [
+            'application' => ['android:largeHeap' => true],
+        ])]);
+
+        $this->assertStringContainsString('android:largeHeap="true"', $this->manifest());
+    }
+
+    public function test_it_targets_the_launcher_activity_without_touching_the_application(): void
+    {
+        $this->compileWith([$this->plugin('deeplinks/plugin', [
+            'main_activity' => ['android:launchMode' => 'singleTask'],
+        ])]);
+
+        $this->assertStringContainsString('android:launchMode="singleTask"', $this->manifest());
+        $this->assertStringNotContainsString('android:launchMode="singleTop"', $this->manifest());
+        $this->assertStringContainsString('android:theme="@style/Theme.AndroidPHP"', $this->manifest());
+    }
+
+    /**
+     * The manifest is installed once and edited in place, so an attribute that
+     * is no longer declared has to go back to what core ships.
+     */
+    public function test_it_gives_an_attribute_back_when_the_plugin_stops_declaring_it(): void
+    {
+        $this->compileWith([$this->plugin('splash/plugin', [
+            'application' => ['android:theme' => '@style/Theme.Splash'],
+            'main_activity' => ['android:launchMode' => 'singleTask'],
+        ])]);
+
+        $this->compileWith([$this->plugin('splash/plugin', [])]);
+
+        $this->assertStringContainsString('android:theme="@style/Theme.AndroidPHP"', $this->manifest());
+        $this->assertStringContainsString('android:launchMode="singleTop"', $this->manifest());
+        $this->assertStringNotContainsString('NativePHP Plugin Attributes', $this->manifest());
+    }
+
+    /**
+     * An attribute core never declared has no value to go back to, so giving
+     * it back means removing it.
+     */
+    public function test_it_removes_an_attribute_the_template_never_had(): void
+    {
+        $this->compileWith([$this->plugin('ml/plugin', [
+            'application' => ['android:largeHeap' => true],
+        ])]);
+
+        $this->compileWith([]);
+
+        $this->assertStringNotContainsString('android:largeHeap=', $this->manifest());
+        $this->assertStringNotContainsString('NativePHP Plugin Attributes', $this->manifest());
+    }
+
+    public function test_it_is_idempotent_across_rebuilds(): void
+    {
+        $plugins = [$this->plugin('splash/plugin', [
+            'application' => ['android:theme' => '@style/Theme.Splash'],
+        ])];
+
+        $this->compileWith($plugins);
+        $first = $this->manifest();
+
+        $this->compileWith($plugins);
+
+        $this->assertSame($first, $this->manifest());
+        $this->assertSame(1, substr_count($this->manifest(), 'android:theme='));
+    }
+
+    public function test_it_allows_two_plugins_that_agree(): void
+    {
+        $this->compileWith([
+            $this->plugin('one/plugin', ['application' => ['android:largeHeap' => true]]),
+            $this->plugin('two/plugin', ['application' => ['android:largeHeap' => true]]),
+        ]);
+
+        $this->assertSame(1, substr_count($this->manifest(), 'android:largeHeap='));
+    }
+
+    public function test_it_refuses_to_choose_between_two_plugins_that_disagree(): void
+    {
+        $this->expectException(PluginConflictException::class);
+        $this->expectExceptionMessageMatches('/android:theme on <application>.*one\/plugin.*two\/plugin/s');
+
+        $this->compileWith([
+            $this->plugin('one/plugin', ['application' => ['android:theme' => '@style/Theme.One']]),
+            $this->plugin('two/plugin', ['application' => ['android:theme' => '@style/Theme.Two']]),
+        ]);
+    }
+
+    public function test_it_rejects_an_unknown_target(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Unknown manifest attribute target 'provider'");
+
+        $this->plugin('bad/plugin', ['provider' => ['android:exported' => 'false']]);
+    }
+
+    public function test_it_rejects_an_invalid_attribute_name(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid manifest attribute name '<script>'");
+
+        $this->plugin('bad/plugin', ['application' => ['<script>' => 'x']]);
+    }
+
+    private function manifest(): string
+    {
+        return $this->files->get($this->manifestPath);
+    }
+
+    /**
+     * @param  array<string, array<string, string|bool|int>>  $attributes
+     */
+    private function plugin(string $name, array $attributes): Plugin
+    {
+        $data = [
+            'name' => $name,
+            'namespace' => 'TestPlugin',
+            'android' => ['manifest_attributes' => $attributes],
+        ];
+
+        return new Plugin(
+            name: $name,
+            version: '1.0.0',
+            path: $this->testBasePath.'/plugins/'.md5($name),
+            manifest: new PluginManifest($data)
+        );
+    }
+
+    /**
+     * @param  list<Plugin>  $plugins
+     */
+    private function compileWith(array $plugins): void
+    {
+        $registry = Mockery::mock(PluginRegistry::class);
+        $registry->shouldReceive('detectConflicts')->andReturn([]);
+        $registry->shouldReceive('all')->andReturn(collect($plugins));
+
+        (new AndroidPluginCompiler($this->files, $registry, $this->testBasePath))->compile();
+    }
+}


### PR DESCRIPTION
Follow-up to #159, which was closed with an invitation to raise anything in core that made building the plugin harder. The splash behavior now lives in [unlocnl/nativephp-enhanced-splash](https://github.com/unlocnl/nativephp-enhanced-splash), and this is the last of the three things that turned up while building it.

It is also the least splash-specific: the plugin needs it to set one attribute, but core itself needs it in four places, and the capability is missing for every plugin category, not just splash.

Plugins can already **add** manifest nodes — `permissions`, `features`, `activities`, `services`, `receivers`, `providers`, `meta_data` all merge cleanly through `mergeManifestEntries()`. What no plugin can do is **change a node core emits itself**.

So a plugin that needs any of these has no route but to patch `AndroidManifest.xml` by string match:

- `<application android:name>` — a custom Application class (Firebase, Sentry, multidex init)
- `android:launchMode` — core hardcodes `singleTop`; a single-instance or deep-link plugin needs `singleTask`
- `android:windowSoftInputMode` — core hardcodes `adjustResize`
- `android:largeHeap` — ML, camera and video plugins
- `android:networkSecurityConfig` — core sets it; a cert-pinning plugin has to override it
- `android:theme` — splash plugins, of which there are at least two in the wild

## Core has the same need, four different ways

This isn't only a plugin-side gap. `RunsAndroid` already sets attributes on these same nodes, inconsistently:

|Location|Approach|
|-|-|
|`updateAppDisplayName()`|`preg_replace('/android:label=".*?"/')` — unanchored, so it rewrites the attribute on *any* element carrying it, not just `<application>`|
|`updateScreenOrientation()`|regex with an add-or-update branch, anchored on MainActivity|
|`updateDeepLinkConfiguration()`|marker-delimited block injected into MainActivity|
|`updatePermissions()`|string matching, add and remove|

A general mechanism has in-core callers on day one.

## The change

`android.manifest_attributes` in `nativephp.json`, keyed by a closed target set:

```json
"android": {
    "manifest_attributes": {
        "application":   { "android:theme": "@style/Theme.MyPlugin.Splash" },
        "main_activity": { "android:launchMode": "singleTask" }
    }
}
```

`application` and `main_activity` are the two nodes core declares. The set is closed on purpose — this exists so a plugin can configure the app's application and launcher activity, not so it can rewrite arbitrary XML.

### Releasing is the hard part, and the template solves it

Attributes are edits, not additions, so applying one is only safe if it can also be given back — and the manifest is installed once and edited in place from then on, so there is no clean slate to fall back to.

Core doesn't need to record the original values, because it ships them: `resources/androidstudio/app/src/main/AndroidManifest.xml`. A marker comment records which attributes are currently plugin-managed, and each build releases them first — restoring the template's value, or removing the attribute where the template declares none — before applying the current declarations.

That release runs *before* the `$allPlugins->isEmpty()` early return, alongside the ProGuard and Gradle-plugin steps that are already there for the same reason, so uninstalling the last plugin is enough to get the manifest back.

### Conflicts fail the build

Two plugins setting one attribute to different values raises `PluginConflictException`, naming both plugins and both values:

```
Manifest attribute android:theme on <application> is set to different values by
one/plugin and two/plugin:
    one/plugin → @style/Theme.One
    two/plugin → @style/Theme.Two
```

Resolving by registration order would make the winner depend on something the user doesn't meaningfully control, and the loser would fail somewhere that points nowhere near the cause. Two plugins declaring the *same* value is not a conflict.

## Testing

`tests/Feature/Plugins/AndroidManifestAttributesTest.php` — 10 tests: applying to either target, attributes the template does and doesn't declare, release on stop-declaring and on full uninstall, idempotence across rebuilds, agreement between plugins, conflict, and both validation rejections.

## Note

Unrelated, spotted while writing this: the `component` conflict type added to `PluginRegistry::detectConflicts()` falls through to the `else` branch in `PluginConflictException`, so a component collision reports itself as "Bridge function '…' is registered by both". Left alone here — happy to send a one-liner separately.
