### PR TITLE
Add mount dependency injection

### DIFF
--- a/src/Edge/ImplicitlyBoundMethod.php
+++ b/src/Edge/ImplicitlyBoundMethod.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Native\Mobile\Edge;
+
+use Illuminate\Container\BoundMethod;
+use Illuminate\Contracts\Routing\UrlRoutable as ImplicitlyBindable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use ReflectionClass;
+use ReflectionNamedType;
+
+/**
+ * Resolves component method parameters with the same rules as Livewire:
+ * ordinary classes come from the container; routable models and backed enums
+ * are implicitly bound from matching values passed to the method.
+ */
+class ImplicitlyBoundMethod extends BoundMethod
+{
+    protected static function getMethodDependencies($container, $callback, array $parameters = [])
+    {
+        return static::resolveMethodDependencies($container, $callback, $parameters)['positional'];
+    }
+
+    public static function resolveMethodDependencies($container, $callback, array $parameters = []): array
+    {
+        $positional = [];
+        $named = [];
+        $parameterIndex = 0;
+
+        foreach (static::getCallReflector($callback)->getParameters() as $parameter) {
+            $parameterPosition = count($positional);
+
+            static::substituteNameBindingForCallParameter($parameter, $parameters, $parameterIndex);
+            static::substituteImplicitBindingForCallParameter($container, $parameter, $parameters);
+            static::addDependencyForCallParameter($container, $parameter, $parameters, $positional);
+
+            $parameterDependencies = array_slice($positional, $parameterPosition);
+
+            if ($parameterDependencies !== []) {
+                $named[$parameter->getName()] = $parameter->isVariadic()
+                    ? $parameterDependencies
+                    : $parameterDependencies[0];
+            }
+        }
+
+        return [
+            'positional' => array_values(array_merge($positional, $parameters)),
+            'named' => $named,
+        ];
+    }
+
+    protected static function substituteNameBindingForCallParameter($parameter, array &$parameters, int &$parameterIndex): void
+    {
+        if (! array_key_exists($parameterIndex, $parameters)) {
+            return;
+        }
+
+        if ($parameter->isVariadic()) {
+            $parameters = array_merge(
+                array_filter($parameters, fn ($key) => ! is_int($key), ARRAY_FILTER_USE_KEY),
+                array_values(array_filter($parameters, fn ($key) => is_int($key), ARRAY_FILTER_USE_KEY)),
+            );
+
+            return;
+        }
+
+        $class = static::getClassForDependencyInjection($parameter);
+
+        if ($class !== null && ! $parameters[$parameterIndex] instanceof $class) {
+            return;
+        }
+
+        if (! array_key_exists($parameter->getName(), $parameters)) {
+            $parameters[$parameter->getName()] = $parameters[$parameterIndex];
+            unset($parameters[$parameterIndex]);
+            $parameterIndex++;
+        }
+    }
+
+    protected static function substituteImplicitBindingForCallParameter($container, $parameter, array &$parameters): void
+    {
+        $class = static::getClassForImplicitBinding($parameter);
+
+        if ($class === null) {
+            return;
+        }
+
+        $name = $parameter->getName();
+
+        if (array_key_exists($name, $parameters) && ! $parameters[$name] instanceof $class) {
+            $parameters[$name] = static::getImplicitBinding($container, $class, $parameters[$name]);
+        } elseif (array_key_exists($class, $parameters) && ! $parameters[$class] instanceof $class) {
+            $parameters[$class] = static::getImplicitBinding($container, $class, $parameters[$class]);
+        }
+    }
+
+    protected static function getClassForDependencyInjection($parameter): ?string
+    {
+        $class = static::getParameterClassName($parameter);
+
+        if ($class === null || static::isEnum($parameter) || static::implementsImplicitlyBindable($parameter)) {
+            return null;
+        }
+
+        return $class;
+    }
+
+    protected static function getClassForImplicitBinding($parameter): ?string
+    {
+        $class = static::getParameterClassName($parameter);
+
+        if ($class === null) {
+            return null;
+        }
+
+        return static::isEnum($parameter) || static::implementsImplicitlyBindable($parameter)
+            ? $class
+            : null;
+    }
+
+    protected static function getImplicitBinding($container, string $class, mixed $value): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ((new ReflectionClass($class))->isEnum()) {
+            return $class::tryFrom($value);
+        }
+
+        $model = $container->make($class)->resolveRouteBinding($value);
+
+        if (! $model) {
+            throw (new ModelNotFoundException)->setModel($class, [$value]);
+        }
+
+        return $model;
+    }
+
+    public static function getParameterClassName($parameter): ?string
+    {
+        $type = $parameter->getType();
+
+        if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return null;
+        }
+
+        return $type->getName();
+    }
+
+    public static function implementsImplicitlyBindable($parameter): bool
+    {
+        $class = static::getParameterClassName($parameter);
+
+        return $class !== null
+            && (new ReflectionClass($class))->implementsInterface(ImplicitlyBindable::class);
+    }
+
+    public static function isEnum($parameter): bool
+    {
+        $class = static::getParameterClassName($parameter);
+
+        return $class !== null && (new ReflectionClass($class))->isEnum();
+    }
+}

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -2,6 +2,9 @@
 
 namespace Native\Mobile\Edge;
 
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Illuminate\View\Engines\CompilerEngine;
@@ -1969,9 +1972,138 @@ abstract class NativeComponent
         return new $eventClass(...$args);
     }
 
