### PR TITLE
Resolve a theme token under dark: to its dark value

### DIFF
--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -476,6 +476,22 @@ class TailwindParser
                 return null;
             }
 
+            // A theme token resolves its own dark companion, so wrapping it blindly
+            // buried that companion a level deeper — where the merge in parse() never
+            // lifts it — and left the LIGHT hex sitting in the dark slot:
+            //
+            //   dark:bg-theme-surface
+            //     was  {dark: {bg: #FFF, dark: {bg: #000}}}   → white in dark mode
+            //     now  {dark: {bg: #000}}                     → black in dark mode
+            //
+            // Asking for a theme token under `dark:` can only mean its dark-mode form,
+            // so promote the companion rather than nest it.
+            if (isset($inner['dark']) && is_array($inner['dark'])) {
+                $companion = $inner['dark'];
+                unset($inner['dark']);
+                $inner = array_merge($inner, $companion);
+            }
+
             return ['dark' => $inner];
         }
 

--- a/tests/Unit/Edge/ThemeClassTokensTest.php
+++ b/tests/Unit/Edge/ThemeClassTokensTest.php
@@ -46,6 +46,27 @@ it('applies the opacity modifier to the dark companion too', function () {
         ->and($parsed['dark']['bg'])->toBe('#80FFA85C');
 });
 
+it('resolves a theme token under dark: to that token\'s dark value', function () {
+    // A theme token already carries its own dark companion, so wrapping the result in
+    // another `dark` layer buried the companion where parse()'s merge never lifts it —
+    // and left the LIGHT hex sitting in the dark slot, i.e. white in dark mode.
+    expect(TailwindParser::parse('dark:bg-theme-primary'))->toBe(['dark' => ['bg' => '#FFA85C']]);
+});
+
+it('keeps a dark: theme token that has no dark companion on its light value', function () {
+    // `success` resolves light-only. Asking for it under dark: can then only mean the
+    // one colour it has, rather than nothing at all.
+    expect(TailwindParser::parse('dark:bg-theme-success'))->toBe(['dark' => ['bg' => '#00E475']]);
+});
+
+it('pairs a bare theme token with its companion as before', function () {
+    // The unprefixed form is unchanged: light at the top, dark alongside it.
+    // toEqual, not toBe: the parser emits the companion before the light value and the
+    // order of the keys is not part of the contract the renderers read.
+    expect(TailwindParser::parse('bg-theme-primary'))
+        ->toEqual(['bg' => '#FF6B00', 'dark' => ['bg' => '#FFA85C']]);
+});
+
 it('leaves unknown theme tokens unresolved rather than guessing', function () {
     expect(TailwindParser::parse('bg-theme-nonexistent'))->toBe([]);
 });


### PR DESCRIPTION
### The bug

`dark:bg-theme-surface` renders the **light** colour in dark mode.

A theme token resolves its own dark companion, so `bg-theme-surface` already returns `['bg' => light, 'dark' => ['bg' => dark]]`. The `dark:` prefix then wrapped that entire result in a second `dark` layer:

```php
TailwindParser::parse('dark:bg-theme-primary');
// was  ['dark' => ['bg' => '#FF6B00', 'dark' => ['bg' => '#FFA85C']]]
// now  ['dark' => ['bg' => '#FFA85C']]
```

`parse()` merges one `dark` level, so the buried companion is never lifted: the light hex ends up in the dark slot, and the nested `dark` key travels to the renderers as a prop they know nothing about.

### The fix

Asking for a theme token under `dark:` can only mean that token's dark-mode form, so the companion is promoted instead of nested. A token whose resolver answers light-only keeps its single colour — the only sensible reading of the request, and the same thing the unprefixed form does.

The unprefixed path is untouched.

### Verification

- Three tests added to `tests/Unit/Edge/ThemeClassTokensTest.php`: the dark-companion case, the light-only case, and the unprefixed shape staying exactly as it was.
- The first fails against `main` and passes with this change.
- `vendor/bin/pest tests/Unit/Edge/`: 276 passed. Full-suite failures match `main`'s baseline (Android splash-screen and release-build tests, unrelated).
- `vendor/bin/pint --test` clean on both touched files.