### PR TITLE
Fix empty POST bodies and 404s on redirect in the iOS scheme handler

### DIFF
--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -478,6 +478,22 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
         return NSError(domain: "PHPAppSchemeHandler", code: code, userInfo: [NSLocalizedDescriptionKey: description])
     }
 
+    // Laravel writes absolute redirect URLs, so a hop back into the app arrives
+    // as php://127.0.0.1/path?query. PHP needs those split apart, with
+    // percent-encoding intact, the way extractRequestData does.
+    private func internalRedirectTarget(for location: String) -> (uri: String, query: String?)? {
+        guard let components = URLComponents(string: location),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "php" || scheme == "http",
+              components.host == domain else {
+            return nil
+        }
+
+        let path = components.percentEncodedPath
+
+        return (path.isEmpty ? "/" : path, components.percentEncodedQuery)
+    }
+
     private func forwardToPHP(requestData: RequestData, schemeTask: WKURLSchemeTask, redirectCount: Int = 0) {
         getResponse(request: requestData) { result in
             guard self.isTaskActive(schemeTask) else {
@@ -568,30 +584,23 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
 
                 var request = requestData
                 if let location = headers["location"] {
-                    request.uri = location.trimmingCharacters(in: .whitespaces)
+                    let trimmedLocation = location.trimmingCharacters(in: .whitespaces)
                     request.method = "GET"
 
-                    // Fix root URL redirects: ensure php://127.0.0.1 has trailing slash
-                    if request.uri == "php://127.0.0.1" {
-                        request.uri = "php://127.0.0.1/"
-                    }
-
-                    // Perform an external redirect to the webview, not trying to pass the location to PHP again
-                    if !request.uri.hasPrefix("http://") && !request.uri.hasPrefix("php://") {
-                        let trimmedLocation = location.trimmingCharacters(in: .whitespaces)
-                        let absoluteURL: String
-
-                        if trimmedLocation.hasPrefix("/") {
-                            // Convert relative path to absolute URL
-                            absoluteURL = "php://127.0.0.1\(trimmedLocation)"
-                        } else {
-                            // Already absolute or relative without leading slash
-                            absoluteURL = trimmedLocation
-                        }
+                    // Anything not aimed back at our own host is a navigation the
+                    // webview owns, so hand it over rather than asking PHP to
+                    // route a URL that was never one of its paths.
+                    guard let target = self.internalRedirectTarget(for: trimmedLocation) else {
+                        let absoluteURL = trimmedLocation.hasPrefix("/")
+                            ? "php://\(self.domain)\(trimmedLocation)"
+                            : trimmedLocation
 
                         NotificationCenter.default.post(name: .redirectToURLNotification, object: nil, userInfo: ["url": absoluteURL])
                         return
                     }
+
+                    request.uri = target.uri
+                    request.query = target.query
 
                     WebView.dataStore.httpCookieStore.getAllCookies { cookies in
                         guard self.isTaskActive(schemeTask) else { return }

--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -311,11 +311,35 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
         // Extract Headers
         let headers = request.allHTTPHeaderFields ?? [:]
 
-        // Extract POST data if method is POST/PUT/PATCH
+        // A request body arrives either whole or as a stream. WKWebView streams it
+        // whenever the sender watches upload progress, as every axios call does.
+        // Reading the stream back is the only way those bodies reach PHP.
         var data: String?
-        if ["POST", "PUT", "PATCH"].contains(method.uppercased()), let httpBody = request.httpBody {
-            if let body = String(data: httpBody, encoding: .utf8) {
-                data = body
+        if ["POST", "PUT", "PATCH"].contains(method.uppercased()) {
+            if let httpBody = request.httpBody {
+                data = String(data: httpBody, encoding: .utf8)
+            } else if let stream = request.httpBodyStream {
+                stream.open()
+                defer { stream.close() }
+
+                var bodyData = Data()
+                bodyData.reserveCapacity(Int(headers["Content-Length"] ?? "") ?? 0)
+
+                let bufferSize = 65536
+                let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+                defer { buffer.deallocate() }
+
+                while stream.hasBytesAvailable {
+                    let bytesRead = stream.read(buffer, maxLength: bufferSize)
+                    if bytesRead <= 0 {
+                        break
+                    }
+                    bodyData.append(buffer, count: bytesRead)
+                }
+
+                if !bodyData.isEmpty {
+                    data = String(data: bodyData, encoding: .utf8)
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #275. Two commits, both in `PHPSchemeHandler`, independent of each other.

## Empty request bodies

Every Inertia POST reached Laravel with an empty body. Forms failed validation with the fields visibly filled in, and login was impossible.

Inertia registers an upload progress handler on every request. That puts axios into streamed request mode, and WKWebView then delivers the body on `httpBodyStream` instead of `httpBody`. `extractRequestData` only read `httpBody`, so the body was dropped.

Plain `fetch()` and `XMLHttpRequest` are not affected, which is why this looks like a total failure in an Inertia app and nothing at all in a vanilla one. It also means the bug is invisible unless you test with the framework in place.

This was fixed once before in fcc8449 (#147) and lost in the SuperNative squash. The fallback here is the reporter's patch, with the read buffer sized off `Content-Length` when it is present.

## 404 after any redirect

Separate bug, found while reproducing the first one. A 302 whose `Location` is absolute came back to PHP as the request path, so Laravel was asked to route `php://127.0.0.1/dashboard` and returned a 404.

Laravel writes absolute URLs by default, so this fires on any redirecting flow. Relative Locations already worked, which is why it went unnoticed.

`internalRedirectTarget(for:)` now reduces a Location pointing at our own host to its path and query, keeping them as the separate values PHP expects and preserving percent encoding. Anything pointing elsewhere goes to the webview as before.

Worth fixing together with the body bug: without it, login authenticates and then dies on the redirect, so #275 alone does not give the reporter a working app.

## Verification

Built to an iOS 26.0 simulator against a Laravel 13 app with Inertia and Vue, posting through Inertia's own form helper.

Each fix was reverted and reapplied on its own to confirm which one does what:

| build | POST body | redirect resolves to |
| --- | --- | --- |
| before | 0 bytes | `GET http://127.0.0.1`, 404 |
| body fix only | 60 bytes | `GET php://127.0.0.1/landed`, 404 |
| both | 60 bytes | `GET /landed` |

Query strings survive the redirect intact, including reserved characters: `code=abc 123/x%2Fy` round trips exactly, with `%252F` arriving as a literal `%2F`.

Android is unaffected by both. It captures request bodies in JavaScript rather than reading the native request, and already reduces redirect Locations to a path.

## Not covered here

`handleOrphanedNativeExit` builds a path from a `Location` the same way, with no host check and using decoded `.path`. Same bug class, left alone because I have no reproduction for that path.

There is no test. The `NativePHPTests` target is empty boilerplate and no workflow runs `xcodebuild`, so a Swift test would not execute. Given this exact fix was already lost once to a squash, a guard that runs in CI seems worth adding, happy to do that here if you want it.
