### PR TITLE
Android: unset the request's header env vars after each dispatch

### DIFF
--- a/resources/androidstudio/app/src/main/cpp/php_bridge.c
+++ b/resources/androidstudio/app/src/main/cpp/php_bridge.c
@@ -765,6 +765,14 @@ JNIEXPORT jint JNICALL native_set_env(JNIEnv *env, jobject thiz,
     return result;
 }
 
+JNIEXPORT void JNICALL native_unset_env(JNIEnv *env, jobject thiz, jstring name) {
+    const char *nameStr = (*env)->GetStringUTFChars(env, name, NULL);
+
+    unsetenv(nameStr);
+
+    (*env)->ReleaseStringUTFChars(env, name, nameStr);
+}
+
 JNIEXPORT void JNICALL native_set_request_info(JNIEnv *env, jobject thiz,
                                                      jstring method, jstring uri,
                                                      jstring post_data) {
@@ -1646,6 +1654,7 @@ static JNINativeMethod gMethods[] = {
 
         // LaravelEnvironment
         {"nativeSetEnv", "(Ljava/lang/String;Ljava/lang/String;I)I", (void *) native_set_env},
+        {"nativeUnsetEnv", "(Ljava/lang/String;)V", (void *) native_unset_env},
         {"nativeHandleRequest","(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",(void *) native_handle_request},
         // Legacy name for compat
         {"nativeHandleRequestOnce","(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;",(void *) native_handle_request},

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/PHPBridge.kt
@@ -41,6 +41,7 @@ class PHPBridge(private val context: Context) {
 
     external fun nativeExecuteScript(filename: String): String
     external fun nativeSetEnv(name: String, value: String, overwrite: Int): Int
+    external fun nativeUnsetEnv(name: String)
     external fun runArtisanCommand(command: String): String
     external fun initialize()
     external fun setRequestInfo(method: String, uri: String, postData: String?)
@@ -319,47 +320,54 @@ class PHPBridge(private val context: Context) {
         val future = phpExecutor.submit<String> {
             val prepStart = System.currentTimeMillis()
 
-            // Clear Inertia-related env vars first - they persist between requests
-            // and cause Laravel to return JSON instead of HTML
-            val inertiaEnvVars = listOf(
-                "HTTP_X_INERTIA",
-                "HTTP_X_INERTIA_VERSION",
-                "HTTP_X_INERTIA_PARTIAL_DATA",
-                "HTTP_X_INERTIA_PARTIAL_COMPONENT",
-                "HTTP_X_INERTIA_PARTIAL_EXCEPT"
-            )
-            inertiaEnvVars.forEach { envVar ->
-                nativeSetEnv(envVar, "", 1)
+            // Headers travel as process env vars, which outlive the dispatch,
+            // so the next request would inherit every header of this one.
+            // Track what this request sets and drop it afterwards — the same
+            // thing iOS does in PersistentPHPRuntime.swift.
+            val headerEnvKeys = mutableListOf<String>()
+
+            fun setHeaderEnv(name: String, value: String) {
+                headerEnvKeys.add(name)
+
+                if (nativeSetEnv(name, value, 1) != 0) {
+                    headerEnvKeys.removeAt(headerEnvKeys.lastIndex)
+                    error("Failed to set request environment variable: $name")
+                }
             }
 
-            request.headers.forEach { (key, value) ->
-                val envKey = "HTTP_" + key.replace("-", "_").uppercase()
-                nativeSetEnv(envKey, value, 1)
-            }
+            val prepTime: Long
+            val jniStart: Long
 
-            val cookieHeader = LaravelCookieStore.asCookieHeader()
-            nativeSetEnv("HTTP_COOKIE", cookieHeader, 1)
+            val output = try {
+                request.headers.forEach { (key, value) ->
+                    setHeaderEnv("HTTP_" + key.replace("-", "_").uppercase(), value)
+                }
 
-            val prepTime = System.currentTimeMillis() - prepStart
-            val jniStart = System.currentTimeMillis()
+                setHeaderEnv("HTTP_COOKIE", LaravelCookieStore.asCookieHeader())
 
-            val output = if (persistentMode && persistentBooted) {
-                // Persistent mode: dispatch through the already-running interpreter
-                nativePersistentDispatch(
-                    request.method,
-                    request.uri,
-                    request.body,
-                    nativePhpScript
-                )
-            } else {
-                // Classic mode: full init/shutdown per request
-                ensureRuntimeInitialized()
-                nativeHandleRequest(
-                    request.method,
-                    request.uri,
-                    request.body,
-                    nativePhpScript
-                )
+                prepTime = System.currentTimeMillis() - prepStart
+                jniStart = System.currentTimeMillis()
+
+                if (persistentMode && persistentBooted) {
+                    // Persistent mode: dispatch through the already-running interpreter
+                    nativePersistentDispatch(
+                        request.method,
+                        request.uri,
+                        request.body,
+                        nativePhpScript
+                    )
+                } else {
+                    // Classic mode: full init/shutdown per request
+                    ensureRuntimeInitialized()
+                    nativeHandleRequest(
+                        request.method,
+                        request.uri,
+                        request.body,
+                        nativePhpScript
+                    )
+                }
+            } finally {
+                headerEnvKeys.forEach { nativeUnsetEnv(it) }
             }
 
             val jniTime = System.currentTimeMillis() - jniStart


### PR DESCRIPTION
## Summary
 
Fixes #324. Follow-up to #119.
 
Headers reach PHP as `HTTP_*` environment variables, and the environment outlives a dispatch, so a request inherits every header of the one before it: a POST's `Content-Type` is still set when the next GET is dispatched, and so are `X-Requested-With`, `Referer`, `Origin`, and anything a JS library sends on only some requests.
 
#119 addressed the visible symptom by stripping `HTTP_*` and `CONTENT_*` from `$_SERVER` at the top of each dispatch, but the same eval re-imports the environment twenty lines later:
 
```php
foreach (getenv() as $__k => $__v) { $_SERVER[$__k] = $__v; }
```
 
so the stale keys return immediately. The Kotlin band-aid in `PHPBridge.kt` covers this for `X-Inertia` only, and by blanking rather than removing.
 
iOS already does the right thing — `PersistentPHPRuntime.swift` records the keys it sets and `unsetenv`s them after the dispatch. This brings Android to the same behaviour.
 
## What changed
 
`handleLaravelRequest()` records every header env var it sets (`headerEnvKeys`), runs the dispatch inside a `try`, and unsets them in `finally` — so a failed dispatch, including the native early returns (`php_embed_init()` failure, "runtime not initialized"), cannot leave its headers behind either. The list is local to the request on the single `phpExecutor` thread, so there is no shared state and nothing to lock. The C side gains one small JNI method, `nativeUnsetEnv`, since `System.getenv()` is a JVM snapshot and Kotlin otherwise has no way to remove a process variable.
 
Track-and-remove rather than sweeping `environ` for anything matching `HTTP_*`, for three reasons: pre-existing `HTTP_*` variables whose names the current request does not set are left alone (and a request that does send a `Proxy:` header has its `HTTP_PROXY` removed afterwards — the safer outcome either way); there is no name-length cutoff past which a header would escape removal; and it is exactly what iOS does.
 
The five-name Inertia blanking block is gone — it was this fix, restricted to five names and blanking instead of removing.
 
One deliberate behaviour change: a failed `setenv` used to go unnoticed and the request was dispatched with that header missing. It now aborts the request, and `finally` still removes whatever had been set up to that point.
 
Notes:
 
- `HTTP_HOST` is re-set by the C side per dispatch (`php_bridge.c:286`, `:487`), which is untracked and unchanged — it is constant for the embedded server, so persisting is harmless.
- `native_webview_php_request()` is unaffected: it receives its cookies and content type as parameters rather than through the environment, so there is nothing to unset.
- bionic's `setenv`/`unsetenv` are not safe against a concurrent `getenv()` from another thread. That is a pre-existing property of passing headers through the environment; this change does not add to it — all header `setenv`/`unsetenv` calls stay on the single `phpExecutor` thread, as before.
## Test plan
 
Physical device (Pixel 4a 5G, Android 14), release build via `native:package android --build-type=release`.
 
- [x] `Route::get('/leak', fn () => response($_SERVER['HTTP_X_FOO'] ?? '(absent)'))`; one `fetch` with `X-Foo: bar`, then two without — before: `bar`, `bar`, `bar`; after: `bar`, `(absent)`, `(absent)`
- [x] Inertia visit followed by a top-level navigation returns HTML, not a raw page object
- [x] Regular Inertia XHR navigation still receives JSON
- [x] `POST` with `Content-Type: application/x-www-form-urlencoded` still parses into `$_POST` after the change
- [x] Login → tab navigation → logout completes on a release build
- [ ] Classic (non-persistent) runtime mode — `nativeHandleRequest()` sits inside the same `try`/`finally` so the path is covered identically, but I have only exercised the persistent default