### PR TITLE
Add native component lifecycle foundations

### DIFF
--- a/src/Attributes/Renderless.php
+++ b/src/Attributes/Renderless.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Native\Mobile\Attributes;
+
+use Attribute;
+
+/**
+ * Prevent the render cycle that would normally follow this component action.
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+class Renderless {}

--- a/src/Edge/BenchmarkComponent.php
+++ b/src/Edge/BenchmarkComponent.php
@@ -415,7 +415,7 @@ class BenchmarkComponent extends NativeComponent
                 $this->nativeRunning = false;
                 break;
             }
-            $this->dispatch($event);
+            $this->dispatchUiEvent($event);
 
             // If dispatch set up a scenario queue, break out to run it
             if (! empty($this->scenarioQueue)) {
@@ -444,7 +444,7 @@ class BenchmarkComponent extends NativeComponent
                 $this->backToMenu();
                 break;
             }
-            $this->dispatch($event);
+            $this->dispatchUiEvent($event);
         }
     }
 
@@ -612,7 +612,7 @@ class BenchmarkComponent extends NativeComponent
                 $this->nativeRunning = false;
                 break;
             }
-            $this->dispatch($event);
+            $this->dispatchUiEvent($event);
         }
 
         $exportResult = nativephp_call('Perf.Export', '{}');
@@ -701,7 +701,7 @@ class BenchmarkComponent extends NativeComponent
                 $this->nativeRunning = false;
                 break;
             }
-            $this->dispatch($event);
+            $this->dispatchUiEvent($event);
         }
 
         $exportResult = nativephp_call('Perf.Export', '{}');
@@ -777,7 +777,7 @@ class BenchmarkComponent extends NativeComponent
                 $this->nativeRunning = false;
                 break;
             }
-            $this->dispatch($event);
+            $this->dispatchUiEvent($event);
         }
 
         $exportResult = nativephp_call('Perf.Export', '{}');
@@ -1283,7 +1283,7 @@ class BenchmarkComponent extends NativeComponent
                 $this->nativeRunning = false;
                 break;
             }
-            $this->dispatch($event);
+            $this->dispatchUiEvent($event);
         }
 
         $exportResult = nativephp_call('Perf.Export', '{}');

--- a/src/Edge/ComponentEvent.php
+++ b/src/Edge/ComponentEvent.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Native\Mobile\Edge;
+
+/** A component event whose destination can be fluently narrowed. */
+class ComponentEvent
+{
+    protected bool $self = false;
+
+    protected string|NativeComponent|null $component = null;
+
+    public function __construct(
+        protected string $name,
+        protected array $params,
+    ) {
+        if (isset($params['self'])) {
+            $this->self();
+            unset($this->params['self']);
+        }
+
+        if (isset($params['component'])) {
+            $this->component($params['component']);
+            unset($this->params['component']);
+        }
+
+        if (isset($params['to'])) {
+            $this->component($params['to']);
+            unset($this->params['to']);
+        }
+    }
+
+    public function self(): static
+    {
+        $this->self = true;
+
+        return $this;
+    }
+
+    public function component(string|NativeComponent|null $component): static
+    {
+        $this->component = $component;
+
+        return $this;
+    }
+
+    public function to(string|NativeComponent|null $component = null): static
+    {
+        return $this->component($component);
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function params(): array
+    {
+        return $this->params;
+    }
+
+    public function isSelfOnly(): bool
+    {
+        return $this->self;
+    }
+
+    public function target(): string|NativeComponent|null
+    {
+        return $this->component;
+    }
+
+    public function serialize(): array
+    {
+        $event = [
+            'name' => $this->name,
+            'params' => $this->params,
+        ];
+
+        if ($this->self) {
+            $event['self'] = true;
+        }
+
+        if ($this->component !== null) {
+            $event['component'] = $this->component instanceof NativeComponent
+                ? $this->component::class
+                : $this->component;
+        }
+
+        return $event;
+    }
+}

--- a/src/Edge/ComponentMethodInvoker.php
+++ b/src/Edge/ComponentMethodInvoker.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Native\Mobile\Edge;
+
+use Illuminate\Container\BoundMethod;
+use Illuminate\Contracts\Routing\UrlRoutable as ImplicitlyBindable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Str;
+use Native\Mobile\Attributes\Renderless;
+use Native\Mobile\Edge\Exceptions\ComponentMethodNotFoundException;
+use Native\Mobile\Edge\Exceptions\DirectlyCallingLifecycleHooksNotAllowedException;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+
+/**
+ * The single invocation path for methods called by component interactions.
+ *
+ * It enforces component action rules: only public userland methods may be
+ * called, lifecycle hooks are protected, ordinary classes are injected from
+ * Laravel's container, and routable models/backed enums are implicitly bound.
+ */
+class ComponentMethodInvoker extends BoundMethod
+{
+    public static function invoke(
+        NativeComponent $component,
+        string $method,
+        array $parameters = [],
+    ): mixed {
+        static::ensureCallable($component, $method);
+
+        $result = static::call(app(), [$component, $method], $parameters);
+
+        $reflection = new ReflectionMethod($component, $method);
+        if ($reflection->getAttributes(Renderless::class) !== []) {
+            $component->skipRender();
+        }
+
+        return $result;
+    }
+
+    /** @internal Framework-owned lifecycle invocation with the same DI rules. */
+    public static function invokeLifecycle(
+        NativeComponent $component,
+        string $method,
+        array $parameters = [],
+    ): mixed {
+        return static::call(app(), [$component, $method], $parameters);
+    }
+
+    protected static function ensureCallable(NativeComponent $component, string $method): void
+    {
+        $protectedMethods = [
+            'mount',
+            'boot',
+            'booted',
+            'exception',
+            'hydrate*',
+            'dehydrate*',
+            'updating*',
+            'updated*',
+            'rendering',
+            'rendered',
+            'scriptSrc',
+        ];
+
+        foreach (class_uses_recursive($component) as $trait) {
+            $traitName = class_basename($trait);
+            $protectedMethods[] = 'mount'.$traitName;
+            $protectedMethods[] = 'boot'.$traitName;
+            $protectedMethods[] = 'booted'.$traitName;
+        }
+
+        if (Str::is($protectedMethods, $method)) {
+            throw new DirectlyCallingLifecycleHooksNotAllowedException($method, $component);
+        }
+
+        if (! method_exists($component, $method)) {
+            throw new ComponentMethodNotFoundException($method, $component);
+        }
+
+        $reflection = new ReflectionMethod($component, $method);
+
+        if (! $reflection->isPublic()
+            || $reflection->isStatic()
+            || $method === 'render'
+            || $reflection->getDeclaringClass()->getName() === NativeComponent::class) {
+            throw new ComponentMethodNotFoundException($method, $component);
+        }
+    }
+
+    protected static function getMethodDependencies($container, $callback, array $parameters = [])
+    {
+        return static::resolveMethodDependencies($container, $callback, $parameters)['positional'];
+    }
+
+    public static function resolveMethodDependencies($container, $callback, array $parameters = []): array
+    {
+        $positional = [];
+        $named = [];
+        $parameterIndex = 0;
+
+        foreach (static::getCallReflector($callback)->getParameters() as $parameter) {
+            $parameterPosition = count($positional);
+
+            static::substituteNameBindingForCallParameter($parameter, $parameters, $parameterIndex);
+            static::substituteImplicitBindingForCallParameter($container, $parameter, $parameters);
+            static::addDependencyForCallParameter($container, $parameter, $parameters, $positional);
+
+            $parameterDependencies = array_slice($positional, $parameterPosition);
+
+            if ($parameterDependencies !== []) {
+                $named[$parameter->getName()] = $parameter->isVariadic()
+                    ? $parameterDependencies
+                    : $parameterDependencies[0];
+            }
+        }
+
+        return [
+            'positional' => array_values(array_merge($positional, $parameters)),
+            'named' => $named,
+        ];
+    }
+
+    protected static function substituteNameBindingForCallParameter($parameter, array &$parameters, int &$parameterIndex): void
+    {
+        if (! array_key_exists($parameterIndex, $parameters)) {
+            return;
+        }
+
+        if ($parameter->isVariadic()) {
+            $parameters = array_merge(
+                array_filter($parameters, fn ($key) => ! is_int($key), ARRAY_FILTER_USE_KEY),
+                array_values(array_filter($parameters, fn ($key) => is_int($key), ARRAY_FILTER_USE_KEY)),
+            );
+
+            return;
+        }
+
+        $class = static::getClassForDependencyInjection($parameter);
+
+        if ($class !== null && ! $parameters[$parameterIndex] instanceof $class) {
+            return;
+        }
+
+        if (! array_key_exists($parameter->getName(), $parameters)) {
+            $parameters[$parameter->getName()] = $parameters[$parameterIndex];
+            unset($parameters[$parameterIndex]);
+            $parameterIndex++;
+        }
+    }
+
+    protected static function substituteImplicitBindingForCallParameter($container, $parameter, array &$parameters): void
+    {
+        $class = static::getClassForImplicitBinding($parameter);
+
+        if ($class === null) {
+            return;
+        }
+
+        $name = $parameter->getName();
+
+        if (array_key_exists($name, $parameters) && ! $parameters[$name] instanceof $class) {
+            $parameters[$name] = static::getImplicitBinding($container, $class, $parameters[$name]);
+        } elseif (array_key_exists($class, $parameters) && ! $parameters[$class] instanceof $class) {
+            $parameters[$class] = static::getImplicitBinding($container, $class, $parameters[$class]);
+        }
+    }
+
+    protected static function getClassForDependencyInjection($parameter): ?string
+    {
+        $class = static::getParameterClassName($parameter);
+
+        if ($class === null || static::isEnum($parameter) || static::implementsImplicitlyBindable($parameter)) {
+            return null;
+        }
+
+        return $class;
+    }
+
+    protected static function getClassForImplicitBinding($parameter): ?string
+    {
+        $class = static::getParameterClassName($parameter);
+
+        if ($class === null) {
+            return null;
+        }
+
+        return static::isEnum($parameter) || static::implementsImplicitlyBindable($parameter)
+            ? $class
+            : null;
+    }
+
+    protected static function getImplicitBinding($container, string $class, mixed $value): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ((new ReflectionClass($class))->isEnum()) {
+            return $class::tryFrom($value);
+        }
+
+        $model = $container->make($class)->resolveRouteBinding($value);
+
+        if (! $model) {
+            throw (new ModelNotFoundException)->setModel($class, [$value]);
+        }
+
+        return $model;
+    }
+
+    public static function getParameterClassName($parameter): ?string
+    {
+        $type = $parameter->getType();
+
+        if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return null;
+        }
+
+        return $type->getName();
+    }
+
+    public static function implementsImplicitlyBindable($parameter): bool
+    {
+        $class = static::getParameterClassName($parameter);
+
+        return $class !== null
+            && (new ReflectionClass($class))->implementsInterface(ImplicitlyBindable::class);
+    }
+
+    public static function isEnum($parameter): bool
+    {
+        $class = static::getParameterClassName($parameter);
+
+        return $class !== null && (new ReflectionClass($class))->isEnum();
+    }
+}

--- a/src/Edge/ComponentMethodInvoker.php
+++ b/src/Edge/ComponentMethodInvoker.php
@@ -5,6 +5,7 @@ namespace Native\Mobile\Edge;
 use Illuminate\Container\BoundMethod;
 use Illuminate\Contracts\Routing\UrlRoutable as ImplicitlyBindable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Support\Str;
 use Native\Mobile\Attributes\Renderless;
 use Native\Mobile\Edge\Exceptions\ComponentMethodNotFoundException;
@@ -30,11 +31,7 @@ class ComponentMethodInvoker extends BoundMethod
         static::ensureCallable($component, $method);
 
         $result = static::call(app(), [$component, $method], $parameters);
-
-        $reflection = new ReflectionMethod($component, $method);
-        if ($reflection->getAttributes(Renderless::class) !== []) {
-            $component->skipRender();
-        }
+        static::applyRenderlessAttribute($component, $method);
 
         return $result;
     }
@@ -51,8 +48,21 @@ class ComponentMethodInvoker extends BoundMethod
             $parameters,
         )['positional'];
 
-        return (new ReflectionMethod($component, $method))
+        $result = (new ReflectionMethod($component, $method))
             ->invokeArgs($component, $dependencies);
+
+        static::applyRenderlessAttribute($component, $method);
+
+        return $result;
+    }
+
+    private static function applyRenderlessAttribute(NativeComponent $component, string $method): void
+    {
+        $reflection = new ReflectionMethod($component, $method);
+
+        if ($reflection->getAttributes(Renderless::class) !== []) {
+            $component->__applyRenderlessAttribute();
+        }
     }
 
     protected static function ensureCallable(NativeComponent $component, string $method): void
@@ -205,7 +215,13 @@ class ComponentMethodInvoker extends BoundMethod
         }
 
         if (is_a($class, \BackedEnum::class, true)) {
-            return $class::tryFrom($value);
+            $resolved = $class::tryFrom($value);
+
+            if ($resolved === null) {
+                throw new BackedEnumCaseNotFoundException($class, $value);
+            }
+
+            return $resolved;
         }
 
         $model = $container->make($class)->resolveRouteBinding($value);

--- a/src/Edge/ComponentMethodInvoker.php
+++ b/src/Edge/ComponentMethodInvoker.php
@@ -45,7 +45,14 @@ class ComponentMethodInvoker extends BoundMethod
         string $method,
         array $parameters = [],
     ): mixed {
-        return static::call(app(), [$component, $method], $parameters);
+        $dependencies = static::resolveMethodDependencies(
+            app(),
+            [$component, $method],
+            $parameters,
+        )['positional'];
+
+        return (new ReflectionMethod($component, $method))
+            ->invokeArgs($component, $dependencies);
     }
 
     protected static function ensureCallable(NativeComponent $component, string $method): void
