### PR TITLE
Hold the extraction lock across the background artisan commands

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
@@ -992,14 +992,24 @@ openssl.cafile="${context.filesDir.absolutePath}/$CACERT_FILE"
             setupDirectories()
             // Run extraction too. If MainActivity already extracted, the isUpToDate
             // check returns false (no work). If MainActivity is mid-extract, the
-            // lock inside extractLaravelBundle() blocks us here until it finishes.
-            // If we arrived first (WorkManager cold start after an app update), we
-            // do the extraction ourselves before the ephemeral runtime touches vendor/.
-            val didExtract = extractLaravelBundle()
-            setupEnvironment(didExtract)
-            if (didExtract) {
-                Log.d(TAG, "📦 Running post-extraction artisan commands (background path)...")
-                runBaseArtisanCommands()
+            // lock blocks us here until it finishes. If we arrived first
+            // (WorkManager cold start after an app update), we do the extraction
+            // ourselves before the ephemeral runtime touches vendor/.
+            //
+            // The lock spans the artisan commands as well, exactly as initialize()
+            // holds it: bootPersistentRuntime() takes the same lock, and a classic
+            // embed cycle running beside a persistent boot is what the extractionLock
+            // comment above describes. Releasing after extraction alone would let
+            // MainActivity boot straight into that overlap.
+            extractionLock.withLock {
+                val didExtract = extractLaravelBundleUnlocked()
+
+                setupEnvironment(didExtract)
+
+                if (didExtract) {
+                    Log.d(TAG, "📦 Running post-extraction artisan commands (background path)...")
+                    runBaseArtisanCommands()
+                }
             }
             Log.d(TAG, "Background environment initialized")
         } catch (e: Exception) {


### PR DESCRIPTION
Not a revert. This is a bug we found while proofing #329, and it is not covered by it.

## The asymmetry

`initialize()` holds `extractionLock` across extraction, environment setup and the artisan commands:

```kotlin
extractionLock.withLock {
    val didExtract = extractLaravelBundleUnlocked()
    setupEnvironment(didExtract)
    if (didExtract) runBaseArtisanCommands()
}
```

`initializeForBackground()` calls `extractLaravelBundle()`, which is the *locked wrapper*. It takes the lock, extracts, and releases. `setupEnvironment()` and `runBaseArtisanCommands()` then run with no lock at all.

The comment on `initialize()` explains why the span matters: `bootPersistentRuntime()` takes the same lock, and a classic embed cycle running beside a persistent boot corrupts the interpreter. The background path skips exactly that protection, and nothing documents the difference, so it reads as an oversight rather than a decision.

## Why #329 does not cover this

#329 makes the artisan lane safe when a runtime is already live. This is the opposite ordering: artisan goes first, then persistent boot runs into it.

`native_persistent_boot` checks `persistent_initialized` before booting, not `php_initialized`. So if classic artisan is mid-flight and has already run `php_embed_init`, persistent boot calls it a second time regardless. The crash lands in the boot, not in artisan.

The two mutexes involved are different, `g_ephemeral_mutex` for artisan and `g_php_request_mutex` for persistent boot, so nothing in C serialises them either. `extractionLock` is the only thing that can, and the background path was not holding it.

## Reproduction

A throwaway plugin declares a `ContentProvider`, which Android creates before `Application.onCreate`. Its thread calls `initializeForBackground()` while MainActivity is on its way to `bootPersistentRuntime()`. That is the WorkManager-cold-start ordering a scheduler plugin produces.

Before, both lanes enter and the process dies:

```
TSRMPROBE: provider onCreate: starting background-init race thread
TSRMPROBE: runBaseArtisanCommands ENTER tid=76
TSRMPROBE: runBaseArtisanCommands ENTER tid=83
Fatal signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x10
```

```
#05 php_tsrm_startup_ex+44
#06 php_embed_init+36
#07 native_persistent_boot+276
```

After, the lanes serialise and the run completes:

```
TSRMPROBE: runBaseArtisanCommands ENTER tid=77
runArtisanCommand: optimize:clear … view:cache        (all seven)
TSRMPROBE: race thread: SURVIVED initializeForBackground
TSRMPROBE: runBaseArtisanCommands ENTER tid=83
```

Zero crashes, process alive. Cold boot without the plugin is unchanged, seven commands, no crash.

## Honest note on the repro

I widened the window with a `Thread.sleep` placed before the `baseArtisanRanThisProcess` check, in the generated project only, so both threads reliably got past it. That check is a non-atomic check-then-set on a `@Volatile` flag, so two threads can pass it unaided, but the window is narrow and I could not get them to collide without help. The sleep changes timing, not behaviour, and the identical instrumentation was used on both runs.

Worth saying plainly: this needs a plugin that boots a background Laravel lane. Core alone has no caller for `initializeForBackground()`, so nothing in this repo can reach it today.
