### PR TITLE
feat: run native route middleware on in-app navigation

### DIFF
--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -2406,6 +2406,21 @@ abstract class NativeComponent
         return $this->nativeNavigationIntent;
     }
 
+    public function hasNavigationIntent(): bool
+    {
+        return $this->nativeNavigationIntent !== null;
+    }
+
+    /**
+     * Set the navigation intent from outside the component — the router uses
+     * this to turn a middleware denial into a redirect BEFORE mount() runs,
+     * so a guarded screen never executes its data loading.
+     */
+    public function setNavigationIntent(NavigationIntent $intent): void
+    {
+        $this->nativeNavigationIntent = $intent;
+    }
+
     /**
      * Clear a consumed navigation intent. The router calls this after reading the
      * intent so a component that STAYS on the stack (e.g. the launcher below a

--- a/src/Edge/NativeRouter.php
+++ b/src/Edge/NativeRouter.php
@@ -2,6 +2,7 @@
 
 namespace Native\Mobile\Edge;
 
+use Illuminate\Routing\Route as LaravelRoute;
 use Native\Mobile\Events\Screen\ScreenMounted;
 use Native\Mobile\Events\Screen\ScreenResumed;
 use Native\Mobile\Events\Screen\ScreenUnmounted;
@@ -164,6 +165,23 @@ class NativeRouter
         }
     }
 
+    /**
+     * Attach the Laravel route object backing a native route, so navigation
+     * can run its middleware ([ScreenGuard]).
+     *
+     * The INSTANCE is stored, not a snapshot of its middleware: `->middleware()`
+     * chains onto the route after `Route::native()` has already returned, and
+     * group middleware is merged at registration. Holding the object means the
+     * guard reads the final list whenever it runs, however it was assembled.
+     */
+    public static function bindRoute(string $uri, LaravelRoute $route): void
+    {
+        $pattern = '/'.ltrim($uri, '/');
+        if (isset(static::$routes[$pattern])) {
+            static::$routes[$pattern]['route'] = $route;
+        }
+    }
+
     public static function beginGroup(string $layout): void
     {
         static::$currentGroupLayout = $layout;
@@ -186,6 +204,7 @@ class NativeRouter
                 'class' => $entry['class'],
                 'layout' => $entry['layout'] ?? null,
                 'params' => [],
+                'route' => $entry['route'] ?? null,
             ];
         }
 
@@ -201,6 +220,7 @@ class NativeRouter
                     'class' => $entry['class'],
                     'layout' => $entry['layout'] ?? null,
                     'params' => $params,
+                    'route' => $entry['route'] ?? null,
                 ];
             }
         }
@@ -394,6 +414,11 @@ class NativeRouter
                 'component' => $component,
                 'uri' => $uri,
                 'params' => $params,
+                // The launch screen arrived as a real HTTP request, so the
+                // kernel already ran this route's middleware against the real
+                // request. Running it again here would double-count anything
+                // stateful (rate limiters, "last seen" writes).
+                'guarded' => true,
             ];
 
             return $this->loop();
@@ -420,15 +445,30 @@ class NativeRouter
 
             static::debugLog('loop: top, component='.get_class($component).' freshPush='.($freshPush ? 'Y' : 'N').' stack='.count($this->stack));
 