-    public function mount(): void
+    /**
+     * Hydrate route-bound public properties and invoke the component's
+     * optional mount() method through Laravel's container.
+     *
+     * NativeComponent deliberately does not declare mount() itself. That lets
+     * application components use any signature, including route-bound models
+     * and container dependencies, without violating PHP's inheritance rules.
+     *
+     * @internal Called by the router, runloop, and test harness.
+     */
+    final public function mountComponent(): void
     {
-        //
+        $this->hydrateRouteBoundProperties();
+
+        if (! method_exists($this, 'mount')) {
+            return;
+        }
+
+        $parameters = [];
+
+        foreach ((new \ReflectionMethod($this, 'mount'))->getParameters() as $parameter) {
+            $routeParameter = $this->routeParameterFor($parameter->getName());
+
+            if ($routeParameter === null) {
+                continue;
+            }
+
+            [$routeParameterName, $value] = $routeParameter;
+            $value = $this->resolveRouteValue($parameter->getType(), $value);
+
+            $parameters[$parameter->getName()] = $value;
+            $this->nativeParams[$routeParameterName] = $value;
+        }
+
+        ImplicitlyBoundMethod::call(app(), [$this, 'mount'], $parameters);
+    }
+
+    /** Hydrate Livewire-style public properties from matching route params. */
+    private function hydrateRouteBoundProperties(): void
+    {
+        $reflection = new \ReflectionClass($this);
+
+        foreach ($reflection->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            $routeParameter = $this->routeParameterFor($property->getName());
+
+            if ($routeParameter === null) {
+                continue;
+            }
+
+            [$routeParameterName, $value] = $routeParameter;
+            $value = $this->resolveRouteValue($property->getType(), $value);
+
+            $property->setValue($this, $value);
+            $this->nativeParams[$routeParameterName] = $value;
+        }
+    }
+
+    /** @return array{string, mixed}|null */
+    private function routeParameterFor(string $name): ?array
+    {
+        foreach ([$name, Str::snake($name)] as $candidate) {
+            if (array_key_exists($candidate, $this->nativeParams)) {
+                return [$candidate, $this->nativeParams[$candidate]];
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveRouteValue(?\ReflectionType $type, mixed $value): mixed
+    {
+        if (! $type instanceof \ReflectionNamedType || $type->isBuiltin()) {
+            return $value;
+        }
+
+        $class = $type->getName();
+
+        if (enum_exists($class) && is_subclass_of($class, \BackedEnum::class)) {
+            return $this->resolveRouteEnum($class, $value);
+        }
+
+        if (is_a($class, UrlRoutable::class, true)) {
+            return $this->resolveRouteBinding($class, $value);
+        }
+
+        return $value;
+    }
+
+    /** @param class-string<\BackedEnum> $class */
+    private function resolveRouteEnum(string $class, mixed $value): ?\BackedEnum
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof $class) {
+            return $value;
+        }
+
+        $resolved = $class::tryFrom($value);
+
+        if ($resolved === null) {
+            throw new BackedEnumCaseNotFoundException($class, $value);
+        }
+
+        return $resolved;
+    }
+
+    /** @param class-string<UrlRoutable> $class */
+    private function resolveRouteBinding(string $class, mixed $value): ?UrlRoutable
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof $class) {
+            return $value;
+        }
+
+        /** @var UrlRoutable $instance */
+        $instance = app()->make($class);
+        $resolved = $instance->resolveRouteBinding($value);
+
+        if (! $resolved instanceof $class) {
+            throw (new ModelNotFoundException)->setModel($class, [$value]);
+        }
+
+        return $resolved;
     }
 
     public function unmount(): void
