### PR TITLE
Seed the Vite hot file into the simulator container on watch start

### DIFF
--- a/src/Concerns/WatchesIos.php
+++ b/src/Concerns/WatchesIos.php
@@ -102,6 +102,18 @@ trait WatchesIos
 
             $this->iosAppContainer = $derivedDataPath;
 
+            // Seed the hot file into the container. The app resolves Vite through
+            // Vite::useHotFile(public_path('ios-hot')), and by the time watching
+            // starts the file already exists, so no change event will ever
+            // carry it across.
+            if ($viteRunning) {
+                $this->info('Vite dev server detected - syncing hot file to simulator');
+                $hotFileDestination = $derivedDataPath.'/Documents/app/public/ios-hot';
+                @mkdir(dirname($hotFileDestination), 0755, true);
+                copy($viteHotFile, $hotFileDestination);
+                $this->triggerIosReload();
+            }
+
             $this->startIosWatching($derivedDataPath, $viteHotFile);
         } else {
             $this->startIosWatchingDevice($target, $appId);


### PR DESCRIPTION
Restores the iOS watcher half of #62, which the squash dropped. Putting it up because it was on the squash list, but I am not convinced it should merge, and the reasons are below. Your call.

## What it does

The app reads the dev server URL from `public/ios-hot` inside its own container, via `Vite::useHotFile(public_path('ios-hot'))` in `NativeServiceProvider`. That is the only channel; nothing else tells the app where Vite is. #62 copied the file in when watching started.

## The case against

`RunsIos.php:119` starts Vite before the build, with the comment "so hot file is present during build". The bundle excludes nothing matching `*-hot`, so `public/ios-hot` ships inside `app.zip`, and `AppUpdateManager` re-extracts on every launch while the version is `DEBUG`.

So on `native:run ios --watch --vite`, which I take to be the normal flow, the app already has the hot file before the watcher starts. This block then copies an identical file over it and fires an extra reload straight after launch. That early-Vite start is newer than #62 and looks like it was added precisely to solve this, which would make the watcher copy obsolete rather than missing.

The gap it genuinely closes is standalone `native:watch ios --vite` against an app built earlier without Vite. That is real but narrow, and you will know better than me how much it is used.

I tried guarding the redundant case by comparing the container copy first. It does not work: at watch-start the app has just wiped `Documents/app` and is mid re-extraction, so the check sees nothing there and copies anyway. Two attempts, both failed on device.

## Scope note

Vite is opt-in. `shouldRunVite()` requires an explicit `--vite` and both `RunCommand` and `WatchCommand` document it as off by default. The `-W` path used by native and EDGE apps drives `triggerIosReload()` over watchman and never touches Vite or the hot file, so none of this affects the default workflow.

## Verification

With `public/ios-hot` present on the host and the container copy removed, starting the watcher logs `Vite dev server detected - syncing hot file to simulator` and the file lands in `Documents/app/public/ios-hot` with the right contents. So it does what it says. The question is whether it needs to.

## Two things worth doing regardless

These came out of checking this one and are not in the diff.

`stopViteDevServer()` calls `cleanupHotFile()`, which deletes only the host copy. The container keeps its own, so with a real version string, where `DEBUG` re-extraction does not kick in, the app goes on pointing at a dead dev server. An unlink when Vite is not running is arguably worth more than this copy.

Android has the same gap and no seeding at all. `WatchesAndroid` only pushes the hot file when a change event names it, so `native:watch android --vite` should be affected the same way.