+            // Run the route's middleware before the screen is allowed to
+            // mount. Denial is expressed as a navigation intent on the
+            // component, which runLoop() honors by returning immediately —
+            // so mount() never runs and the guarded screen performs none of
+            // its data loading before being turned away.
+            if ($freshPush && ! ($entry['guarded'] ?? false)) {
+                $entry['guarded'] = true;
+                $denial = $this->guard($component, $entry['uri'] ?? '');
+
+                if ($denial !== null) {
+                    static::debugLog('loop: guard DENIED '.get_class($component)." type={$denial->type} uri={$denial->uri}");
+                    $component->setNavigationIntent($denial);
+                }
+            }
+
             try {
-                if ($freshPush) {
+                if ($freshPush && ! $component->hasNavigationIntent()) {
                     // For #[Lazy] screens, paint the placeholder before the
                     // (potentially slow) mount() so navigation feels instant.
                     $component->publishPlaceholder();
                     static::debugLog('loop: calling mount() on '.get_class($component));
                     $component->mount();
                     $this->announce(new ScreenMounted(get_class($component), $entry['uri'] ?? null));
-                } else {
+                } elseif (! $freshPush) {
                     static::debugLog('loop: calling onResume() on '.get_class($component));
                     $component->onResume();
                     $this->announce(new ScreenResumed(get_class($component), $entry['uri'] ?? null));
@@ -600,6 +640,35 @@ class NativeRouter
     {
         $component->unmount();
         $this->announce(new ScreenUnmounted(get_class($component), $this->currentUri()));
+    }
+
+    /**
+     * Run the target route's middleware for a screen about to mount.
+     * Null means the navigation is allowed.
+     *
+     * A guard that throws is treated as a denial rather than taking the
+     * runloop down: failing open would silently grant access, which is the
+     * bug this whole mechanism exists to fix.
+     */
+    protected function guard(NativeComponent $component, string $uri): ?NavigationIntent
+    {
+        if ($uri === '') {
+            return null;
+        }
+
+        $resolved = static::resolve($uri);
+
+        if ($resolved === null || ($resolved['route'] ?? null) === null) {
+            return null;
+        }
+
+        try {
+            return ScreenGuard::check($resolved['route'], $uri);
+        } catch (\Throwable $e) {
+            static::debugLog('guard FAILED for '.$uri.': '.$e->getMessage());
+
+            return new NavigationIntent(NavigationIntent::BACK);
+        }
     }
 
     /**

--- a/src/Edge/ScreenGuard.php
+++ b/src/Edge/ScreenGuard.php
@@ -110,7 +110,18 @@ class ScreenGuard
             return null;
         }
 
+        // Bind the route to the synthesized request. SubstituteBindings — and
+        // anything else reaching for $route->parameters() — throws "Route is
+        // not bound" otherwise, and since routes registered through
+        // `withRouting(web: ...)` all carry the `web` group, that is the
+        // common case rather than an exotic one.
+        //
+        // A CLONE is bound, never the instance held in Laravel's
+        // RouteCollection: real HTTP requests still match against that one,
+        // and binding mutates it.
+        $route = clone $route;
         $request = static::request($uri, $route);
+        $route->bind($request);
 
         // The pipeline's destination must return a real Response, not null:
         // middleware routinely type-hints `$next($request)` as

--- a/src/Edge/ScreenGuard.php
+++ b/src/Edge/ScreenGuard.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Native\Mobile\Edge;
+
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Http\Request;
+use Illuminate\Pipeline\Pipeline;
+use Illuminate\Routing\Route as LaravelRoute;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+use Symfony\Component\HttpFoundation\RedirectResponse as SymfonyRedirect;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * Runs a native route's middleware before its screen mounts.
+ *
+ * `Route::native()` returns a real Laravel route, so `->middleware('auth')`
+ * — and any group middleware wrapping it — binds exactly as it would on a
+ * web route. The catch is that only the FIRST screen arrives as an HTTP
+ * request; every screen reached by in-app navigation is mounted straight
+ * from the runloop, with no request and no kernel to run a pipeline. That
+ * used to mean the middleware silently did nothing after cold start.
+ *
+ * This runs the same middleware stack against a **synthesized** request for
+ * the target URI. It carries the live session, the launch request's user
+ * resolver, its cookies and its server bag — so session-backed middleware
+ * (auth, verified, can:) resolves the real user. It does NOT carry a body,
+ * query string, uploaded files, or the device's real headers and client IP:
+ * the method is always GET, and anything transport-level reads defaults.
+ * Middleware needing those should opt out via [skip].
+ *
+ * Outcome, per navigation:
+ *
+ *   - pipeline runs to completion  → `null`, the screen mounts
+ *   - middleware returns a redirect → REPLACE onto the matching native
+ *     screen, or EXIT_WEB when the target is not a native route
+ *   - middleware aborts (403, or returns a response) → BACK, the
+ *     navigation is refused and the user stays where they were
+ */
+class ScreenGuard
+{
+    /**
+     * Middleware that must not run per-navigation. These are request-lifecycle
+     * concerns that already ran once for the real HTTP request that launched
+     * the app; re-running them for every screen push would rotate CSRF tokens,
+     * re-open the session, and re-emit cookies against a request that is never
+     * actually sent anywhere.
+     *
+     * @var array<int, class-string>
+     */
+    public const DEFAULT_SKIP = [
+        StartSession::class,
+        AuthenticateSession::class,
+        VerifyCsrfToken::class,
+        EncryptCookies::class,
+        AddQueuedCookiesToResponse::class,
+        ShareErrorsFromSession::class,
+    ];
+
+    /** @var array<int, class-string> */
+    public static array $skip = self::DEFAULT_SKIP;
+
+    /**
+     * Let an app opt additional middleware out of per-navigation execution —
+     * a rate limiter or an analytics logger that should count one visit per
+     * app launch, not one per screen push.
+     *
+     * @param  array<int, class-string>  $middleware
+     */
+    public static function skip(array $middleware): void
+    {
+        static::$skip = array_values(array_unique([...static::$skip, ...$middleware]));
+    }
+
+    /**
+     * Decide whether $uri may be mounted. Null means allow.
+     *
+     * Fails CLOSED: any exception escaping the pipeline (an unresolvable
+     * middleware alias, a guard with a bug) refuses the navigation. Failing
+     * open would silently grant access, which is the failure mode this whole
+     * mechanism exists to remove.
+     */
+    public static function check(?LaravelRoute $route, string $uri): ?NavigationIntent
+    {
+        if ($route === null || $uri === '') {
+            return null;
+        }
+
+        try {
+            return static::run($route, $uri);
+        } catch (\Throwable $e) {
+            NativeRouter::debugLog("ScreenGuard: {$uri} guard threw ".$e::class.': '.$e->getMessage());
+
+            return new NavigationIntent(NavigationIntent::BACK);
+        }
+    }
+
+    protected static function run(LaravelRoute $route, string $uri): ?NavigationIntent
+    {
+        $middleware = static::resolve($route);
+
+        if ($middleware === []) {
+            return null;
+        }
+
+        $request = static::request($uri, $route);
+
+        try {
+            $response = (new Pipeline(app()))
+                ->send($request)
+                ->through($middleware)
+                ->then(fn () => null);
+        } catch (AuthenticationException $e) {
+            return static::redirect($e->redirectTo() ?? static::loginUri(), $uri);
+        } catch (HttpException) {
+            return new NavigationIntent(NavigationIntent::BACK);
+        } catch (HttpResponseException $e) {
+            $response = $e->getResponse();
+        }
+
+        if ($response === null) {
+            return null;
+        }
+
+        if ($response instanceof SymfonyRedirect) {
+            return static::redirect($response->getTargetUrl(), $uri);
+        }
+
+        if ($response instanceof SymfonyResponse && $response->isRedirection()) {
+            return static::redirect((string) $response->headers->get('Location'), $uri);
+        }
+
+        // Middleware short-circuited with a rendered response (a 403 page,
+        // say). There is nothing to render it into on a native screen, so
+        // the navigation is simply refused.
+        return new NavigationIntent(NavigationIntent::BACK);
+    }
+
+    /**
+     * Expand aliases and middleware groups the same way the HTTP kernel
+     * does, then drop the request-lifecycle middleware listed in $skip.
+     *
+     * @return array<int, mixed>
+     */
+    protected static function resolve(LaravelRoute $route): array
+    {
+        $gathered = app('router')->resolveMiddleware(
+            $route->gatherMiddleware(),
+            $route->excludedMiddleware(),
+        );
+
+        return array_values(array_filter(
+            $gathered,
+            fn ($middleware) => ! in_array(
+                is_string($middleware) ? strtok($middleware, ':') : $middleware,
+                static::$skip,
+                true,
+            ),
+        ));
+    }
+
+    /**
+     * A request standing in for the navigation. Cookies, server bag and the
+     * live session/user resolver are carried over from the request that
+     * launched the app so session-backed middleware (auth, verified, can:)
+     * resolves the real user rather than a guest.
+     */
+    protected static function request(string $uri, LaravelRoute $route): Request
+    {
+        $current = app()->bound('request') && app('request') instanceof Request
+            ? app('request')
+            : null;
+
+        $request = Request::create(
+            $uri,
+            'GET',
+            [],
+            $current?->cookies->all() ?? [],
+            [],
+            $current?->server->all() ?? [],
+        );
+
+        $request->setRouteResolver(fn () => $route);
+
+        if ($current !== null) {
+            $request->setUserResolver($current->getUserResolver());
+        }
+
+        // The persistent runtime keeps one session store alive across the
+        // whole app lifetime, so the navigation can read the same session
+        // the launch request opened without StartSession running again.
+        if (app()->bound('session.store')) {
+            $request->setLaravelSession(app('session.store'));
+        }
+
+        return $request;
+    }
+
+    /**
+     * Turn a redirect target into a navigation intent. A target matching a
+     * native route becomes an in-app REPLACE; anything else hands off to the
+     * WebView, which is what a redirect to a non-native URL means on device.
+     */
+    protected static function redirect(?string $target, string $from): NavigationIntent
+    {
+        if ($target === null || $target === '') {
+            return new NavigationIntent(NavigationIntent::BACK);
+        }
+
+        $path = '/'.ltrim((string) (parse_url($target, PHP_URL_PATH) ?: '/'), '/');
+
+        // A guard that redirects to the screen it is guarding would bounce
+        // forever. Refuse the navigation instead of hanging the runloop.
+        if ($path === '/'.ltrim($from, '/')) {
+            NativeRouter::debugLog("ScreenGuard: {$from} redirects to itself — refusing navigation");
+
+            return new NavigationIntent(NavigationIntent::BACK);
+        }
+
+        if (NativeRouter::resolve($path) !== null) {
+            return new NavigationIntent(NavigationIntent::REPLACE, $path);
+        }
+
+        return new NavigationIntent(NavigationIntent::EXIT_WEB, $target);
+    }
+
+    /** Best-effort login URI for an AuthenticationException with no redirect set. */
+    protected static function loginUri(): ?string
+    {
+        try {
+            return app('router')->has('login') ? route('login', absolute: false) : null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Edge/ScreenGuard.php
+++ b/src/Edge/ScreenGuard.php
@@ -8,6 +8,7 @@ use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Routing\Route as LaravelRoute;
 use Illuminate\Session\Middleware\AuthenticateSession;
@@ -111,11 +112,19 @@ class ScreenGuard
 
         $request = static::request($uri, $route);
 
+        // The pipeline's destination must return a real Response, not null:
+        // middleware routinely type-hints `$next($request)` as
+        // `Symfony\...\Response` (Laravel's own `make:middleware` stub does),
+        // and handing it null throws a TypeError. This sentinel is compared
+        // by identity below — getting it back means every middleware called
+        // $next() and nobody short-circuited.
+        $passed = new Response('', SymfonyResponse::HTTP_NO_CONTENT);
+
         try {
             $response = (new Pipeline(app()))
                 ->send($request)
                 ->through($middleware)
-                ->then(fn () => null);
+                ->then(fn () => $passed);
         } catch (AuthenticationException $e) {
             return static::redirect($e->redirectTo() ?? static::loginUri(), $uri);
         } catch (HttpException) {
@@ -124,7 +133,7 @@ class ScreenGuard
             $response = $e->getResponse();
         }
 
-        if ($response === null) {
+        if ($response === $passed || $response === null) {
             return null;
         }
 

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -305,7 +305,7 @@ class NativeServiceProvider extends PackageServiceProvider
         Route::macro('native', function (string $uri, string $componentClass) {
             NativeRouter::register($uri, $componentClass);
 
-            return Route::get($uri, function () use ($componentClass) {
+            $route = Route::get($uri, function () use ($componentClass) {
                 // Native route reached without a native runtime — a shared
                 // app link opened in a plain browser, a crawler, a
                 // misconfigured deploy. The runloop can never satisfy these
@@ -389,6 +389,14 @@ class NativeServiceProvider extends PackageServiceProvider
 
                 return '';
             });
+
+            // Hand the route object to the native registry so in-app
+            // navigation can run this route's middleware too — see
+            // [ScreenGuard]. Stored as the live instance, so middleware
+            // chained AFTER this macro returns is still picked up.
+            NativeRouter::bindRoute($uri, $route);
+
+            return $route;
         });
 
         // Route::nativeGroup(layout: TabsLayout::class, function () { ... })

--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -8,6 +8,7 @@ use Native\Mobile\Edge\NativeComponent;
 use Native\Mobile\Edge\NativeDumpException;
 use Native\Mobile\Edge\NativeRouter;
 use Native\Mobile\Edge\NavigationIntent;
+use Native\Mobile\Edge\ScreenGuard;
 use Native\Mobile\Edge\TailwindParser;
 use Native\Mobile\Edge\Transition;
 use Native\Mobile\Platform;
@@ -155,10 +156,16 @@ class TestableComponent
             "No native route registered for [{$uri}]. Register it with Route::native() or test the component class directly."
         );
 
-        return new static($resolved['class'], $resolved['params'], $data, $resolved['layout'], $platform, $uri);
+        // Run the route's middleware exactly as in-app navigation does, so a
+        // screen guarded by `->middleware('auth')` is testable — mounting the
+        // component class directly bypasses this, which is how a middleware
+        // regression can hide from an otherwise thorough suite.
+        $denial = ScreenGuard::check($resolved['route'] ?? null, $uri);
+
+        return new static($resolved['class'], $resolved['params'], $data, $resolved['layout'], $platform, $uri, $denial);
     }
 
-    protected function __construct(string $componentClass, array $params, array $data, ?string $layout, ?string $platform = null, ?string $uri = null)
+    protected function __construct(string $componentClass, array $params, array $data, ?string $layout, ?string $platform = null, ?string $uri = null, ?NavigationIntent $denial = null)
     {
         $this->bridge = FakeBridge::enable();
         $this->platform = $platform;
@@ -210,7 +217,16 @@ class TestableComponent
             $this->registerNativeEventListeners();
         });
 
-        $this->guard(function () use ($component) {
+        $this->guard(function () use ($component, $denial) {
+            // Middleware refused this navigation — the router turns that into
+            // an intent and never mounts, so neither do we.
+            if ($denial !== null) {
+                $component->setNavigationIntent($denial);
+                $this->lastTree = $this->bridge->lastPublish();
+
+                return;
+            }
+
             // #[Lazy] components paint a placeholder before mount() on
             // device; keep that behavior so the publish is observable.
             $component->publishPlaceholder();

--- a/tests/Feature/NativeRouteMiddlewareTest.php
+++ b/tests/Feature/NativeRouteMiddlewareTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Route;
+use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Edge\ScreenGuard;
+use Native\Mobile\Testing\Native;
+use Tests\Fixtures\Edge\AllowMiddleware;
+use Tests\Fixtures\Edge\CounterScreen;
+use Tests\Fixtures\Edge\DenyMiddleware;
+use Tests\Fixtures\Edge\GuardedScreen;
+
+beforeEach(function () {
+    NativeRouter::clearRoutes();
+    AllowMiddleware::reset();
+    DenyMiddleware::reset();
+    GuardedScreen::reset();
+    ScreenGuard::$skip = ScreenGuard::DEFAULT_SKIP;
+});
+
+afterEach(function () {
+    NativeRouter::clearRoutes();
+});
+
+// ── The reported bug (#252) ─────────────────────────
+
+it('runs route middleware for a screen reached by in-app navigation', function () {
+    Route::native('/guarded', GuardedScreen::class)->middleware(DenyMiddleware::class);
+    Route::native('/login', CounterScreen::class);
+
+    Native::visit('/guarded')->assertReplacedWith('/login');
+
+    expect(DenyMiddleware::$seen)->toBe(['guarded']);
+});
+
+it('never mounts a screen whose middleware refused the navigation', function () {
+    Route::native('/guarded', GuardedScreen::class)->middleware(DenyMiddleware::class);
+    Route::native('/login', CounterScreen::class);
+
+    Native::visit('/guarded')->assertReplacedWith('/login');
+
+    // The whole point: a guarded screen must not run its data loading before
+    // being turned away. A refused navigation publishes no frame either —
+    // there is no render to leak content from.
+    expect(GuardedScreen::$mounts)->toBe(0);
+});
+
+it('mounts the screen when middleware allows the navigation', function () {
+    Route::native('/guarded', GuardedScreen::class)->middleware(AllowMiddleware::class);
+
+    Native::visit('/guarded')->assertSee('Guarded screen content');
+
+    expect(AllowMiddleware::$seen)->toBe(['guarded']);
+    expect(GuardedScreen::$mounts)->toBe(1);
+});
+
+// ── How the middleware gets attached ────────────────
+
+it('picks up middleware chained after Route::native() returns', function () {
+    // The macro hands the live Route object to the registry, so middleware
+    // added by the caller afterwards is still seen at navigation time.
+    Route::native('/guarded', GuardedScreen::class)->middleware(AllowMiddleware::class);
+
+    Native::visit('/guarded');
+
+    expect(AllowMiddleware::$seen)->toBe(['guarded']);
+});
+
+it('picks up middleware from a surrounding route group', function () {
+    // The v3 → v4 migration shape from the issue: a group wrapping many
+    // native routes, with no per-route middleware at all.
+    Route::middleware([DenyMiddleware::class])->group(function () {
+        Route::native('/guarded', GuardedScreen::class);
+    });
+    Route::native('/login', CounterScreen::class);
+
+    Native::visit('/guarded')->assertReplacedWith('/login');
+
+    expect(DenyMiddleware::$seen)->toBe(['guarded']);
+    expect(GuardedScreen::$mounts)->toBe(0);
+});
+
+it('leaves routes without middleware untouched', function () {
+    Route::native('/guarded', GuardedScreen::class);
+
+    Native::visit('/guarded')->assertSee('Guarded screen content');
+
+    expect(GuardedScreen::$mounts)->toBe(1);
+});
+
+// ── Redirect mapping ────────────────────────────────
+
+it('exits to the web when the redirect target is not a native route', function () {
+    DenyMiddleware::$redirectTo = '/billing/upgrade';
+
+    Route::native('/guarded', GuardedScreen::class)->middleware(DenyMiddleware::class);
+
+    // The WebView needs a loadable URL, so EXIT_WEB carries the redirect's
+    // full target rather than just its path.
+    Native::visit('/guarded')->assertExitedToWeb(url('/billing/upgrade'));
+});
+
+it('refuses rather than looping when a guard redirects to its own screen', function () {
+    DenyMiddleware::$redirectTo = '/guarded';
+
+    Route::native('/guarded', GuardedScreen::class)->middleware(DenyMiddleware::class);
+
+    Native::visit('/guarded')->assertWentBack();
+
+    expect(GuardedScreen::$mounts)->toBe(0);
+});
+
+// ── Request-lifecycle middleware is skipped ─────────
+
+it('does not re-run session middleware per navigation', function () {
+    // StartSession et al already ran for the real HTTP request that launched
+    // the app; re-running them per screen push would reopen the session and
+    // rotate CSRF tokens against a request that is never sent anywhere.
+    Route::native('/guarded', GuardedScreen::class)
+        ->middleware([StartSession::class, AllowMiddleware::class]);
+
+    Native::visit('/guarded')->assertSee('Guarded screen content');
+
+    // The non-lifecycle middleware in the same stack still ran.
+    expect(AllowMiddleware::$seen)->toBe(['guarded']);
+});
+
+it('lets an app opt its own middleware out of per-navigation runs', function () {
+    ScreenGuard::skip([AllowMiddleware::class]);
+
+    Route::native('/guarded', GuardedScreen::class)->middleware(AllowMiddleware::class);
+
+    Native::visit('/guarded')->assertSee('Guarded screen content');
+
+    expect(AllowMiddleware::$seen)->toBe([]);
+});
+
+// ── Guard failure must not fail open ────────────────
+
+it('refuses the navigation when the middleware itself blows up', function () {
+    // An unresolvable alias throws inside the pipeline. Failing OPEN here
+    // would silently grant access — the exact bug this mechanism exists to
+    // fix — so the router turns any guard exception into a refusal.
+    Route::native('/guarded', GuardedScreen::class)->middleware('no-such-middleware-alias');
+
+    Native::visit('/guarded')->assertWentBack();
+
+    expect(GuardedScreen::$mounts)->toBe(0);
+});

--- a/tests/Feature/NativeRouteMiddlewareTest.php
+++ b/tests/Feature/NativeRouteMiddlewareTest.php
@@ -1,7 +1,11 @@
 <?php
 
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Native\Mobile\Edge\NativeRouter;
 use Native\Mobile\Edge\ScreenGuard;
 use Native\Mobile\Testing\Native;
@@ -80,6 +84,42 @@ it('picks up middleware from a surrounding route group', function () {
     expect(GuardedScreen::$mounts)->toBe(0);
 });
 
+it('survives the web group that withRouting() puts every native route in', function () {
+    // `withRouting(web: routes/mobile.php)` is the normal way to register
+    // native routes, and it wraps every one of them in the `web` group. Most
+    // of that group is skipped, but SubstituteBindings runs — and it calls
+    // $route->parameters(), which throws "Route is not bound" unless the
+    // route has been bound to the request. Failing closed then refuses every
+    // navigation in the entire app.
+    registerWebGroup();
+
+    Route::middleware('web')->group(function () {
+        Route::native('/plain', GuardedScreen::class);
+        Route::native('/bound/{id}', GuardedScreen::class);
+    });
+
+    Native::visit('/plain')->assertSee('Guarded screen content');
+    Native::visit('/bound/42')->assertSee('Guarded screen content');
+
+    expect(GuardedScreen::$mounts)->toBe(2);
+});
+
+it('does not mutate the route instance the HTTP router matches against', function () {
+    // The guard binds a clone; binding the registry's own instance would
+    // leave stale parameters on the route real requests still match.
+    registerWebGroup();
+
+    Route::middleware('web')->group(function () {
+        Route::native('/bound/{id}', GuardedScreen::class);
+    });
+
+    Native::visit('/bound/42');
+
+    $route = NativeRouter::resolve('/bound/42')['route'];
+
+    expect(fn () => $route->parameters())->toThrow(LogicException::class);
+});
+
 it('leaves routes without middleware untouched', function () {
     Route::native('/guarded', GuardedScreen::class);
 
@@ -147,3 +187,19 @@ it('refuses the navigation when the middleware itself blows up', function () {
 
     expect(GuardedScreen::$mounts)->toBe(0);
 });
+
+/**
+ * The `web` group as a real app has it. Testbench doesn't register one, but
+ * `withRouting(web: routes/mobile.php)` puts every native route inside it —
+ * so this is the shape the guard actually meets in production.
+ */
+function registerWebGroup(): void
+{
+    app('router')->middlewareGroup('web', [
+        EncryptCookies::class,
+        AddQueuedCookiesToResponse::class,
+        StartSession::class,
+        ShareErrorsFromSession::class,
+        SubstituteBindings::class,
+    ]);
+}

--- a/tests/Fixtures/Edge/AllowMiddleware.php
+++ b/tests/Fixtures/Edge/AllowMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Closure;
+use Illuminate\Http\Request;
+
+/** Passes the request straight through, recording that it ran. */
+class AllowMiddleware
+{
+    /** Every URI this middleware was asked to authorize, in order. */
+    public static array $seen = [];
+
+    public static function reset(): void
+    {
+        static::$seen = [];
+    }
+
+    public function handle(Request $request, Closure $next)
+    {
+        static::$seen[] = $request->path();
+
+        return $next($request);
+    }
+}

--- a/tests/Fixtures/Edge/AllowMiddleware.php
+++ b/tests/Fixtures/Edge/AllowMiddleware.php
@@ -4,8 +4,15 @@ namespace Tests\Fixtures\Edge;
 
 use Closure;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
 
-/** Passes the request straight through, recording that it ran. */
+/**
+ * Passes the request straight through, recording that it ran.
+ *
+ * The `: Response` return type is load-bearing, not decoration — it is what
+ * Laravel's own `make:middleware` stub generates, and it means the guard's
+ * pipeline destination MUST return a real Response rather than null.
+ */
 class AllowMiddleware
 {
     /** Every URI this middleware was asked to authorize, in order. */
@@ -16,7 +23,7 @@ class AllowMiddleware
         static::$seen = [];
     }
 
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next): Response
     {
         static::$seen[] = $request->path();
 

--- a/tests/Fixtures/Edge/DenyMiddleware.php
+++ b/tests/Fixtures/Edge/DenyMiddleware.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Closure;
+use Illuminate\Http\Request;
+
+/**
+ * Stands in for `auth` — refuses the request and redirects, which is the
+ * shape almost every real screen guard takes.
+ */
+class DenyMiddleware
+{
+    /** Every URI this middleware was asked to authorize, in order. */
+    public static array $seen = [];
+
+    public static string $redirectTo = '/login';
+
+    public static function reset(): void
+    {
+        static::$seen = [];
+        static::$redirectTo = '/login';
+    }
+
+    public function handle(Request $request, Closure $next)
+    {
+        static::$seen[] = $request->path();
+
+        return redirect(static::$redirectTo);
+    }
+}

--- a/tests/Fixtures/Edge/GuardedScreen.php
+++ b/tests/Fixtures/Edge/GuardedScreen.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\Elements\Text;
+use Native\Mobile\Edge\NativeComponent;
+
+/**
+ * Records whether it ever mounted, so a guarded navigation can assert the
+ * screen performed none of its data loading before being turned away.
+ */
+class GuardedScreen extends NativeComponent
+{
+    public static int $mounts = 0;
+
+    public static function reset(): void
+    {
+        static::$mounts = 0;
+    }
+
+    public function mount(): void
+    {
+        static::$mounts++;
+    }
+
+    public function render(): Element
+    {
+        return Column::make(
+            Text::make('Guarded screen content'),
+        );
+    }
+}


### PR DESCRIPTION
Fixes #252. Docs PR: NativePHP/nativephp.com#474

## The bug

`Route::native()` returns a real Laravel route, so this binds exactly as it would on a web route — and looks like it works:

```php
Route::middleware(['auth.device', 'auth.lock'])->group(function () {
    Route::native('/', Dashboard::class);
    // …13 more
});
```

It only ever ran for the screen the app launched into, because that screen alone arrives as an HTTP request. Every screen reached by in-app navigation resolves through `NativeRouter::loop()` and mounts the component directly — no request, no kernel, no pipeline.

So a v3 → v4 migration that moved routes out of a middleware group **silently dropped every guard**, with nothing failing and nothing logged. As the reporter notes, component tests can't catch it either, because they mount screens directly.

Worth being precise about the depth of it: the middleware wasn't merely unapplied, it was **never recorded**. `NativeRouter::register()` stored `class` + `layout` only, so `resolve()` couldn't have applied it even in principle.

## Approach

`->middleware()` should work, because that's the Laravel way — so this makes it work rather than inventing a parallel API or just erroring.

**Capture.** `Route::native()` now hands the live `Route` object to the native registry. The instance, not a snapshot of its middleware: `->middleware()` chains on *after* the macro returns, and group middleware is merged at registration. Holding the object means the guard reads the final list however it was assembled. Both spellings above work with **no change to app code**.

**Execution.** `ScreenGuard` runs that stack against a synthesized `GET` request for the target URI, through Laravel's own `Pipeline`, before the screen mounts.

The synthesized request is the deliberate trade-off, and it's documented rather than hidden. It carries the live session, the launch request's user resolver, its cookies and server bag — so `auth`, `verified`, and `can:` resolve the real user. It does **not** carry a body, query string, uploaded files, or the device's real headers and client IP. Middleware that needs those should opt out.

**Skipped by default.** Request-lifecycle middleware — `StartSession`, `AuthenticateSession`, `VerifyCsrfToken`, `EncryptCookies`, `AddQueuedCookiesToResponse`, `ShareErrorsFromSession`. Each ran once for the real launch request; re-running per screen push would reopen the session and rotate CSRF tokens against a request that is never sent anywhere. Apps can add their own via `ScreenGuard::skip([...])` for things that should count once per launch rather than once per screen.

**Denial** maps onto the navigation intents that already exist:

| Middleware does | Native result |
|---|---|
| passes through | screen mounts |
| redirects to a native route | `REPLACE` onto that screen |
| redirects elsewhere | `EXIT_WEB` with the full URL |
| throws `AuthenticationException` | redirect to `redirectTo()`, else the `login` route |
| aborts (403) / returns a response | `BACK` — refused, user stays put |

## Two guarantees

**A refused screen never mounts.** The guard runs before `mount()`, so a guarded screen performs none of its data loading — no queries, no API calls — and publishes no frame. This is why the check sits in `loop()` ahead of `mount()` rather than inside the component.

**It fails closed.** Middleware that throws (unresolvable alias, a bug in a guard) refuses the navigation. Failing open would silently grant access, which is precisely the bug being fixed.

Also handled: cold start is marked already-guarded so the kernel's real run isn't double-counted (this matters for anything stateful, like rate limiters); and a guard redirecting to the screen it guards is detected rather than looping the runloop forever.

## Testability

`Native::visit()` now runs guards, so the regression class is finally catchable:

```php
Native::visit('/dashboard')->assertReplacedWith('/login');
```

`Native::test(Dashboard::class)` still mounts directly and deliberately does **not** run middleware — it has no route. That distinction is documented, since a suite built only on `Native::test()` is exactly what let this hide.

## Tests

11 new tests in `NativeRouteMiddlewareTest`, covering in-app navigation, mount suppression, group middleware, middleware chained after the macro, redirect mapping (native / web / self-redirect loop), the skip list, opt-out, and fail-closed.

**9 of the 11 fail** when the guard is stubbed out to simulate pre-fix behavior. The two that pass are the correct controls — the no-middleware route and the opted-out middleware.

Suite before: 901 tests / 3021 assertions / 0 failures. After: 912 / 3072 / 0 failures.

## Review notes

The parts most worth a second opinion:

- **The default skip list** — whether it's the right set, and whether skipping should be opt-in rather than opt-out. Skipping too little risks side effects per navigation; skipping too much reintroduces "some of your middleware silently doesn't run", which is this bug.
- **`EXIT_WEB` on a non-native redirect target.** Reasonable for `auth` redirecting to a web login, but it does mean a misconfigured redirect drops the user out of the native app.
- **Non-redirect denials become `BACK`.** With nothing on the stack there is nowhere to go back to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Two bugs found by running the demo app, not the suite

Both were in this branch and are fixed here. Recording them because each exposed a blind spot in the tests, and the tests were extended to cover them.

**1. The pipeline destination returned `null`.** Middleware routinely type-hints its return as `Symfony\...\Response` — Laravel's own `make:middleware` stub generates exactly that — so handing `$next($request)` a null destination throws a `TypeError`. The guard fails closed, so **any typed middleware that allowed a navigation silently refused it instead**. The destination now returns an empty 204 sentinel compared by identity. The `AllowMiddleware` fixture had no return type, which is why the suite was happy; it now carries `: Response`, and both allow-path tests fail without the fix.

**2. The route was never bound to the synthesized request.** `SubstituteBindings` calls `$route->parameters()`, which throws `LogicException: Route is not bound`. Failing closed turned that into a refusal — and since `withRouting(web: routes/mobile.php)` puts **every** native route in the `web` group, and `SubstituteBindings` is the one member of that group not on the skip list, this refused **every navigation in a normally-configured app**. Nothing was clickable.

Now a *clone* of the route is bound, so the instance in Laravel's `RouteCollection` — which real HTTP requests still match against — is never mutated.

The suite missed this because every test registered routes bare, with no group, so no `web` middleware was ever gathered. Testbench registers no `web` group either, so two new tests install the real one and exercise it: navigation through `web` both parameterised and not, plus the guarantee that the registry's route instance is left unbound. Both fail without the fix.

Suite now: 914 tests / 3083 assertions / 0 failures, against a 901 / 3021 baseline on `main`.

## One consequence worth a reviewer's opinion

Because `withRouting(web: ...)` is the standard setup, this guard runs on essentially every navigation in every app, not only on routes the developer explicitly guarded. That is what makes the fail-closed behavior high-stakes: a middleware that throws for any reason takes out *all* navigation, as bug 2 demonstrated.

Fail-closed is still right for a security control — failing open silently drops guards, which is #252 itself. But it does mean a configuration error degrades to "the app is frozen" rather than "one screen is unreachable". Worth deciding whether that trade is acceptable, or whether a guard exception should be loud (error screen) instead of silent (refused navigation).
