### PR TITLE
Android: mirror cookies into the WebView jar against https://127.0.0.1

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebRenderer.kt
@@ -43,7 +43,7 @@ class WebRenderer(
         WebCookieMirror.markWebViewAvailable()
         val jar = CookieManager.getInstance()
         LaravelCookieStore.all().forEach { (name, value) ->
-            jar.setCookie("http://127.0.0.1", "$name=$value")
+            jar.setCookie(WebCookieMirror.COOKIE_ORIGIN, "$name=$value")
         }
         jar.flush()
 

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/security/WebCookieMirror.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/security/WebCookieMirror.kt
@@ -13,6 +13,11 @@ import android.webkit.CookieManager
  * calls [markWebViewAvailable] and back-fills the jar from the store.
  */
 object WebCookieMirror {
+    // CookieManager silently drops Secure cookies set for an HTTP URL. Chromium
+    // treats http://127.0.0.1 as trustworthy, so cookies written against HTTPS
+    // remain available on the HTTP origin the app is served from.
+    internal const val COOKIE_ORIGIN = "https://127.0.0.1"
+
     @Volatile
     private var available = false
 
@@ -22,7 +27,7 @@ object WebCookieMirror {
 
     fun set(cookieHeaderValue: String) {
         if (!available) return
-        CookieManager.getInstance().setCookie("http://127.0.0.1", cookieHeaderValue)
+        CookieManager.getInstance().setCookie(COOKIE_ORIGIN, cookieHeaderValue)
     }
 
     fun flush() {


### PR DESCRIPTION
## Summary
 
Fixes #325.
 
`WebCookieMirror.set()` writes the raw `Set-Cookie` line to `CookieManager` against `http://127.0.0.1`. `CookieManager.setCookie()` refuses a `Secure` cookie from a plain-http URL and reports nothing, so as soon as an app's cookies carry `Secure` — `SESSION_SECURE_COOKIE=true`, or relayed from a backend that sets it — nothing is mirrored. `document.cookie` then holds only what `WebRenderer.init` seeded (bare `name=value`, no attributes, so those writes land), and anything that builds `X-XSRF-TOKEN` from `document.cookie` sends a token belonging to no session: every state-changing request comes back 419.
 
## What changed
 
The origin becomes a single `internal const val COOKIE_ORIGIN = "https://127.0.0.1"` on `WebCookieMirror`, with the reason for the unusual scheme documented where it is defined. Both writers use it — the mirror itself and `WebRenderer.init`'s back-fill — so the choice is explained once instead of appearing unannounced in two files. The `Set-Cookie` line itself is untouched.
 
Measured on the device before the change — same API, same host, only the scheme and the attributes varying:
 
| probe | `setCookie()` URL | attributes | lands? |
| --- | --- | --- | --- |
| A | `http://127.0.0.1` | `path=/; secure` | no |
| B | `http://127.0.0.1` | `path=/` | yes |
| C | `https://127.0.0.1` | `path=/; secure` | yes |
| D | `http://127.0.0.1` | `secure; samesite=none` | no |
| E | `https://127.0.0.1` | `secure; samesite=none` | yes |
 
Chromium treats `127.0.0.1` as a trustworthy loopback origin, so a page served over `http://127.0.0.1` reads those cookies back (C and E). Nothing has to strip `Secure` or `SameSite=None`.
 
Stripping `Secure` before mirroring would also make the write land, but it breaks `SameSite=None`, which Chromium rejects without `Secure` — an app with `SESSION_SAME_SITE=none` would end up worse off than today. That was the first version of this patch and I dropped it.
 
`WebRenderer.init`'s seeding moves to the same URL so both writers address the jar the same way.
 
**Known assumption.** This relies on Chromium's loopback exception and on cookies not being scheme-bound. If origin-bound (scheme-bound) cookies become the default in WebView, a cookie stored under `https://127.0.0.1` stops being visible to an `http://127.0.0.1` page, and this goes quiet rather than failing loudly. An instrumentation test asserting `getCookie("http://127.0.0.1")` after a `Secure` write would pin it against older and future providers, but `resources/androidstudio` is a template with unresolved placeholders (`REPLACE_COMPILE_SDK`), so there is no harness to add it to.
 
**Relationship to #148.** That is the fix at the origin. If Android moves off `http://127.0.0.1` to a secure custom scheme the way iOS uses `php://`, `setCookie()` accepts these lines unchanged and this patch should be revisited or dropped as part of that work.
 
## Test plan
 
Physical device (Pixel 4a 5G, Android 14, WebView 150.0.7871.183), release build, `pm clear` before each run, app-side CSRF workarounds removed. The WebView version is worth noting here — the acceptance rule below is Chromium behaviour, not an Android API contract.
 
- [x] Probes A–E above, before the change
- [x] `document.cookie` immediately after a fresh install contains `XSRF-TOKEN`; the session cookie is correctly withheld (`HttpOnly`)
- [x] Login POST: 419 before, 302 → dashboard after
- [x] Logout POST: 419 before, 302 → guest screen after
- [x] Tab navigation between authenticated pages keeps the session
- [x] Restart path (`WebRenderer.init`'s back-fill) — the jar holds `XSRF-TOKEN` after an app restart, not only after a fresh mirror write
- [ ] An app whose cookies carry no `Secure` at all — unchanged in principle (probe B and the seeding path are unaffected by the scheme), but I have not run a full pass on one