@@ -171,7 +178,7 @@ class ComponentMethodInvoker extends BoundMethod
     {
         $class = static::getParameterClassName($parameter);
 
-        if ($class === null || static::isEnum($parameter) || static::implementsImplicitlyBindable($parameter)) {
+        if ($class === null || enum_exists($class) || static::implementsImplicitlyBindable($parameter)) {
             return null;
         }
 
@@ -197,7 +204,7 @@ class ComponentMethodInvoker extends BoundMethod
             return null;
         }
 
-        if ((new ReflectionClass($class))->isEnum()) {
+        if (is_a($class, \BackedEnum::class, true)) {
             return $class::tryFrom($value);
         }
 
@@ -233,6 +240,6 @@ class ComponentMethodInvoker extends BoundMethod
     {
         $class = static::getParameterClassName($parameter);
 
-        return $class !== null && (new ReflectionClass($class))->isEnum();
+        return $class !== null && is_a($class, \BackedEnum::class, true);
     }
 }

--- a/src/Edge/ComponentRouteBinder.php
+++ b/src/Edge/ComponentRouteBinder.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Native\Mobile\Edge;
+
+use BackedEnum;
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
+use Illuminate\Routing\Route;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionProperty;
+
+/** Resolve route models and enums used by mount() or typed public properties. */
+class ComponentRouteBinder
+{
+    public static function resolve(Route $route, string $componentClass): void
+    {
+        $types = array_replace(
+            static::publicPropertyTypes($componentClass),
+            static::mountParameterTypes($componentClass),
+        );
+
+        // URI order matters for scoped bindings: a child model must resolve
+        // after its parent parameter has become an UrlRoutable instance.
+        foreach ($route->parametersWithoutNulls() as $name => $value) {
+            $class = $types[$name] ?? null;
+
+            if ($class === null || ! static::isBindable($class)) {
+                continue;
+            }
+
+            $route->setParameter(
+                $name,
+                static::resolveParameter($route, $name, $class, $value),
+            );
+        }
+    }
+
+    /** @return array<string, class-string> */
+    private static function publicPropertyTypes(string $componentClass): array
+    {
+        $types = [];
+
+        foreach ((new ReflectionClass($componentClass))->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($property->isStatic() || $property->getDeclaringClass()->getName() === NativeComponent::class) {
+                continue;
+            }
+
+            if (($class = static::className($property->getType())) !== null) {
+                $types[$property->getName()] = $class;
+            }
+        }
+
+        return $types;
+    }
+
+    /** @return array<string, class-string> */
+    private static function mountParameterTypes(string $componentClass): array
+    {
+        if (! method_exists($componentClass, 'mount')) {
+            return [];
+        }
+
+        $types = [];
+
+        foreach ((new ReflectionMethod($componentClass, 'mount'))->getParameters() as $parameter) {
+            if (($class = static::className($parameter->getType())) !== null) {
+                $types[$parameter->getName()] = $class;
+            }
+        }
+
+        return $types;
+    }
+
+    /** @return class-string|null */
+    private static function className(?\ReflectionType $type): ?string
+    {
+        return $type instanceof ReflectionNamedType && ! $type->isBuiltin()
+            ? $type->getName()
+            : null;
+    }
+
+    private static function isBindable(string $class): bool
+    {
+        return is_a($class, UrlRoutable::class, true)
+            || (enum_exists($class) && is_a($class, BackedEnum::class, true));
+    }
+
+    private static function resolveParameter(Route $route, string $name, string $class, mixed $value): mixed
+    {
+        if ($value instanceof $class) {
+            return $value;
+        }
+
+        if (enum_exists($class)) {
+            $resolved = $class::tryFrom($value);
+
+            if ($resolved === null) {
+                throw new BackedEnumCaseNotFoundException($class, $value);
+            }
+
+            return $resolved;
+        }
+
+        /** @var UrlRoutable $instance */
+        $instance = app()->make($class);
+        $parent = $route->parentOfParameter($name);
+        $shouldScope = $parent instanceof UrlRoutable
+            && ! $route->preventsScopedBindings()
+            && ($route->enforcesScopedBindings() || array_key_exists($name, $route->bindingFields()));
+
+        if ($shouldScope) {
+            $resolved = $parent->resolveChildRouteBinding(
+                $name,
+                $value,
+                $route->bindingFieldFor($name),
+            );
+        } elseif ($route->allowsTrashedBindings()) {
+            $resolved = $instance->resolveSoftDeletableRouteBinding(
+                $value,
+                $route->bindingFieldFor($name),
+            );
+        } else {
+            $resolved = $instance->resolveRouteBinding(
+                $value,
+                $route->bindingFieldFor($name),
+            );
+        }
+
+        if (! $resolved) {
+            throw (new ModelNotFoundException)->setModel($class, [$value]);
+        }
+
+        return $resolved;
+    }
+}

--- a/src/Edge/ComponentRouteBinder.php
+++ b/src/Edge/ComponentRouteBinder.php
@@ -5,8 +5,10 @@ namespace Native\Mobile\Edge;
 use BackedEnum;
 use Illuminate\Contracts\Routing\UrlRoutable;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Routing\Route;
+use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionNamedType;
@@ -25,7 +27,7 @@ class ComponentRouteBinder
         // URI order matters for scoped bindings: a child model must resolve
         // after its parent parameter has become an UrlRoutable instance.
         foreach ($route->parametersWithoutNulls() as $name => $value) {
-            $class = $types[$name] ?? null;
+            $class = $types[$name] ?? $types[Str::camel($name)] ?? null;
 
             if ($class === null || ! static::isBindable($class)) {
                 continue;
@@ -107,23 +109,27 @@ class ComponentRouteBinder
         /** @var UrlRoutable $instance */
         $instance = app()->make($class);
         $parent = $route->parentOfParameter($name);
+        $usesSoftDeletes = in_array(SoftDeletes::class, class_uses_recursive($instance), true);
         $shouldScope = $parent instanceof UrlRoutable
             && ! $route->preventsScopedBindings()
             && ($route->enforcesScopedBindings() || array_key_exists($name, $route->bindingFields()));
 
         if ($shouldScope) {
-            $resolved = $parent->resolveChildRouteBinding(
+            $method = $route->allowsTrashedBindings() && $usesSoftDeletes
+                ? 'resolveSoftDeletableChildRouteBinding'
+                : 'resolveChildRouteBinding';
+
+            $resolved = $parent->{$method}(
                 $name,
                 $value,
                 $route->bindingFieldFor($name),
             );
-        } elseif ($route->allowsTrashedBindings()) {
-            $resolved = $instance->resolveSoftDeletableRouteBinding(
-                $value,
-                $route->bindingFieldFor($name),
-            );
         } else {
-            $resolved = $instance->resolveRouteBinding(
+            $method = $route->allowsTrashedBindings() && $usesSoftDeletes
+                ? 'resolveSoftDeletableRouteBinding'
+                : 'resolveRouteBinding';
+
+            $resolved = $instance->{$method}(
                 $value,
                 $route->bindingFieldFor($name),
             );

--- a/src/Edge/ComponentState.php
+++ b/src/Edge/ComponentState.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Native\Mobile\Edge;
+
+use Native\Mobile\Attributes\Locked;
+use Native\Mobile\Edge\Exceptions\LockedPropertyException;
+use ReflectionProperty;
+
+/** Central state writer for native:model and the component test harness. */
+class ComponentState
+{
+    public static function set(NativeComponent $component, string $path, mixed $value): void
+    {
+        $segments = explode('.', $path);
+        $property = array_shift($segments);
+
+        if ($property === '' || ! property_exists($component, $property)) {
+            return;
+        }
+
+        $reflection = new ReflectionProperty($component, $property);
+
+        if (! $reflection->isPublic() || $reflection->isStatic()) {
+            return;
+        }
+
+        if ($reflection->getAttributes(Locked::class) !== []) {
+            throw new LockedPropertyException($component::class, $property);
+        }
+
+        $propertyName = str($property)->studly()->toString();
+        $nestedName = $segments === []
+            ? null
+            : str(str_replace('.', '_', $path))->studly()->toString();
+        $keyAfterFirstDot = $segments === [] ? null : implode('.', $segments);
+        $keyAfterLastDot = $segments === [] ? null : end($segments);
+
+        $component->__invokeStateHook('updating', [$path, $value]);
+        $component->__invokeStateHook('updating'.$propertyName, [$value, $keyAfterFirstDot]);
+
+        if ($nestedName !== null) {
+            $component->__invokeStateHook('updating'.$nestedName, [$value, $keyAfterLastDot]);
+        }
+
+        if ($segments === []) {
+            $component->{$property} = $value;
+        } else {
+            $target = $component->{$property};
+            data_set($target, implode('.', $segments), $value);
+            $component->{$property} = $target;
+        }
+
+        $component->__forgetComputedAfterStateMutation();
+
+        $component->__invokeStateHook('updated', [$path, $value]);
+        $component->__invokeStateHook('updated'.$propertyName, [$value, $keyAfterFirstDot]);
+
+        if ($nestedName !== null) {
+            $component->__invokeStateHook('updated'.$nestedName, [$value, $keyAfterLastDot]);
+        }
+    }
+}

--- a/src/Edge/Exceptions/ComponentMethodNotFoundException.php
+++ b/src/Edge/Exceptions/ComponentMethodNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Native\Mobile\Edge\Exceptions;
+
+use BadMethodCallException;
+use Native\Mobile\Edge\NativeComponent;
+
+class ComponentMethodNotFoundException extends BadMethodCallException
+{
+    public function __construct(string $method, NativeComponent $component)
+    {
+        parent::__construct(
+            'Public method ['.$method.'] not found on component ['.$component::class.'].'
+        );
+    }
+}

--- a/src/Edge/Exceptions/DirectlyCallingLifecycleHooksNotAllowedException.php
+++ b/src/Edge/Exceptions/DirectlyCallingLifecycleHooksNotAllowedException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Native\Mobile\Edge\Exceptions;
+
+use BadMethodCallException;
+use Native\Mobile\Edge\NativeComponent;
+
+class DirectlyCallingLifecycleHooksNotAllowedException extends BadMethodCallException
+{
+    public function __construct(string $method, NativeComponent $component)
+    {
+        parent::__construct(
+            'Lifecycle hook ['.$method.'] cannot be called directly on component ['.$component::class.'].'
+        );
+    }
+}

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -3435,14 +3435,9 @@ abstract class NativeComponent
     }
 
     /** Skip exactly the next render that would follow a component interaction. */
-    public function skipRender(mixed $html = null): void
+    public function skipRender(): void
     {
         $this->rootScreen()->nativeShouldSkipRender = true;
-    }
-
-    public function shouldSkipRender(): bool
-    {
-        return $this->rootScreen()->nativeShouldSkipRender;
     }
 
     /** @internal Consumes the one-shot renderless state. */
@@ -3735,7 +3730,17 @@ abstract class NativeComponent
             '__syncProperty',
         ];
 
-        if (in_array($method, $internalCallbacks, true)) {
+        // Direct template navigation remains supported for compatibility.
+        // New templates should prefer @navigate; component PHP can continue
+        // calling these methods normally.
+        $navigationCallbacks = [
+            'navigate',
+            'back',
+            'replace',
+            'exitToWeb',
+        ];
+
+        if (in_array($method, [...$internalCallbacks, ...$navigationCallbacks], true)) {
             return $this->{$method}(...$parameters);
         }
 

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -2,6 +2,9 @@
 
 namespace Native\Mobile\Edge;
 
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Illuminate\View\Engines\CompilerEngine;
@@ -96,6 +99,17 @@ abstract class NativeComponent
     protected array $nativeParams = [];
 
     protected array $nativeNavigationData = [];
+
+    /** One-shot render suppression requested by skipRender()/#[Renderless]. */
+    private bool $nativeShouldSkipRender = false;
+
+    /** @var list<array{source: NativeComponent, event: ComponentEvent}> */
+    private array $nativePendingComponentEvents = [];
+
+    /** @var list<array{name: string, params: array, self?: bool, component?: string}> */
+    private array $nativeDispatchedComponentEvents = [];
+
+    private bool $nativeFlushingComponentEvents = false;
 
     /** Layout class for this screen (set by router from route metadata). */
     protected ?string $nativeLayout = null;
@@ -1604,7 +1618,7 @@ abstract class NativeComponent
                 }
 
                 if ($def['method'] !== null && method_exists($this, $def['method'])) {
-                    $this->{$def['method']}();
+                    ComponentMethodInvoker::invoke($this, $def['method']);
                 }
 
                 $this->pollDefinitions[$i]['next'] = $now + $def['ms'];
@@ -1796,34 +1810,19 @@ abstract class NativeComponent
         }
 
         if (is_array($payload)) {
-            $reflect = new \ReflectionMethod($this, $method);
-            $args = [];
-            foreach ($reflect->getParameters() as $param) {
-                $name = $param->getName();
-                if (array_key_exists($name, $payload)) {
-                    $value = $payload[$name];
-
-                    // Coerce the value to match the parameter's type hint
-                    $type = $param->getType();
-                    if ($type instanceof \ReflectionNamedType && $type->isBuiltin()) {
-                        $value = match ($type->getName()) {
-                            'int' => (int) $value,
-                            'float' => (float) $value,
-                            'string' => (string) $value,
-                            'bool' => (bool) $value,
-                            default => $value,
-                        };
-                    }
-
-                    $args[] = $value;
-                } elseif ($param->isDefaultValueAvailable()) {
-                    $args[] = $param->getDefaultValue();
+            $parameters = [];
+            foreach ((new \ReflectionMethod($this, $method))->getParameters() as $parameter) {
+                if (array_key_exists($parameter->getName(), $payload)) {
+                    $parameters[$parameter->getName()] = $payload[$parameter->getName()];
                 }
             }
-            $this->$method(...$args);
-        } else {
-            $this->$method($payload);
+
+            ComponentMethodInvoker::invoke($this, $method, $parameters);
+
+            return;
         }
+
+        ComponentMethodInvoker::invoke($this, $method, [$payload]);
     }
 
     /**
@@ -1969,9 +1968,138 @@ abstract class NativeComponent
         return new $eventClass(...$args);
     }
 
-    public function mount(): void
+    /**
+     * Hydrate route-bound public properties and invoke the component's
+     * optional mount() method through Laravel's container.
+     *
+     * NativeComponent deliberately does not declare mount() itself. That lets
+     * application components use any signature, including route-bound models
+     * and container dependencies, without violating PHP's inheritance rules.
+     *
+     * @internal Called by the router, runloop, and test harness.
+     */
+    final public function mountComponent(): void
     {
-        //
+        $this->hydrateRouteBoundProperties();
+
+        if (! method_exists($this, 'mount')) {
+            return;
+        }
+
+        $parameters = [];
+
+        foreach ((new \ReflectionMethod($this, 'mount'))->getParameters() as $parameter) {
+            $routeParameter = $this->routeParameterFor($parameter->getName());
+
+            if ($routeParameter === null) {
+                continue;
+            }
+
+            [$routeParameterName, $value] = $routeParameter;
+            $value = $this->resolveRouteValue($parameter->getType(), $value);
+
+            $parameters[$parameter->getName()] = $value;
+            $this->nativeParams[$routeParameterName] = $value;
+        }
+
+        ComponentMethodInvoker::invokeLifecycle($this, 'mount', $parameters);
+    }
+
+    /** Hydrate typed public properties from matching route parameters. */
+    private function hydrateRouteBoundProperties(): void
+    {
+        $reflection = new \ReflectionClass($this);
+
+        foreach ($reflection->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            $routeParameter = $this->routeParameterFor($property->getName());
+
+            if ($routeParameter === null) {
+                continue;
+            }
+
+            [$routeParameterName, $value] = $routeParameter;
+            $value = $this->resolveRouteValue($property->getType(), $value);
+
+            $property->setValue($this, $value);
+            $this->nativeParams[$routeParameterName] = $value;
+        }
+    }
+
+    /** @return array{string, mixed}|null */
+    private function routeParameterFor(string $name): ?array
+    {
+        foreach ([$name, Str::snake($name)] as $candidate) {
+            if (array_key_exists($candidate, $this->nativeParams)) {
+                return [$candidate, $this->nativeParams[$candidate]];
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveRouteValue(?\ReflectionType $type, mixed $value): mixed
+    {
+        if (! $type instanceof \ReflectionNamedType || $type->isBuiltin()) {
+            return $value;
+        }
+
+        $class = $type->getName();
+
+        if (enum_exists($class) && is_subclass_of($class, \BackedEnum::class)) {
+            return $this->resolveRouteEnum($class, $value);
+        }
+
+        if (is_a($class, UrlRoutable::class, true)) {
+            return $this->resolveRouteBinding($class, $value);
+        }
+
+        return $value;
+    }
+
+    /** @param class-string<\BackedEnum> $class */
+    private function resolveRouteEnum(string $class, mixed $value): ?\BackedEnum
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof $class) {
+            return $value;
+        }
+
+        $resolved = $class::tryFrom($value);
+
+        if ($resolved === null) {
+            throw new BackedEnumCaseNotFoundException($class, $value);
+        }
+
+        return $resolved;
+    }
+
+    /** @param class-string<UrlRoutable> $class */
+    private function resolveRouteBinding(string $class, mixed $value): ?UrlRoutable
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof $class) {
+            return $value;
+        }
+
+        /** @var UrlRoutable $instance */
+        $instance = app()->make($class);
+        $resolved = $instance->resolveRouteBinding($value);
+
+        if (! $resolved instanceof $class) {
+            throw (new ModelNotFoundException)->setModel($class, [$value]);
+        }
+
+        return $resolved;
     }
 
     public function unmount(): void
@@ -2083,7 +2211,7 @@ abstract class NativeComponent
         $this->publishPlaceholder();
 
         try {
-            $this->mount();
+            $this->mountComponent();
         } catch (NativeDumpException $e) {
             $this->renderDumpScreen($e);
         } catch (\Throwable $e) {
@@ -2092,10 +2220,17 @@ abstract class NativeComponent
         }
 
         while ($this->nativeRunning) {
-            $this->nativeCallbacks->reset();
-            $this->resetComputedCache();
+            $this->flushDispatchedEvents();
+            $skipRender = $this->consumeRenderSkip();
 
-            if (! $this->nativeHasError) {
+            // A skipped render leaves the previous native tree on screen, so
+            // its callback ids must remain resolvable for the next event.
+            if (! $skipRender) {
+                $this->nativeCallbacks->reset();
+                $this->resetComputedCache();
+            }
+
+            if (! $this->nativeHasError && ! $skipRender) {
                 try {
                     if (! $this->renderStreaming()) {
                         $element = $this->renderToElement();
@@ -2173,15 +2308,15 @@ abstract class NativeComponent
             // (except overlay controls like font size buttons)
             if (! $this->nativeHasError) {
                 try {
-                    $this->dispatch($event);
+                    $this->dispatchUiEvent($event);
                 } catch (NativeDumpException $e) {
                     $this->renderDumpScreen($e);
                 } catch (\Throwable $e) {
-                    NativeRouter::debugLog('dispatch() FAILED in '.static::class.': '.$e->getMessage());
+                    NativeRouter::debugLog('dispatchUiEvent() FAILED in '.static::class.': '.$e->getMessage());
                     $this->renderErrorScreen($e);
                 }
             } elseif (in_array($event['callback_id'] ?? 0, $this->overlayCallbackIds)) {
-                $this->dispatch($event);
+                $this->dispatchUiEvent($event);
             }
         }
 
@@ -2268,10 +2403,17 @@ abstract class NativeComponent
                 break;
             }
 
-            $this->nativeCallbacks->reset();
-            $this->resetComputedCache();
+            $this->flushDispatchedEvents();
+            $skipRender = $this->consumeRenderSkip();
 
-            if (! $this->nativeHasError) {
+            // A skipped render leaves the previous native tree on screen, so
+            // its callback ids must remain resolvable for the next event.
+            if (! $skipRender) {
+                $this->nativeCallbacks->reset();
+                $this->resetComputedCache();
+            }
+
+            if (! $this->nativeHasError && ! $skipRender) {
                 try {
                     $t0 = microtime(true);
 
@@ -2388,15 +2530,15 @@ abstract class NativeComponent
             // (except overlay controls like font size buttons)
             if (! $this->nativeHasError) {
                 try {
-                    $this->dispatch($event);
+                    $this->dispatchUiEvent($event);
                 } catch (NativeDumpException $e) {
                     $this->renderDumpScreen($e);
                 } catch (\Throwable $e) {
-                    NativeRouter::debugLog('dispatch() FAILED in '.static::class.': '.$e->getMessage());
+                    NativeRouter::debugLog('dispatchUiEvent() FAILED in '.static::class.': '.$e->getMessage());
                     $this->renderErrorScreen($e);
                 }
             } elseif (in_array($event['callback_id'] ?? 0, $this->overlayCallbackIds)) {
-                $this->dispatch($event);
+                $this->dispatchUiEvent($event);
             }
         }
     }
@@ -3009,27 +3151,30 @@ abstract class NativeComponent
 
     // ── Model binding ──────────────────────────────
 
+    /**
+     * Apply an externally supplied state update through the shared pipeline.
+     *
+     * @throws LockedPropertyException when the root property has #[Locked]
+     *
+     * @see Locked
+     */
     public function __syncProperty(string $property, mixed $value): void
     {
-        if (! property_exists($this, $property)) {
-            return;
+        ComponentState::set($this, $property, $value);
+    }
+
+    /** @internal State pipeline hook dispatch, scoped inside the component. */
+    final public function __invokeStateHook(string $method, array $parameters): void
+    {
+        if (method_exists($this, $method)) {
+            $this->{$method}(...$parameters);
         }
+    }
 
-        if ((new \ReflectionProperty($this, $property))->getAttributes(Locked::class) !== []) {
-            throw new LockedPropertyException(static::class, $property);
-        }
-
-        $this->{$property} = $value;
-
-        // A state change can invalidate any computed value (incl.
-        // persisted ones) — drop the whole memo so they recompute.
+    /** @internal State pipeline computed-cache invalidation. */
+    final public function __forgetComputedAfterStateMutation(): void
+    {
         $this->computedCache = [];
-
-        $hook = 'updated'.ucfirst($property);
-
-        if (method_exists($this, $hook)) {
-            $this->{$hook}($value);
-        }
     }
 
     // ── Child components (nested <native:*> component tags) ──
@@ -3163,7 +3308,7 @@ abstract class NativeComponent
         $this->nativeChildComponentsSeen[$identity] = true;
 
         if ($isNew) {
-            $child->mount();
+            $child->mountComponent();
         }
 
         $child->renderAsChild();
@@ -3289,6 +3434,132 @@ abstract class NativeComponent
         return $component;
     }
 
+    /** Skip exactly the next render that would follow a component interaction. */
+    public function skipRender(mixed $html = null): void
+    {
+        $this->rootScreen()->nativeShouldSkipRender = true;
+    }
+
+    public function shouldSkipRender(): bool
+    {
+        return $this->rootScreen()->nativeShouldSkipRender;
+    }
+
+    /** @internal Consumes the one-shot renderless state. */
+    public function consumeRenderSkip(): bool
+    {
+        $root = $this->rootScreen();
+        $skip = $root->nativeShouldSkipRender;
+        $root->nativeShouldSkipRender = false;
+
+        return $skip;
+    }
+
+    /**
+     * Queue a component event for delivery after the current interaction.
+     *
+     * Delivery happens after the current action returns, leaving time for the
+     * returned event to be narrowed with ->self() or ->to(Component::class).
+     */
+    public function dispatch(string $event, mixed ...$params): ComponentEvent
+    {
+        $dispatch = new ComponentEvent($event, $params);
+        $this->rootScreen()->nativePendingComponentEvents[] = [
+            'source' => $this,
+            'event' => $dispatch,
+        ];
+
+        return $dispatch;
+    }
+
+    /** @internal Flush events queued during the preceding interaction. */
+    public function flushDispatchedEvents(): void
+    {
+        $root = $this->rootScreen();
+
+        if ($root !== $this) {
+            $root->flushDispatchedEvents();
+
+            return;
+        }
+
+        if ($this->nativeFlushingComponentEvents) {
+            return;
+        }
+
+        $this->nativeFlushingComponentEvents = true;
+
+        try {
+            while ($queued = array_shift($this->nativePendingComponentEvents)) {
+                $source = $queued['source'];
+                $event = $queued['event'];
+
+                $this->nativeDispatchedComponentEvents[] = $event->serialize();
+                $this->deliverComponentEvent($source, $event);
+            }
+        } finally {
+            $this->nativeFlushingComponentEvents = false;
+        }
+    }
+
+    /** @return list<array{name: string, params: array, self?: bool, component?: string}> */
+    public function dispatchedEvents(): array
+    {
+        return $this->rootScreen()->nativeDispatchedComponentEvents;
+    }
+
+    private function deliverComponentEvent(NativeComponent $source, ComponentEvent $event): void
+    {
+        if ($event->isSelfOnly()) {
+            $source->invokeComponentEventListener($event->name(), $event->params());
+
+            return;
+        }
+
+        if (($target = $event->target()) !== null) {
+            foreach ($this->componentTree() as $component) {
+                $matches = $target instanceof NativeComponent
+                    ? $component === $target
+                    : is_a($component, $target);
+
+                if ($matches) {
+                    $component->invokeComponentEventListener($event->name(), $event->params());
+                }
+            }
+
+            return;
+        }
+
+        // Native component events bubble from their source through its parent
+        // chain, preserving parent-first component event bubbling.
+        $source->invokeComponentEventListener($event->name(), $event->params());
+
+        $parent = $source->nativeParentComponent;
+        if ($parent !== null && isset($source->nativeChildEventBindings[$event->name()])) {
+            $binding = CallbackRegistry::parse($source->nativeChildEventBindings[$event->name()]);
+
+            ComponentMethodInvoker::invoke(
+                $parent,
+                $binding['method'],
+                [...$binding['args'], ...$event->params()],
+            );
+        }
+
+        for ($ancestor = $parent; $ancestor !== null; $ancestor = $ancestor->nativeParentComponent) {
+            $ancestor->invokeComponentEventListener($event->name(), $event->params());
+        }
+    }
+
+    /** @return \Generator<int, NativeComponent> */
+    private function componentTree(): \Generator
+    {
+        yield $this;
+
+        foreach ($this->nativeChildComponents as $child) {
+            yield from $child->componentTree();
+        }
+    }
+
     /**
      * Emit a component event up the ancestor chain (child → parent → … →
      * screen). Delivery, per ancestor:
@@ -3313,7 +3584,11 @@ abstract class NativeComponent
             $binding = CallbackRegistry::parse($this->nativeChildEventBindings[$event]);
 
             if (method_exists($parent, $binding['method'])) {
-                $parent->{$binding['method']}(...[...$binding['args'], ...$args]);
+                ComponentMethodInvoker::invoke(
+                    $parent,
+                    $binding['method'],
+                    [...$binding['args'], ...$args],
+                );
             }
         }
 
@@ -3334,13 +3609,13 @@ abstract class NativeComponent
             ?? null;
 
         if ($method !== null && method_exists($this, $method)) {
-            $this->{$method}(...$args);
+            ComponentMethodInvoker::invoke($this, $method, $args);
         }
     }
 
     // ── Event dispatch ──────────────────────────────
 
-    protected function dispatch(array $event): void
+    protected function dispatchUiEvent(array $event): void
     {
         $callbackId = (int) ($event['callback_id'] ?? 0);
 
@@ -3356,7 +3631,7 @@ abstract class NativeComponent
         }
 
         if ($owner !== $this) {
-            $owner->dispatch($event);
+            $owner->dispatchUiEvent($event);
 
             return;
         }
@@ -3393,7 +3668,7 @@ abstract class NativeComponent
         $kind = $this->nativeCallbacks->kind($event['callback_id'] ?? 0);
 
         if ($kind === 'search_query') {
-            $result = $this->$method(...[...$args, ...$eventArgs]);
+            $result = $this->invokeUiCallback($method, [...$args, ...$eventArgs]);
             if (is_array($result)) {
                 $this->pendingSearchResults = array_values($result);
             }
@@ -3410,7 +3685,7 @@ abstract class NativeComponent
             $parts = explode(',', $payload, 2);
             $from = (int) ($parts[0] ?? 0);
             $to = (int) ($parts[1] ?? 0);
-            $this->$method(...[...$args, $from, $to]);
+            $this->invokeUiCallback($method, [...$args, $from, $to]);
 
             return;
         }
@@ -3442,11 +3717,28 @@ abstract class NativeComponent
                 $start = $end = mb_strlen($text, 'UTF-8');
             }
 
-            $this->$method(...[...$args, $text, $start, $end]);
+            $this->invokeUiCallback($method, [...$args, $text, $start, $end]);
 
             return;
         }
 
-        $this->$method(...[...$args, ...$eventArgs]);
+        $this->invokeUiCallback($method, [...$args, ...$eventArgs]);
+    }
+
+    private function invokeUiCallback(string $method, array $parameters): mixed
+    {
+        $internalCallbacks = [
+            '__navigate',
+            '__overlayBack',
+            '__overlayDismiss',
+            '__overlaySetFontSize',
+            '__syncProperty',
+        ];
+
+        if (in_array($method, $internalCallbacks, true)) {
+            return $this->{$method}(...$parameters);
+        }
+
+        return ComponentMethodInvoker::invoke($this, $method, $parameters);
     }
 }

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -111,6 +111,9 @@ abstract class NativeComponent
 
     private bool $nativeFlushingComponentEvents = false;
 
+    /** Depth of synchronous component-event listener delivery. */
+    private int $nativeComponentEventListenerDepth = 0;
+
     /** Layout class for this screen (set by router from route metadata). */
     protected ?string $nativeLayout = null;
 
@@ -1617,11 +1620,13 @@ abstract class NativeComponent
                     continue;
                 }
 
+                // Reschedule before user code runs so a failing callback is
+                // contained by the error screen without becoming a hot-loop.
+                $this->pollDefinitions[$i]['next'] = $now + $def['ms'];
+
                 if ($def['method'] !== null && method_exists($this, $def['method'])) {
                     ComponentMethodInvoker::invokeLifecycle($this, $def['method']);
                 }
-
-                $this->pollDefinitions[$i]['next'] = $now + $def['ms'];
             }
         }
 
@@ -1632,6 +1637,19 @@ abstract class NativeComponent
         }
 
         $this->flushDispatchedEvents();
+    }
+
+    /** Keep callback failures inside the component's error-screen lifecycle. */
+    private function runGuardedInteraction(string $operation, callable $interaction): void
+    {
+        try {
+            $interaction();
+        } catch (NativeDumpException $e) {
+            $this->renderDumpScreen($e);
+        } catch (\Throwable $e) {
+            NativeRouter::debugLog($operation.' FAILED in '.static::class.': '.$e->getMessage());
+            $this->renderErrorScreen($e);
+        }
     }
 
     // ── Lazy placeholder (#[Lazy]) ───────────────────
@@ -2242,7 +2260,10 @@ abstract class NativeComponent
         }
 
         while ($this->nativeRunning) {
-            $this->flushDispatchedEvents();
+            $this->runGuardedInteraction(
+                'flushDispatchedEvents()',
+                fn () => $this->flushDispatchedEvents(),
+            );
             $skipRender = $this->consumeRenderSkip();
 
             // A skipped render leaves the previous native tree on screen, so
@@ -2275,7 +2296,10 @@ abstract class NativeComponent
             if ($event === null) {
                 // Idle tick (poll interval elapsed, or no event yet) —
                 // fire any due polls, then loop back to re-render.
-                $this->runDuePolls();
+                $this->runGuardedInteraction(
+                    'runDuePolls()',
+                    fn () => $this->runDuePolls(),
+                );
 
                 continue;
             }
@@ -2426,7 +2450,10 @@ abstract class NativeComponent
                 break;
             }
 
-            $this->flushDispatchedEvents();
+            $this->runGuardedInteraction(
+                'flushDispatchedEvents()',
+                fn () => $this->flushDispatchedEvents(),
+            );
             $skipRender = $this->consumeRenderSkip();
 
             // A skipped render leaves the previous native tree on screen, so
@@ -2482,7 +2509,10 @@ abstract class NativeComponent
             if ($event === null) {
                 // Idle tick (poll interval elapsed, or no event yet) —
                 // fire any due polls, then loop back to re-render.
-                $this->runDuePolls();
+                $this->runGuardedInteraction(
+                    'runDuePolls()',
+                    fn () => $this->runDuePolls(),
+                );
 
                 continue;
             }
@@ -2530,8 +2560,10 @@ abstract class NativeComponent
 
                     continue;
                 }
