### PR TITLE
fix: honour per-screen tab-bar hiding on the custom-Column chrome path

### DIFF
--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -526,6 +526,17 @@ abstract class NativeComponent
             }
         } elseif (! $hasCustomBottomNav && $layout !== null) {
             $tabBar = $layout->tabBar($this);
+            // Per-screen opt-out ($hidesTabBar shortcut + tabBarOptions()
+            // builder), mirroring the NavBar handling above. On the
+            // custom-Column path hiding is identical to the layout
+            // returning null — dropping the bar also hands the bottom
+            // safe-area edge back to the wrapper in buildChromeColumn().
+            // The native-chrome path instead keeps the config and folds a
+            // `hide_tab_bar` prop onto the sentinel, so the TabView
+            // survives for tab switching.
+            if ($tabBar !== null && ! $usesNativeChrome && $this->shouldHideTabBar()) {
+                $tabBar = null;
+            }
             if ($tabBar !== null) {
                 $currentUri = $this->nativeRouter?->currentUri();
                 if ($currentUri !== null) {

--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -951,14 +951,28 @@ class TestableComponent
         return $this;
     }
 
+    /**
+     * Assert the tab bar is hidden on this screen (`$hidesTabBar` /
+     * `tabBarOptions()->hidden()`), across both chrome paths: on the
+     * native-chrome path the sentinel carries `hide_tab_bar`; on the
+     * custom-Column path the bar is simply not rendered.
+     */
     public function assertTabBarHidden(): static
     {
         $tabs = $this->findElement($this->tree(), 'native_root_tabs');
 
-        Assert::assertNotNull($tabs, 'No native tab chrome rendered — nothing to be hidden.');
-        Assert::assertTrue(
-            (bool) ($tabs['props']['hide_tab_bar'] ?? false),
-            'Expected the tab bar to be hidden on this screen, but hide_tab_bar is not set.'
+        if ($tabs !== null) {
+            Assert::assertTrue(
+                (bool) ($tabs['props']['hide_tab_bar'] ?? false),
+                'Expected the tab bar to be hidden on this screen, but hide_tab_bar is not set.'
+            );
+
+            return $this;
+        }
+
+        Assert::assertNull(
+            $this->findElement($this->tree(), 'bottom_nav'),
+            'Expected the tab bar to be hidden on this screen, but a bottom_nav element was rendered.'
         );
 
         return $this;
@@ -968,10 +982,18 @@ class TestableComponent
     {
         $tabs = $this->findElement($this->tree(), 'native_root_tabs');
 
-        Assert::assertNotNull($tabs, 'No native tab chrome rendered.');
-        Assert::assertFalse(
-            (bool) ($tabs['props']['hide_tab_bar'] ?? false),
-            'Expected the tab bar to be visible, but hide_tab_bar is set.'
+        if ($tabs !== null) {
+            Assert::assertFalse(
+                (bool) ($tabs['props']['hide_tab_bar'] ?? false),
+                'Expected the tab bar to be visible, but hide_tab_bar is set.'
+            );
+
+            return $this;
+        }
+
+        Assert::assertNotNull(
+            $this->findElement($this->tree(), 'bottom_nav'),
+            'Expected the tab bar to be visible, but no bottom_nav element was rendered.'
         );
 
         return $this;

--- a/tests/Feature/TestingSuiteV2Test.php
+++ b/tests/Feature/TestingSuiteV2Test.php
@@ -12,6 +12,7 @@ use Tests\Fixtures\Edge\DetailScreen;
 use Tests\Fixtures\Edge\GateScreen;
 use Tests\Fixtures\Edge\HiddenNavOptionsScreen;
 use Tests\Fixtures\Edge\HiddenNavScreen;
+use Tests\Fixtures\Edge\HiddenTabOptionsScreen;
 use Tests\Fixtures\Edge\HiddenTabScreen;
 use Tests\Fixtures\Edge\PingReceived;
 use Tests\Fixtures\Edge\PlatformScreen;
@@ -247,6 +248,25 @@ it('drops the top bar entirely on the custom-Column chrome path', function () {
     Native::test(ChromeScreen::class, layout: ChromeColumnLayout::class)
         ->assertNavBarVisible()
         ->assertNavTitle('Chrome Demo');
+});
+
+it('hides the tab bar via the tabBarOptions builder', function () {
+    Native::test(HiddenTabOptionsScreen::class, layout: ChromeTabsLayout::class)
+        ->assertTabBarHidden();
+});
+
+it('drops the tab bar entirely on the custom-Column chrome path', function () {
+    // Both spellings — the $hidesTabBar shortcut and the tabBarOptions()
+    // builder — must hide the bar here, exactly as they do on the native
+    // chrome path.
+    Native::test(HiddenTabScreen::class, layout: ChromeColumnLayout::class)
+        ->assertTabBarHidden();
+
+    Native::test(HiddenTabOptionsScreen::class, layout: ChromeColumnLayout::class)
+        ->assertTabBarHidden();
+
+    Native::test(ChromeScreen::class, layout: ChromeColumnLayout::class)
+        ->assertTabBarVisible();
 });
 
 it('fails nav title assertions helpfully', function () {

--- a/tests/Fixtures/Edge/ChromeColumnLayout.php
+++ b/tests/Fixtures/Edge/ChromeColumnLayout.php
@@ -3,17 +3,28 @@
 namespace Tests\Fixtures\Edge;
 
 use Native\Mobile\Edge\Layouts\Builders\NavBar;
+use Native\Mobile\Edge\Layouts\Builders\Tab;
+use Native\Mobile\Edge\Layouts\Builders\TabBar;
 use Native\Mobile\Edge\Layouts\NativeLayout;
 use Native\Mobile\Edge\NativeComponent;
 
 /**
- * Custom-Column chrome path (usesNativeChrome() = false) — the bar
- * renders as a `top_bar` element instead of a native sentinel.
+ * Custom-Column chrome path (usesNativeChrome() = false) — the bars
+ * render as `top_bar` / `bottom_nav` elements instead of a native
+ * sentinel.
  */
 class ChromeColumnLayout extends NativeLayout
 {
     public function navBar(NativeComponent $screen): ?NavBar
     {
         return NavBar::make()->title($screen->navTitle());
+    }
+
+    public function tabBar(NativeComponent $screen): ?TabBar
+    {
+        return TabBar::make()
+            ->add(Tab::link('Home', '/'))
+            ->add(Tab::link('Detail', '/detail/1'))
+            ->highlight('/');
     }
 }

--- a/tests/Fixtures/Edge/HiddenTabOptionsScreen.php
+++ b/tests/Fixtures/Edge/HiddenTabOptionsScreen.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Native\Mobile\Edge\Layouts\Builders\TabBarOptions;
+
+/**
+ * Hides the tab bar via the `tabBarOptions()` builder rather than the
+ * `$hidesTabBar` shortcut — the form reported in #250.
+ */
+class HiddenTabOptionsScreen extends ChromeScreen
+{
+    public function navTitle(): string
+    {
+        return 'Pushed Detail';
+    }
+
+    public function tabBarOptions(): ?TabBarOptions
+    {
+        return TabBarOptions::make()->hidden();
+    }
+}


### PR DESCRIPTION
Fixes #250.

## The bug

```php
public function tabBarOptions(): ?TabBarOptions
{
    return TabBarOptions::make()->hidden();
}
```

No effect. Same for the `protected bool $hidesTabBar = true;` shortcut.

## Cause

There are two chrome paths (`NativeComponent.php:539`), and per-screen tab hiding was only wired into one of them:

- **Native chrome** → `wrapWithNativeChrome()` checks `shouldHideTabBar()` and folds `hideTabBar` onto the sentinel. Works.
- **Custom Column** → `buildChromeColumn()` appends `$tabBar->toElement()` unconditionally. `shouldHideTabBar()` had exactly one caller in the codebase — inside `wrapWithNativeChrome()` — so nothing on this path could ever remove the bar.

Which path you get is the crux: **`NativeLayout::usesNativeChrome()` returns `false` by default**. A layout that defines `tabBar()` without also overriding it lands on the broken path, which is the common case and matches the report.

The asymmetry that makes this clearly a bug rather than a design choice: NavBar already had the equivalent guard, 24 lines earlier —

```php
// NativeComponent.php:502
if ($navBar !== null && ! $usesNativeChrome && $this->shouldHideNavBar()) {
    $navBar = null;
}
```

so `$hidesNavBar` / `navigationOptions()->hidden()` worked where the TabBar equivalents did not.

## Fix

Mirror that guard in the TabBar branch. Nulling the bar (rather than passing a flag) is deliberate and matches the NavBar comment — *"On the custom-Column path hiding is identical to the layout returning null"* — and it's also what `buildChromeColumn()` needs: it picks its safe-area variant from which bars exist (lines 726–730), so a null tab bar correctly hands the bottom edge back to the wrapper.

The native-chrome path is untouched: it keeps the bar config and folds `hide_tab_bar` onto the sentinel, because the TabView has to survive for tab switching.

## Not the cause

The wire path was intact end to end, so despite the report being Android-only, neither renderer was at fault:

- `NativeRootTabs.php:109` maps `hideTabBar` → `hide_tab_bar`
- `NativeRootTabsRenderer.kt:169,305` reads it and skips the bottom bar
- `NativeRootTabsRenderer.swift:463` does the same

`TabBarOptions::hidden()` / `isHidden()` were also correct.

## Why it shipped

The only test covering this (`TestingSuiteV2Test.php:223`) used `ChromeTabsLayout`, whose `usesNativeChrome()` returns `true` — so it exercised only the working path, and only through the `$hidesTabBar` boolean, never the builder. The Column path had zero coverage for tab hiding.

Added:

- tab hiding on the Column path, both spellings, with a visible control
- tab hiding via the `tabBarOptions()` builder on the native path

The new Column-path test fails on `main` and passes with the fix. The new native-path builder test passes on `main` — it's pinning down behavior that already worked but was untested, and it's what confirms the builder itself was never broken.

`assertTabBarHidden()` / `assertTabBarVisible()` carried the same asymmetry as the source — they only understood the native sentinel and hard-failed with "No native tab chrome rendered" on the Column path. They now handle both, matching `assertNavBarHidden()`.

## Test run

Before: 901 tests / 3021 assertions / 0 failures. After: 903 / 3029 / 0 failures.

## One caveat

The reporter didn't share their layout, so I can't be certain theirs doesn't override `usesNativeChrome()`. If it does, their symptom has a different cause and this is a separate bug found while investigating. The default-`false` behavior makes this by far the likelier explanation, and the missing guard is a real bug regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)