### PR TITLE
Decode zip entry names as UTF-8 when extracting the app bundle

### DIFF
--- a/resources/xcode/NativePHP/AppUpdateManager.swift
+++ b/resources/xcode/NativePHP/AppUpdateManager.swift
@@ -118,7 +118,18 @@ class AppUpdateManager {
         var fileDataMap: [(path: URL, data: Data)] = []
 
         for entry in archive {
-            let destinationPath = destinationURL.appendingPathComponent(entry.path)
+            // ZIPFoundation 0.9.19's `entry.path` decodes as CP437 unless the EFS bit
+            // is set on the entry — and macOS `zip` often omits that flag even for
+            // UTF-8 names, producing mojibake (⚡️ → ΓÜí∩╕Å). Force UTF-8 decode via
+            // path(using:); fall back to `entry.path` only if the bytes aren't valid
+            // UTF-8 (which shouldn't happen for archives we build).
+            let utf8Path = entry.path(using: .utf8)
+            let rawPath = utf8Path.isEmpty ? entry.path : utf8Path
+
+            // Normalize to NFC: macOS sources may emit NFD filenames; iOS APFS stores
+            // bytes verbatim, but PHP autoloaders look up the NFC form.
+            let normalizedPath = (rawPath as NSString).precomposedStringWithCanonicalMapping
+            let destinationPath = destinationURL.appendingPathComponent(normalizedPath)
 
             switch entry.type {
             case .directory:


### PR DESCRIPTION
Restores #138's `AppUpdateManager` change. The squash put back the line that reads `entry.path` directly.

## What breaks

ZIPFoundation decodes an entry path as CP437 unless the archive sets the EFS bit, and macOS `zip` frequently omits that flag even for UTF-8 names. Every non-ASCII filename in the bundle therefore lands on disk as mojibake.

Livewire 4 components are the obvious casualty, since `⚡️counter.blade.php` is an idiomatic name, but it hits any accented or non-Latin filename. Nothing errors during extraction. The file is simply not at the path PHP later looks for.

## Verification

Two probe files in `public/`, one emoji and one with a combining accent, then a clean install on an iOS 26.0 simulator. Filenames read back as raw bytes off the app container rather than off a screenshot, since the on-screen text is too small to trust for this.

Before:

```
cafe e295a0 75cc88 2d70 726f 6265 2e74 7874
ce93 55cc88 69cc81 e288a9 ... 70726f 62652e747874
```

After:

```
cafe cc81 2d70 726f 6265 2e74 7874
e29aa1 efb88f 70726f 62652e747874
```

`e29aa1 efb88f` is exactly UTF-8 for `⚡️`. Before, those bytes were the CP437 reading of them, which is the corruption #138 described.

## One correction to #138's second half

The commit also normalises to NFC, and I restored that line verbatim. It does not survive: the café probe lands on disk as `cafe cc81`, still decomposed, because `URL.appendingPathComponent()` re-decomposes path components on Apple platforms. So the observable fix here is the UTF-8 decode alone.

I have kept the line for fidelity with the original and because it costs nothing, but it should not be read as doing any work. A `file_exists()` check on the decomposed name passes either way, since the filesystem compares normalisation-insensitively, which is what nearly fooled me into reporting it as working.

## On the restore

Checked for a replacement before restoring, after being burned on that with #329. ZIPFoundation is still pinned at the same 0.9.19 it was when #138 landed, so `path(using:)` is the same API, and `precomposedString` and `path(using:` appear nowhere else under `resources/xcode`. Nothing had taken over the job.

Restored verbatim, 12 lines.