-                $this->onBackPressed();
-                $this->flushDispatchedEvents();
+                $this->runGuardedInteraction('onBackPressed()', function () {
+                    $this->onBackPressed();
+                    $this->flushDispatchedEvents();
+                });
 
                 continue;
             }
@@ -2663,6 +2695,7 @@ abstract class NativeComponent
             return $this;
         }
 
+        $this->flushDispatchedEvents();
         $this->nativeNavigationIntent = new NavigationIntent(NavigationIntent::NAVIGATE, $uri, $data);
         $this->publishFinalState();
         $this->stop();
@@ -2694,6 +2727,7 @@ abstract class NativeComponent
             return $this;
         }
 
+        $this->flushDispatchedEvents();
         $this->nativeNavigationIntent = new NavigationIntent(NavigationIntent::BACK);
         $this->publishFinalState();
         $this->stop();
@@ -2710,6 +2744,7 @@ abstract class NativeComponent
             return $this;
         }
 
+        $this->flushDispatchedEvents();
         $this->nativeNavigationIntent = new NavigationIntent(NavigationIntent::REPLACE, $uri, $data);
         $this->publishFinalState();
         $this->stop();
@@ -3465,6 +3500,20 @@ abstract class NativeComponent
         $this->rootScreen()->nativeShouldSkipRender = true;
     }
 
+    /** @internal Apply a method-level #[Renderless] marker in the current invocation scope. */
+    final public function __applyRenderlessAttribute(): void
+    {
+        $root = $this->rootScreen();
+
+        // A component-event listener is nested inside the interaction that
+        // emitted or dispatched it. Its attribute describes the listener,
+        // not the source interaction's required frame. An explicit
+        // skipRender() inside the listener remains authoritative.
+        if ($root->nativeComponentEventListenerDepth === 0) {
+            $root->nativeShouldSkipRender = true;
+        }
+    }
+
     /** @internal Consumes the one-shot renderless state. */
     public function consumeRenderSkip(): bool
     {
@@ -3508,7 +3557,6 @@ abstract class NativeComponent
         }
 
         $this->nativeFlushingComponentEvents = true;
-        $skipRender = $this->nativeShouldSkipRender;
 
         try {
             while ($queued = array_shift($this->nativePendingComponentEvents)) {
@@ -3519,10 +3567,6 @@ abstract class NativeComponent
                 $this->deliverComponentEvent($source, $event);
             }
         } finally {
-            // A nested listener's #[Renderless] marker applies to that
-            // listener, not to the interaction that dispatched it. Preserve
-            // only the source interaction's render decision.
-            $this->nativeShouldSkipRender = $skipRender;
             $this->nativeFlushingComponentEvents = false;
         }
     }
