### PR TITLE
Stop the callback expression parser corrupting and dropping arguments

### DIFF
--- a/src/Edge/CallbackRegistry.php
+++ b/src/Edge/CallbackRegistry.php
@@ -200,10 +200,86 @@ class CallbackRegistry
             return ['method' => $method, 'args' => []];
         }
 
-        // Convert single quotes to double for JSON compatibility
-        $json = '['.str_replace("'", '"', $argsString).']';
+        $json = '['.self::toJsonArgs($argsString).']';
         $args = json_decode($json, true);
 
-        return ['method' => $method, 'args' => $args ?? []];
+        if (! is_array($args)) {
+            // Still `[]`, because callers spread this (NativeComponent.php:3316, :3371)
+            // and a null would be a TypeError — changing the contract belongs in its own
+            // change, not a bug fix. But it is no longer *silent*: previously a handler
+            // was invoked with no arguments and nothing said so anywhere.
+            error_log("CallbackRegistry: could not parse arguments for '{$expression}' — calling {$method}() with none.");
+
+            return ['method' => $method, 'args' => []];
+        }
+
+        return ['method' => $method, 'args' => $args];
+    }
+
+    /**
+     * Convert PHP-style single-quoted argument literals to JSON.
+     *
+     * The previous `str_replace("'", '"')` rewrote every apostrophe in the string,
+     * whatever its role, which produced three distinct silent failures:
+     *
+     *   save("don't")        → args dropped entirely (invalid JSON)
+     *   setName('O'Brien')   → args dropped entirely
+     *   rename('it\'s fine') → args CORRUPTED to `it"s fine` — no error, wrong data
+     *
+     * The third is the dangerous one: the handler runs, with a value the author never
+     * wrote. So the conversion now tracks which quote actually opened the current
+     * string and leaves apostrophes inside double-quoted strings alone.
+     */
+    private static function toJsonArgs(string $args): string
+    {
+        $out = '';
+        $quote = null;
+        $length = strlen($args);
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = $args[$i];
+
+            if ($quote !== null && $char === '\\' && $i + 1 < $length) {
+                $next = $args[$i + 1];
+                // \' is only an escape inside a single-quoted literal, and JSON has no
+                // such escape — emit the bare apostrophe.
+                if ($quote === "'" && $next === "'") {
+                    $out .= "'";
+                } else {
+                    $out .= $char.$next;
+                }
+                $i++;
+
+                continue;
+            }
+
+            if ($quote === null && ($char === "'" || $char === '"')) {
+                $quote = $char;
+                $out .= '"';
+
+                continue;
+            }
+
+            if ($char === $quote) {
+                $quote = null;
+                $out .= '"';
+
+                continue;
+            }
+
+            // A double quote inside a single-quoted literal is data, not a delimiter, so
+            // it has to be escaped rather than rewritten. (The mirror case needs no
+            // branch: a double quote inside a double-quoted string closes it above,
+            // which is what PHP's own tokenizer does with an unescaped one.)
+            if ($quote === "'" && $char === '"') {
+                $out .= '\\"';
+
+                continue;
+            }
+
+            $out .= $char;
+        }
+
+        return $out;
     }
 }

--- a/tests/Unit/Edge/CallbackRegistryTest.php
+++ b/tests/Unit/Edge/CallbackRegistryTest.php
@@ -70,3 +70,45 @@ it('exposes stored navigation configs keyed by stable content-addressed keys', f
         // Same config re-registered anywhere reproduces the identical key.
         ->and((new CallbackRegistry)->registerNavigation(['uri' => '/detail/7']))->toBe($key);
 });
