### PR TITLE
Symmetric keyboard dismissal with keep-focus-on-submit as the escape hatch

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/KeyboardFocusPolicy.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/KeyboardFocusPolicy.kt
@@ -1,0 +1,32 @@
+package com.nativephp.mobile.ui.nativerender
+
+/**
+ * Focus policy shared between the text-input renderers, which know
+ * whether the focused field opted into `keep-focus-on-submit`, and
+ * the gesture layer, which decides whether a tap on an interactive
+ * element should also dismiss the keyboard (mobile-air #335).
+ */
+object KeyboardFocusPolicy {
+    /** Set by the input renderers on every focus change, cleared on blur. */
+    @Volatile
+    var focusedFieldKeepsFocus = false
+
+    /**
+     * Registered by the root renderer from composition, since gesture
+     * modifiers run outside composable scope and cannot reach the
+     * FocusManager themselves. Cleared when the root leaves.
+     */
+    @Volatile
+    var clearFocus: (() -> Unit)? = null
+
+    /**
+     * Clear focus for a tap on an interactive element, unless the focused
+     * field asked to keep focus through sends. Plain-area taps skip
+     * this and always clear, so tap-away keeps working.
+     */
+    fun dismissForInteractiveTap() {
+        if (!focusedFieldKeepsFocus) {
+            clearFocus?.invoke()
+        }
+    }
+}

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeUIRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeUIRenderer.kt
@@ -54,6 +54,16 @@ fun NativeUIContent() {
 
     val focusManager = LocalFocusManager.current
 
+    // Gesture modifiers dispatch @press outside composable scope, so the
+    // policy carries a clear-focus hook for them; interactive taps route
+    // through it and honor `keep-focus-on-submit` (mobile-air #335).
+    DisposableEffect(focusManager) {
+        KeyboardFocusPolicy.clearFocus = { focusManager.clearFocus() }
+        onDispose {
+            KeyboardFocusPolicy.clearFocus = null
+        }
+    }
+
     BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
@@ -62,7 +72,9 @@ fun NativeUIContent() {
                 indication = null,
                 interactionSource = remember { MutableInteractionSource() }
             ) {
-                // Tap outside any input dismisses keyboard
+                // Tap on a plain area dismisses the keyboard. Fires only for
+                // taps no child consumed; interactive elements dismiss via
+                // KeyboardFocusPolicy in their own handlers instead.
                 focusManager.clearFocus()
             }
     ) {

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeModifiers.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeModifiers.kt
@@ -328,19 +328,26 @@ fun Modifier.nodeGestures(
     if (callbackId == 0 && longPressId == 0 && doubleTapId == 0) return mod
 
     val onClickAction: () -> Unit = {
+        KeyboardFocusPolicy.dismissForInteractiveTap()
         if (callbackId != 0) {
             NativeElementBridge.sendPressEvent(callbackId, nodeId)
         }
     }
     val onLongClickAction: (() -> Unit)? = if (longPressId != 0) {
-        { NativeElementBridge.sendLongPressEvent(longPressId, nodeId) }
+        {
+            KeyboardFocusPolicy.dismissForInteractiveTap()
+            NativeElementBridge.sendLongPressEvent(longPressId, nodeId)
+        }
     } else {
         null
     }
     // Double-tap reuses the press event type — the callback id alone routes
     // to the @doubleTap handler on the PHP side.
     val onDoubleClickAction: (() -> Unit)? = if (doubleTapId != 0) {
-        { NativeElementBridge.sendPressEvent(doubleTapId, nodeId) }
+        {
+            KeyboardFocusPolicy.dismissForInteractiveTap()
+            NativeElementBridge.sendPressEvent(doubleTapId, nodeId)
+        }
     } else {
         null
     }

--- a/resources/xcode/NativePHP/NativeRender/SwiftUINodeRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/SwiftUINodeRenderer.swift
@@ -103,6 +103,51 @@ struct NativeTreeRenderer: View {
 
 // MARK: - Tap-to-dismiss Keyboard
 
+/// Focus policy shared between the text-input renderers, which know
+/// whether the focused field opted into `keep-focus-on-submit`, and
+/// the gesture layer, which decides whether a tap on an interactive
+/// element should also dismiss the keyboard (mobile-air #335).
+enum KeyboardFocusPolicy {
+    /// Set by the input renderers on every focus change, cleared on blur.
+    static var focusedFieldKeepsFocus = false
+
+    /// True while any text field holds focus, so press dispatch knows
+    /// a pending autocorrection or debounced change might be in play.
+    static var focusedFieldActive = false
+
+    /// Registered by the focused input; flushes its undispatched text
+    /// change so PHP sees the field's latest value before a press.
+    static var flushFocusedField: (() -> Void)?
+
+    /// Dispatch a press event with focus handling around it: flush the
+    /// focused field's pending change, resign unless the field keeps
+    /// focus, and defer the press one runloop turn while focused so
+    /// a tap-committed autocorrection's change event lands in PHP
+    /// before the press does (mobile-air #335).
+    static func dispatchPress(_ send: @escaping () -> Void) {
+        flushFocusedField?()
+
+        if !focusedFieldKeepsFocus {
+            resignKeyboard()
+        }
+
+        if focusedFieldActive {
+            DispatchQueue.main.async(execute: send)
+        } else {
+            send()
+        }
+    }
+
+    static func resignKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil
+        )
+    }
+}
+
 extension View {
     /// Dismiss the keyboard when the user taps anywhere in this subtree.
     ///
@@ -120,20 +165,20 @@ extension View {
     /// also the correct scope — a tap on the tab bar or a toolbar button is
     /// that control's business, not a dismiss.
     ///
-    /// `simultaneousGesture` rather than `onTapGesture` so it runs ALONGSIDE
-    /// whatever it lands on: buttons, pressables and list rows underneath keep
-    /// receiving their own taps instead of having them swallowed.
+    /// A regular gesture rather than `simultaneousGesture`, so a child's own
+    /// tap wins and this only fires for taps nothing else claimed: the
+    /// plain-area tap-away path. Interactive elements dismiss through
+    /// `KeyboardFocusPolicy.dismissForInteractiveTap()` in their own
+    /// handlers, which is what lets `keep-focus-on-submit` exempt
+    /// them (mobile-air #335). The `contentShape` keeps empty
+    /// regions of the screen hit-testable for the gesture.
     func dismissesKeyboardOnTap() -> some View {
-        simultaneousGesture(
-            TapGesture().onEnded {
-                UIApplication.shared.sendAction(
-                    #selector(UIResponder.resignFirstResponder),
-                    to: nil,
-                    from: nil,
-                    for: nil
-                )
-            }
-        )
+        contentShape(Rectangle())
+            .gesture(
+                TapGesture().onEnded {
+                    KeyboardFocusPolicy.resignKeyboard()
+                }
+            )
     }
 }
 
@@ -325,7 +370,9 @@ private struct DoubleTapModifier: ViewModifier {
             content.onTapGesture(count: 2) {
                 // Reuses the Press event type — the callback id alone routes
                 // to the @doubleTap handler, and Press dispatch passes no args.
-                NativeElementBridge.sendPressEvent(callbackId, nodeId: nodeId)
+                KeyboardFocusPolicy.dispatchPress {
+                    NativeElementBridge.sendPressEvent(callbackId, nodeId: nodeId)
+                }
             }
         } else {
             content
@@ -340,7 +387,9 @@ private struct TapModifier: ViewModifier {
     func body(content: Content) -> some View {
         if callbackId != 0 {
             content.onTapGesture {
-                NativeElementBridge.sendPressEvent(callbackId, nodeId: nodeId)
+                KeyboardFocusPolicy.dispatchPress {
+                    NativeElementBridge.sendPressEvent(callbackId, nodeId: nodeId)
+                }
             }
         } else {
             content
@@ -355,7 +404,9 @@ private struct LongPressModifier: ViewModifier {
     func body(content: Content) -> some View {
         if callbackId != 0 {
             content.onLongPressGesture(minimumDuration: 0.5) {
-                NativeElementBridge.sendLongPressEvent(callbackId, nodeId: nodeId)
+                KeyboardFocusPolicy.dispatchPress {
+                    NativeElementBridge.sendLongPressEvent(callbackId, nodeId: nodeId)
+                }
             }
         } else {
             content

--- a/resources/xcode/NativePHP/NativeRender/ViewClickHandlers.swift
+++ b/resources/xcode/NativePHP/NativeRender/ViewClickHandlers.swift
@@ -84,7 +84,9 @@ private struct ClickHandlerModifier: ViewModifier {
             let nodeId = node.id
             view = AnyView(
                 view.onTapGesture(count: 2) {
-                    NativeUIBridge.sendPressEvent(doubleTapId, nodeId: nodeId)
+                    KeyboardFocusPolicy.dispatchPress {
+                        NativeUIBridge.sendPressEvent(doubleTapId, nodeId: nodeId)
+                    }
                 }
             )
         }
@@ -94,7 +96,9 @@ private struct ClickHandlerModifier: ViewModifier {
             let nodeId = node.id
             view = AnyView(
                 view.onTapGesture {
-                    NativeUIBridge.sendPressEvent(cbId, nodeId: nodeId)
+                    KeyboardFocusPolicy.dispatchPress {
+                        NativeUIBridge.sendPressEvent(cbId, nodeId: nodeId)
+                    }
                 }
             )
         }
@@ -104,7 +108,9 @@ private struct ClickHandlerModifier: ViewModifier {
             let nodeId = node.id
             view = AnyView(
                 view.onLongPressGesture(minimumDuration: 0.5) {
-                    NativeUIBridge.sendLongPressEvent(cbId, nodeId: nodeId)
+                    KeyboardFocusPolicy.dispatchPress {
+                        NativeUIBridge.sendLongPressEvent(cbId, nodeId: nodeId)
+                    }
                 }
             )
         }


### PR DESCRIPTION
Fixes #335. Companion PR: NativePHP/mobile-ui#53 carries the input-renderer half. They need to land together.

The report was a chat composer, a bare-text-input and a send pressable in one row. On iOS, tapping send fires @press and dismisses the keyboard in the same tap, so the user re-focuses the field after every message. keep-focus-on-submit didn't help, it only covered the return key. Reproduced exactly as filed.

While verifying I mapped the dismissal behaviour on both platforms, and they disagreed on nearly everything. Tapping a button while a field was focused dismissed on iOS but not on Android. Submit dismissed on iOS but not on Android, even though the docs describe dismiss as the default. And keep-focus-on-submit worked on iOS but was silently ignored on Android, the renderer never parsed the prop.

The fix rests on three decisions. The platforms should behave identically, and the web-like default wins: the keyboard drops on submit and on any tap outside the field, which is also the right default for regular forms, where tapping Submit should close the keyboard. Only Android's defaults change, iOS already behaved this way and its defaults are untouched. And keep-focus-on-submit becomes the one escape hatch that genuinely works on both platforms, keeping the field focused through the return key and through button sends alike. Tapping empty space always dismisses, even with the attribute, same as iMessage and WhatsApp transcripts.

Mechanically, the screen-level dismiss gesture is now a regular gesture instead of a simultaneousGesture, so it only fires for taps nothing else claimed, the plain-area path. Taps on interactive elements dismiss through a small KeyboardFocusPolicy that press dispatch consults, which is what lets the focused field's attribute exempt them. Android mirrors the same shape, its existing root clickable stays the plain-area path and the press modifiers route through the policy.

While testing on iOS we also caught a subtle one, worth spelling out because it shaped how press dispatch works. iOS commits a pending autocorrect suggestion when you tap elsewhere, and with the keyboard no longer resigning on a send tap, that commit now lands after the press has already been dispatched. The sequence was: tap send, PHP receives the press and sends the draft as typed, iOS then applies the correction to the field, and the late change event re-fills the server-side draft that send() just cleared. The field stays filled with the corrected word, and tapping send again produces a ghost second message.

Press dispatch on iOS now does two things about that. It flushes the focused field's pending change first, and it defers the press event by one runloop turn, so the correction's change event reaches PHP before the press does. A send with a pending suggestion now sends the corrected text, clears the field, and adds exactly one message. Verified on the simulator. Android turned out not to have the race at all, Gboard only suggests passively and never applies a correction on an unrelated tap, also verified on the emulator.

The behavioural change is Android-only and lives mostly in the companion PR: return and button taps start dropping the keyboard by default there, like iOS always did. No API changes, existing code runs as is. Android chat screens that relied on the keyboard staying up add keep-focus-on-submit to the input.

Verified on device, Android emulator (dumpsys mInputShown plus screenshots) and iOS simulator (manual):

| | iOS before | iOS after | Android before | Android after |
|---|---|---|---|---|
| Button tap, default | drops | drops | keeps | **drops** |
| Submit, default | drops | drops | keeps | **drops** |
| Plain-area tap, default | drops | drops | drops | drops |
| Button tap + attr | drops | **keeps** | keeps | keeps |
| Submit + attr | keeps | keeps | keeps | keeps |
| Plain-area tap + attr | drops | drops | drops | drops |

Also verified on both platforms: the multiline composer from the issue (return inserts a newline, the send button sends the whole draft, the keyboard never moves) and the autocorrect scenario above.

One known limitation, pre-existing: with the attribute on a single-line field, the return key still shows a brief keyboard bounce on iOS (resign then refocus). That's an [acknowledged SwiftUI platform bug](https://developer.apple.com/forums/thread/770226), Apple's own focus sample reproduces it, and the in-code notes in NativeUITextInputCore already point at a UIKit-backed field as the eventual fix if it ever becomes worth it. It doesn't affect button sends or multiline composers, which is where the attribute matters.