@@ -3563,7 +3607,7 @@ abstract class NativeComponent
         if ($parent !== null && isset($source->nativeChildEventBindings[$event->name()])) {
             $binding = CallbackRegistry::parse($source->nativeChildEventBindings[$event->name()]);
 
-            ComponentMethodInvoker::invoke(
+            $this->invokeComponentEventAction(
                 $parent,
                 $binding['method'],
                 [...$binding['args'], ...$event->params()],
@@ -3609,7 +3653,7 @@ abstract class NativeComponent
             $binding = CallbackRegistry::parse($this->nativeChildEventBindings[$event]);
 
             if (method_exists($parent, $binding['method'])) {
-                ComponentMethodInvoker::invoke(
+                $this->invokeComponentEventAction(
                     $parent,
                     $binding['method'],
                     [...$binding['args'], ...$args],
@@ -3634,7 +3678,22 @@ abstract class NativeComponent
             ?? null;
 
         if ($method !== null && method_exists($this, $method)) {
-            ComponentMethodInvoker::invoke($this, $method, $args);
+            $this->invokeComponentEventAction($this, $method, $args);
+        }
+    }
+
+    private function invokeComponentEventAction(
+        NativeComponent $component,
+        string $method,
+        array $parameters,
+    ): mixed {
+        $root = $this->rootScreen();
+        $root->nativeComponentEventListenerDepth++;
+
+        try {
+            return ComponentMethodInvoker::invoke($component, $method, $parameters);
+        } finally {
+            $root->nativeComponentEventListenerDepth--;
         }
     }
 

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -1618,7 +1618,7 @@ abstract class NativeComponent
                 }
 
                 if ($def['method'] !== null && method_exists($this, $def['method'])) {
-                    ComponentMethodInvoker::invoke($this, $def['method']);
+                    ComponentMethodInvoker::invokeLifecycle($this, $def['method']);
                 }
 
                 $this->pollDefinitions[$i]['next'] = $now + $def['ms'];
@@ -1630,6 +1630,8 @@ abstract class NativeComponent
                 $this->bladePollDeadlines[$ms] = $now + $ms;
             }
         }
+
+        $this->flushDispatchedEvents();
     }
 
     // ── Lazy placeholder (#[Lazy]) ───────────────────
@@ -1813,7 +1815,10 @@ abstract class NativeComponent
             $parameters = [];
             foreach ((new \ReflectionMethod($this, $method))->getParameters() as $parameter) {
                 if (array_key_exists($parameter->getName(), $payload)) {
-                    $parameters[$parameter->getName()] = $payload[$parameter->getName()];
+                    $parameters[$parameter->getName()] = $this->coerceNativePayloadValue(
+                        $parameter,
+                        $payload[$parameter->getName()],
+                    );
                 }
             }
 
@@ -1823,6 +1828,23 @@ abstract class NativeComponent
         }
 
         ComponentMethodInvoker::invoke($this, $method, [$payload]);
+    }
+
+    private function coerceNativePayloadValue(\ReflectionParameter $parameter, mixed $value): mixed
+    {
+        $type = $parameter->getType();
+
+        if (! $type instanceof \ReflectionNamedType || ! $type->isBuiltin()) {
+            return $value;
+        }
+
+        return match ($type->getName()) {
+            'int' => (int) $value,
+            'float' => (float) $value,
+            'string' => (string) $value,
+            'bool' => (bool) $value,
+            default => $value,
+        };
     }
 
     /**
@@ -2294,6 +2316,7 @@ abstract class NativeComponent
             if (($event['type'] ?? -1) === self::EVENT_NATIVE) {
                 try {
                     $this->dispatchNativeEvent($event);
+                    $this->flushDispatchedEvents();
                 } catch (NativeDumpException $e) {
                     $this->renderDumpScreen($e);
                 } catch (\Throwable $e) {
@@ -2508,6 +2531,7 @@ abstract class NativeComponent
                     continue;
                 }
                 $this->onBackPressed();
+                $this->flushDispatchedEvents();
 
                 continue;
             }
@@ -2516,6 +2540,7 @@ abstract class NativeComponent
             if (($event['type'] ?? -1) === self::EVENT_NATIVE) {
                 try {
                     $this->dispatchNativeEvent($event);
+                    $this->flushDispatchedEvents();
                 } catch (NativeDumpException $e) {
                     $this->renderDumpScreen($e);
                 } catch (\Throwable $e) {
@@ -3483,6 +3508,7 @@ abstract class NativeComponent
         }
 
         $this->nativeFlushingComponentEvents = true;
+        $skipRender = $this->nativeShouldSkipRender;
 
         try {
             while ($queued = array_shift($this->nativePendingComponentEvents)) {
@@ -3493,6 +3519,10 @@ abstract class NativeComponent
                 $this->deliverComponentEvent($source, $event);
             }
         } finally {
+            // A nested listener's #[Renderless] marker applies to that
+            // listener, not to the interaction that dispatched it. Preserve
+            // only the source interaction's render decision.
+            $this->nativeShouldSkipRender = $skipRender;
             $this->nativeFlushingComponentEvents = false;
         }
     }
@@ -3663,7 +3693,7 @@ abstract class NativeComponent
         $kind = $this->nativeCallbacks->kind($event['callback_id'] ?? 0);
 
         if ($kind === 'search_query') {
-            $result = $this->invokeUiCallback($method, [...$args, ...$eventArgs]);
+            $result = $this->invokeUiInteraction($method, [...$args, ...$eventArgs]);
             if (is_array($result)) {
                 $this->pendingSearchResults = array_values($result);
             }
@@ -3680,7 +3710,7 @@ abstract class NativeComponent
             $parts = explode(',', $payload, 2);
             $from = (int) ($parts[0] ?? 0);
             $to = (int) ($parts[1] ?? 0);
-            $this->invokeUiCallback($method, [...$args, $from, $to]);
+            $this->invokeUiInteraction($method, [...$args, $from, $to]);
 
             return;
         }
@@ -3712,12 +3742,20 @@ abstract class NativeComponent
                 $start = $end = mb_strlen($text, 'UTF-8');
             }
 
-            $this->invokeUiCallback($method, [...$args, $text, $start, $end]);
+            $this->invokeUiInteraction($method, [...$args, $text, $start, $end]);
 
             return;
         }
 
-        $this->invokeUiCallback($method, [...$args, ...$eventArgs]);
+        $this->invokeUiInteraction($method, [...$args, ...$eventArgs]);
+    }
+
+    private function invokeUiInteraction(string $method, array $parameters): mixed
+    {
+        $result = $this->invokeUiCallback($method, $parameters);
+        $this->flushDispatchedEvents();
+
+        return $result;
     }
 
     private function invokeUiCallback(string $method, array $parameters): mixed
@@ -3738,6 +3776,7 @@ abstract class NativeComponent
             'back',
             'replace',
             'exitToWeb',
+            'emit',
         ];
 
         if (in_array($method, [...$internalCallbacks, ...$navigationCallbacks], true)) {

--- a/src/Edge/NativeRouter.php
+++ b/src/Edge/NativeRouter.php
@@ -192,6 +192,37 @@ class NativeRouter
 
     public static function resolve(string $uri): ?array
     {
+        $match = static::matchRoute($uri);
+
+        if ($match === null) {
+            return null;
+        }
+
+        $entry = $match['entry'];
+        $route = clone $match['route'];
+        $route->bind($match['request']);
+
+        if (function_exists('app') && app()->bound('router')) {
+            $router = app('router');
+            $router->substituteBindings($route);
+            ComponentRouteBinder::resolve($route, $entry['class']);
+        }
+
+        return [
+            'class' => $entry['class'],
+            'layout' => $entry['layout'] ?? null,
+            'params' => $route->parametersWithoutNulls(),
+            'route' => $route,
+        ];
+    }
+
+    /**
+     * Match a registered route without binding its parameters.
+     *
+     * @return array{entry: array, route: IlluminateRoute, request: Request}|null
+     */
+    private static function matchRoute(string $uri): ?array
+    {
         $request = Request::create('/'.ltrim($uri, '/'), 'GET');
 
         $literalRoutes = [];
@@ -214,26 +245,17 @@ class NativeRouter
             }
 
             // Match the registered route so its compiled pattern is retained
-            // across this long-lived process. Bind only a clone because route
-            // instances retain the parameters from their most recent request.
+            // across this long-lived process. Binding happens only in
+            // resolve(); predicates such as isNativeRoute() stay side-effect
+            // free and cannot trigger model lookups.
             if (! $registeredRoute->matches($request)) {
                 continue;
             }
 
-            $route = clone $registeredRoute;
-            $route->bind($request);
-
-            if (function_exists('app') && app()->bound('router')) {
-                $router = app('router');
-                $router->substituteBindings($route);
-                ComponentRouteBinder::resolve($route, $entry['class']);
-            }
-
             return [
-                'class' => $entry['class'],
-                'layout' => $entry['layout'] ?? null,
-                'params' => $route->parametersWithoutNulls(),
-                'route' => $route,
+                'entry' => $entry,
+                'route' => $registeredRoute,
+                'request' => $request,
             ];
         }
 
@@ -242,7 +264,11 @@ class NativeRouter
 
     public static function isNativeRoute(string $uri): bool
     {
-        return static::resolve($uri) !== null;
+        try {
+            return static::matchRoute($uri) !== null;
+        } catch (\Throwable) {
+            return false;
+        }
     }
 
     /**
@@ -445,6 +471,7 @@ class NativeRouter
     protected function loop(): ?string
     {
         $freshPush = true;
+        $reenterCurrentScreen = false;
 
         while (! empty($this->stack)) {
             $entry = &$this->stack[count($this->stack) - 1];
@@ -460,7 +487,7 @@ class NativeRouter
                     static::debugLog('loop: calling mount() on '.get_class($component));
                     $component->mountComponent();
                     $this->announce(new ScreenMounted(get_class($component), $entry['uri'] ?? null));
-                } else {
+                } elseif (! $reenterCurrentScreen) {
                     static::debugLog('loop: calling onResume() on '.get_class($component));
                     $component->onResume();
                     $this->announce(new ScreenResumed(get_class($component), $entry['uri'] ?? null));
@@ -471,6 +498,8 @@ class NativeRouter
                 static::debugLog('mount/onResume FAILED in '.get_class($component).': '.$e->getMessage());
                 $component->renderErrorScreen($e);
             }
+
+            $reenterCurrentScreen = false;
 
             static::debugLog('loop: entering runLoop() on '.get_class($component));
             $component->runLoop();
@@ -502,7 +531,16 @@ class NativeRouter
             switch ($intent->type) {
                 case NavigationIntent::NAVIGATE:
                     static::debugLog("NAVIGATE: resolving uri={$intent->uri}");
-                    $resolved = static::resolve($intent->uri);
+                    try {
+                        $resolved = static::resolve($intent->uri);
+                    } catch (\Throwable $e) {
+                        static::debugLog('NAVIGATE binding FAILED: '.$e->getMessage()."\n".$e->getTraceAsString());
+                        $component->renderErrorScreen($e);
+                        $freshPush = false;
+                        $reenterCurrentScreen = true;
+
+                        break;
+                    }
 
                     if ($resolved === null) {
                         static::debugLog('NAVIGATE: unresolved, exiting to web');
@@ -553,7 +591,16 @@ class NativeRouter
 
                 case NavigationIntent::REPLACE:
                     static::debugLog("REPLACE: resolving uri={$intent->uri}");
-                    $resolved = static::resolve($intent->uri);
+                    try {
+                        $resolved = static::resolve($intent->uri);
+                    } catch (\Throwable $e) {
+                        static::debugLog('REPLACE binding FAILED: '.$e->getMessage()."\n".$e->getTraceAsString());
+                        $component->renderErrorScreen($e);
+                        $freshPush = false;
+                        $reenterCurrentScreen = true;
+
+                        break;
+                    }
 
                     if ($resolved === null) {
                         static::debugLog('REPLACE: unresolved, exiting to web');

--- a/src/Edge/NativeRouter.php
+++ b/src/Edge/NativeRouter.php
@@ -194,21 +194,33 @@ class NativeRouter
     {
         $request = Request::create('/'.ltrim($uri, '/'), 'GET');
 
+        $literalRoutes = [];
+        $parameterizedRoutes = [];
+
         foreach (static::$routes as $entry) {
-            // Bind a clone: Illuminate routes keep their last parameters on
-            // the instance, while Native's long-lived process resolves the
-            // same route repeatedly across navigation and hot reloads.
-            $route = clone $entry['route'];
+            if ($entry['route']->parameterNames() === []) {
+                $literalRoutes[] = $entry;
+            } else {
+                $parameterizedRoutes[] = $entry;
+            }
+        }
+
+        foreach ([...$literalRoutes, ...$parameterizedRoutes] as $entry) {
+            $registeredRoute = $entry['route'];
 
             if (function_exists('app') && app()->bound('router')) {
-                $route->setRouter(app('router'));
-                $route->setContainer(app());
+                $registeredRoute->setRouter(app('router'));
+                $registeredRoute->setContainer(app());
             }
 
-            if (! $route->matches($request)) {
+            // Match the registered route so its compiled pattern is retained
+            // across this long-lived process. Bind only a clone because route
+            // instances retain the parameters from their most recent request.
+            if (! $registeredRoute->matches($request)) {
                 continue;
             }
 
+            $route = clone $registeredRoute;
             $route->bind($request);
 
             if (function_exists('app') && app()->bound('router')) {

--- a/src/Edge/NativeRouter.php
+++ b/src/Edge/NativeRouter.php
@@ -2,6 +2,8 @@
 
 namespace Native\Mobile\Edge;
 
+use Illuminate\Http\Request;
+use Illuminate\Routing\Route as IlluminateRoute;
 use Native\Mobile\Events\Screen\ScreenMounted;
 use Native\Mobile\Events\Screen\ScreenResumed;
 use Native\Mobile\Events\Screen\ScreenUnmounted;
@@ -84,9 +86,10 @@ class NativeRouter
      * URI → component class registry.
      * Populated by Route::native() calls.
      *
-     * Each entry: ['class' => string, 'layout' => ?string]
+     * Each entry retains the actual Illuminate route so native navigation and
+     * HTTP routing share matching, constraints, decoding, and route binders.
      *
-     * @var array<string, array{class: string, layout: ?string}>
+     * @var array<string, array{class: string, layout: ?string, route: IlluminateRoute}>
      */
     protected static array $routes = [];
 
@@ -132,12 +135,25 @@ class NativeRouter
 
     // ── Static registry ─────────────────────────────
 
-    public static function register(string $uri, string $class, ?string $layout = null): void
+    public static function register(string|IlluminateRoute $uri, string $class, ?string $layout = null): void
     {
-        $pattern = '/'.ltrim($uri, '/');
+        if ($uri instanceof IlluminateRoute) {
+            $route = $uri;
+            $pattern = '/'.ltrim($route->uri(), '/');
+        } else {
+            $pattern = '/'.ltrim($uri, '/');
+            $route = new IlluminateRoute(['GET'], ltrim($pattern, '/'), fn () => null);
+
+            if (function_exists('app') && app()->bound('router')) {
+                $route->setRouter(app('router'));
+                $route->setContainer(app());
+            }
+        }
+
         static::$routes[$pattern] = [
             'class' => $class,
             'layout' => $layout ?? static::$currentGroupLayout,
+            'route' => $route,
         ];
     }
 
