### PR TITLE
Stop a theme border overruling an explicit border width

### DIFF
--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -296,6 +296,12 @@ class TailwindParser
             $result = array_merge($result, $parsed);
         }
 
+        // Apply a theme border's implied width only where no class set one explicitly.
+        if (isset($result['borderWidthDefault'])) {
+            $result['borderWidth'] ??= $result['borderWidthDefault'];
+            unset($result['borderWidthDefault']);
+        }
+
         self::$cache[$classString] = $result;
         self::$unsupportedCache[$classString] = array_keys($unsupported);
         self::recordUnsupported(self::$unsupportedCache[$classString]);
@@ -1136,7 +1142,12 @@ class TailwindParser
             return null;
         }
         $dark = self::resolveThemeToken($token, true);
-        $out = ['borderColor' => $light, 'borderWidth' => 1];
+        // borderWidthDefault, not borderWidth: a theme border needs *a* width to be
+        // visible at all, but must not overrule an explicit one. Asserting
+        // borderWidth here made `border-2 border-theme-outline` render 1px, while the
+        // reverse order rendered 2px — an order dependence with no visible cause.
+        // parse() resolves this key at the end, so the outcome is order-independent.
+        $out = ['borderColor' => $light, 'borderWidthDefault' => 1];
         if ($dark !== null && $dark !== $light) {
             $out['dark'] = ['borderColor' => $dark];
         }

--- a/tests/Unit/Edge/ThemeClassTokensTest.php
+++ b/tests/Unit/Edge/ThemeClassTokensTest.php
@@ -46,6 +46,28 @@ it('applies the opacity modifier to the dark companion too', function () {
         ->and($parsed['dark']['bg'])->toBe('#80FFA85C');
 });
 
+it('lets an explicit border width beat the one a theme border implies', function () {
+    // A theme border needs *a* width to be visible at all, but asserting one made the
+    // outcome depend on class order: `border-2 border-theme-primary` rendered 1px while
+    // `border-theme-primary border-2` rendered 2px, with nothing on screen to explain it.
+    expect(TailwindParser::parse('border-2 border-theme-primary'))
+        ->toMatchArray(['borderColor' => '#FF6B00', 'borderWidth' => 2])
+        ->and(TailwindParser::parse('border-theme-primary border-2'))
+        ->toMatchArray(['borderColor' => '#FF6B00', 'borderWidth' => 2]);
+});
+
+it('still gives a bare theme border a width of its own', function () {
+    expect(TailwindParser::parse('border-theme-success'))
+        ->toBe(['borderColor' => '#00E475', 'borderWidth' => 1]);
+});
+
+it('never leaks the internal default-width key into the parsed output', function () {
+    // parse() resolves it at the end; the renderers read this array directly, so a
+    // leftover key would reach the wire as an unknown style prop.
+    expect(TailwindParser::parse('border-theme-primary'))->not->toHaveKey('borderWidthDefault')
+        ->and(TailwindParser::parse('border-4 border-theme-primary'))->not->toHaveKey('borderWidthDefault');
+});
+
 it('leaves unknown theme tokens unresolved rather than guessing', function () {
     expect(TailwindParser::parse('bg-theme-nonexistent'))->toBe([]);
 });


### PR DESCRIPTION
### The bug

`border-theme-*` has to imply *a* width — without one a theme border is invisible — but it asserted `borderWidth => 1` outright. `TailwindParser::parse()` merges each token's result in string order, so the implied width overwrote an explicit one whenever the theme class came second:

```php
TailwindParser::parse('border-2 border-theme-primary');  // borderWidth => 1  ❌
TailwindParser::parse('border-theme-primary border-2');  // borderWidth => 2  ✅
```

Same two classes, same intent, different result depending on the order they were typed — and nothing on the device hints at why, since both classes are present and one of them silently wins.

### The fix

A theme border now emits `borderWidthDefault`, and `parse()` collapses that into `borderWidth` at the very end, only when no class set one explicitly. The outcome no longer depends on order, and the internal key never reaches the parsed output — a bare `border-theme-primary` produces exactly what it produced before.

### Verification

- Three tests added to `tests/Unit/Edge/ThemeClassTokensTest.php`: both class orders, a bare theme border keeping its 1px, and the internal key never leaking into the output.
- The precedence test fails against `main` and passes with this change.
- `vendor/bin/pest` for the Edge suites: 114 passed. Full suite matches `main`'s baseline — the 13 failures on both are in the Android splash-screen and release-build tests and are unrelated to this change.
- `vendor/bin/pint --test` clean on both touched files.

`border border-theme-outline` pairs appear in super-native's own templates, so this affects the demo as well as apps.