### PR TITLE
Restore the video and audio MIME types the squash dropped

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPWebViewClient.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/PHPWebViewClient.kt
@@ -464,6 +464,9 @@ class PHPWebViewClient(
             "png" -> "image/png"
             "jpg", "jpeg" -> "image/jpeg"
             "gif" -> "image/gif"
+            "webp" -> "image/webp"
+            "heic" -> "image/heic"
+            "heif" -> "image/heif"
             "svg" -> "image/svg+xml"
             "json" -> "application/json"
             "pdf" -> "application/pdf"
@@ -475,6 +478,26 @@ class PHPWebViewClient(
             "eot" -> "application/vnd.ms-fontobject"
             "otf" -> "font/otf"
             "ico" -> "image/x-icon"
+            // Video — Chromium WebView refuses to play <video src> without an
+            // explicit video/* Content-Type. Without these entries the asset
+            // handler returned application/octet-stream and the player
+            // stayed black on Android.
+            "mp4" -> "video/mp4"
+            "m4v" -> "video/x-m4v"
+            "mov" -> "video/quicktime"
+            "webm" -> "video/webm"
+            "mkv" -> "video/x-matroska"
+            "avi" -> "video/x-msvideo"
+            "3gp" -> "video/3gpp"
+            // HLS playlist + segments for locally served streams.
+            "m3u8" -> "application/vnd.apple.mpegurl"
+            "ts" -> "video/mp2t"
+            // Audio
+            "mp3" -> "audio/mpeg"
+            "wav" -> "audio/wav"
+            "m4a" -> "audio/mp4"
+            "aac" -> "audio/aac"
+            "ogg" -> "audio/ogg"
             else -> {
                 Log.w(TAG, "⚠️ Unknown file extension for: $fileName. Defaulting to application/octet-stream")
                 "application/octet-stream"

--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -272,10 +272,47 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
             return "image/jpeg"
         case "gif":
             return "image/gif"
+        case "webp":
+            return "image/webp"
+        case "heic":
+            return "image/heic"
+        case "heif":
+            return "image/heif"
         case "svg":
             return "image/svg+xml"
+        // Video — keep parity with the Android handler so plugin-staged media
+        // (and any other locally served clips) play with the correct
+        // Content-Type. WKWebView byte-sniffs in some cases, but stricter
+        // clients still need an explicit video/* type.
+        case "mp4":
+            return "video/mp4"
+        case "m4v":
+            return "video/x-m4v"
+        case "mov":
+            return "video/quicktime"
+        case "webm":
+            return "video/webm"
+        case "mkv":
+            return "video/x-matroska"
+        case "avi":
+            return "video/x-msvideo"
+        case "3gp":
+            return "video/3gpp"
+        case "m3u8":
+            return "application/vnd.apple.mpegurl"
+        case "ts":
+            return "video/mp2t"
+        // Audio
         case "m4a":
             return "audio/mp4"
+        case "mp3":
+            return "audio/mpeg"
+        case "wav":
+            return "audio/wav"
+        case "aac":
+            return "audio/aac"
+        case "ogg":
+            return "audio/ogg"
         default:
             return "application/octet-stream"
         }


### PR DESCRIPTION
Restores #137. The squash carried an older copy of both scheme handlers, so `guessMimeType` is back to knowing about images, CSS and JS and nothing else.

## What breaks

Any locally served media file comes back as `application/octet-stream`. On Android that means a `<video src>` never plays, Chromium refuses without an explicit `video/*` type. iOS byte sniffs in some cases so it fails less predictably, which is arguably worse to debug.

The image types went with them, so webp, heic and heif are served as octet-stream too.

## Verified

Eight probe files fetched through the asset handler on both platforms, reading Content-Type off the response.

| file | before | after |
| --- | --- | --- |
| probe.mp4 | application/octet-stream | video/mp4 |
| probe.webm | application/octet-stream | video/webm |
| probe.webp | application/octet-stream | image/webp |
| probe.mp3 | application/octet-stream | audio/mpeg |
| probe.m4a | audio/mp4 on iOS, octet-stream on Android | audio/mp4 |
| probe.ogg | application/octet-stream | audio/ogg |
| probe.m3u8 | application/octet-stream | application/vnd.apple.mpegurl |
| probe.heic | application/octet-stream | image/heic |

Android emulator and iOS 26.0 simulator, same eight files, same result on both.

`m4a` is the odd one out. The squash kept that single case on iOS and dropped the other fifteen, which is why it was already passing there but not on Android.

## On the restore itself

I diffed the pre-squash list against current main on both files before touching anything, in case something had been added since that a straight revert would clobber. Nothing had. Current main was a strict subset both times, so this is #137 put back as it was, 60 insertions and no deletions.

Third regression from that squash so far. #275 on iOS and the Android query string handling were the other two.

## Unrelated thing I noticed

Android sends Content-Type twice, `video/mp4, video/mp4`. The MIME goes in both as the `WebResourceResponse` constructor argument and inside the headers map. It predates this change and nothing seems to mind, but it tripped up my test before I spotted it.