@@ -176,33 +192,37 @@ class NativeRouter
 
     public static function resolve(string $uri): ?array
     {
-        $uri = '/'.ltrim($uri, '/');
+        $request = Request::create('/'.ltrim($uri, '/'), 'GET');
 
-        // Exact match first
-        if (isset(static::$routes[$uri])) {
-            $entry = static::$routes[$uri];
+        foreach (static::$routes as $entry) {
+            // Bind a clone: Illuminate routes keep their last parameters on
+            // the instance, while Native's long-lived process resolves the
+            // same route repeatedly across navigation and hot reloads.
+            $route = clone $entry['route'];
+
+            if (function_exists('app') && app()->bound('router')) {
+                $route->setRouter(app('router'));
+                $route->setContainer(app());
+            }
+
+            if (! $route->matches($request)) {
+                continue;
+            }
+
+            $route->bind($request);
+
+            if (function_exists('app') && app()->bound('router')) {
+                $router = app('router');
+                $router->substituteBindings($route);
+                ComponentRouteBinder::resolve($route, $entry['class']);
+            }
 
             return [
                 'class' => $entry['class'],
                 'layout' => $entry['layout'] ?? null,
-                'params' => [],
+                'params' => $route->parametersWithoutNulls(),
+                'route' => $route,
             ];
-        }
-
-        // Pattern match with route parameters
-        foreach (static::$routes as $pattern => $entry) {
-            $regex = preg_replace('/\{(\w+)\}/', '(?P<$1>[^/]+)', $pattern);
-            $regex = '#^'.$regex.'$#';
-
-            if (preg_match($regex, $uri, $matches)) {
-                $params = array_filter($matches, fn ($key) => is_string($key), ARRAY_FILTER_USE_KEY);
-
-                return [
-                    'class' => $entry['class'],
-                    'layout' => $entry['layout'] ?? null,
-                    'params' => $params,
-                ];
-            }
         }
 
         return null;
@@ -350,7 +370,7 @@ class NativeRouter
                 if (! empty($resolved['layout'])) {
                     $component->setLayout($resolved['layout']);
                 }
-                $component->mount();
+                $component->mountComponent();
             } catch (\Throwable $e) {
                 static::debugLog("preloadStack: skipped $uri — ".$e->getMessage());
 
@@ -426,7 +446,7 @@ class NativeRouter
                     // (potentially slow) mount() so navigation feels instant.
                     $component->publishPlaceholder();
                     static::debugLog('loop: calling mount() on '.get_class($component));
-                    $component->mount();
+                    $component->mountComponent();
                     $this->announce(new ScreenMounted(get_class($component), $entry['uri'] ?? null));
                 } else {
                     static::debugLog('loop: calling onResume() on '.get_class($component));

--- a/src/Edge/NativeTagPrecompiler.php
+++ b/src/Edge/NativeTagPrecompiler.php
@@ -195,7 +195,7 @@ class NativeTagPrecompiler
         // Kept for backwards compatibility; prefer `native:model` going forward.
         $value = preg_replace_callback(
             '/@model=["\']([^"\']+)["\']/',
-            fn ($m) => ':value="$'.$m[1].'" _change="__syncProperty(\''.$m[1].'\')" sync-mode="live"',
+            fn ($m) => ':value="data_get($this, \''.$m[1].'\')" _change="__syncProperty(\''.$m[1].'\')" sync-mode="live"',
             $value
         );
 
@@ -386,7 +386,7 @@ class NativeTagPrecompiler
             // `.live` or anything unknown falls through to syncMode=live.
         }
 
-        $out = ':value="$'.$prop.'" _change="__syncProperty(\''.$prop.'\')" sync-mode="'.$syncMode.'"';
+        $out = ':value="data_get($this, \''.$prop.'\')" _change="__syncProperty(\''.$prop.'\')" sync-mode="'.$syncMode.'"';
         if ($debounceMs > 0) {
             $out .= ' debounce-ms="'.$debounceMs.'"';
         }

--- a/src/Edge/NativeTagPrecompiler.php
+++ b/src/Edge/NativeTagPrecompiler.php
@@ -195,7 +195,7 @@ class NativeTagPrecompiler
         // Kept for backwards compatibility; prefer `native:model` going forward.
         $value = preg_replace_callback(
             '/@model=["\']([^"\']+)["\']/',
-            fn ($m) => ':value="data_get($this, \''.$m[1].'\')" _change="__syncProperty(\''.$m[1].'\')" sync-mode="live"',
+            fn ($m) => ':value="data_get(get_defined_vars(), \''.$m[1].'\')" _change="__syncProperty(\''.$m[1].'\')" sync-mode="live"',
             $value
         );
 
@@ -386,7 +386,7 @@ class NativeTagPrecompiler
             // `.live` or anything unknown falls through to syncMode=live.
         }
 
-        $out = ':value="data_get($this, \''.$prop.'\')" _change="__syncProperty(\''.$prop.'\')" sync-mode="'.$syncMode.'"';
+        $out = ':value="data_get(get_defined_vars(), \''.$prop.'\')" _change="__syncProperty(\''.$prop.'\')" sync-mode="'.$syncMode.'"';
         if ($debounceMs > 0) {
             $out .= ' debounce-ms="'.$debounceMs.'"';
         }

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -303,9 +303,7 @@ class NativeServiceProvider extends PackageServiceProvider
         });
 
         Route::macro('native', function (string $uri, string $componentClass) {
-            NativeRouter::register($uri, $componentClass);
-
-            return Route::get($uri, function () use ($componentClass) {
+            $route = Route::get($uri, function () use ($componentClass) {
                 // Native route reached without a native runtime — a shared
                 // app link opened in a plain browser, a crawler, a
                 // misconfigured deploy. The runloop can never satisfy these
@@ -331,7 +329,7 @@ class NativeServiceProvider extends PackageServiceProvider
 
                 $router = new NativeRouter;
                 $path = '/'.ltrim(request()->path(), '/');
-                $resolved = NativeRouter::resolve($path);
+                $resolved = NativeRouter::resolve(request()->getRequestUri());
                 $params = $resolved ? $resolved['params'] : [];
 
                 // Hot-reload stack restoration. PHP wrote the full
@@ -389,6 +387,10 @@ class NativeServiceProvider extends PackageServiceProvider
 
                 return '';
             });
+
+            NativeRouter::register($route, $componentClass);
+
+            return $route;
         });
 
         // Route::nativeGroup(layout: TabsLayout::class, function () { ... })

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -329,7 +329,7 @@ class NativeServiceProvider extends PackageServiceProvider
 
                 $router = new NativeRouter;
                 $path = '/'.ltrim(request()->path(), '/');
-                $resolved = NativeRouter::resolve(request()->getRequestUri());
+                $resolved = NativeRouter::resolve($path);
                 $params = $resolved ? $resolved['params'] : [];
 
                 // Hot-reload stack restoration. PHP wrote the full

--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -4,6 +4,7 @@ namespace Native\Mobile\Testing;
 
 use Illuminate\Support\Traits\Macroable;
 use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\ComponentMethodInvoker;
 use Native\Mobile\Edge\NativeComponent;
 use Native\Mobile\Edge\NativeDumpException;
 use Native\Mobile\Edge\NativeRouter;
@@ -34,7 +35,7 @@ use PHPUnit\Framework\TestCase;
  *
  * Interactions dispatch through the same code paths the on-device runloop
  * uses: taps resolve a callback id from the published tree and go through
- * NativeComponent::dispatch(); native events go through
+ * NativeComponent::dispatchUiEvent(); native events go through
  * dispatchNativeEvent(); after every interaction the component re-renders,
  * mirroring the render → wait → dispatch loop. Exceptions thrown by the
  * component bubble to the test instead of painting the error screen; a
@@ -215,11 +216,13 @@ class TestableComponent
             // device; keep that behavior so the publish is observable.
             $component->publishPlaceholder();
 
-            $component->mount();
+            $component->mountComponent();
+            $component->flushDispatchedEvents();
+            $skipRender = $component->consumeRenderSkip();
 
             // A redirect from mount() (e.g. an auth gate) skips the first
             // render, exactly like runLoop() honoring a pre-set intent.
-            if ($component->getNavigationIntent() === null) {
+            if ($component->getNavigationIntent() === null && ! $skipRender) {
                 $this->renderFrame();
             } else {
                 $this->lastTree = $this->bridge->lastPublish();
@@ -238,9 +241,11 @@ class TestableComponent
     {
         $this->startInteraction();
 
+        $rootProperty = explode('.', $property, 2)[0];
+
         Assert::assertTrue(
-            property_exists($this->component, $property),
-            'Public property [$'.$property.'] does not exist on '.get_class($this->component).'.'
+            property_exists($this->component, $rootProperty),
+            'Public property [$'.$rootProperty.'] does not exist on '.get_class($this->component).'.'
         );
 
         $this->guard(fn () => $this->component->__syncProperty($property, $value));
@@ -253,12 +258,7 @@ class TestableComponent
     {
         $this->startInteraction();
 
-        Assert::assertTrue(
-            method_exists($this->component, $method),
-            'Method ['.$method.'] does not exist on '.get_class($this->component).'.'
-        );
-
-        $this->guard(fn () => $this->component->{$method}(...$args));
+        $this->guard(fn () => ComponentMethodInvoker::invoke($this->component, $method, $args));
 
         return $this->afterInteraction();
     }
@@ -540,7 +540,7 @@ class TestableComponent
             "No #[Poll] method [{$method}] on ".get_class($this->component).'. Declared: '.(implode(', ', $defined) ?: '(none)')
         );
 
-        $this->guard(fn () => $this->component->{$method}());
+        $this->guard(fn () => ComponentMethodInvoker::invoke($this->component, $method));
 
         return $this->afterInteraction();
     }
@@ -697,7 +697,11 @@ class TestableComponent
 
         $this->guard(function () {
             $this->component->onResume();
-            $this->renderFrame();
+            $this->component->flushDispatchedEvents();
+
+            if (! $this->component->consumeRenderSkip()) {
+                $this->renderFrame();
+            }
         });
     }
 
@@ -922,6 +926,67 @@ class TestableComponent
         );
 
         return $this;
+    }
+
+    // ── Component event assertions ──────────────────
+
+    public function assertDispatched(string $event, mixed ...$params): static
+    {
+        Assert::assertTrue(
+            $this->testDispatched($event, $params),
+            "Failed asserting that an event [{$event}] was dispatched."
+        );
+
+        return $this;
+    }
+
+    public function assertNotDispatched(string $event, mixed ...$params): static
+    {
+        Assert::assertFalse(
+            $this->testDispatched($event, $params),
+            "Failed asserting that an event [{$event}] was not dispatched."
+        );
+
+        return $this;
+    }
+
+    public function assertDispatchedTo(string $target, string $event, mixed ...$params): static
+    {
+        $this->assertDispatched($event, ...$params);
+
+        Assert::assertTrue(
+            collect($this->component->dispatchedEvents())->contains(
+                fn (array $item) => $item['name'] === $event
+                    && ($item['component'] ?? null) === $target
+            ),
+            "Failed asserting that event [{$event}] was dispatched to [{$target}]."
+        );
+
+        return $this;
+    }
+
+    private function testDispatched(string $event, array $params): bool
+    {
+        $events = collect($this->component->dispatchedEvents())
+            ->where('name', $event);
+
+        if ($params === []) {
+            return $events->isNotEmpty();
+        }
+
+        if (isset($params[0]) && is_callable($params[0]) && ! is_string($params[0])) {
+            $dispatch = $events->first();
+
+            return $dispatch !== null && (bool) $params[0]($event, $dispatch['params']);
+        }
+
+        return $events->contains(function (array $dispatch) use ($params) {
+            $common = array_intersect_key($dispatch['params'], $params);
+            ksort($common);
+            ksort($params);
+
+            return $common === $params;
+        });
     }
 
     // ── Chrome assertions ───────────────────────────
@@ -1283,7 +1348,7 @@ class TestableComponent
     /** Read a public or #[Computed] property. */
     public function get(string $property): mixed
     {
-        return $this->component->{$property};
+        return data_get($this->component, $property);
     }
 
     /** The most recently published wire tree. */
@@ -1403,12 +1468,12 @@ class TestableComponent
         $this->frameCount++;
     }
 
-    /** Dispatch a UI event through NativeComponent::dispatch(). */
+    /** Dispatch a UI event through NativeComponent::dispatchUiEvent(). */
     protected function dispatchUiEvent(array $event): static
     {
         $this->guard(fn () => $this->scoped(function () use ($event) {
             /** @var NativeComponent $this */
-            $this->dispatch($event);
+            $this->dispatchUiEvent($event);
         }));
 
         return $this->afterInteraction();
@@ -1428,9 +1493,12 @@ class TestableComponent
      */
     protected function afterInteraction(): static
     {
-        if ($this->component->getNavigationIntent() === null && $this->isRunning()) {
+        $this->guard(fn () => $this->component->flushDispatchedEvents());
+        $skipRender = $this->component->consumeRenderSkip();
+
+        if ($this->component->getNavigationIntent() === null && $this->isRunning() && ! $skipRender) {
             $this->guard(fn () => $this->renderFrame());
-        } else {
+        } elseif ($this->component->getNavigationIntent() !== null) {
             $this->lastTree = $this->bridge->lastPublish() ?? $this->lastTree;
         }
 

--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -516,7 +516,7 @@ class TestableComponent
             /** @var NativeComponent $this */
             foreach ($this->pollDefinitions() as $def) {
                 if ($def['method'] !== null && method_exists($this, $def['method'])) {
-                    $this->{$def['method']}();
+                    ComponentMethodInvoker::invokeLifecycle($this, $def['method']);
                 }
             }
         }));
@@ -540,7 +540,7 @@ class TestableComponent
             "No #[Poll] method [{$method}] on ".get_class($this->component).'. Declared: '.(implode(', ', $defined) ?: '(none)')
         );
 
-        $this->guard(fn () => ComponentMethodInvoker::invoke($this->component, $method));
+        $this->guard(fn () => ComponentMethodInvoker::invokeLifecycle($this->component, $method));
 
         return $this->afterInteraction();
     }

--- a/tests/Feature/Edge/ComponentFeaturesTest.php
+++ b/tests/Feature/Edge/ComponentFeaturesTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Routing\Route as IlluminateRoute;
+use Illuminate\Support\Facades\Route;
+use Native\Mobile\Edge\Exceptions\ComponentMethodNotFoundException;
+use Native\Mobile\Edge\Exceptions\DirectlyCallingLifecycleHooksNotAllowedException;
+use Native\Mobile\Edge\Exceptions\LockedPropertyException;
+use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Testing\Native;
+use Tests\Fixtures\Edge\ComponentFeaturesScreen;
+use Tests\Fixtures\Edge\ParityRecord;
+
+beforeEach(fn () => NativeRouter::clearRoutes());
+afterEach(fn () => NativeRouter::clearRoutes());
+
+it('injects services and implicitly binds models and enums into component actions', function () {
+    Native::test(ComponentFeaturesScreen::class)
+        ->call('resolveAction', '42', 'active')
+        ->assertSet('injected', '42:container:active');
+});
+
+it('throws a model not found exception when an action binding is missing', function () {
+    Native::test(ComponentFeaturesScreen::class)->call('resolveAction', 'missing', 'active');
+})->throws(ModelNotFoundException::class);
+
+it('only invokes public userland actions and protects lifecycle hooks', function () {
+    expect(fn () => Native::test(ComponentFeaturesScreen::class)->call('secret'))
+        ->toThrow(ComponentMethodNotFoundException::class)
+        ->and(fn () => Native::test(ComponentFeaturesScreen::class)->call('mount'))
+        ->toThrow(DirectlyCallingLifecycleHooksNotAllowedException::class);
+});
+
+it('runs component update hooks in order for dotted state paths', function () {
+    Native::test(ComponentFeaturesScreen::class)
+        ->set('profile.name', 'Caleb')
+        ->assertSet('profile.name', 'Caleb')
+        ->assertSet('hookLog', [
+            'updating:profile.name:Caleb',
+            'updatingProfile:name:Caleb',
+            'updatingProfileName:name:Caleb',
+            'updated:profile.name:Caleb',
+            'updatedProfile:name:Caleb',
+            'updatedProfileName:name:Caleb',
+        ]);
+});
+
+it('applies locked protection through the shared state pipeline', function () {
+    Native::test(ComponentFeaturesScreen::class)->set('accountId', 99);
+})->throws(LockedPropertyException::class);
+
+it('supports renderless attributes and imperative one-shot render skipping', function () {
+    Native::test(ComponentFeaturesScreen::class)
+        ->assertRenderCount(1)
+        ->call('incrementRenderless')
+        ->assertSet('count', 1)
+        ->assertRenderCount(1)
+        ->assertNotRerendered()
+        ->call('increment')
+        ->assertSet('count', 2)
+        ->assertRenderCount(2)
+        ->call('incrementAndSkip')
+        ->assertSet('count', 3)
+        ->assertRenderCount(2)
+        ->assertNotRerendered();
+});
+
+it('dispatches bubbling, self-only, and targeted component events', function () {
+    Native::test(ComponentFeaturesScreen::class)
+        ->call('dispatchNormally')
+        ->call('dispatchToSelf')
+        ->call('dispatchToClass')
+        ->assertSet('events', ['10:container', '11:container', '12:container'])
+        ->assertDispatched('parity-saved', id: 10)
+        ->assertDispatched('parity-saved', fn ($name, $params) => $name === 'parity-saved' && $params['id'] === 10)
+        ->assertDispatchedTo(ComponentFeaturesScreen::class, 'parity-saved', id: 12)
+        ->assertNotDispatched('never-happened');
+});
+
+it('uses Illuminate route matching, constraints, optional parameters, and explicit binders', function () {
+    Route::bind('parity_record', function (string $value, IlluminateRoute $route) {
+        return new ParityRecord($value.'@'.$route->bindingFieldFor('parity_record'));
+    });
+
+    Route::native(
+        '/parity-route/{parity_record:slug}/{section?}',
+        ComponentFeaturesScreen::class,
+    )->whereNumber('parity_record');
+
+    $resolved = NativeRouter::resolve('/parity-route/42?tab=details');
+
+    expect($resolved)
+        ->not->toBeNull()
+        ->and($resolved['params']['parity_record'])->toBeInstanceOf(ParityRecord::class)
+        ->and($resolved['params']['parity_record']->id)->toBe('42@slug')
+        ->and($resolved['params'])->not->toHaveKey('section')
+        ->and($resolved['params'])->not->toHaveKey('tab')
+        ->and($resolved['route'])->toBeInstanceOf(IlluminateRoute::class)
+        ->and(NativeRouter::resolve('/parity-route/not-a-number'))->toBeNull();
+});
+
+it('honors Laravel route prefixes and URL decoding', function () {
+    Route::prefix('settings')->group(function () {
+        Route::native('/search/{term}', ComponentFeaturesScreen::class);
+    });
+
+    $resolved = NativeRouter::resolve('/settings/search/hello%20world');
+
+    expect($resolved['params']['term'])->toBe('hello world')
+        ->and(array_keys(NativeRouter::registeredRoutes()))
+        ->toContain('/settings/search/{term}');
+});
+
+it('implicitly binds typed public properties using custom route keys', function () {
+    Route::native('/parity-property/{record:slug}', ComponentFeaturesScreen::class);
+
+    Native::visit('/parity-property/native-php')
+        ->assertSet('record.id', 'native-php@slug');
+});

