### PR TITLE
Make optional route segments resolvable

### DIFF
--- a/src/Edge/NativeRouter.php
+++ b/src/Edge/NativeRouter.php
@@ -191,11 +191,26 @@ class NativeRouter
 
         // Pattern match with route parameters
         foreach (static::$routes as $pattern => $entry) {
-            $regex = preg_replace('/\{(\w+)\}/', '(?P<$1>[^/]+)', $pattern);
+            // Optional segments FIRST, and consuming their leading slash: `\w` does not
+            // match `?`, so a `{slug?}` placeholder previously survived into the regex
+            // literally and the pattern could only ever match the string "{slug?}".
+            // BootPlanner on both platforms matches these patterns happily, so a route
+            // using the documented `{param?}` syntax booted into the native runloop and
+            // then resolved to no screen at all — /posts/{slug?} matched neither
+            // /posts/hello nor /posts.
+            $regex = preg_replace('#/\{(\w+)\?\}#', '(?:/(?P<$1>[^/]+))?', $pattern);
+            $regex = preg_replace('/\{(\w+)\}/', '(?P<$1>[^/]+)', $regex);
             $regex = '#^'.$regex.'$#';
 
             if (preg_match($regex, $uri, $matches)) {
-                $params = array_filter($matches, fn ($key) => is_string($key), ARRAY_FILTER_USE_KEY);
+                // An omitted optional segment reports as an empty string; drop those so
+                // a screen sees a missing parameter rather than a blank one. `[^/]+`
+                // cannot match empty, so nothing legitimate is lost.
+                $params = array_filter(
+                    $matches,
+                    fn ($value, $key) => is_string($key) && $value !== '',
+                    ARRAY_FILTER_USE_BOTH
+                );
 
                 return [
                     'class' => $entry['class'],

--- a/tests/Unit/Edge/NativeRouterOptionalParamsTest.php
+++ b/tests/Unit/Edge/NativeRouterOptionalParamsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use Native\Mobile\Edge\NativeRouter;
+use Tests\Fixtures\Edge\CounterScreen;
+
+// `{param?}` is the documented optional-segment syntax, but `\w` does not match `?`, so
+// the placeholder survived into the regex literally and the pattern could only ever match
+// the string "{param?}". BootPlanner (both platforms) matches these patterns happily, so a
+// route written this way booted into the native runloop and then resolved to no screen at
+// all — with or without the segment present.
+
+beforeEach(fn () => NativeRouter::clearRoutes());
+afterEach(fn () => NativeRouter::clearRoutes());
+
+it('resolves an optional segment when it is present', function () {
+    NativeRouter::register('/posts/{slug?}', CounterScreen::class);
+
+    $resolved = NativeRouter::resolve('/posts/hello-world');
+
+    expect($resolved)->not->toBeNull()
+        ->and($resolved['class'])->toBe(CounterScreen::class)
+        ->and($resolved['params'])->toBe(['slug' => 'hello-world']);
+});
+
+it('resolves the same route when the optional segment is omitted', function () {
+    NativeRouter::register('/posts/{slug?}', CounterScreen::class);
+
+    $resolved = NativeRouter::resolve('/posts');
+
+    expect($resolved)->not->toBeNull()
+        ->and($resolved['class'])->toBe(CounterScreen::class)
+        // Absent, not blank: a screen checks whether it has the parameter, and an empty
+        // string would answer yes.
+        ->and($resolved['params'])->toBe([]);
+});
+
+it('reports both forms as native routes, which is what the hosts ask', function () {
+    // BootPlanner decides the boot mode from this answer, so disagreeing with resolve()
+    // is what produced a native launch with nothing to show.
+    NativeRouter::register('/posts/{slug?}', CounterScreen::class);
+
+    expect(NativeRouter::isNativeRoute('/posts/hello'))->toBeTrue()
+        ->and(NativeRouter::isNativeRoute('/posts'))->toBeTrue();
+});
+
+it('still requires a required segment', function () {
+    NativeRouter::register('/posts/{slug}', CounterScreen::class);
+
+    expect(NativeRouter::resolve('/posts/hello'))->not->toBeNull()
+        ->and(NativeRouter::resolve('/posts'))->toBeNull();
+});
+
+it('handles an optional segment after a required one', function () {
+    NativeRouter::register('/users/{id}/posts/{slug?}', CounterScreen::class);
+
+    expect(NativeRouter::resolve('/users/7/posts/hello')['params'])->toBe(['id' => '7', 'slug' => 'hello'])
+        ->and(NativeRouter::resolve('/users/7/posts')['params'])->toBe(['id' => '7'])
+        ->and(NativeRouter::resolve('/users/7'))->toBeNull();
+});
+
+it('does not let an optional segment swallow a deeper path', function () {
+    NativeRouter::register('/posts/{slug?}', CounterScreen::class);
+
+    expect(NativeRouter::resolve('/posts/2026/august'))->toBeNull();
+});


### PR DESCRIPTION
### The bug

```php
Route::native('/posts/{slug?}', PostScreen::class);
```

This route cannot match any URI at all — not `/posts/hello`, not `/posts`.

`NativeRouter::resolve()` compiles its pattern with `preg_replace('/\{(\w+)\}/', '(?P<$1>[^/]+)', $pattern)`, and `\w` does not match `?`. The `{slug?}` placeholder therefore survives into the regex verbatim, so the compiled pattern only ever matches the literal string `/posts/{slug?}`.

What turns a dead pattern into a device-visible failure: `BootPlanner` on both Android and iOS matches these patterns when it decides whether to boot native. An app using the documented optional syntax boots into the native runloop and *then* resolves to no screen — a blank native window instead of the WebView fallback that would otherwise have carried it.

### The fix

- Optional segments are substituted first, and the pattern consumes the leading slash with them (`#/\{(\w+)\?\}#` → `(?:/(?P<$1>[^/]+))?`), so the segment and its separator disappear together and `/posts` matches.
- An omitted segment is dropped from `params` rather than reported as `''`. A screen checking whether it received a parameter should not be told yes for a segment nobody sent. `[^/]+` cannot match empty, so no legitimate value is filtered.

Required segments are unaffected.

### Verification

New `tests/Unit/Edge/NativeRouterOptionalParamsTest.php` — 6 cases: segment present, segment omitted, `isNativeRoute()` agreeing with `resolve()` for both (the BootPlanner half), required segments still required, an optional segment after a required one, and an optional segment not swallowing a deeper path.

4 of the 6 fail against `main`. Full suite: 887 passed, and the 13 failures are identical to `main`'s baseline (Android splash-screen and release-build tests, unrelated to this change). `vendor/bin/pint --test` clean.