### PR TITLE
Restore the Android query string handling the SuperNative squash reverted

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPRequest.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPRequest.kt
@@ -6,16 +6,20 @@ data class PHPRequest(
     val body: String = "",
     val headers: Map<String, String> = emptyMap(),
     val getParameters: Map<String, String> = emptyMap(),
+    val queryString: String = "",
     val postParameters: Map<String, String> = emptyMap(),
     val cookies: Map<String, String> = emptyMap()
 ) {
     val uri: String
         get() {
-            val queryString = if (getParameters.isNotEmpty()) {
-                "?" + getParameters.entries.joinToString("&") { (key, value) ->
+            return if (queryString.isNotBlank()) {
+                "$url?$queryString"
+            } else if (getParameters.isNotEmpty()) {
+                "$url?" + getParameters.entries.joinToString("&") { (key, value) ->
                     "$key=$value"
                 }
-            } else ""
-            return url + queryString
+            } else {
+                url
+            }
         }
 }

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPWebViewClient.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPWebViewClient.kt
@@ -121,7 +121,7 @@ class PHPWebViewClient(
                     method = "GET",
                     body = "",
                     headers = mapOf("Accept" to "*/*"),
-                    getParameters = emptyMap()
+                    queryString = Uri.parse(url).encodedQuery ?: ""
                 )
 
                 val response = phpBridge.handleLaravelRequest(phpRequest)
@@ -183,9 +183,7 @@ class PHPWebViewClient(
             method = request.method,
             body = if (method in listOf("POST", "PUT", "PATCH")) postData ?: "" else "",
             headers = headers,
-            getParameters = request.url.queryParameterNames?.associateWith {
-                request.url.getQueryParameter(it) ?: ""
-            } ?: emptyMap()
+            queryString = request.url.encodedQuery ?: ""
         )
 
         val prepTime = System.currentTimeMillis() - requestStart
@@ -216,9 +214,17 @@ class PHPWebViewClient(
         if (statusCode in 300..399) {
             val location = responseHeaders["Location"] ?: responseHeaders["location"]
             if (!location.isNullOrEmpty()) {
+                // An absolute Location carries its query too, and Laravel writes
+                // absolute URLs by default. Taking the path alone drops every
+                // parameter the redirect was meant to hand on.
                 val redirectUrl = when {
                     location.startsWith("/") -> location
-                    location.startsWith("http") -> Uri.parse(location).encodedPath ?: "/"
+                    location.startsWith("http") -> {
+                        val parsedUri = Uri.parse(location)
+                        val path = parsedUri.encodedPath ?: "/"
+                        val query = parsedUri.encodedQuery
+                        if (!query.isNullOrEmpty()) "$path?$query" else path
+                    }
                     else -> "/$location"
                 }
 


### PR DESCRIPTION
Restores #143 in full. The squash carried a stale copy of both files and put the pre-#143 code back, which cost three separate pieces of query data.

## What was broken

**Query dropped on absolute redirects.** `handlePHPRequest` kept only the path from an absolute `Location`, and Laravel writes absolute URLs by default, so `redirect()->route('callback', ['code' => ...])` landed on the right route with nothing in `$request->query()`.

**Encoded values decoded twice.** The request query was rebuilt from `queryParameterNames` and `getQueryParameter`, which return *decoded* values. PHP then decoded them again, so `%252F` reached the app as `/` instead of `%2F`.

**Repeated parameters collapsed.** `getQueryParameter(name)` returns only the first value, so `tag[]=alpha&tag[]=beta` arrived as a single entry. Livewire's array `#[Url]` props and any `filter[]` style parameter lose data this way.

None of it failed loudly. Routes resolved, pages rendered, the values were just wrong or missing.

## Why it came back

#143 (`6bebb7d`, "Preserve repeated query parameters in Android requests") fixed all three, across four hunks in `PHPRequest.kt` and `PHPWebViewClient.kt`. The squash `f34a6a6` reverted every one of them.

This restores those hunks verbatim rather than writing something new, so the diff reads as the revert-of-a-revert it is. `forwardToRemote` in the same file kept its query handling through the squash, which is why one redirect path was correct and the other was not.

Second confirmed regression from that squash. The first was #275 on iOS, where `fcc8449` went the same way.

## Verification

Android emulator, Laravel 13 app with Inertia and Vue. Redirect case is `redirect()->route('landed', [...])`; the control hits the same URL directly with no redirect involved, which is how the decode bug was separated from the redirect bug.

| | before | after |
| --- | --- | --- |
| query on absolute redirect | `NONE`, all params missing | present |
| `code=abc%20123%2Fx%252Fy` | `abc 123/x/y` | `abc 123/x%2Fy` |
| `tag[]=alpha&tag[]=beta` | one value | `["alpha","beta"]` |

The `after` column for the decode case now matches what iOS produces for the same input.

I also instrumented the Kotlin during diagnosis to confirm the encoding survives the redirect path rather than inferring it:

```
raw Location          = http://127.0.0.1/landed?code=abc%20123%2Fx%252Fy&next=%2Fdash
computed redirectUrl  = /landed?code=abc%20123%2Fx%252Fy&next=%2Fdash
reparsed encodedQuery = code=abc%20123%2Fx%252Fy&next=%2Fdash
```

## Not covered here

`MainActivity.handleNativeSessionExit` builds a path from a `Location` with the same `encodedPath` call and drops the query too. Left alone, I have no reproduction for that path.

The path-and-query idiom now appears in six places across `PHPWebViewClient`, `WebViewManager` and `MainActivity`, and the one above is the broken one. A shared helper would collapse them, but that is a refactor rather than this fix.