--- a/tests/Feature/Edge/ComponentFeaturesTest.php
+++ b/tests/Feature/Edge/ComponentFeaturesTest.php
@@ -10,7 +10,9 @@ use Native\Mobile\Edge\NativeRouter;
 use Native\Mobile\Testing\Native;
 use Tests\Fixtures\Edge\ComponentFeaturesScreen;
 use Tests\Fixtures\Edge\CounterScreen;
+use Tests\Fixtures\Edge\ParityPureStatus;
 use Tests\Fixtures\Edge\ParityRecord;
+use Tests\Fixtures\Edge\RouterBindingFailureScreen;
 
 beforeEach(fn () => NativeRouter::clearRoutes());
 afterEach(fn () => NativeRouter::clearRoutes());
@@ -78,6 +80,38 @@ it('dispatches bubbling, self-only, and targeted component events', function () 
         ->assertNotDispatched('never-happened');
 });
 
+it('flushes component events before a navigation intent leaves the device interaction', function () {
+    $screen = Native::test(ComponentFeaturesScreen::class);
+    $callbackId = (new ReflectionMethod($screen, 'callbackIdFor'))
+        ->invoke($screen, 'dispatchThenNavigate');
+
+    (new ReflectionMethod($screen->instance(), 'dispatchUiEvent'))
+        ->invoke($screen->instance(), ['type' => 0, 'callback_id' => $callbackId]);
+
+    expect($screen->instance()->dispatchedEvents())
+        ->toContain(['name' => 'parity-saved', 'params' => ['id' => 13]])
+        ->and($screen->instance()->events)->toBe(['13:container']);
+});
+
+it('does not let a renderless component-event listener suppress its triggering action frame', function () {
+    Native::test(ComponentFeaturesScreen::class)
+        ->assertRenderCount(1)
+        ->call('incrementAndDispatchRenderless')
+        ->assertSet('count', 1)
+        ->assertSet('renderlessListenerCalls', 1)
+        ->assertRenderCount(2)
+        ->assertSee('Count: 1');
+});
+
+it('does not attempt implicit binding for pure enums', function () {
+    Native::test(ComponentFeaturesScreen::class)
+        ->call('resolvePureEnum', ParityPureStatus::Active)
+        ->assertSet('pureEnum', 'Active');
+
+    expect(fn () => Native::test(ComponentFeaturesScreen::class)->call('resolvePureEnum', 'active'))
+        ->toThrow(TypeError::class);
+});
+
 it('uses Illuminate route matching, constraints, optional parameters, and explicit binders', function () {
     Route::bind('parity_record', function (string $value, IlluminateRoute $route) {
         return new ParityRecord($value.'@'.$route->bindingFieldFor('parity_record'));
@@ -125,6 +159,35 @@ it('binds snake-cased route parameters to camel-cased typed properties', functio
     Native::visit('/parity-property-snake/native-php')
         ->assertSet('parityRecord.id', 'native-php@slug');
 });
+
+it('coerces compatible scalar route properties and rejects incompatible values', function () {
+    Route::native('/pages/{page}', ComponentFeaturesScreen::class);
+
+    Native::visit('/pages/42')->assertSet('page', 42);
+
+    expect(fn () => Native::visit('/pages/not-a-number'))->toThrow(TypeError::class);
+});
+
+it('checks whether a route matches without running its model binders', function () {
+    Route::native('/binding-check/{record}', ComponentFeaturesScreen::class);
+
+    expect(NativeRouter::isNativeRoute('/binding-check/missing'))->toBeTrue();
+});
+
+it('keeps navigation binding failures inside the current screen lifecycle', function (string $intent) {
+    Route::native('/binding-failure/{record}', ComponentFeaturesScreen::class);
+    NativeRouter::register('/binding-source', RouterBindingFailureScreen::class);
+    Native::fakeBridge();
+
+    RouterBindingFailureScreen::$runCount = 0;
+    RouterBindingFailureScreen::$intent = $intent;
+
+    expect((new NativeRouter)->start(
+        RouterBindingFailureScreen::class,
+        uri: '/binding-source',
+    ))->toBe('/recovered')
+        ->and(RouterBindingFailureScreen::$runCount)->toBe(2);
+})->with(['navigate', 'replace']);
 
 it('prefers literal routes and reuses compiled route patterns', function () {
     Route::native('/items/{record}', ComponentFeaturesScreen::class);

--- a/tests/Feature/Edge/ComponentFeaturesTest.php
+++ b/tests/Feature/Edge/ComponentFeaturesTest.php
@@ -1,18 +1,22 @@
 <?php
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
 use Illuminate\Routing\Route as IlluminateRoute;
 use Illuminate\Support\Facades\Route;
 use Native\Mobile\Edge\Exceptions\ComponentMethodNotFoundException;
 use Native\Mobile\Edge\Exceptions\DirectlyCallingLifecycleHooksNotAllowedException;
 use Native\Mobile\Edge\Exceptions\LockedPropertyException;
 use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Testing\FakeBridge;
 use Native\Mobile\Testing\Native;
 use Tests\Fixtures\Edge\ComponentFeaturesScreen;
 use Tests\Fixtures\Edge\CounterScreen;
+use Tests\Fixtures\Edge\InteractionFailureScreen;
 use Tests\Fixtures\Edge\ParityPureStatus;
 use Tests\Fixtures\Edge\ParityRecord;
 use Tests\Fixtures\Edge\RouterBindingFailureScreen;
+use Tests\Fixtures\Edge\ScriptedEventBridge;
 
 beforeEach(fn () => NativeRouter::clearRoutes());
 afterEach(fn () => NativeRouter::clearRoutes());
@@ -26,6 +30,10 @@ it('injects services and implicitly binds models and enums into component action
 it('throws a model not found exception when an action binding is missing', function () {
     Native::test(ComponentFeaturesScreen::class)->call('resolveAction', 'missing', 'active');
 })->throws(ModelNotFoundException::class);
+
+it('throws the route-compatible exception when an action enum case is invalid', function () {
+    Native::test(ComponentFeaturesScreen::class)->call('resolveAction', '42', 'invalid');
+})->throws(BackedEnumCaseNotFoundException::class);
 
 it('only invokes public userland actions and protects lifecycle hooks', function () {
     expect(fn () => Native::test(ComponentFeaturesScreen::class)->call('secret'))
@@ -81,16 +89,14 @@ it('dispatches bubbling, self-only, and targeted component events', function () 
 });
 
 it('flushes component events before a navigation intent leaves the device interaction', function () {
-    $screen = Native::test(ComponentFeaturesScreen::class);
-    $callbackId = (new ReflectionMethod($screen, 'callbackIdFor'))
-        ->invoke($screen, 'dispatchThenNavigate');
-
-    (new ReflectionMethod($screen->instance(), 'dispatchUiEvent'))
-        ->invoke($screen->instance(), ['type' => 0, 'callback_id' => $callbackId]);
+    $screen = Native::test(ComponentFeaturesScreen::class)
+        ->tap('Dispatch then navigate')
+        ->assertNavigatedTo('/next');
 
     expect($screen->instance()->dispatchedEvents())
         ->toContain(['name' => 'parity-saved', 'params' => ['id' => 13]])
-        ->and($screen->instance()->events)->toBe(['13:container']);
+        ->and($screen->instance()->events)->toBe(['13:container'])
+        ->and(json_encode($screen->bridge()->lastPublish()))->toContain('Events: 13:container');
 });
 
 it('does not let a renderless component-event listener suppress its triggering action frame', function () {
@@ -101,6 +107,43 @@ it('does not let a renderless component-event listener suppress its triggering a
         ->assertSet('renderlessListenerCalls', 1)
         ->assertRenderCount(2)
         ->assertSee('Count: 1');
+});
+
+it('preserves an imperative render skip requested inside a component-event listener', function () {
+    Native::test(ComponentFeaturesScreen::class)
+        ->assertRenderCount(1)
+        ->call('incrementAndDispatchImperativeSkip')
+        ->assertSet('count', 1)
+        ->assertSet('imperativeSkipListenerCalls', 1)
+        ->assertRenderCount(1)
+        ->assertNotRerendered()
+        ->assertSee('Count: 0');
+});
+
+it('contains component-event failures raised while handling system back', function () {
+    $bridge = new ScriptedEventBridge([
+        ['type' => 8],
+        ['type' => ComponentFeaturesScreen::EVENT_SHUTDOWN],
+    ]);
+    app()->instance(FakeBridge::class, $bridge);
+
+    $screen = new InteractionFailureScreen;
+    $screen->runLoop();
+
+    expect($screen->hasErrorState())->toBeTrue();
+});
+
+it('contains component-event failures raised while flushing due polls', function () {
+    $bridge = new ScriptedEventBridge([
+        null,
+        ['type' => ComponentFeaturesScreen::EVENT_SHUTDOWN],
+    ]);
+    app()->instance(FakeBridge::class, $bridge);
+
+    $screen = new InteractionFailureScreen;
+    $screen->runLoop();
+
+    expect($screen->hasErrorState())->toBeTrue();
 });
 
 it('does not attempt implicit binding for pure enums', function () {

--- a/tests/Feature/Edge/ComponentFeaturesTest.php
+++ b/tests/Feature/Edge/ComponentFeaturesTest.php
@@ -9,6 +9,7 @@ use Native\Mobile\Edge\Exceptions\LockedPropertyException;
 use Native\Mobile\Edge\NativeRouter;
 use Native\Mobile\Testing\Native;
 use Tests\Fixtures\Edge\ComponentFeaturesScreen;
+use Tests\Fixtures\Edge\CounterScreen;
 use Tests\Fixtures\Edge\ParityRecord;
 
 beforeEach(fn () => NativeRouter::clearRoutes());
@@ -116,4 +117,56 @@ it('implicitly binds typed public properties using custom route keys', function 
 
     Native::visit('/parity-property/native-php')
         ->assertSet('record.id', 'native-php@slug');
+});
+
+it('binds snake-cased route parameters to camel-cased typed properties', function () {
+    Route::native('/parity-property-snake/{parity_record:slug}', ComponentFeaturesScreen::class);
+
+    Native::visit('/parity-property-snake/native-php')
+        ->assertSet('parityRecord.id', 'native-php@slug');
+});
+
+it('prefers literal routes and reuses compiled route patterns', function () {
+    Route::native('/items/{record}', ComponentFeaturesScreen::class);
+    Route::native('/items/create', CounterScreen::class);
+
+    $registered = NativeRouter::registeredRoutes();
+
+    expect($registered['/items/{record}']['route']->getCompiled())->toBeNull()
+        ->and($registered['/items/create']['route']->getCompiled())->toBeNull();
+
+    $literal = NativeRouter::resolve('/items/create');
+
+    expect($literal['class'])->toBe(CounterScreen::class)
+        ->and($literal['params'])->toBe([])
+        ->and($registered['/items/create']['route']->getCompiled())->not->toBeNull()
+        ->and($registered['/items/{record}']['route']->getCompiled())->toBeNull();
+
+    $parameterized = NativeRouter::resolve('/items/native-php');
+
+    expect($parameterized['class'])->toBe(ComponentFeaturesScreen::class)
+        ->and($parameterized['params']['record'])->toBeInstanceOf(ParityRecord::class)
+        ->and($registered['/items/{record}']['route']->getCompiled())->not->toBeNull();
+});
+
+it('uses normal binding for non-soft records on routes that allow trashed models', function () {
+    Route::native('/records/{record}', ComponentFeaturesScreen::class)->withTrashed();
+
+    $resolved = NativeRouter::resolve('/records/42');
+
+    expect($resolved['params']['record'])
+        ->toBeInstanceOf(ParityRecord::class)
+        ->id->toBe('42');
+});
+
+it('uses soft-deletable child binding for scoped routes that allow trashed models', function () {
+    Route::native(
+        '/parents/{parent_record}/children/{child_record}',
+        ComponentFeaturesScreen::class,
+    )->scopeBindings()->withTrashed();
+
+    $resolved = NativeRouter::resolve('/parents/1/children/2');
+
+    expect($resolved['params']['parent_record']->id)->toBe('parent:1')
+        ->and($resolved['params']['child_record']->id)->toBe('trashed-child:2');
 });

--- a/tests/Feature/Edge/MountDependencyInjectionTest.php
+++ b/tests/Feature/Edge/MountDependencyInjectionTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Routing\Exceptions\BackedEnumCaseNotFoundException;
+use Illuminate\View\View;
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Testing\Native;
+
+final class MountInjectedClick implements UrlRoutable
+{
+    public function __construct(public ?int $id = null) {}
+
+    public function getRouteKey(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function resolveRouteBinding($value, $field = null): ?self
+    {
+        return $value === 'missing' ? null : new self((int) $value);
+    }
+
+    public function resolveChildRouteBinding($childType, $value, $field): null
+    {
+        return null;
+    }
+}
+
+final class MountInjectedService
+{
+    public string $value = 'from the container';
+}
+
+enum MountInjectedState: string
+{
+    case Active = 'active';
+}
+
+final class MountInjectedScreen extends NativeComponent
+{
+    public MountInjectedClick $click;
+
+    public ?int $clickId = null;
+
+    public bool $propertyWasHydratedBeforeMount = false;
+
+    public string $serviceValue = '';
+
+    public string $label = '';
+
+    public function mount(MountInjectedClick $click, MountInjectedService $service, string $label = 'default'): void
+    {
+        $this->propertyWasHydratedBeforeMount = $this->click === $click;
+        $this->clickId = $click->id;
+        $this->serviceValue = $service->value;
+        $this->label = $label;
+    }
+
+    public function render(): Element|View
+    {
+        return Text::make("Click {$this->clickId}: {$this->serviceValue} ({$this->label})");
+    }
+}
+
+final class RouteBoundPropertyScreen extends NativeComponent
+{
+    public MountInjectedClick $click;
+
+    public string $label = '';
+
+    public MountInjectedState $state;
+
+    public function render(): Element|View
+    {
+        return Text::make("Property click {$this->click->id}: {$this->label} ({$this->state->value})");
+    }
+}
+
+final class RouteBoundEnumMountScreen extends NativeComponent
+{
+    public string $stateValue = '';
+
+    public function mount(MountInjectedState $state): void
+    {
+        $this->stateValue = $state->value;
+    }
+
+    public function render(): Element|View
+    {
+        return Text::make("Mount state {$this->stateValue}");
+    }
+}
+
+beforeEach(fn () => NativeRouter::clearRoutes());
+afterEach(fn () => NativeRouter::clearRoutes());
+
+it('injects route-bound models, container dependencies, and primitive parameters into mount', function () {
+    NativeRouter::register('/counter/{click}/{label}', MountInjectedScreen::class);
+
+    Native::visit('/counter/88/example')
+        ->assertSet('clickId', 88)
+        ->assertSet('propertyWasHydratedBeforeMount', true)
+        ->assertSet('serviceValue', 'from the container')
+        ->assertSet('label', 'example')
+        ->assertSee('Click 88: from the container (example)');
+});
+
+it('hydrates a typed public model property from the matching route parameter', function () {
+    NativeRouter::register('/counter/{click}/{label}/{state}', RouteBoundPropertyScreen::class);
+
+    $screen = Native::visit('/counter/88/example/active')
+        ->assertSet('label', 'example')
+        ->assertSet('state', MountInjectedState::Active)
+        ->assertSee('Property click 88: example (active)');
+
+    expect($screen->get('click'))
+        ->toBeInstanceOf(MountInjectedClick::class)
+        ->id->toBe(88);
+});
+
+it('throws a model not found exception when route binding fails', function () {
+    NativeRouter::register('/counter/{click}', RouteBoundPropertyScreen::class);
+
+    Native::visit('/counter/missing');
+})->throws(ModelNotFoundException::class, MountInjectedClick::class);
+
+it('binds backed enums passed to mount and rejects invalid cases', function () {
+    NativeRouter::register('/state/{state}', RouteBoundEnumMountScreen::class);
+
+    Native::visit('/state/active')
+        ->assertSet('stateValue', 'active')
+        ->assertSee('Mount state active');
+
+    Native::visit('/state/invalid');
+})->throws(BackedEnumCaseNotFoundException::class);

--- a/tests/Feature/Edge/NestedComponentsTest.php
+++ b/tests/Feature/Edge/NestedComponentsTest.php
@@ -202,6 +202,13 @@ it('delivers emit() to the parent through the @event tag binding', function () {
     expect($screen->instance()->savedEvents)->toBe(['tag:solo:1']);
 });
 
+it('keeps direct emit callbacks working for child templates', function () {
+    $screen = Native::test(NestedHostScreen::class)
+        ->tap('emit-solo');
+
+    expect($screen->instance()->savedEvents)->toBe(['tag:direct:9']);
+});
+
 it('bubbles a grandchild emit() past its parent to the screen #[On] listener', function () {
     $screen = Native::test(NestedHostScreen::class)
         ->tap('poke-a');

--- a/tests/Feature/Edge/NestedComponentsTest.php
+++ b/tests/Feature/Edge/NestedComponentsTest.php
@@ -210,10 +210,11 @@ it('keeps direct emit callbacks working for child templates', function () {
 });
 
 it('bubbles a grandchild emit() past its parent to the screen #[On] listener', function () {
-    $screen = Native::test(NestedHostScreen::class)
-        ->tap('poke-a');
-
-    expect($screen->instance()->pokes)->toBe(['badge-of-a']);
+    Native::test(NestedHostScreen::class)
+        ->tap('poke-a')
+        ->assertSet('pokes', ['badge-of-a'])
+        ->assertSee('Pokes: badge-of-a')
+        ->assertRerendered();
 });
 
 it('re-renders after an emit so handler state changes paint', function () {

--- a/tests/Feature/NativeRouteHttpTest.php
+++ b/tests/Feature/NativeRouteHttpTest.php
@@ -1,7 +1,13 @@
 <?php
 
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Native\Mobile\Edge\Contracts\NativeRouteFallback;
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\NativeComponent;
 use Native\Mobile\Edge\NativeRouter;
 use Native\Mobile\Testing\Native;
 use Tests\Fixtures\Edge\CounterScreen;
@@ -34,3 +40,48 @@ it('registers native routes with the router for the component harness', function
     Native::visit('/native-detail/42', ['from' => 'http-route'])
         ->assertSee('Detail 42 from http-route');
 });
+
+it('resolves route parameters from the normalized path in subdirectory deployments', function () {
+    Route::native('/native-subdir/{id}', SubdirectoryParamScreen::class);
+    Native::fakeBridge();
+
+    $originalEnvironment = app()->environment();
+    app()->instance('env', 'production');
+
+    $request = Request::create(
+        'http://localhost/subdirectory/native-subdir/42?tab=details',
+        'GET',
+        server: [
+            'SCRIPT_NAME' => '/subdirectory/index.php',
+            'SCRIPT_FILENAME' => '/var/www/public/index.php',
+            'PHP_SELF' => '/subdirectory/index.php',
+        ],
+    );
+
+    $kernel = app(Kernel::class);
+
+    try {
+        $response = $kernel->handle($request);
+        $kernel->terminate($request, $response);
+    } finally {
+        app()->instance('env', $originalEnvironment);
+    }
+
+    expect(SubdirectoryParamScreen::$mountedId)->toBe('42');
+});
+
+class SubdirectoryParamScreen extends NativeComponent
+{
+    public static string $mountedId = '';
+
+    public function mount(string $id = 'missing'): void
+    {
+        static::$mountedId = $id;
+        $this->exitToWeb('/done');
+    }
+
+    public function render(): Element
+    {
+        return Column::make(Text::make('Subdirectory route'));
+    }
+}

--- a/tests/Feature/NativeTestingSuiteTest.php
+++ b/tests/Feature/NativeTestingSuiteTest.php
@@ -112,6 +112,24 @@ it('asserts exit-to-web navigation', function () {
         ->assertExitedToWeb('/settings');
 });
 
+it('keeps direct navigation callbacks working for compatibility', function () {
+    Native::test(NavScreen::class)
+        ->tap('Direct push')
+        ->assertNavigatedTo('/detail/9');
+
+    Native::test(NavScreen::class)
+        ->tap('Direct replace')
+        ->assertReplacedWith('/login');
+
+    Native::test(NavScreen::class)
+        ->tap('Direct exit')
+        ->assertExitedToWeb('/settings');
+
+    Native::test(NavScreen::class)
+        ->tap('Direct back')
+        ->assertWentBack();
+});
+
 it('follows navigation onto the next screen with params and data', function () {
     NativeRouter::register('/detail/{id}', DetailScreen::class);
 

--- a/tests/Feature/NativeTestingSuiteTest.php
+++ b/tests/Feature/NativeTestingSuiteTest.php
@@ -80,6 +80,22 @@ it('delivers native events to #[On] listeners', function () {
         ->assertSet('pings', ['yo', 'again']);
 });
 
+it('preserves explicit scalar coercion for native event payloads', function () {
+    Native::test(CounterScreen::class)
+        ->emitNative('ScalarPayloadReceived', [
+            'count' => 'not-a-number',
+            'ratio' => 'not-a-number',
+            'label' => 123,
+            'enabled' => '0',
+        ])
+        ->assertSet('scalarPayload', [
+            'count' => 0,
+            'ratio' => 0.0,
+            'label' => '123',
+            'enabled' => false,
+        ]);
+});
+
 it('records native bridge calls and plays back scripted responses', function () {
     Native::fakeBridge()->respondTo('Geolocation.GetCurrentPosition', [
         'latitude' => 40.7,

--- a/tests/Feature/TestingSuiteV2Test.php
+++ b/tests/Feature/TestingSuiteV2Test.php
@@ -16,6 +16,7 @@ use Tests\Fixtures\Edge\HiddenTabScreen;
 use Tests\Fixtures\Edge\PingReceived;
 use Tests\Fixtures\Edge\PlatformScreen;
 use Tests\Fixtures\Edge\PollScreen;
+use Tests\Fixtures\Edge\RenderlessPollScreen;
 use Tests\Fixtures\Edge\SearchableScreen;
 
 beforeEach(function () {
@@ -127,6 +128,15 @@ it('injects dependencies into protected poll methods through the internal invoca
     Native::test(PollScreen::class)
         ->firePoll('injectedTick')
         ->assertSet('injectedTicks', 3);
+});
+
+it('honors renderless attributes on protected poll methods', function () {
+    Native::test(RenderlessPollScreen::class)
+        ->assertRenderCount(1)
+        ->firePoll('tickWithoutRendering')
+        ->assertSet('ticks', 3)
+        ->assertRenderCount(1)
+        ->assertNotRerendered();
 });
 
 it('rejects unknown poll methods', function () {

--- a/tests/Feature/TestingSuiteV2Test.php
+++ b/tests/Feature/TestingSuiteV2Test.php
@@ -123,6 +123,12 @@ it('fires a single poll method by name', function () {
         ->assertSet('slowTicks', 0);
 });
 
+it('injects dependencies into protected poll methods through the internal invocation path', function () {
+    Native::test(PollScreen::class)
+        ->firePoll('injectedTick')
+        ->assertSet('injectedTicks', 3);
+});
+
 it('rejects unknown poll methods', function () {
     Native::test(PollScreen::class)->firePoll('nonexistent');
 })->throws(AssertionFailedError::class);

--- a/tests/Fixtures/Edge/ComponentFeaturesScreen.php
+++ b/tests/Fixtures/Edge/ComponentFeaturesScreen.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\View\View;
+use Native\Mobile\Attributes\Locked;
+use Native\Mobile\Attributes\On;
+use Native\Mobile\Attributes\Renderless;
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\NativeComponent;
+
+class ComponentFeaturesScreen extends NativeComponent
+{
+    public int $count = 0;
+
+    public int $renders = 0;
+
+    public array $profile = ['name' => 'Taylor'];
+
+    public array $hookLog = [];
+
+    #[Locked]
+    public int $accountId = 7;
+
+    public ?string $injected = null;
+
+    public array $events = [];
+
+    public ParityRecord $record;
+
+    public function resolveAction(
+        ParityRecord $record,
+        ParityActionService $service,
+        ParityStatus $status,
+    ): void {
+        $this->injected = "{$record->id}:{$service->label}:{$status->value}";
+    }
+
+    public function increment(): void
+    {
+        $this->count++;
+    }
+
+    #[Renderless]
+    public function incrementRenderless(): void
+    {
+        $this->count++;
+    }
+
+    public function incrementAndSkip(): void
+    {
+        $this->count++;
+        $this->skipRender();
+    }
+
+    public function dispatchNormally(): void
+    {
+        $this->dispatch('parity-saved', id: 10);
+    }
+
+    public function dispatchToSelf(): void
+    {
+        $this->dispatch('parity-saved', id: 11)->self();
+    }
+
+    public function dispatchToClass(): void
+    {
+        $this->dispatch('parity-saved', id: 12)->to(self::class);
+    }
+
+    #[On('parity-saved')]
+    public function recordEvent(int $id, ParityActionService $service): void
+    {
+        $this->events[] = "{$id}:{$service->label}";
+    }
+
+    public function updating(string $path, mixed $value): void
+    {
+        $this->hookLog[] = "updating:{$path}:{$value}";
+    }
+
+    public function updatingProfile(mixed $value, ?string $key): void
+    {
+        $this->hookLog[] = "updatingProfile:{$key}:{$value}";
+    }
+
+    public function updatingProfileName(mixed $value, ?string $key): void
+    {
+        $this->hookLog[] = "updatingProfileName:{$key}:{$value}";
+    }
+
+    public function updated(string $path, mixed $value): void
+    {
+        $this->hookLog[] = "updated:{$path}:{$value}";
+    }
+
+    public function updatedProfile(mixed $value, ?string $key): void
+    {
+        $this->hookLog[] = "updatedProfile:{$key}:{$value}";
+    }
+
+    public function updatedProfileName(mixed $value, ?string $key): void
+    {
+        $this->hookLog[] = "updatedProfileName:{$key}:{$value}";
+    }
+
+    protected function secret(): void
+    {
+        $this->count = 999;
+    }
+
+    public function render(): Element|View
+    {
+        $this->renders++;
+
+        return Column::make(
+            Text::make("Count: {$this->count}"),
+            Text::make("Renders: {$this->renders}"),
+        );
+    }
+}
+
+class ParityActionService
+{
+    public string $label = 'container';
+}
+
+class ParityRecord implements UrlRoutable
+{
+    public function __construct(public string $id = '') {}
+
+    public function getRouteKey(): string
+    {
+        return $this->id;
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function resolveRouteBinding($value, $field = null): ?static
+    {
+        $suffix = $field === null ? '' : '@'.$field;
+
+        return $value === 'missing' ? null : new static((string) $value.$suffix);
+    }
+
+    public function resolveChildRouteBinding($childType, $value, $field): mixed
+    {
+        return null;
+    }
+}
+
+enum ParityStatus: string
+{
+    case Active = 'active';
+    case Archived = 'archived';
+}

--- a/tests/Fixtures/Edge/ComponentFeaturesScreen.php
+++ b/tests/Fixtures/Edge/ComponentFeaturesScreen.php
@@ -9,6 +9,7 @@ use Native\Mobile\Attributes\Locked;
 use Native\Mobile\Attributes\On;
 use Native\Mobile\Attributes\Renderless;
 use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Button;
 use Native\Mobile\Edge\Elements\Column;
 use Native\Mobile\Edge\Elements\Text;
 use Native\Mobile\Edge\NativeComponent;
@@ -29,6 +30,12 @@ class ComponentFeaturesScreen extends NativeComponent
     public ?string $injected = null;
 
     public array $events = [];
+
+    public int $renderlessListenerCalls = 0;
+
+    public ?string $pureEnum = null;
+
+    public int $page = 0;
 
     public ParityRecord $record;
 
@@ -78,10 +85,34 @@ class ComponentFeaturesScreen extends NativeComponent
         $this->dispatch('parity-saved', id: 12)->to(self::class);
     }
 
+    public function dispatchThenNavigate(): void
+    {
+        $this->dispatch('parity-saved', id: 13);
+        $this->navigate('/next');
+    }
+
+    public function incrementAndDispatchRenderless(): void
+    {
+        $this->count++;
+        $this->dispatch('renderless-listener');
+    }
+
     #[On('parity-saved')]
     public function recordEvent(int $id, ParityActionService $service): void
     {
         $this->events[] = "{$id}:{$service->label}";
+    }
+
+    #[On('renderless-listener')]
+    #[Renderless]
+    public function recordRenderlessEvent(): void
+    {
+        $this->renderlessListenerCalls++;
+    }
+
+    public function resolvePureEnum(ParityPureStatus $status): void
+    {
+        $this->pureEnum = $status->name;
     }
 
     public function updating(string $path, mixed $value): void
@@ -126,6 +157,7 @@ class ComponentFeaturesScreen extends NativeComponent
         return Column::make(
             Text::make("Count: {$this->count}"),
             Text::make("Renders: {$this->renders}"),
+            Button::make('Dispatch then navigate')->onPress('dispatchThenNavigate'),
         );
     }
 }
@@ -228,4 +260,9 @@ enum ParityStatus: string
 {
     case Active = 'active';
     case Archived = 'archived';
+}
+
+enum ParityPureStatus
+{
+    case Active;
 }

--- a/tests/Fixtures/Edge/ComponentFeaturesScreen.php
+++ b/tests/Fixtures/Edge/ComponentFeaturesScreen.php
@@ -33,6 +33,8 @@ class ComponentFeaturesScreen extends NativeComponent
 
     public int $renderlessListenerCalls = 0;
 
+    public int $imperativeSkipListenerCalls = 0;
+
     public ?string $pureEnum = null;
 
     public int $page = 0;
@@ -97,6 +99,12 @@ class ComponentFeaturesScreen extends NativeComponent
         $this->dispatch('renderless-listener');
     }
 
+    public function incrementAndDispatchImperativeSkip(): void
+    {
+        $this->count++;
+        $this->dispatch('imperative-skip-listener');
+    }
+
     #[On('parity-saved')]
     public function recordEvent(int $id, ParityActionService $service): void
     {
@@ -108,6 +116,13 @@ class ComponentFeaturesScreen extends NativeComponent
     public function recordRenderlessEvent(): void
     {
         $this->renderlessListenerCalls++;
+    }
+
+    #[On('imperative-skip-listener')]
+    public function recordImperativeSkipEvent(): void
+    {
+        $this->imperativeSkipListenerCalls++;
+        $this->skipRender();
     }
 
     public function resolvePureEnum(ParityPureStatus $status): void
@@ -157,6 +172,7 @@ class ComponentFeaturesScreen extends NativeComponent
         return Column::make(
             Text::make("Count: {$this->count}"),
             Text::make("Renders: {$this->renders}"),
+            Text::make('Events: '.implode(',', $this->events)),
             Button::make('Dispatch then navigate')->onPress('dispatchThenNavigate'),
         );
     }

--- a/tests/Fixtures/Edge/ComponentFeaturesScreen.php
+++ b/tests/Fixtures/Edge/ComponentFeaturesScreen.php
@@ -3,6 +3,7 @@
 namespace Tests\Fixtures\Edge;
 
 use Illuminate\Contracts\Routing\UrlRoutable;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\View\View;
 use Native\Mobile\Attributes\Locked;
 use Native\Mobile\Attributes\On;
@@ -30,6 +31,12 @@ class ComponentFeaturesScreen extends NativeComponent
     public array $events = [];
 
     public ParityRecord $record;
+
+    public ParityRecord $parityRecord;
+
+    public ParityParentRecord $parentRecord;
+
+    public ParitySoftRecord $childRecord;
 
     public function resolveAction(
         ParityRecord $record,
@@ -147,6 +154,68 @@ class ParityRecord implements UrlRoutable
         $suffix = $field === null ? '' : '@'.$field;
 
         return $value === 'missing' ? null : new static((string) $value.$suffix);
+    }
+
+    public function resolveChildRouteBinding($childType, $value, $field): mixed
+    {
+        return null;
+    }
+}
+
+class ParityParentRecord implements UrlRoutable
+{
+    public function __construct(public string $id = '') {}
+
+    public function getRouteKey(): string
+    {
+        return $this->id;
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function resolveRouteBinding($value, $field = null): ?static
+    {
+        return new static('parent:'.$value);
+    }
+
+    public function resolveChildRouteBinding($childType, $value, $field): mixed
+    {
+        return new ParitySoftRecord('regular-child:'.$value);
+    }
+
+    public function resolveSoftDeletableChildRouteBinding($childType, $value, $field): mixed
+    {
+        return new ParitySoftRecord('trashed-child:'.$value);
+    }
+}
+
+class ParitySoftRecord implements UrlRoutable
+{
+    use SoftDeletes;
+
+    public function __construct(public string $id = '') {}
+
+    public function getRouteKey(): string
+    {
+        return $this->id;
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'id';
+    }
+
+    public function resolveRouteBinding($value, $field = null): ?static
+    {
+        return new static('regular:'.$value);
+    }
+
+    public function resolveSoftDeletableRouteBinding($value, $field = null): ?static
+    {
+        return new static('trashed:'.$value);
     }
 
     public function resolveChildRouteBinding($childType, $value, $field): mixed

--- a/tests/Fixtures/Edge/CounterScreen.php
+++ b/tests/Fixtures/Edge/CounterScreen.php
@@ -26,6 +26,8 @@ class CounterScreen extends NativeComponent
 
     public array $pings = [];
 
+    public array $scalarPayload = [];
+
     public ?float $lat = null;
 
     public int $resumes = 0;
@@ -65,6 +67,12 @@ class CounterScreen extends NativeComponent
     public function onPing(string $message): void
     {
         $this->pings[] = $message;
+    }
+
+    #[On('ScalarPayloadReceived')]
+    public function onScalarPayload(int $count, float $ratio, string $label, bool $enabled): void
+    {
+        $this->scalarPayload = compact('count', 'ratio', 'label', 'enabled');
     }
 
     public function locate(): void

--- a/tests/Fixtures/Edge/InteractionFailureScreen.php
+++ b/tests/Fixtures/Edge/InteractionFailureScreen.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Native\Mobile\Attributes\On;
+use Native\Mobile\Attributes\Poll;
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\NativeComponent;
+
+class InteractionFailureScreen extends NativeComponent
+{
+    public function onBackPressed(): void
+    {
+        $this->dispatch('interaction-failed');
+    }
+
+    #[Poll(0)]
+    public function dispatchFromPoll(): void
+    {
+        $this->dispatch('interaction-failed');
+    }
+
+    #[On('interaction-failed')]
+    public function failInteraction(): void
+    {
+        throw new \RuntimeException('Component-event listener failed');
+    }
+
+    public function hasErrorState(): bool
+    {
+        return $this->nativeHasError;
+    }
+
+    public function render(): Element
+    {
+        return Column::make(Text::make('Interaction failure probe'));
+    }
+}

--- a/tests/Fixtures/Edge/NavScreen.php
+++ b/tests/Fixtures/Edge/NavScreen.php
@@ -50,6 +50,10 @@ class NavScreen extends NativeComponent
             Button::make('Push with transition')->onPress('pushWithTransition'),
             Button::make('Replace with transition')->onPress('replaceWithTransition'),
             Button::make('Push named')->onPress('pushNamed'),
+            Button::make('Direct push')->onPress("navigate('/detail/9')"),
+            Button::make('Direct replace')->onPress("replace('/login')"),
+            Button::make('Direct exit')->onPress("exitToWeb('/settings')"),
+            Button::make('Direct back')->onPress('back'),
         );
     }
 }

--- a/tests/Fixtures/Edge/NestedHostScreen.php
+++ b/tests/Fixtures/Edge/NestedHostScreen.php
@@ -4,6 +4,7 @@ namespace Tests\Fixtures\Edge;
 
 use Illuminate\View\View;
 use Native\Mobile\Attributes\On;
+use Native\Mobile\Attributes\Renderless;
 use Native\Mobile\Edge\NativeComponent;
 
 /**
@@ -33,6 +34,7 @@ class NestedHostScreen extends NativeComponent
     }
 
     #[On('badge-poked')]
+    #[Renderless]
     public function onBadgePoked(string $from): void
     {
         $this->pokes[] = $from;

--- a/tests/Fixtures/Edge/PollScreen.php
+++ b/tests/Fixtures/Edge/PollScreen.php
@@ -15,6 +15,8 @@ class PollScreen extends NativeComponent
 
     public int $slowTicks = 0;
 
+    public int $injectedTicks = 0;
+
     #[Poll(1000)]
     public function tick(): void
     {
@@ -27,6 +29,12 @@ class PollScreen extends NativeComponent
         $this->slowTicks++;
     }
 
+    #[Poll(30000)]
+    protected function injectedTick(PollDependency $dependency): void
+    {
+        $this->injectedTicks += $dependency->amount;
+    }
+
     public function render(): Element|View
     {
         return Column::make(
@@ -34,4 +42,9 @@ class PollScreen extends NativeComponent
             Text::make("Slow: {$this->slowTicks}"),
         );
     }
+}
+
+class PollDependency
+{
+    public int $amount = 3;
 }

--- a/tests/Fixtures/Edge/RenderlessPollScreen.php
+++ b/tests/Fixtures/Edge/RenderlessPollScreen.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Native\Mobile\Attributes\Poll;
+use Native\Mobile\Attributes\Renderless;
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\NativeComponent;
+
+class RenderlessPollScreen extends NativeComponent
+{
+    public int $ticks = 0;
+
+    #[Poll(30000)]
+    #[Renderless]
+    protected function tickWithoutRendering(RenderlessPollDependency $dependency): void
+    {
+        $this->ticks += $dependency->amount;
+    }
+
+    public function render(): Element
+    {
+        return Column::make(Text::make("Ticks: {$this->ticks}"));
+    }
+}
+
+class RenderlessPollDependency
+{
+    public int $amount = 3;
+}

--- a/tests/Fixtures/Edge/RouterBindingFailureScreen.php
+++ b/tests/Fixtures/Edge/RouterBindingFailureScreen.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Illuminate\View\View;
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\NativeComponent;
+
+class RouterBindingFailureScreen extends NativeComponent
+{
+    public static int $runCount = 0;
+
+    public static string $intent = 'navigate';
+
+    public function runLoop(): void
+    {
+        static::$runCount++;
+
+        if (static::$runCount === 1) {
+            static::$intent === 'replace'
+                ? $this->replace('/binding-failure/missing')
+                : $this->navigate('/binding-failure/missing');
+
+            return;
+        }
+
+        $this->exitToWeb('/recovered');
+    }
+
+    public function render(): Element|View
+    {
+        return Column::make(Text::make('Binding failure source'));
+    }
+}

--- a/tests/Fixtures/Edge/ScriptedEventBridge.php
+++ b/tests/Fixtures/Edge/ScriptedEventBridge.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Testing\FakeBridge;
+
+class ScriptedEventBridge extends FakeBridge
+{
+    /** @param list<array|null> $events */
+    public function __construct(private array $events) {}
+
+    public function elementWaitEvent(int $timeoutMs): ?array
+    {
+        if ($this->events === []) {
+            return ['type' => NativeComponent::EVENT_SHUTDOWN];
+        }
+
+        return array_shift($this->events);
+    }
+}

--- a/tests/Fixtures/views/nested-host-screen.blade.php
+++ b/tests/Fixtures/views/nested-host-screen.blade.php
@@ -1,5 +1,6 @@
 <native:column>
     <native:text>{{ $title }}</native:text>
+    <native:text>Pokes: {{ implode(',', $pokes) }}</native:text>
     @if ($showCard)
         <native:user-card-child name="solo" level="3" @card-saved="markSaved('tag')" />
     @endif

--- a/tests/Fixtures/views/user-card-child.blade.php
+++ b/tests/Fixtures/views/user-card-child.blade.php
@@ -6,6 +6,9 @@
     <native:pressable ref="save-{{ $name }}" @tap="save">
         <native:text>Save</native:text>
     </native:pressable>
+    <native:pressable ref="emit-{{ $name }}" @tap="emit('card-saved', 'direct', 9)">
+        <native:text>Emit directly</native:text>
+    </native:pressable>
     @include('user-card-note')
     <native:badge-child :owner="$name" />
 </native:column>

--- a/tests/Fixtures/views/user-card-child.blade.php
+++ b/tests/Fixtures/views/user-card-child.blade.php
@@ -6,6 +6,6 @@
     <native:pressable ref="save-{{ $name }}" @tap="save">
         <native:text>Save</native:text>
     </native:pressable>
-    <native:text-input ref="note-{{ $name }}" label="Note" native:model="note" />
+    @include('user-card-note')
     <native:badge-child :owner="$name" />
 </native:column>

--- a/tests/Fixtures/views/user-card-note.blade.php
+++ b/tests/Fixtures/views/user-card-note.blade.php
@@ -1,0 +1,5 @@
+<native:text-input
+    ref="note-{{ $name }}"
+    label="Note"
+    native:model="note"
+/>

--- a/tests/Unit/Edge/NativeTagPrecompilerTest.php
+++ b/tests/Unit/Edge/NativeTagPrecompilerTest.php
@@ -205,11 +205,11 @@ it('handles text-input hyphenated name', function () {
     expect($result)->toContain("::leaf('text_input', ['placeholder' => 'Search...'])");
 });
 
-it('compiles dotted native model paths through the bound component', function () {
+it('compiles dotted native model paths through view data', function () {
     $result = ($this->precompiler)('<native:text-input native:model="profile.name" />');
 
     expect($result)
-        ->toContain("'value' => (data_get(\$this, 'profile.name'))")
+        ->toContain("'value' => (data_get(get_defined_vars(), 'profile.name'))")
         ->toContain("'_change' => '__syncProperty(\\'profile.name\\')'")
         ->toContain("'sync-mode' => 'live'");
 });

--- a/tests/Unit/Edge/NativeTagPrecompilerTest.php
+++ b/tests/Unit/Edge/NativeTagPrecompilerTest.php
@@ -205,6 +205,15 @@ it('handles text-input hyphenated name', function () {
     expect($result)->toContain("::leaf('text_input', ['placeholder' => 'Search...'])");
 });
 
+it('compiles dotted native model paths through the bound component', function () {
+    $result = ($this->precompiler)('<native:text-input native:model="profile.name" />');
+
+    expect($result)
+        ->toContain("'value' => (data_get(\$this, 'profile.name'))")
+        ->toContain("'_change' => '__syncProperty(\\'profile.name\\')'")
+        ->toContain("'sync-mode' => 'live'");
+});
+
 it('preserves Blade directives like @foreach', function () {
     $input = '@foreach($items as $item) <native:text>{{ $item }}</native:text> @endforeach';
     $result = ($this->precompiler)($input);


### PR DESCRIPTION
## Summary

This change gives native components one consistent path for method invocation, route binding, state mutation, render suppression, and component events.

It adds:

- container injection plus implicit model and backed-enum binding for mount methods, actions, poll callbacks, and component-event listeners
- typed public route-model properties, hydrated before mount runs
- Illuminate route matching, constraints, optional parameters, explicit binders, custom route keys, scoped child bindings, URL decoding, prefixes, and query-string separation
- a shared dotted-property mutation pipeline with locking and deterministic updating/updated hook order
- one-shot render suppression through `skipRender()` and `#[Renderless]`
- component events with bubbling, self-only delivery, class targeting, listener injection, and test assertions
- dotted `native:model` compilation through view data, including nested Blade partials
- test-harness support for the same runtime behavior

This change intentionally does not introduce a form or data-validation API.

## Public API examples

### Route-bound mount dependencies

```php
Route::native('/counter/{click}/{section?}', CounterWithClick::class)
    ->whereNumber('click');

class CounterWithClick extends NativeComponent
{
    public Click $click;

    public function mount(
        Click $click,
        CounterService $service,
        string $section = 'overview',
    ): void {
        // $this->click is already hydrated from the route.
        $this->count = $click->count;
    }
}
```

`NativeComponent` deliberately does not declare a fixed `mount()` signature, so application components can define the parameters they need.

### Action dependencies

```php
public function inspect(
    Click $click,
    CounterService $service,
    DemoMode $mode,
): void {
    // Scalar interaction arguments are converted to declared scalar types.
}
```

### Protected poll callbacks with dependencies

```php
#[Poll(30_000)]
protected function refreshStatus(StatusService $service): void
{
    $this->status = $service->current();
}
```

Poll callbacks use the internal lifecycle invocation path, so they may remain protected while still receiving container dependencies.

### Nested state hooks

```blade
<outlined-text-input native:model="profile.name" />
```

```php
public function updatingProfileName(mixed $value, ?string $key): void
{
    // Runs before assignment.
}

public function updatedProfileName(mixed $value, ?string $key): void
{
    // Runs after assignment.
}
```

### Render suppression and component events

```php
#[Renderless]
public function incrementQuietly(): void
{
    $this->count++;
}

public function notify(): void
{
    $this->dispatch('count-changed', count: $this->count)->self();
}

#[On('count-changed')]
public function recordChange(int $count, AuditService $service): void
{
    // Listener dependencies are resolved by the container.
}
```

## Safety and compatibility

- only public application-defined actions are callable from interactions
- lifecycle hooks and inherited framework internals remain protected
- direct template calls to `navigate()`, `replace()`, `back()`, `exitToWeb()`, and `emit()` remain accepted for existing applications; new navigation bindings should use `@navigate`
- component PHP may continue calling navigation and event methods normally
- route-match predicates never execute parameter binders; actual navigation resolution still does
- route-binding failures during navigate or replace render on the current screen and stay inside its lifecycle
- literal routes retain priority over parameterized routes regardless of registration order
- route matching caches compiled patterns while bound parameters remain isolated between navigations
- request routing uses the normalized path, including subdirectory deployments and query strings
- compatible scalar route values hydrate typed public properties; incompatible values retain PHP's `TypeError` contract
- native event payloads retain explicit scalar conversion before dependency resolution
- pure enums are never treated as implicitly bindable; backed enums retain value binding
- soft-deletable and scoped child binding paths follow the route and model capabilities
- missing implicit model bindings fail with the normal model-not-found exception
- only public properties participate in external state synchronization, and locked public properties reject updates
- queued component events flush before final navigation frames are published and before navigate, back, or replace intents are consumed, so listener mutations reach the outgoing frame
- a nested renderless event listener cannot suppress the frame required by the interaction that dispatched it, while an explicit listener call to `skipRender()` remains authoritative
- protected poll callbacks retain both container injection and `#[Renderless]` behavior
- poll and system-back listener failures render through the active screen's error lifecycle instead of unwinding the run loop
- invalid backed-enum action arguments fail with the same binding exception used by route parameters
- a skipped render preserves the callback registry for the still-visible native tree
- all lifecycle entry points route through the same mount dispatcher

## Verification

- full Pest suite completed successfully with 3,154 assertions
- broader Edge, routing, navigation, and test-harness suite: 145 tests, 711 assertions
- focused regression suite: 77 tests, 405 assertions
- GitHub Actions at `a54533e`: PHP 8.4 tests, static analysis, and code style passed
- targeted local static analysis: no errors
- Pint: passed
- scratch feature and navigation suite: 15 passed, 93 assertions
- scratch registered-screen smoke suite: 35 passed, 105 assertions
- all scratch Blade templates compiled successfully
- patch, filenames, branch name, commit text, and PR copy scanned case-insensitively for prohibited comparison branding: no matches

## Scope

The branch contains the feature foundation followed by three focused compatibility and regression-hardening commits. The scratch application and its Composer lockfile are intentionally not part of this repository diff.