+
+// ── Argument literals ───────────────────────────────
+
+// The conversion to JSON used to be `str_replace("'", '"')`, which rewrote every
+// apostrophe whatever its role. Three silent failures came out of that, and the
+// third is the one worth the guard: the handler runs, with data nobody wrote.
+
+it('keeps an apostrophe inside a double-quoted argument', function () {
+    expect(CallbackRegistry::parse('save("don\'t")'))
+        ->toBe(['method' => 'save', 'args' => ["don't"]]);
+});
+
+it('keeps an escaped apostrophe inside a single-quoted argument', function () {
+    // Previously became `it"s fine` — no error, wrong value, handler invoked anyway.
+    expect(CallbackRegistry::parse("rename('it\\'s fine')"))
+        ->toBe(['method' => 'rename', 'args' => ["it's fine"]]);
+});
+
+it('keeps a double quote inside a single-quoted argument', function () {
+    expect(CallbackRegistry::parse("say('he said \"hi\"')"))
+        ->toBe(['method' => 'say', 'args' => ['he said "hi"']]);
+});
+
+it('still parses the ordinary literals', function () {
+    expect(CallbackRegistry::parse('add(5)'))->toBe(['method' => 'add', 'args' => [5]])
+        ->and(CallbackRegistry::parse("setName('Ada')"))->toBe(['method' => 'setName', 'args' => ['Ada']])
+        ->and(CallbackRegistry::parse('flag(true, null)'))->toBe(['method' => 'flag', 'args' => [true, null]])
+        ->and(CallbackRegistry::parse("pair('a', 'b')"))->toBe(['method' => 'pair', 'args' => ['a', 'b']])
+        ->and(CallbackRegistry::parse('increment'))->toBe(['method' => 'increment', 'args' => []])
+        ->and(CallbackRegistry::parse('reset()'))->toBe(['method' => 'reset', 'args' => []]);
+});
+
+it('keeps a comma inside a quoted argument out of the argument split', function () {
+    expect(CallbackRegistry::parse("greet('Hello, world')"))
+        ->toBe(['method' => 'greet', 'args' => ['Hello, world']]);
+});
+
+it('falls back to no arguments for an expression it cannot parse', function () {
+    // The contract callers rely on (they spread the result), but no longer silent.
+    expect(CallbackRegistry::parse('save(this is not a literal)'))
+        ->toBe(['method' => 'save', 'args' => []]);
+});


### PR DESCRIPTION
### The bug

`CallbackRegistry::parse()` converted argument literals to JSON with `str_replace("'", '"')`, which rewrites every apostrophe in the expression regardless of its role. Three distinct failures, none of which reports anything:

| Expression | Result |
|---|---|
| `save("don't")` | arguments **dropped** — the apostrophe becomes a quote, the JSON is invalid |
| `setName('O'Brien')` | arguments **dropped** |
| `rename('it\'s fine')` | arguments **corrupted** to `it"s fine` |

The third is the one worth being careful about: `json_decode` succeeds, so the handler runs — with a value the author never wrote. The first two invoke the handler with no arguments at all, which for something like `save($draft)` looks exactly like a call that worked.

### The fix

The conversion now walks the string tracking which quote opened the current literal:

- an apostrophe inside a double-quoted literal is data and stays put;
- `\'` inside a single-quoted literal becomes a bare apostrophe, since JSON has no such escape;
- a double quote inside a single-quoted literal is escaped rather than rewritten.

An expression that still cannot be parsed keeps the existing contract — `args => []`, because callers spread the result and a `null` would be a TypeError — but it now says so via `error_log` instead of failing silently. Changing that contract felt like it belongs in its own change rather than a bug fix.

### Verification

Six cases added to `tests/Unit/Edge/CallbackRegistryTest.php`: apostrophe in a double-quoted argument, escaped apostrophe in a single-quoted one, double quote inside a single-quoted one, the ordinary literals (int, string, bool, null, multiple args, no parens, empty parens), a comma inside a quoted argument, and the unparseable fallback.

Three fail against `main`. Full suite: 887 passed, with the 13 failures identical to `main`'s baseline (Android splash-screen and release-build tests, unrelated). `vendor/bin/pint` clean.