### PR TITLE
Ignore file URLs in DeepLinkRouter

### DIFF
--- a/resources/xcode/NativePHP/DeepLinkRouter.swift
+++ b/resources/xcode/NativePHP/DeepLinkRouter.swift
@@ -55,6 +55,17 @@ final class DeepLinkRouter {
         DebugLogger.shared.log("🔗 DeepLinkRouter.handle() called with: \(url)")
         DebugLogger.shared.log("🔗 Current state - WebView ready: \(isWebViewReady), PHP ready: \(isPhpReady)")
 
+        // Guard: DeepLinkRouter only handles deep links (custom URL schemes and universal links).
+        // File URLs are delivered to the app when CFBundleDocumentTypes / LSSupportsOpeningDocumentsInPlace
+        // are declared (e.g. when the user picks the app from another app's share sheet or "Open In…").
+        // Without this guard, the file path is treated as a Laravel route and the WebView displays
+        // a 404 like "route /private/var/mobile/.../filename.pdf could not be found". Plugins that
+        // declare document types are responsible for handling file URLs before they reach this router.
+        guard !url.isFileURL else {
+            DebugLogger.shared.log("🔗 Ignoring file URL — DeepLinkRouter only handles deep links: \(url)")
+            return
+        }
+
         // PROTOTYPE: jump://native — leave WebView mode and return to native-ui.
         // The local native runloop kept running underneath (WebView sessions
         // don't touch it), so re-showing its tree is immediately interactive.


### PR DESCRIPTION
Restores #106. The squash dropped the guard, so a file URL is treated as a Laravel route again.

## What happens without it

`application(_:open:options:)` receives file URLs, not just deep links, once an app declares `CFBundleDocumentTypes` or `LSSupportsOpeningDocumentsInPlace`. That happens when the user sends a document to the app from a share sheet or "Open In".

`DeepLinkRouter.handle(url:)` has no notion of file URLs. It takes any URL, keeps the path, and rewrites it to `php://127.0.0.1<path>`, so the app navigates to a route named after an absolute filesystem path and shows a 404.

## Verification

The routing half is demonstrated end to end. Feeding the router a URL with the shape a file URL has, no host and an absolute filesystem path, on an iOS 26.0 simulator:

```
🔗 DeepLinkRouter.handle() called with: airprobe:///Users/…/Desktop/probe.txt
🔗 Current state - WebView ready: true, PHP ready: true
🔗 Normalized to: php://127.0.0.1/Users/…/Desktop/probe.txt
🔗 Both ready, navigating with Inertia
🔗 navigateWithInertia() posting notification for path: /Users/…/Desktop/probe.txt
```

It does not merely build the wrong route, it navigates to it. That is the 404 the guard prevents.

What I could not do is have iOS deliver a real `file://` URL. `simctl openurl` rejects them with `LSApplicationWorkspaceErrorDomain code=115`, and dropping a file on the simulator does not reach the app either. So `url.isFileURL` is not exercised by a run. It is a documented Foundation property and the guard is a plain early return, but the distinction belongs in the description rather than being glossed.

## Not superseded

Checked before restoring. `isFileURL` appears nowhere under `resources/xcode`, and nothing else inspects the URL before `handle(url:)` builds a route.

## Two things worth knowing

A plugin cannot declare document types today. `IosPluginCompiler::injectPlistEntries` only emits arrays of strings, so an array of dicts like `CFBundleDocumentTypes` cannot be expressed in `nativephp.json`. The `resources/ios/Info.plist` merge path is also gated behind the plugin having a non-empty `ios.info_plist` or dependencies, so a plugin shipping only a plist is skipped silently. That matters because plugins declaring document types are exactly who this guard protects.

`DebugLogger` writes to `Library/Application Support/nativephp_debug.log` rather than the unified log, which is worth knowing before spending time on `log stream` predicates that will never match.