@@ -2083,7 +2215,7 @@ abstract class NativeComponent
         $this->publishPlaceholder();
 
         try {
-            $this->mount();
+            $this->mountComponent();
         } catch (NativeDumpException $e) {
             $this->renderDumpScreen($e);
         } catch (\Throwable $e) {
@@ -3163,7 +3295,7 @@ abstract class NativeComponent
         $this->nativeChildComponentsSeen[$identity] = true;
 
         if ($isNew) {
-            $child->mount();
+            $child->mountComponent();
         }
 
         $child->renderAsChild();

--- a/src/Edge/NativeRouter.php
+++ b/src/Edge/NativeRouter.php
@@ -350,7 +350,7 @@ class NativeRouter
                 if (! empty($resolved['layout'])) {
                     $component->setLayout($resolved['layout']);
                 }
-                $component->mount();
+                $component->mountComponent();
             } catch (\Throwable $e) {
                 static::debugLog("preloadStack: skipped $uri — ".$e->getMessage());
 
@@ -426,7 +426,7 @@ class NativeRouter
                     // (potentially slow) mount() so navigation feels instant.
                     $component->publishPlaceholder();
                     static::debugLog('loop: calling mount() on '.get_class($component));
-                    $component->mount();
+                    $component->mountComponent();
                     $this->announce(new ScreenMounted(get_class($component), $entry['uri'] ?? null));
                 } else {
                     static::debugLog('loop: calling onResume() on '.get_class($component));

--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -215,7 +215,7 @@ class TestableComponent
             // device; keep that behavior so the publish is observable.
             $component->publishPlaceholder();
 
-            $component->mount();
+            $component->mountComponent();
 
             // A redirect from mount() (e.g. an auth gate) skips the first
             // render, exactly like runLoop() honoring a pre-set intent.

--- a/tests/Feature/Edge/MountDependencyInjectionTest.php
+++ b/tests/Feature/Edge/MountDependencyInjectionTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
+use Illuminate\View\View;
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Testing\Native;
+
+final class MountInjectedClick implements UrlRoutable
+{
+    public function __construct(public ?int $id = null) {}
+
+    public function getRouteKey(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function resolveRouteBinding($value, $field = null): ?self
+    {
+        return $value === 'missing' ? null : new self((int) $value);
+    }
+
+    public function resolveChildRouteBinding($childType, $value, $field): null
+    {
+        return null;
+    }
+}
+
+final class MountInjectedService
+{
+    public string $value = 'from the container';
+}
+
+enum MountInjectedState: string
+{
+    case Active = 'active';
+}
+
+final class MountInjectedScreen extends NativeComponent
+{
+    public MountInjectedClick $click;
+
+    public ?int $clickId = null;
+
+    public bool $propertyWasHydratedBeforeMount = false;
+
+    public string $serviceValue = '';
+
+    public string $label = '';
+
+    public function mount(MountInjectedClick $click, MountInjectedService $service, string $label = 'default'): void
+    {
+        $this->propertyWasHydratedBeforeMount = $this->click === $click;
+        $this->clickId = $click->id;
+        $this->serviceValue = $service->value;
+        $this->label = $label;
+    }
+
+    public function render(): Element|View
+    {
+        return Text::make("Click {$this->clickId}: {$this->serviceValue} ({$this->label})");
+    }
+}
+
+final class RouteBoundPropertyScreen extends NativeComponent
+{
+    public MountInjectedClick $click;
+
+    public string $label = '';
+
+    public MountInjectedState $state;
+
+    public function render(): Element|View
+    {
+        return Text::make("Property click {$this->click->id}: {$this->label} ({$this->state->value})");
+    }
+}
+
+final class RouteBoundEnumMountScreen extends NativeComponent
+{
+    public string $stateValue = '';
+
+    public function mount(MountInjectedState $state): void
+    {
+        $this->stateValue = $state->value;
+    }
+
+    public function render(): Element|View
+    {
+        return Text::make("Mount state {$this->stateValue}");
+    }
+}
+
+beforeEach(function () {
+    NativeRouter::clearRoutes();
+});
+
+afterEach(function () {
+    NativeRouter::clearRoutes();
+});
+
+it('injects route-bound models, container dependencies, and primitive parameters into mount', function () {
+    NativeRouter::register('/counter/{click}/{label}', MountInjectedScreen::class);
+
+    Native::visit('/counter/88/example')
+        ->assertSet('clickId', 88)
+        ->assertSet('propertyWasHydratedBeforeMount', true)
+        ->assertSet('serviceValue', 'from the container')
+        ->assertSet('label', 'example')
+        ->assertSee('Click 88: from the container (example)');
+});
+
+it('hydrates a typed public model property from the matching route parameter', function () {
+    NativeRouter::register('/counter/{click}/{label}/{state}', RouteBoundPropertyScreen::class);
+
+    $screen = Native::visit('/counter/88/example/active')
+        ->assertSet('label', 'example')
+        ->assertSet('state', MountInjectedState::Active)
+        ->assertSee('Property click 88: example (active)');
+
+    expect($screen->get('click'))
+        ->toBeInstanceOf(MountInjectedClick::class)
+        ->id->toBe(88);
+});
+
+it('throws a model not found exception when route binding fails', function () {
+    NativeRouter::register('/counter/{click}', RouteBoundPropertyScreen::class);
+
+    Native::visit('/counter/missing');
+})->throws(ModelNotFoundException::class, MountInjectedClick::class);
+
+it('binds backed enums passed to mount and rejects invalid cases', function () {
+    NativeRouter::register('/state/{state}', RouteBoundEnumMountScreen::class);
+
+    Native::visit('/state/active')
+        ->assertSet('stateValue', 'active')
+        ->assertSee('Mount state active');
+
+    Native::visit('/state/invalid');
+})->throws(BackedEnumCaseNotFoundException::class);


### PR DESCRIPTION
## What changed

- add a Native component lifecycle dispatcher that hydrates matching public route properties before calling `mount()`
- resolve Eloquent/UrlRoutable models and backed enums from route parameters
- inject ordinary class dependencies through Laravel's container
- update router, standalone, nested-component, and testing mount call sites
- add regression coverage for model binding, public-property binding, primitive parameters, container services, backed enums, and missing models

## Why

`NativeComponent` declared a parameterless `mount(): void`, so PHP rejected component hooks such as `mount(Click $click)` as incompatible overrides. Native components also received raw route values rather than Livewire-style implicit bindings.

The base class now exposes an internal `mountComponent()` dispatcher and deliberately leaves `mount()` undeclared, allowing application components to use Livewire-compatible hook signatures.

## Impact

Native routes such as `/counter/{click}` can now either hydrate `public Click $click` directly or inject the model through `mount(Click $click)`. Components may combine route-bound values with services resolved from Laravel's container.

## Validation

- focused dependency-injection tests: 4 tests, 26 assertions
- full Pest suite passed with 3,039 assertions (existing PHP 8.5 deprecation/risky notices remain)
- PHPStan: no errors in the affected framework classes
- Pint: clean
- validated end-to-end with a real Eloquent `Click` model in the Native scratchpad app
