### PR TITLE
Stop registering view paths the bundle never ships

### DIFF
--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -60,7 +60,6 @@ class NativeServiceProvider extends PackageServiceProvider
         $package
             ->name('nativephp-mobile')
             ->hasConfigFile('nativephp')
-            ->hasViews()
             ->hasRoute('api')
             ->hasCommands([
                 PackageCommand::class,
@@ -195,8 +194,10 @@ class NativeServiceProvider extends PackageServiceProvider
     {
         parent::boot();
 
+        // Only src/resources/views is registered. The package root
+        // resources/ dir never ships in the app bundle, and the
+        // device's view:cache throws on any missing path.
         $this->loadViewsFrom(__DIR__.'/resources/views', 'nativephp-mobile');
-        $this->loadViewsFrom(__DIR__.'/../resources/jump/views', 'jump');
 
         // Register `resources/views/native` as a primary view-finder
         // location (mirrors Livewire's `resources/views/livewire`

--- a/src/Support/BundleExclusions.php
+++ b/src/Support/BundleExclusions.php
@@ -63,6 +63,11 @@ class BundleExclusions
         'storage/framework/cache',
         'storage/framework/sessions',
         'storage/framework/views',
+        // The provider registers this as a view-finder location for every
+        // app, and the device's view:cache throws when it is missing.
+        // Only native:make-component creates it, so apps without a
+        // scaffolded component must still ship the empty dir.
+        'resources/views/native',
     ];
 
     /** Non-runtime patterns matched only inside vendor packages. */

--- a/tests/Feature/ReleaseBuildBundleTest.php
+++ b/tests/Feature/ReleaseBuildBundleTest.php
@@ -92,6 +92,11 @@ class ReleaseBuildBundleTest extends TestCase
         $this->assertFalse($zip->statName('bootstrap/cache/packages.php'));
         $this->assertNotFalse($zip->statName('bootstrap/cache/'));
 
+        // The provider registers this location unconditionally, so the
+        // bundle must ship it even when the app never scaffolded a
+        // native component, or view:cache throws on device (#322).
+        $this->assertNotFalse($zip->statName('resources/views/native/'));
+
         // Delegation to BundleFileManager, asserted by outcome: config
         // excludes and vendor slimming patterns shape the final zip.
         $this->assertNotFalse($zip->statName('app/Example.php'));

--- a/tests/Feature/ViewRegistrationTest.php
+++ b/tests/Feature/ViewRegistrationTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Support\Str;
+
+// The bundle packers strip the package root resources/ dir, and the
+// device's view:cache walks every registered path with a Finder
+// that throws when one is missing. So no registration may
+// ever point inside that directory (#322).
+it('registers no view paths under the unshipped package resources directory', function () {
+    $packageResources = realpath(__DIR__.'/../../resources');
+
+    $finder = app('view')->getFinder();
+
+    $registered = collect($finder->getPaths())
+        ->merge(collect($finder->getHints())->flatten());
+
+    $offenders = $registered
+        ->map(fn ($path) => realpath($path) ?: $path)
+        ->filter(fn ($path) => Str::startsWith($path, $packageResources.DIRECTORY_SEPARATOR));
+
+    expect($offenders->values()->all())->toBe([]);
+});
+
+it('keeps the package component views resolvable', function () {
+    expect(view()->exists('nativephp-mobile::components.native-element-with-children'))->toBeTrue();
+});

--- a/tests/Feature/ViewRegistrationTest.php
+++ b/tests/Feature/ViewRegistrationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
+use League\Flysystem\WhitespacePathNormalizer;
 use Native\Mobile\Support\BundleExclusions;
 
 // The device's view:cache walks every path registered on the view finder
@@ -12,42 +13,13 @@ it('registers only package view paths that ship in the app bundle', function () 
     // Resolve ".." segments lexically so a path like src/../resources/views
     // is caught even when the directory no longer exists and realpath
     // falls back to the raw string, as Spatie's hasViews() does.
-    $normalize = function (string $path): string {
-        $segments = [];
-        foreach (explode('/', str_replace('\\', '/', $path)) as $segment) {
-            if ($segment === '' || $segment === '.') {
-                continue;
-            }
-            if ($segment === '..') {
-                array_pop($segments);
-            } else {
-                $segments[] = $segment;
-            }
-        }
+    $normalize = fn (string $path): string => '/'.(new WhitespacePathNormalizer)->normalizePath($path);
 
-        return '/'.implode('/', $segments);
-    };
-
-    $strippedFromBundle = function (string $bundleRelative): bool {
-        $parts = explode('/', $bundleRelative);
-
-        $ancestors = collect(range(1, count($parts)))
-            ->map(fn ($i) => implode('/', array_slice($parts, 0, $i)));
-
-        foreach (BundleExclusions::VENDOR_PATHS as $pattern) {
-            if ($ancestors->contains(fn ($ancestor) => fnmatch($pattern, $ancestor, FNM_PATHNAME))) {
-                return true;
-            }
-        }
-
-        foreach (BundleExclusions::ANY_DEPTH as $name) {
-            if (collect(array_slice($parts, 3))->contains(fn ($part) => fnmatch($name, $part))) {
-                return true;
-            }
-        }
-
-        return false;
-    };
+    // A registered dir is stripped when it is an excluded path itself or
+    // sits anywhere below one, hence the slash-crossing second match.
+    $strippedFromBundle = fn (string $path): bool => collect(BundleExclusions::VENDOR_PATHS)
+        ->contains(fn ($pattern) => fnmatch($pattern, $path, FNM_PATHNAME)
+            || fnmatch($pattern.'/*', $path));
 
     $packageRoot = $normalize(dirname(__DIR__, 2));
 

--- a/tests/Feature/ViewRegistrationTest.php
+++ b/tests/Feature/ViewRegistrationTest.php
@@ -1,24 +1,74 @@
 <?php
 
 use Illuminate\Support\Str;
+use Native\Mobile\Support\BundleExclusions;
 
-// The bundle packers strip the package root resources/ dir, and the
-// device's view:cache walks every registered path with a Finder
-// that throws when one is missing. So no registration may
-// ever point inside that directory (#322).
-it('registers no view paths under the unshipped package resources directory', function () {
-    $packageResources = realpath(__DIR__.'/../../resources');
+// The device's view:cache walks every path registered on the view finder
+// and Symfony's Finder throws when any of them is missing. On device
+// the package lives at vendor/nativephp/mobile with the exclusion
+// paths stripped, so a package registration is only safe when
+// it exists here AND survives the bundle packers (#322).
+it('registers only package view paths that ship in the app bundle', function () {
+    // Resolve ".." segments lexically so a path like src/../resources/views
+    // is caught even when the directory no longer exists and realpath
+    // falls back to the raw string, as Spatie's hasViews() does.
+    $normalize = function (string $path): string {
+        $segments = [];
+        foreach (explode('/', str_replace('\\', '/', $path)) as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+            if ($segment === '..') {
+                array_pop($segments);
+            } else {
+                $segments[] = $segment;
+            }
+        }
+
+        return '/'.implode('/', $segments);
+    };
+
+    $strippedFromBundle = function (string $bundleRelative): bool {
+        $parts = explode('/', $bundleRelative);
+
+        $ancestors = collect(range(1, count($parts)))
+            ->map(fn ($i) => implode('/', array_slice($parts, 0, $i)));
+
+        foreach (BundleExclusions::VENDOR_PATHS as $pattern) {
+            if ($ancestors->contains(fn ($ancestor) => fnmatch($pattern, $ancestor, FNM_PATHNAME))) {
+                return true;
+            }
+        }
+
+        foreach (BundleExclusions::ANY_DEPTH as $name) {
+            if (collect(array_slice($parts, 3))->contains(fn ($part) => fnmatch($name, $part))) {
+                return true;
+            }
+        }
+
+        return false;
+    };
+
+    $packageRoot = $normalize(dirname(__DIR__, 2));
 
     $finder = app('view')->getFinder();
 
+    // Keep only paths the package itself registers. The repo's own vendor/
+    // holds the testbench skeleton and framework hints, which map to
+    // the app side on device and can't be validated from here.
     $registered = collect($finder->getPaths())
-        ->merge(collect($finder->getHints())->flatten());
+        ->merge(collect($finder->getHints())->flatten())
+        ->map($normalize)
+        ->filter(fn ($path) => Str::startsWith($path, $packageRoot.'/')
+            && ! Str::startsWith($path, $packageRoot.'/vendor/'));
 
-    $offenders = $registered
-        ->map(fn ($path) => realpath($path) ?: $path)
-        ->filter(fn ($path) => Str::startsWith($path, $packageResources.DIRECTORY_SEPARATOR));
+    $missing = $registered->reject(fn ($path) => is_dir($path));
+    expect($missing->values()->all())->toBe([]);
 
-    expect($offenders->values()->all())->toBe([]);
+    $stripped = $registered->filter(fn ($path) => $strippedFromBundle(
+        'vendor/nativephp/mobile/'.Str::after($path, $packageRoot.'/')
+    ));
+    expect($stripped->values()->all())->toBe([]);
 });
 
 it('keeps the package component views resolvable', function () {


### PR DESCRIPTION
Fixes #322.

Every debug boot runs `view:cache` on the device, and it walks every registered view path with a Symfony Finder that throws when a path is missing. Two of the provider's registrations point at directories no bundle ever contains, because all three packers strip `vendor/nativephp/mobile/resources` (11MB of project templates the runtime never reads). So every cold boot logs this and dies:

```
The ".../vendor/nativephp/mobile/src/../resources/views" directory does not exist.
```

The two registrations are `->hasViews()` and the `jump` namespace. Neither serves a purpose at runtime. `hasViews()` registers the package root `resources/views`, which contains a single `.gitkeep`, and its publish tag (`nativephp-mobile-views`) is never published by `native:install`. As far as I can tell it's scaffolding from the Spatie package skeleton: the `.gitkeep`-only views dir and the provider call both match the template, unchanged since the Init commit. The empty dir is deleted here as well. The real component views went to `src/resources/views` instead, under a separate registration that ships fine and stays. The `jump::` namespace has zero `view()` references anywhere, the jump server reads those blades as raw text with `file_get_contents` on the host.

I checked whether anything contributes files into those two directories in a userland project before deleting the registrations. Nothing does: my test project symlinks the package into vendor, so any runtime write would show up in git status, and after many install, plugin-register and build cycles the tree is clean. mobile-ui registers no view namespace and every plugin write path resolves into the native build tree.

I actually went the other way first, shipping the two dirs as empty entries from every packer. It worked, but it put the burden on three different packers forever, and once it was clear the registrations are unused skeleton there was nothing left to ship around. Two deleted lines in the provider instead.

While hardening the regression test I found a third leg of the same crash: the provider also registers `resources/views/native` as a view location for every app, and only `native:make-component` ever creates that dir. An app that never scaffolded a native component hits the same `view:cache` crash, after `view:clear` has already run, so it's left with no compiled views at all. That location is genuinely wanted (it's where an app's own native views live), so this leg is fixed the way the issue originally suggested: `resources/views/native` joins `BundleExclusions::REQUIRED_DIRECTORIES` and ships as an empty entry, which every packer already honors.

The provider has a comment documenting a deliberate choice to register view paths unconditionally so IDE plugins that scan providers statically can index them. That argument holds for `resources/views/native` and the `src/resources/views` namespace, both of which stay exactly as they are, but an IDE gains nothing from indexing a `.gitkeep` or a namespace no code references. If I'm missing a reason either registration needs to stay, @simonhamp @shanerbaner82, happy to hear it.

## Verification

- A new test locks the invariant down: every view path the package registers must exist and must survive the bundle excludes. Paths are normalized lexically (Flysystem's path normalizer), because Spatie registers the raw `src/../resources/views` string when the dir is missing and `realpath()`-based checks go blind on it. Proven red for both regression shapes: re-adding `hasViews()` and re-adding the jump registration.
- A second test pins `nativephp-mobile::components.native-element-with-children` staying resolvable, since it rides the registration that stays. The release bundle test additionally asserts `resources/views/native/` ships.
- Full suite green, pint clean, and `view:cache` on the host exits clean.
- Android emulator, fresh build and forced cold boot: the bundle contains no `vendor/nativephp/mobile/resources` entries, logcat shows `view:cache` running post-extraction and producing 66 compiled views, and the `DirectoryNotFoundException` count in the persisted log stayed frozen at the 5 pre-fix entries. The app renders normally.
- The third leg, proven in the failing shape: built the test app with `resources/views/native` deleted from its source. The bundle ships it as an empty entry, the dir lands on device, `view:cache` runs clean, and the exception count stays frozen. That exact build crashed on every boot before this change.
- iOS simulator: `app.zip` contains no vendor resources entries, ships `resources/views/native/`, and the app boots and renders.
- Ran `native:jump` against the branch: the QR page renders and serves normally, since the jump server reads its blades directly off disk and never used the removed namespace.
