### PR TITLE
Fix glass elements ignoring their corner radius on iOS

### DIFF
--- a/resources/xcode/NativePHP/NativeRender/NodeStyleModifier.swift
+++ b/resources/xcode/NativePHP/NativeRender/NodeStyleModifier.swift
@@ -46,6 +46,15 @@ struct NodeStyleModifier: ViewModifier {
             // a tint — that's what you want for `bg-red-500 glass` to
             // produce tinted glass.
             .background(backgroundFill(dark: dark))
+            // Corner clip BEFORE the glass. `.glassEffect(...)` renders into
+            // its own effect layer and a `.clipShape` applied downstream of it
+            // no longer reaches the view's own drawing: the glass plate came
+            // out correctly rounded while the `bg-*` fill stayed a hard
+            // rectangle. Verified on device — `rounded-full glass` drew a
+            // circular plate behind a square fill. Clipping first rounds the
+            // background and content; the glass below still takes its own
+            // shape from the same radii, so tinted glass is unchanged.
+            .modifier(ClipRadiusModifier(radius: radius, radii: radii))
             // Liquid Glass material — iOS 26+ real glass, iOS 18-25 falls
             // back to `.regularMaterial`. Applied AFTER background so the
             // optional bg color tints through. Shape inferred from the
@@ -56,7 +65,6 @@ struct NodeStyleModifier: ViewModifier {
                 cornerRadius: radius,
                 cornerRadii: radii
             ))
-            .modifier(ClipRadiusModifier(radius: radius, radii: radii))
             .overlay(borderOverlay(dark: dark, radius: radius))
             .shadow(
                 color: shadowColor,


### PR DESCRIPTION
## The bug

Any element combining the `glass` class with `rounded-*` painted its `bg-*` fill as a hard rectangle. The corner radius appeared to do nothing at all.

`.glassEffect(...)` renders into its own effect layer, and a `.clipShape` applied downstream of it never reaches the view's own drawing. `NodeStyleModifier` ran the clip *after* `GlassModifier`, so the glass plate took its shape from the `in:` parameter and looked correct, while the background it was tinting stayed square.

## The fix

Move `ClipRadiusModifier` above `GlassModifier`. The background and content are clipped first; the glass below still takes its own shape from the same `radius` / `radii`, so tinted glass renders unchanged. For nodes without `glass` the modifier is an identity, so nothing else moves.

## Verification

Built to an iOS 26.5 simulator with a six-way grid — uniform `rounded-lg` and `rounded-full`, each with no glass / `glass` / `glass:clear:interactive`, on both `column` and `pressable`.

Before: every glass variant rendered a square fill. `rounded-full glass` was the clearest tell — a correctly **circular** glass plate sitting behind a fully **square** background, which is what pinned the cause to the clip rather than to the radius never arriving. The non-glass boxes clipped correctly in the same screenshot.

After: all six clip correctly, `rounded-full glass` is a true circle, and the glass rim highlight follows the rounded edge.

The device verification ran against this change applied to the pre-`#314` file; the version committed here is the same reorder on top of the per-corner radii work, which only threads `radii` through the two modifiers and does not affect ordering.

Android is unaffected — `glass` has no Compose implementation.