### PR TITLE
Attach artisan to the live TSRM instead of re-initialising it

### DIFF
--- a/resources/androidstudio/app/src/main/cpp/php_bridge.c
+++ b/resources/androidstudio/app/src/main/cpp/php_bridge.c
@@ -800,20 +800,67 @@ JNIEXPORT jstring JNICALL native_run_artisan_command(JNIEnv *env, jobject thiz, 
     jstring jLaravelPath = (jstring)(*env)->CallObjectMethod(env, thiz, method);
     const char *cLaravelPath = (*env)->GetStringUTFChars(env, jLaravelPath, NULL);
 
-    // Full init per artisan command
-    setup_embed_module();
-    php_embed_module.ini_entries = "display_errors=1\nimplicit_flush=1\noutput_buffering=0\n";
-    if (php_embed_init(0, NULL) != SUCCESS) {
-        LOGE("Failed to initialize PHP for artisan");
+    // PHP startup must respect any already-initialized TSRM context. When the
+    // persistent runtime (or the queue worker) is alive — e.g. a WorkManager
+    // scheduler job firing while the app process is still up — php_embed_init()
+    // has already run tsrm_startup() process-wide. Calling it again re-runs
+    // php_tsrm_startup_ex → zend_ini_refresh_caches → OnUpdateBool against
+    // half-initialized globals and SIGSEGVs. g_ephemeral_mutex does not help:
+    // native_persistent_boot takes g_php_request_mutex instead. Mirror
+    // ephemeral_embed_init(): hot path attaches to the existing TSRM, cold
+    // path does a full embed init.
+    if (wait_for_persistent_boot_settled(10) != 0) {
+        LOGE("runArtisanCommand: timed out waiting for persistent boot to settle");
         pthread_mutex_unlock(&g_ephemeral_mutex);
         (*env)->ReleaseStringUTFChars(env, jcommand, command);
         (*env)->ReleaseStringUTFChars(env, jLaravelPath, cLaravelPath);
         (*env)->DeleteLocalRef(env, jLaravelPath);
         return (*env)->NewStringUTF(env, "");
     }
-    sapi_module.header_handler = android_header_handler;
-    // nativephp extension self-registers via static linking
-    php_initialized = 1;
+
+    int artisan_hot_path = php_initialized;
+    if (artisan_hot_path) {
+        // Hot path: a PHP runtime is already live on another thread. Allocate a
+        // thread-local TSRM context instead of re-running global startup.
+        LOGI("runArtisanCommand: hot path — attaching to existing TSRM");
+        ts_resource(0);
+        setup_embed_module();
+        if (php_embed_module.startup(&php_embed_module) == FAILURE) {
+            LOGE("runArtisanCommand: hot-path module startup failed");
+            pthread_mutex_unlock(&g_ephemeral_mutex);
+            (*env)->ReleaseStringUTFChars(env, jcommand, command);
+            (*env)->ReleaseStringUTFChars(env, jLaravelPath, cLaravelPath);
+            (*env)->DeleteLocalRef(env, jLaravelPath);
+            return (*env)->NewStringUTF(env, "");
+        }
+        if (php_request_startup() == FAILURE) {
+            LOGE("runArtisanCommand: hot-path request startup failed");
+            php_request_shutdown(NULL);
+            ts_free_thread();
+            pthread_mutex_unlock(&g_ephemeral_mutex);
+            (*env)->ReleaseStringUTFChars(env, jcommand, command);
+            (*env)->ReleaseStringUTFChars(env, jLaravelPath, cLaravelPath);
+            (*env)->DeleteLocalRef(env, jLaravelPath);
+            return (*env)->NewStringUTF(env, "");
+        }
+        sapi_module.header_handler = android_header_handler;
+    } else {
+        // Cold path: no live runtime (e.g. install-time setup, or a WorkManager
+        // cold start after the app was killed) — full embed init is safe.
+        setup_embed_module();
+        php_embed_module.ini_entries = "display_errors=1\nimplicit_flush=1\noutput_buffering=0\n";
+        if (php_embed_init(0, NULL) != SUCCESS) {
+            LOGE("Failed to initialize PHP for artisan");
+            pthread_mutex_unlock(&g_ephemeral_mutex);
+            (*env)->ReleaseStringUTFChars(env, jcommand, command);
+            (*env)->ReleaseStringUTFChars(env, jLaravelPath, cLaravelPath);
+            (*env)->DeleteLocalRef(env, jLaravelPath);
+            return (*env)->NewStringUTF(env, "");
+        }
+        sapi_module.header_handler = android_header_handler;
+        // nativephp extension self-registers via static linking
+        php_initialized = 1;
+    }
 
     char artisanPath[1024];
     snprintf(artisanPath, sizeof(artisanPath), "%s/../artisan.php", cLaravelPath);
@@ -861,8 +908,15 @@ JNIEXPORT jstring JNICALL native_run_artisan_command(JNIEnv *env, jobject thiz, 
     zend_stream_init_filename(&file_handle, artisanPath);
     php_execute_script(&file_handle);
 
-    safe_php_embed_shutdown();
-    php_initialized = 0;
+    if (artisan_hot_path) {
+        // Tear down only this thread's context — leave the live runtime's
+        // global TSRM (and php_initialized) intact.
+        php_request_shutdown(NULL);
+        ts_free_thread();
+    } else {
+        safe_php_embed_shutdown();
+        php_initialized = 0;
+    }
 
     pthread_mutex_unlock(&g_ephemeral_mutex);
 


### PR DESCRIPTION
Restores the C half of #154. The squash reverted it and `native_run_artisan_command` has been calling `php_embed_init(0, NULL)` unconditionally ever since.

## The crash

If any PHP runtime is already live in the process, `php_embed_init` re-runs `tsrm_startup()`, which takes `php_tsrm_startup_ex` through `zend_ini_refresh_caches` against half-initialised globals and SIGSEGVs. #154 hit this with a WorkManager scheduler job firing while the app was still up.

The artisan lane is the only one left without a guard:

| lane | mutex | boot gate | hot path |
| --- | --- | --- | --- |
| `run_php_request` | `g_php_request_mutex` | no | no |
| `native_persistent_boot` | `g_php_request_mutex` | sets IN_PROGRESS | n/a |
| `ephemeral_embed_init` | caller's | `wait_for_persistent_boot_settled` | yes |
| `native_worker_boot` | `g_worker_mutex` | `wait_for_persistent_boot_settled` | yes |
| **`native_run_artisan_command`** | **`g_ephemeral_mutex`** | **none** | **none** |

Note the mutexes. Artisan holds `g_ephemeral_mutex`, persistent boot holds `g_php_request_mutex`. They do not serialise against each other, so the only thing standing between them today is a Kotlin-side lock, and that lock is not held on every path (separate PR).

## The change

Straight restore of #154's approach, adapted to the current function and mirroring `ephemeral_embed_init` which sits a few hundred lines below:

- wait for any in-flight persistent boot to settle, so `php_initialized` is not read mid-boot
- if a runtime is live, `ts_resource(0)` plus module and request startup, giving this thread its own TSRM context
- otherwise the existing full `php_embed_init`, unchanged
- teardown matches: `php_request_shutdown` + `ts_free_thread` on the hot path, `safe_php_embed_shutdown` on the cold one

`php_request_shutdown` + `ts_free_thread` is the same teardown pair used at four other sites in this file.

## What I checked before restoring

The Kotlin half of #154 is NOT restored here, and should not be. It added `nativeIsPersistentRuntimeLive()` because each thread holds its own `PHPBridge`. `main` now has `isPersistentMode()` backed by `@Volatile` fields in a companion object, so it is already process-wide. That half is genuinely superseded and restoring it would add a second mechanism for no gain.

I checked the C half the same way and it is not superseded. `extractionLock` and `baseArtisanRanThisProcess` reduce how often the lanes can overlap, but neither is a substitute for the guard: they are Kotlin-side, and `native_run_artisan_command` is reachable from plugin code compiled into this module via `app/build.gradle.kts:19`.

## Verification

Reproduced the crash on an emulator, then confirmed the fix clears it.

To trigger it I wrote a throwaway plugin whose bridge function spawns a thread calling classic artisan. A bridge function is invoked by the persistent runtime, so `php_initialized` is 1 by definition, which is the same collision a background scheduler job causes without needing WorkManager timing.

Before, the process dies:

```
TSRMPROBE: Boom: persistent runtime is live, spawning classic artisan thread
TSRMPROBE: artisan thread: calling runArtisanCommand
Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x10 in tid 16276
```

The backtrace is the one #154 described:

```
#00 ts_resource_ex+276
#01 OnUpdateBool+32
#02 zend_ini_refresh_caches+108
#03 zend_new_thread_end_handler+16
#04 ts_resource_ex+312
#05 php_tsrm_startup_ex+44
#06 php_embed_init+36
#07 native_run_artisan_command+272
```

After, the same probe on the same build of the app:

```
TSRMPROBE: artisan thread: calling runArtisanCommand
runArtisanCommand: hot path — attaching to existing TSRM
TSRMPROBE: artisan thread: SURVIVED, output=Laravel Framework 13.25.0
```

Zero crashes, process alive, artisan returns real output. Cold boot is unchanged: clean install still runs all seven base commands through the cold path with `php_initialized=0`.

Fourth regression from that squash. #275, #327 and #328 were the others.
