### PR TITLE
Make text whitespace symmetric with the browser, with whitespace-* classes to opt out

### DIFF
--- a/src/Edge/Components/Native/Text.php
+++ b/src/Edge/Components/Native/Text.php
@@ -16,11 +16,13 @@ class Text extends NativeBladeComponent
     public function render(): \Closure
     {
         return function (array $data) {
-            $attrs = $data['attributes']->getAttributes();
-            $text = preg_replace('/\s+/', ' ', trim(html_entity_decode(strip_tags($data['slot']->toHtml()), ENT_QUOTES, 'UTF-8')));
-            if ($text !== '') {
-                $attrs['text'] = $text;
-            }
+            // Merge slot and attribute text through the collector's shared
+            // whitespace policy so this component and the precompiled
+            // <text> tag resolve their text prop identically.
+            $attrs = NativeElementCollector::mergeSlotText(
+                $data['attributes']->getAttributes(),
+                $data['slot']->toHtml()
+            );
 
             if (NativeElementCollector::isStreaming()) {
                 NativeElementCollector::leafStreaming($this->elementType(), $attrs);

--- a/src/Edge/Components/Native/Text.php
+++ b/src/Edge/Components/Native/Text.php
@@ -16,19 +16,15 @@ class Text extends NativeBladeComponent
     public function render(): \Closure
     {
         return function (array $data) {
-            // Merge slot and attribute text through the collector's shared
-            // whitespace policy so this component and the precompiled
-            // <text> tag resolve their text prop identically.
-            $attrs = NativeElementCollector::mergeSlotText(
-                $data['attributes']->getAttributes(),
-                $data['slot']->toHtml()
-            );
+            // Run the same frame cycle as a precompiled <text> tag, so a
+            // nested component becomes a run of its parent, inheriting
+            // its whitespace mode, while a top-level one merges slot
+            // and attribute text through the identical policy. The
+            // close also emits streaming-aware, like any <text>.
+            NativeElementCollector::textOpen($data['attributes']->getAttributes());
+            echo $data['slot']->toHtml();
 
-            if (NativeElementCollector::isStreaming()) {
-                NativeElementCollector::leafStreaming($this->elementType(), $attrs);
-            } else {
-                NativeElementCollector::leaf($this->elementType(), $attrs);
-            }
+            NativeElementCollector::textClose();
 
             return '';
         };

--- a/src/Edge/Components/Native/Text.php
+++ b/src/Edge/Components/Native/Text.php
@@ -6,6 +6,11 @@ use Native\Mobile\Edge\NativeElementCollector;
 
 class Text extends NativeBladeComponent
 {
+    /**
+     * Skips the base withAttributes emission, which also means this
+     * component's frame opens AFTER its slot has rendered, unlike
+     * containers whose element opens before the slot runs.
+     */
     protected bool $handlesCollectorManually = true;
 
     protected function elementType(): string
@@ -21,6 +26,11 @@ class Text extends NativeBladeComponent
             // its whitespace mode, while a top-level one merges slot
             // and attribute text through the identical policy. The
             // close also emits streaming-aware, like any <text>.
+            //
+            // Blade closed the slot-capture buffer before this closure
+            // runs, so the echoed HTML is inert text and textOpen's
+            // buffer handoff sees the enclosing frame, never the
+            // slot's. The cycle depends on that ordering.
             NativeElementCollector::textOpen($data['attributes']->getAttributes());
             echo $data['slot']->toHtml();
 

--- a/src/Edge/Components/Native/Text.php
+++ b/src/Edge/Components/Native/Text.php
@@ -25,7 +25,7 @@ class Text extends NativeBladeComponent
             // nested component becomes a run of its parent, inheriting
             // its whitespace mode, while a top-level one merges slot
             // and attribute text through the identical policy. The
-            // close also emits streaming-aware, like any <text>.
+            // close stays streaming-aware, like any <text>.
             //
             // Blade closed the slot-capture buffer before this closure
             // runs, so the echoed HTML is inert text and textOpen's
@@ -33,7 +33,6 @@ class Text extends NativeBladeComponent
             // slot's. The cycle depends on that ordering.
             NativeElementCollector::textOpen($data['attributes']->getAttributes());
             echo $data['slot']->toHtml();
-
             NativeElementCollector::textClose();
 
             return '';

--- a/src/Edge/Element.php
+++ b/src/Edge/Element.php
@@ -167,6 +167,10 @@ abstract class Element
      * `NativeElementCollector` uses for blade-driven elements, so the
      * resolved keys map to the same node fields with no behavioural
      * drift between blade and programmatic construction.
+     *
+     * One exception: `whitespace-*` is a capture-time policy that only
+     * Blade-authored text passes through. Programmatic text strings
+     * ship verbatim, the way code-built values are literal.
      */
     public function class(string $classes): static
     {

--- a/src/Edge/Element.php
+++ b/src/Edge/Element.php
@@ -169,7 +169,7 @@ abstract class Element
      * drift between blade and programmatic construction.
      *
      * One exception: `whitespace-*` is a capture-time policy that only
-     * Blade-authored text passes through. Programmatic text strings
+     * blade-authored text passes through. Programmatic text strings
      * ship verbatim, the way code-built values are literal.
      */
     public function class(string $classes): static

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -1098,14 +1098,16 @@ class NativeElementCollector
      */
     public static function textOpen(array $attrs): void
     {
+        $inherited = null;
+
         if (! empty(static::$textFrames)) {
             static::captureRawRunIntoTopFrame();
-        }
 
-        // Resolve the whitespace mode as the frame opens so nested runs
-        // inherit the closest classed ancestor, mirroring the way the
-        // CSS white-space property cascades down in the browser.
-        $inherited = empty(static::$textFrames) ? null : end(static::$textFrames)['whitespace'];
+            // Resolve the parent's mode as this frame opens, so a nested
+            // run inherits the closest classed ancestor, mirroring
+            // how the CSS white-space property cascades down.
+            $inherited = end(static::$textFrames)['whitespace'];
+        }
 
         static::$textFrames[] = [
             'attrs' => $attrs,
@@ -1205,7 +1207,7 @@ class NativeElementCollector
      */
     protected static function whitespaceMode(array $attrs): ?string
     {
-        if (! isset($attrs['class']) || ! is_string($attrs['class'])) {
+        if (! is_string($attrs['class'] ?? null)) {
             return null;
         }
 
@@ -1220,7 +1222,7 @@ class NativeElementCollector
     protected static function applyAttributeWhitespace(array $attrs, ?string $mode): array
     {
         if (isset($attrs['text']) && is_string($attrs['text'])) {
-            $attrs['text'] = static::applyWhitespace($attrs['text'], $mode ?? static::DEFAULT_WHITESPACE);
+            $attrs['text'] = static::applyWhitespace($attrs['text'], $mode);
         }
 
         return $attrs;
@@ -1270,9 +1272,9 @@ class NativeElementCollector
      * whitespace run, 'pre-line' keeps newlines while collapsing the
      * horizontal runs around them and trimming, 'pre' touches nothing.
      */
-    protected static function applyWhitespace(string $text, string $mode): string
+    protected static function applyWhitespace(string $text, ?string $mode): string
     {
-        return match ($mode) {
+        return match ($mode ?? static::DEFAULT_WHITESPACE) {
             'pre' => $text,
             'pre-line' => trim(static::collapsePreLine($text)),
             default => preg_replace('/\s+/', ' ', trim($text)),
@@ -1300,16 +1302,16 @@ class NativeElementCollector
      */
     protected static function normalizeRunText(string $raw, ?string $mode = null): string
     {
-        $s = html_entity_decode(strip_tags($raw), ENT_QUOTES, 'UTF-8');
+        $text = html_entity_decode(strip_tags($raw), ENT_QUOTES, 'UTF-8');
 
         // Under the default collapse a purely-whitespace raw segment is
         // template formatting rather than content, so it drops before
         // the shared run transform handles everything that remains.
-        if (($mode ?? static::DEFAULT_WHITESPACE) === 'normal' && trim($s) === '') {
+        if (($mode ?? static::DEFAULT_WHITESPACE) === 'normal' && trim($text) === '') {
             return '';
         }
 
-        return static::applyRunWhitespace($s, $mode);
+        return static::applyRunWhitespace($text, $mode);
     }
 
     /**
@@ -1320,13 +1322,13 @@ class NativeElementCollector
      */
     protected static function normalizeLeafText(string $raw, ?string $mode = null): string
     {
-        $s = html_entity_decode(strip_tags($raw), ENT_QUOTES, 'UTF-8');
+        $text = html_entity_decode(strip_tags($raw), ENT_QUOTES, 'UTF-8');
 
-        if (trim($s) === '') {
+        if (trim($text) === '') {
             return '';
         }
 
-        return static::applyWhitespace($s, $mode ?? static::DEFAULT_WHITESPACE);
+        return static::applyWhitespace($text, $mode);
     }
 
     /**

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -1084,15 +1084,14 @@ class NativeElementCollector
     // ── Inline text runs (<text> with nested <text>) ─────
 
     /**
-     * Default whitespace mode for each text source when no whitespace-*
-     * class is present: slot text keeps its historical full collapse
-     * while attribute text passes through verbatim. Flipping the
-     * attribute default to 'normal' is the planned follow-up
-     * that aligns both sources with the web's behavior.
+     * Default whitespace mode for text when no whitespace-* class is
+     * present. Both sources collapse like the browser does at paint
+     * time, so slot and attribute text can never disagree; adding
+     * whitespace-pre or pre-line opts any element back out.
      */
     protected const SLOT_WHITESPACE = 'normal';
 
-    protected const ATTRIBUTE_WHITESPACE = 'pre';
+    protected const ATTRIBUTE_WHITESPACE = 'normal';
 
     /**
      * Begin capturing a `<text>` element's slot as ordered inline runs.
@@ -1144,8 +1143,11 @@ class NativeElementCollector
             ];
         } elseif ($isNested) {
             // Childless nested <text>: a RUN, normalized without trimming so
-            // meaningful edge spaces survive, under the inherited mode.
-            $attrs = static::applyAttributeWhitespace($frame['attrs'], $mode);
+            // meaningful edge spaces survive, under the inherited mode. Its
+            // attribute text gets the run-shaped transform for the same
+            // reason: the browser trims at block boundaries only, so a
+            // separator run like `:text="' / '"` keeps its spacing.
+            $attrs = static::applyRunAttributeWhitespace($frame['attrs'], $mode);
             $text = static::normalizeRunText($buffer, $mode);
             if ($text !== '') {
                 $attrs['text'] = $text;
@@ -1213,13 +1215,32 @@ class NativeElementCollector
 
     /**
      * Apply the whitespace policy to attribute-sourced text. With no
-     * class present the attribute default ('pre') leaves the string
-     * byte-for-byte untouched, exactly as it always has been.
+     * class present the attribute default collapses like the slot
+     * does, so both sources of text behave identically.
      */
     protected static function applyAttributeWhitespace(array $attrs, ?string $mode): array
     {
         if (isset($attrs['text']) && is_string($attrs['text'])) {
             $attrs['text'] = static::applyWhitespace($attrs['text'], $mode ?? static::ATTRIBUTE_WHITESPACE);
+        }
+
+        return $attrs;
+    }
+
+    /**
+     * Run-shaped counterpart for attribute text on nested runs: collapse
+     * without trimming so explicit edge spaces survive, and never drop
+     * the string, since `:text` content is intentional rather than
+     * template formatting like raw inter-tag whitespace is.
+     */
+    protected static function applyRunAttributeWhitespace(array $attrs, ?string $mode): array
+    {
+        if (isset($attrs['text']) && is_string($attrs['text'])) {
+            $attrs['text'] = match ($mode ?? static::ATTRIBUTE_WHITESPACE) {
+                'pre' => $attrs['text'],
+                'pre-line' => preg_replace('/[^\S\n]+/', ' ', preg_replace('/[^\S\n]*\n[^\S\n]*/', "\n", $attrs['text'])),
+                default => preg_replace('/\s+/', ' ', $attrs['text']),
+            };
         }
 
         return $attrs;

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -1182,13 +1182,12 @@ class NativeElementCollector
 
     /**
      * Merge a captured slot into a text element's attrs under the shared
-     * whitespace policy, applying each source's default when no class
-     * is present. Used by textClose, textLeaf and `<x-native-text>`
-     * so every authoring form resolves text identically.
+     * whitespace policy, applying the default when no class is present.
+     * Only textClose calls this, with the mode its frame resolved at
+     * open time, so every authoring form funnels through one merge.
      */
-    public static function mergeSlotText(array $attrs, string $rawSlot, ?string $mode = null): array
+    protected static function mergeSlotText(array $attrs, string $rawSlot, ?string $mode): array
     {
-        $mode ??= static::whitespaceMode($attrs);
         $attrs = static::applyAttributeWhitespace($attrs, $mode);
 
         $text = static::normalizeLeafText($rawSlot, $mode);

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -1084,6 +1084,17 @@ class NativeElementCollector
     // ── Inline text runs (<text> with nested <text>) ─────
 
     /**
+     * Default whitespace mode for each text source when no whitespace-*
+     * class is present: slot text keeps its historical full collapse
+     * while attribute text passes through verbatim. Flipping the
+     * attribute default to 'normal' is the planned follow-up
+     * that aligns both sources with the web's behavior.
+     */
+    protected const SLOT_WHITESPACE = 'normal';
+
+    protected const ATTRIBUTE_WHITESPACE = 'pre';
+
+    /**
      * Begin capturing a `<text>` element's slot as ordered inline runs.
      * Flushes the parent `<text>`'s pending raw text as a run first (so a
      * nested run lands in document order), then buffers this element's content.
@@ -1094,7 +1105,16 @@ class NativeElementCollector
             static::captureRawRunIntoTopFrame();
         }
 
-        static::$textFrames[] = ['attrs' => $attrs, 'children' => []];
+        // Resolve the whitespace mode as the frame opens so nested runs
+        // inherit the closest classed ancestor, mirroring the way the
+        // CSS white-space property cascades down in the browser.
+        $inherited = empty(static::$textFrames) ? null : end(static::$textFrames)['whitespace'];
+
+        static::$textFrames[] = [
+            'attrs' => $attrs,
+            'children' => [],
+            'whitespace' => static::whitespaceMode($attrs) ?? $inherited,
+        ];
         ob_start();
     }
 
@@ -1110,24 +1130,31 @@ class NativeElementCollector
         $buffer = ob_get_clean();
         $frame = array_pop(static::$textFrames);
         $isNested = ! empty(static::$textFrames);
+        $mode = $frame['whitespace'];
 
         if (! empty($frame['children'])) {
             // Container: its own trailing buffer is a run; own text stays empty.
-            $tail = static::normalizeRunText($buffer);
+            $tail = static::normalizeRunText($buffer, $mode);
             if ($tail !== '') {
                 $frame['children'][] = ['attrs' => ['text' => $tail], 'children' => null];
             }
-            $descriptor = ['attrs' => $frame['attrs'], 'children' => $frame['children']];
-        } else {
-            // Childless <text>: a RUN when nested (preserve meaningful edge
-            // spaces), but a top-level leaf keeps today's exact trimmed +
-            // whitespace-collapsed string so nothing else regresses.
-            $attrs = $frame['attrs'];
-            $text = $isNested ? static::normalizeRunText($buffer) : static::normalizeLeafText($buffer);
+            $descriptor = [
+                'attrs' => static::applyAttributeWhitespace($frame['attrs'], $mode),
+                'children' => $frame['children'],
+            ];
+        } elseif ($isNested) {
+            // Childless nested <text>: a RUN, normalized without trimming so
+            // meaningful edge spaces survive, under the inherited mode.
+            $attrs = static::applyAttributeWhitespace($frame['attrs'], $mode);
+            $text = static::normalizeRunText($buffer, $mode);
             if ($text !== '') {
                 $attrs['text'] = $text;
             }
             $descriptor = ['attrs' => $attrs, 'children' => null];
+        } else {
+            // Top-level leaf: merge slot and attribute text through the
+            // shared whitespace policy (per-source defaults intact).
+            $descriptor = ['attrs' => static::mergeSlotText($frame['attrs'], $buffer), 'children' => null];
         }
 
         if ($isNested) {
@@ -1141,37 +1168,122 @@ class NativeElementCollector
         }
     }
 
+    /**
+     * A self-closing `<text />` carries attribute text only. Routing it
+     * through the same merge the paired form applies at textClose lets
+     * a whitespace-* class govern `:text` however the tag is written.
+     */
+    public static function textLeaf(array $attrs): void
+    {
+        static::leaf('text', static::mergeSlotText($attrs, ''));
+    }
+
+    /**
+     * Merge a captured slot into a text element's attrs under the shared
+     * whitespace policy, applying each source's default when no class
+     * is present. Used by textClose, textLeaf and `<x-native-text>`
+     * so every authoring form resolves text identically.
+     */
+    public static function mergeSlotText(array $attrs, string $rawSlot): array
+    {
+        $mode = static::whitespaceMode($attrs);
+        $attrs = static::applyAttributeWhitespace($attrs, $mode);
+
+        $text = static::normalizeLeafText($rawSlot, $mode);
+        if ($text !== '') {
+            $attrs['text'] = $text;
+        }
+
+        return $attrs;
+    }
+
+    /**
+     * Resolve the whitespace-* utility governing an element's text from
+     * its raw class attribute, or null when the class carries none.
+     * TailwindParser caches per class string, so this is cheap.
+     */
+    public static function whitespaceMode(array $attrs): ?string
+    {
+        if (! isset($attrs['class']) || ! is_string($attrs['class'])) {
+            return null;
+        }
+
+        return TailwindParser::parse($attrs['class'])['whitespace'] ?? null;
+    }
+
+    /**
+     * Apply the whitespace policy to attribute-sourced text. With no
+     * class present the attribute default ('pre') leaves the string
+     * byte-for-byte untouched, exactly as it always has been.
+     */
+    protected static function applyAttributeWhitespace(array $attrs, ?string $mode): array
+    {
+        if (isset($attrs['text']) && is_string($attrs['text'])) {
+            $attrs['text'] = static::applyWhitespace($attrs['text'], $mode ?? static::ATTRIBUTE_WHITESPACE);
+        }
+
+        return $attrs;
+    }
+
+    /**
+     * Leaf-shaped whitespace transform: 'normal' trims and collapses every
+     * whitespace run, 'pre-line' keeps newlines while collapsing the
+     * horizontal runs around them and trimming, 'pre' touches nothing.
+     */
+    protected static function applyWhitespace(string $text, string $mode): string
+    {
+        return match ($mode) {
+            'pre' => $text,
+            'pre-line' => trim(preg_replace('/[^\S\n]+/', ' ', preg_replace('/[^\S\n]*\n[^\S\n]*/', "\n", $text))),
+            default => preg_replace('/\s+/', ' ', trim($text)),
+        };
+    }
+
     /** Flush the currently-buffered raw text as a run of the top frame. */
     protected static function captureRawRunIntoTopFrame(): void
     {
-        $text = static::normalizeRunText(ob_get_clean());
+        $top = count(static::$textFrames) - 1;
+        $text = static::normalizeRunText(ob_get_clean(), static::$textFrames[$top]['whitespace']);
         if ($text !== '') {
-            $top = count(static::$textFrames) - 1;
             static::$textFrames[$top]['children'][] = ['attrs' => ['text' => $text], 'children' => null];
         }
     }
 
     /**
-     * Whitespace policy for a raw run: drop pure-whitespace segments (inter-tag
-     * newlines/indentation are formatting, not content) so multiline markup
-     * doesn't inject spurious spaces; collapse internal runs of whitespace to a
-     * single space but PRESERVE meaningful leading/trailing spaces (a run may be
-     * `" / "`, or prose like `"Use "` before an inline chip).
+     * Whitespace policy for a raw run. The default (and 'normal') drops
+     * pure-whitespace segments (inter-tag newlines/indentation are
+     * formatting, not content) and collapses internal whitespace runs to a
+     * single space while PRESERVING meaningful leading/trailing spaces (a
+     * run may be `" / "`, or prose like `"Use "` before an inline chip).
+     * 'pre-line' keeps newlines and never trims, so run boundaries
+     * still carry their spacing; 'pre' keeps the run verbatim.
      */
-    protected static function normalizeRunText(string $raw): string
+    protected static function normalizeRunText(string $raw, ?string $mode = null): string
     {
         $s = html_entity_decode(strip_tags($raw), ENT_QUOTES, 'UTF-8');
+
+        return match ($mode) {
+            'pre' => $s,
+            'pre-line' => preg_replace('/[^\S\n]+/', ' ', preg_replace('/[^\S\n]*\n[^\S\n]*/', "\n", $s)),
+            default => trim($s) === '' ? '' : preg_replace('/\s+/', ' ', $s),
+        };
+    }
+
+    /**
+     * Leaf `<text>` slot text. A formatting-only slot counts as "no slot"
+     * in every mode, so a paired tag written with pretty indentation can
+     * never clobber `:text`; anything else goes through the policy,
+     * which defaults to today's exact trim-and-collapse shape.
+     */
+    protected static function normalizeLeafText(string $raw, ?string $mode = null): string
+    {
+        $s = html_entity_decode(strip_tags($raw), ENT_QUOTES, 'UTF-8');
+
         if (trim($s) === '') {
             return '';
         }
 
-        return preg_replace('/\s+/', ' ', $s);
-    }
-
-    /** Leaf `<text>` text: today's exact behavior (trim + collapse). */
-    protected static function normalizeLeafText(string $raw): string
-    {
-        return preg_replace('/\s+/', ' ', trim(html_entity_decode(strip_tags($raw), ENT_QUOTES, 'UTF-8')));
+        return static::applyWhitespace($s, $mode ?? static::SLOT_WHITESPACE);
     }
 
     /**

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -1087,7 +1087,7 @@ class NativeElementCollector
      * Default whitespace mode for text when no whitespace-* class is
      * present. Both sources collapse like the browser does at paint
      * time, so slot and attribute text can never disagree; adding
-     * whitespace-pre or pre-line opts any element back out.
+     * whitespace-pre-wrap or pre-line opts any element back out.
      */
     protected const DEFAULT_WHITESPACE = 'normal';
 
@@ -1251,7 +1251,7 @@ class NativeElementCollector
     protected static function applyRunWhitespace(string $text, ?string $mode): string
     {
         return match ($mode ?? static::DEFAULT_WHITESPACE) {
-            'pre' => $text,
+            'pre-wrap' => $text,
             'pre-line' => static::collapsePreLine($text),
             default => preg_replace('/\s+/', ' ', $text),
         };
@@ -1270,12 +1270,12 @@ class NativeElementCollector
     /**
      * Leaf-shaped whitespace transform: 'normal' trims and collapses every
      * whitespace run, 'pre-line' keeps newlines while collapsing the
-     * horizontal runs around them and trimming, 'pre' touches nothing.
+     * horizontal runs around them and trimming, 'pre-wrap' touches nothing.
      */
     protected static function applyWhitespace(string $text, ?string $mode): string
     {
         return match ($mode ?? static::DEFAULT_WHITESPACE) {
-            'pre' => $text,
+            'pre-wrap' => $text,
             'pre-line' => trim(static::collapsePreLine($text)),
             default => preg_replace('/\s+/', ' ', trim($text)),
         };
@@ -1298,7 +1298,7 @@ class NativeElementCollector
      * single space while PRESERVING meaningful leading/trailing spaces (a
      * run may be `" / "`, or prose like `"Use "` before an inline chip).
      * 'pre-line' keeps newlines and never trims, so run boundaries
-     * still carry their spacing; 'pre' keeps the run verbatim.
+     * still carry their spacing; 'pre-wrap' keeps the run verbatim.
      */
     protected static function normalizeRunText(string $raw, ?string $mode = null): string
     {

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -1174,9 +1174,30 @@ class NativeElementCollector
      * A self-closing `<text />` carries attribute text only. Routing it
      * through the same merge the paired form applies at textClose lets
      * a whitespace-* class govern `:text` however the tag is written.
+     *
+     * Inside an open text frame it becomes a RUN of that parent, in
+     * document order and with the run-shaped whitespace transform,
+     * exactly as if it had been written as a paired tag. It used
+     * to escape the frame and emit as a misplaced sibling.
      */
     public static function textLeaf(array $attrs): void
     {
+        if (! empty(static::$textFrames)) {
+            static::captureRawRunIntoTopFrame();
+
+            $top = count(static::$textFrames) - 1;
+            $mode = static::whitespaceMode($attrs) ?? static::$textFrames[$top]['whitespace'];
+
+            static::$textFrames[$top]['children'][] = [
+                'attrs' => static::applyRunAttributeWhitespace($attrs, $mode),
+                'children' => null,
+            ];
+
+            ob_start();
+
+            return;
+        }
+
         static::leaf('text', static::mergeSlotText($attrs, ''));
     }
 

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -1089,9 +1089,7 @@ class NativeElementCollector
      * time, so slot and attribute text can never disagree; adding
      * whitespace-pre or pre-line opts any element back out.
      */
-    protected const SLOT_WHITESPACE = 'normal';
-
-    protected const ATTRIBUTE_WHITESPACE = 'normal';
+    protected const DEFAULT_WHITESPACE = 'normal';
 
     /**
      * Begin capturing a `<text>` element's slot as ordered inline runs.
@@ -1156,7 +1154,7 @@ class NativeElementCollector
         } else {
             // Top-level leaf: merge slot and attribute text through the
             // shared whitespace policy (per-source defaults intact).
-            $descriptor = ['attrs' => static::mergeSlotText($frame['attrs'], $buffer), 'children' => null];
+            $descriptor = ['attrs' => static::mergeSlotText($frame['attrs'], $buffer, $mode), 'children' => null];
         }
 
         if ($isNested) {
@@ -1171,34 +1169,15 @@ class NativeElementCollector
     }
 
     /**
-     * A self-closing `<text />` carries attribute text only. Routing it
-     * through the same merge the paired form applies at textClose lets
-     * a whitespace-* class govern `:text` however the tag is written.
-     *
-     * Inside an open text frame it becomes a RUN of that parent, in
-     * document order and with the run-shaped whitespace transform,
-     * exactly as if it had been written as a paired tag. It used
-     * to escape the frame and emit as a misplaced sibling.
+     * A self-closing `<text />` is a paired tag with an empty slot, so it
+     * runs the exact open/close cycle the paired form does. That makes
+     * a nested one a RUN of its parent in document order, where it
+     * used to escape the frame as a misplaced sibling.
      */
     public static function textLeaf(array $attrs): void
     {
-        if (! empty(static::$textFrames)) {
-            static::captureRawRunIntoTopFrame();
-
-            $top = count(static::$textFrames) - 1;
-            $mode = static::whitespaceMode($attrs) ?? static::$textFrames[$top]['whitespace'];
-
-            static::$textFrames[$top]['children'][] = [
-                'attrs' => static::applyRunAttributeWhitespace($attrs, $mode),
-                'children' => null,
-            ];
-
-            ob_start();
-
-            return;
-        }
-
-        static::leaf('text', static::mergeSlotText($attrs, ''));
+        static::textOpen($attrs);
+        static::textClose();
     }
 
     /**
@@ -1207,9 +1186,9 @@ class NativeElementCollector
      * is present. Used by textClose, textLeaf and `<x-native-text>`
      * so every authoring form resolves text identically.
      */
-    public static function mergeSlotText(array $attrs, string $rawSlot): array
+    public static function mergeSlotText(array $attrs, string $rawSlot, ?string $mode = null): array
     {
-        $mode = static::whitespaceMode($attrs);
+        $mode ??= static::whitespaceMode($attrs);
         $attrs = static::applyAttributeWhitespace($attrs, $mode);
 
         $text = static::normalizeLeafText($rawSlot, $mode);
@@ -1225,7 +1204,7 @@ class NativeElementCollector
      * its raw class attribute, or null when the class carries none.
      * TailwindParser caches per class string, so this is cheap.
      */
-    public static function whitespaceMode(array $attrs): ?string
+    protected static function whitespaceMode(array $attrs): ?string
     {
         if (! isset($attrs['class']) || ! is_string($attrs['class'])) {
             return null;
@@ -1242,7 +1221,7 @@ class NativeElementCollector
     protected static function applyAttributeWhitespace(array $attrs, ?string $mode): array
     {
         if (isset($attrs['text']) && is_string($attrs['text'])) {
-            $attrs['text'] = static::applyWhitespace($attrs['text'], $mode ?? static::ATTRIBUTE_WHITESPACE);
+            $attrs['text'] = static::applyWhitespace($attrs['text'], $mode ?? static::DEFAULT_WHITESPACE);
         }
 
         return $attrs;
@@ -1257,14 +1236,34 @@ class NativeElementCollector
     protected static function applyRunAttributeWhitespace(array $attrs, ?string $mode): array
     {
         if (isset($attrs['text']) && is_string($attrs['text'])) {
-            $attrs['text'] = match ($mode ?? static::ATTRIBUTE_WHITESPACE) {
-                'pre' => $attrs['text'],
-                'pre-line' => preg_replace('/[^\S\n]+/', ' ', preg_replace('/[^\S\n]*\n[^\S\n]*/', "\n", $attrs['text'])),
-                default => preg_replace('/\s+/', ' ', $attrs['text']),
-            };
+            $attrs['text'] = static::applyRunWhitespace($attrs['text'], $mode);
         }
 
         return $attrs;
+    }
+
+    /**
+     * Run-shaped whitespace transform: collapse without trimming, so a
+     * run keeps whatever edge spacing its author gave it. The browser
+     * behaves the same way, trimming at block boundaries only.
+     */
+    protected static function applyRunWhitespace(string $text, ?string $mode): string
+    {
+        return match ($mode ?? static::DEFAULT_WHITESPACE) {
+            'pre' => $text,
+            'pre-line' => static::collapsePreLine($text),
+            default => preg_replace('/\s+/', ' ', $text),
+        };
+    }
+
+    /**
+     * The pre-line collapse: newline runs become one newline first, then
+     * the remaining horizontal runs collapse to single spaces. The two
+     * passes only make sense together and in this order.
+     */
+    protected static function collapsePreLine(string $text): string
+    {
+        return preg_replace('/[^\S\n]+/', ' ', preg_replace('/[^\S\n]*\n[^\S\n]*/', "\n", $text));
     }
 
     /**
@@ -1276,7 +1275,7 @@ class NativeElementCollector
     {
         return match ($mode) {
             'pre' => $text,
-            'pre-line' => trim(preg_replace('/[^\S\n]+/', ' ', preg_replace('/[^\S\n]*\n[^\S\n]*/', "\n", $text))),
+            'pre-line' => trim(static::collapsePreLine($text)),
             default => preg_replace('/\s+/', ' ', trim($text)),
         };
     }
@@ -1304,11 +1303,14 @@ class NativeElementCollector
     {
         $s = html_entity_decode(strip_tags($raw), ENT_QUOTES, 'UTF-8');
 
-        return match ($mode) {
-            'pre' => $s,
-            'pre-line' => preg_replace('/[^\S\n]+/', ' ', preg_replace('/[^\S\n]*\n[^\S\n]*/', "\n", $s)),
-            default => trim($s) === '' ? '' : preg_replace('/\s+/', ' ', $s),
-        };
+        // Under the default collapse a purely-whitespace raw segment is
+        // template formatting rather than content, so it drops before
+        // the shared run transform handles everything that remains.
+        if (($mode ?? static::DEFAULT_WHITESPACE) === 'normal' && trim($s) === '') {
+            return '';
+        }
+
+        return static::applyRunWhitespace($s, $mode);
     }
 
     /**
@@ -1325,7 +1327,7 @@ class NativeElementCollector
             return '';
         }
 
-        return static::applyWhitespace($s, $mode ?? static::SLOT_WHITESPACE);
+        return static::applyWhitespace($s, $mode ?? static::DEFAULT_WHITESPACE);
     }
 
     /**

--- a/src/Edge/NativeTagPrecompiler.php
+++ b/src/Edge/NativeTagPrecompiler.php
@@ -399,6 +399,13 @@ class NativeTagPrecompiler
         $type = $this->tagToType($tag);
         $attrs = $this->compileAttributes($rawAttrs);
 
+        // A self-closing <text /> carries attribute text only. Route it
+        // through textLeaf so a whitespace-* class governs `:text`
+        // exactly as the paired form does at textClose.
+        if ($tag === 'text') {
+            return '<?php '.self::C."::textLeaf({$attrs}); ?>";
+        }
+
         // <native:virtual-list /> is special: open the element, loop the
         // window, render the `item` Blade view once per index (each render
         // streams its own native tags into the same collector), then close.

--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -650,6 +650,14 @@ class TailwindParser
             $class === 'select-text' => ['selectable' => 1],
             $class === 'select-none' => ['selectable' => 0],
 
+            // Whitespace (CSS white-space) for text content. Consumed by the
+            // PHP capture layer before the text prop is serialized, so it
+            // never rides the wire. `nowrap` and `pre-wrap` need native
+            // line-wrap props and stay unparsed for now.
+            $class === 'whitespace-normal' => ['whitespace' => 'normal'],
+            $class === 'whitespace-pre-line' => ['whitespace' => 'pre-line'],
+            $class === 'whitespace-pre' => ['whitespace' => 'pre'],
+
             // Letter spacing (tracking), in em (relative to font size).
             $class === 'tracking-tighter' => ['letterSpacing' => -0.05],
             $class === 'tracking-tight' => ['letterSpacing' => -0.025],

--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -656,7 +656,7 @@ class TailwindParser
             // line-wrap props and stay unparsed for now.
             $class === 'whitespace-normal' => ['whitespace' => 'normal'],
             $class === 'whitespace-pre-line' => ['whitespace' => 'pre-line'],
-            $class === 'whitespace-pre' => ['whitespace' => 'pre'],
+            $class === 'whitespace-pre-wrap' => ['whitespace' => 'pre-wrap'],
 
             // Letter spacing (tracking), in em (relative to font size).
             $class === 'tracking-tighter' => ['letterSpacing' => -0.05],

--- a/tests/Feature/Edge/InlineTextRunsTest.php
+++ b/tests/Feature/Edge/InlineTextRunsTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\NativeElementCollector;
 use Native\Mobile\Edge\NativeTagPrecompiler;
 
@@ -34,20 +33,9 @@ afterEach(function () {
 });
 
 /** Render a Blade string through the native pipeline and return the tree array. */
-function renderInlineTree(string $blade): array
-{
-    $viewPath = __DIR__.'/views/inline-text.blade.php';
-    file_put_contents($viewPath, $blade);
-
-    NativeElementCollector::reset();
-    view('inline-text')->render();
-
-    return NativeElementCollector::collect()->toArray(new CallbackRegistry);
-}
-
 it('emits three ordered run-nodes with whitespace intact', function () {
     // Single line, no inter-tag whitespace — the canonical verify case.
-    $tree = renderInlineTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text><native:text>A </native:text><native:text class="font-mono">B</native:text><native:text> C</native:text></native:text></native:column>'
     );
 
@@ -69,7 +57,7 @@ it('emits three ordered run-nodes with whitespace intact', function () {
 });
 
 it('captures leading, interspersed, and trailing raw text as ordered runs', function () {
-    $tree = renderInlineTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text>Use <native:text class="font-mono">code</native:text> here</native:text></native:column>'
     );
 
@@ -82,7 +70,7 @@ it('captures leading, interspersed, and trailing raw text as ordered runs', func
 
 it('drops inter-tag indentation whitespace in multiline markup', function () {
     // Newlines + indentation between run tags are formatting, not content.
-    $tree = renderInlineTree(<<<'BLADE'
+    $tree = renderEdgeTree(<<<'BLADE'
 <native:column>
     <native:text>
         <native:text>A </native:text>
@@ -100,7 +88,7 @@ BLADE);
 });
 
 it('keeps leaf text on the trimmed-string path (no regression)', function () {
-    $tree = renderInlineTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text :fontSize="24">  Hello   World  </native:text></native:column>'
     );
 

--- a/tests/Feature/Edge/InlineTextRunsTest.php
+++ b/tests/Feature/Edge/InlineTextRunsTest.php
@@ -32,7 +32,6 @@ afterEach(function () {
     }
 });
 
-/** Render a Blade string through the native pipeline and return the tree array. */
 it('emits three ordered run-nodes with whitespace intact', function () {
     // Single line, no inter-tag whitespace — the canonical verify case.
     $tree = renderEdgeTree(

--- a/tests/Feature/Edge/WhitespaceClassesTest.php
+++ b/tests/Feature/Edge/WhitespaceClassesTest.php
@@ -55,11 +55,11 @@ it('preserves newlines in slot text under whitespace-pre-line', function () {
     expect($tree['children'][0]['props']['text'])->toBe("Line one\nLine two");
 });
 
-it('keeps slot text verbatim under whitespace-pre', function () {
+it('keeps slot text verbatim under whitespace-pre-wrap', function () {
     $msg = "Line one\n    Line two\n";
 
     $tree = renderEdgeTree(
-        '<native:column><native:text class="whitespace-pre">{{ $msg }}</native:text></native:column>',
+        '<native:column><native:text class="whitespace-pre-wrap">{{ $msg }}</native:text></native:column>',
         ['msg' => $msg]
     );
 
@@ -104,11 +104,11 @@ it('preserves newlines in attribute text under whitespace-pre-line', function ()
     expect($tree['children'][0]['props']['text'])->toBe("Line one\nLine two");
 });
 
-it('keeps attribute text verbatim under whitespace-pre', function () {
+it('keeps attribute text verbatim under whitespace-pre-wrap', function () {
     $msg = "  Line one \n   Line two  ";
 
     $tree = renderEdgeTree(
-        '<native:column><native:text class="whitespace-pre" :text="$msg" /></native:column>',
+        '<native:column><native:text class="whitespace-pre-wrap" :text="$msg" /></native:column>',
         ['msg' => $msg]
     );
 
@@ -305,7 +305,7 @@ it('resolves text identically across every form, source and class at top level',
         '<x-native-text%s :text="$msg" />',
     ];
 
-    foreach (['', ' class="whitespace-pre-line"', ' class="whitespace-pre"'] as $cls) {
+    foreach (['', ' class="whitespace-pre-line"', ' class="whitespace-pre-wrap"'] as $cls) {
         $baseline = null;
         foreach ($forms as $tpl) {
             $tree = renderEdgeTree('<native:column>'.sprintf($tpl, $cls).'</native:column>', ['msg' => $msg]);
@@ -329,7 +329,7 @@ it('resolves nested runs identically across every nested form', function () {
         '<x-native-text :text="$msg" />',
     ];
 
-    foreach (['', ' class="whitespace-pre-line"', ' class="whitespace-pre"'] as $cls) {
+    foreach (['', ' class="whitespace-pre-line"', ' class="whitespace-pre-wrap"'] as $cls) {
         $baseline = null;
         foreach ($nested as $inner) {
             $tree = renderEdgeTree(

--- a/tests/Feature/Edge/WhitespaceClassesTest.php
+++ b/tests/Feature/Edge/WhitespaceClassesTest.php
@@ -7,9 +7,9 @@ use Native\Mobile\Edge\NativeTagPrecompiler;
 /**
  * The whitespace-* class family governs how text whitespace is resolved
  * before the text prop is serialized, identically for slot-sourced and
- * attribute-sourced text. Without a class the per-source defaults hold:
- * slot text gets the historical trim-and-collapse, attribute text
- * passes through byte-for-byte untouched.
+ * attribute-sourced text. Without a class both sources collapse like
+ * the browser does at paint time, so slot and attribute text can
+ * never disagree; a class opts any element out of that default.
  */
 beforeEach(function () {
     NativeElementCollector::reset();
@@ -34,14 +34,21 @@ afterEach(function () {
     }
 });
 
-/** Render a Blade string through the native pipeline and return the tree array. */
+/**
+ * Render a Blade string through the native pipeline and return the tree
+ * array. The view name is unique per render because the compiler engine
+ * caches per path within one app lifecycle, so reusing a name would
+ * silently re-render the previous template instead of this one.
+ */
 function renderWhitespaceTree(string $blade, array $data = []): array
 {
-    $viewPath = __DIR__.'/views/whitespace-classes.blade.php';
-    file_put_contents($viewPath, $blade);
+    static $sequence = 0;
+    $name = 'whitespace-classes-'.(++$sequence);
+
+    file_put_contents(__DIR__.'/views/'.$name.'.blade.php', $blade);
 
     NativeElementCollector::reset();
-    view('whitespace-classes', $data)->render();
+    view($name, $data)->render();
 
     return NativeElementCollector::collect()->toArray(new CallbackRegistry);
 }
@@ -242,4 +249,46 @@ it('applies whitespace-normal to x-native-text attribute text', function () {
     );
 
     expect($tree['children'][0]['props']['text'])->toBe('Line one Line two');
+});
+
+it('treats a nested self-closing text as a run in document order', function () {
+    // Used to escape the frame system and emit as a sibling BEFORE its
+    // parent with leaf-trimmed text. It is a run like the paired form
+    // now, so the separator keeps its explicit edge spaces too.
+    $sep = ' / ';
+
+    $tree = renderWhitespaceTree(
+        '<native:column><native:text>Docs<native:text :text="$sep" />Guides</native:text></native:column>',
+        ['sep' => $sep]
+    );
+
+    expect($tree['children'])->toHaveCount(1);
+
+    $runs = $tree['children'][0]['children'];
+    expect($runs[0]['props']['text'])->toBe('Docs');
+    expect($runs[1]['props']['text'])->toBe(' / ');
+    expect($runs[2]['props']['text'])->toBe('Guides');
+});
+
+it('lets a run class override the parent whitespace class', function () {
+    $msg = "keep\nme";
+
+    $tree = renderWhitespaceTree(
+        '<native:column><native:text class="whitespace-pre-line">head<native:text class="whitespace-normal" :text="$msg"></native:text></native:text></native:column>',
+        ['msg' => $msg]
+    );
+
+    $runs = $tree['children'][0]['children'];
+    expect($runs[1]['props']['text'])->toBe('keep me');
+});
+
+it('never collapses non-breaking spaces, matching the browser', function () {
+    $msg = "a\u{00A0}\u{00A0}b   c";
+
+    $tree = renderWhitespaceTree(
+        '<native:column><native:text :text="$msg" /></native:column>',
+        ['msg' => $msg]
+    );
+
+    expect($tree['children'][0]['props']['text'])->toBe("a\u{00A0}\u{00A0}b c");
 });

--- a/tests/Feature/Edge/WhitespaceClassesTest.php
+++ b/tests/Feature/Edge/WhitespaceClassesTest.php
@@ -306,13 +306,14 @@ it('resolves text identically across every form, source and class at top level',
     ];
 
     foreach (['', ' class="whitespace-pre-line"', ' class="whitespace-pre"'] as $cls) {
-        $texts = collect($forms)->map(function ($tpl) use ($cls, $msg) {
+        $baseline = null;
+        foreach ($forms as $tpl) {
             $tree = renderEdgeTree('<native:column>'.sprintf($tpl, $cls).'</native:column>', ['msg' => $msg]);
+            $text = collect($tree['children'])->firstWhere('type', 'text')['props']['text'];
 
-            return collect($tree['children'])->firstWhere('type', 'text')['props']['text'];
-        });
-
-        expect($texts->unique()->count())->toBe(1, "forms diverge under class [{$cls}]: ".$texts->join(' | '));
+            $baseline ??= $text;
+            expect($text)->toBe($baseline, "{$tpl} diverges under class [{$cls}]");
+        }
     }
 });
 
@@ -328,17 +329,18 @@ it('resolves nested runs identically across every nested form', function () {
         '<x-native-text :text="$msg" />',
     ];
 
-    foreach (['', ' class="whitespace-pre-line"'] as $cls) {
-        $runShapes = collect($nested)->map(function ($inner) use ($cls, $msg) {
+    foreach (['', ' class="whitespace-pre-line"', ' class="whitespace-pre"'] as $cls) {
+        $baseline = null;
+        foreach ($nested as $inner) {
             $tree = renderEdgeTree(
                 '<native:column><text'.$cls.'>head '.$inner.' tail</text></native:column>',
                 ['msg' => $msg]
             );
             $text = collect($tree['children'])->firstWhere('type', 'text');
+            $shape = json_encode(collect($text['children'])->map(fn ($r) => $r['props']['text'] ?? '')->all());
 
-            return json_encode(collect($text['children'])->map(fn ($r) => $r['props']['text'] ?? '')->all());
-        });
-
-        expect($runShapes->unique()->count())->toBe(1, "nested forms diverge under class [{$cls}]: ".$runShapes->join(' | '));
+            $baseline ??= $shape;
+            expect($shape)->toBe($baseline, "{$inner} diverges under class [{$cls}]");
+        }
     }
 });

--- a/tests/Feature/Edge/WhitespaceClassesTest.php
+++ b/tests/Feature/Edge/WhitespaceClassesTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\NativeElementCollector;
 use Native\Mobile\Edge\NativeTagPrecompiler;
 
@@ -34,29 +33,10 @@ afterEach(function () {
     }
 });
 
-/**
- * Render a Blade string through the native pipeline and return the tree
- * array. The view name is unique per render because the compiler engine
- * caches per path within one app lifecycle, so reusing a name would
- * silently re-render the previous template instead of this one.
- */
-function renderWhitespaceTree(string $blade, array $data = []): array
-{
-    static $sequence = 0;
-    $name = 'whitespace-classes-'.(++$sequence);
-
-    file_put_contents(__DIR__.'/views/'.$name.'.blade.php', $blade);
-
-    NativeElementCollector::reset();
-    view($name, $data)->render();
-
-    return NativeElementCollector::collect()->toArray(new CallbackRegistry);
-}
-
 // ── Slot-sourced text ────────────────────────────────
 
 it('collapses slot text fully under whitespace-normal', function () {
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text class="whitespace-normal">{{ $msg }}</native:text></native:column>',
         ['msg' => "  Line one \n   Line two  "]
     );
@@ -65,7 +45,7 @@ it('collapses slot text fully under whitespace-normal', function () {
 });
 
 it('preserves newlines in slot text under whitespace-pre-line', function () {
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text class="whitespace-pre-line">{{ $msg }}</native:text></native:column>',
         ['msg' => "  Line one   \n   Line  two  "]
     );
@@ -77,7 +57,7 @@ it('preserves newlines in slot text under whitespace-pre-line', function () {
 it('keeps slot text verbatim under whitespace-pre', function () {
     $msg = "Line one\n    Line two\n";
 
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text class="whitespace-pre">{{ $msg }}</native:text></native:column>',
         ['msg' => $msg]
     );
@@ -86,7 +66,7 @@ it('keeps slot text verbatim under whitespace-pre', function () {
 });
 
 it('keeps the exact trim-and-collapse default for slot text without a class', function () {
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text>{{ $msg }}</native:text></native:column>',
         ['msg' => "  Hello \n  World  "]
     );
@@ -97,7 +77,7 @@ it('keeps the exact trim-and-collapse default for slot text without a class', fu
 // ── Attribute-sourced text ───────────────────────────
 
 it('collapses attribute text under whitespace-normal on a self-closing tag', function () {
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text class="whitespace-normal" :text="$msg" /></native:column>',
         ['msg' => "  Line one \n   Line two  "]
     );
@@ -106,7 +86,7 @@ it('collapses attribute text under whitespace-normal on a self-closing tag', fun
 });
 
 it('collapses attribute text under whitespace-normal on a paired tag', function () {
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text class="whitespace-normal" :text="$msg"></native:text></native:column>',
         ['msg' => "  Line one \n   Line two  "]
     );
@@ -115,7 +95,7 @@ it('collapses attribute text under whitespace-normal on a paired tag', function 
 });
 
 it('preserves newlines in attribute text under whitespace-pre-line', function () {
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text class="whitespace-pre-line" :text="$msg" /></native:column>',
         ['msg' => "  Line one   \n   Line  two  "]
     );
@@ -126,7 +106,7 @@ it('preserves newlines in attribute text under whitespace-pre-line', function ()
 it('keeps attribute text verbatim under whitespace-pre', function () {
     $msg = "  Line one \n   Line two  ";
 
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text class="whitespace-pre" :text="$msg" /></native:column>',
         ['msg' => $msg]
     );
@@ -137,11 +117,11 @@ it('keeps attribute text verbatim under whitespace-pre', function () {
 it('collapses attribute text by default, matching slot text and the browser', function () {
     $msg = "  Line one \n   Line two  ";
 
-    $selfClosing = renderWhitespaceTree(
+    $selfClosing = renderEdgeTree(
         '<native:column><native:text :text="$msg" /></native:column>',
         ['msg' => $msg]
     );
-    $paired = renderWhitespaceTree(
+    $paired = renderEdgeTree(
         '<native:column><native:text :text="$msg"></native:text></native:column>',
         ['msg' => $msg]
     );
@@ -156,7 +136,7 @@ it('keeps explicit edge spaces on nested separator runs by default', function ()
     // collapse applies. The raw runs around it stay intact too.
     $sep = ' / ';
 
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text>Docs<native:text :text="$sep"></native:text>Guides</native:text></native:column>',
         ['sep' => $sep]
     );
@@ -170,7 +150,7 @@ it('keeps explicit edge spaces on nested separator runs by default', function ()
 // ── Hand-wrapped template literals ───────────────────
 
 it('unwraps indented multi-line template prose under whitespace-pre-line', function () {
-    $tree = renderWhitespaceTree(<<<'BLADE'
+    $tree = renderEdgeTree(<<<'BLADE'
 <native:column>
     <native:text class="whitespace-pre-line">
         Hand wrapped prose line one
@@ -188,7 +168,7 @@ BLADE);
 // ── Nested runs under a classed parent ───────────────
 
 it('applies the parent whitespace class to nested runs', function () {
-    $tree = renderWhitespaceTree(<<<'BLADE'
+    $tree = renderEdgeTree(<<<'BLADE'
 <native:column><native:text class="whitespace-pre-line">First line
 <native:text class="font-mono">chip</native:text> second line</native:text></native:column>
 BLADE);
@@ -205,7 +185,7 @@ BLADE);
 });
 
 it('keeps default run boundaries and spacing unchanged without a class', function () {
-    $tree = renderWhitespaceTree(<<<'BLADE'
+    $tree = renderEdgeTree(<<<'BLADE'
 <native:column>
     <native:text>
         <native:text>A </native:text>
@@ -225,13 +205,13 @@ BLADE);
 // ── <x-native-text> component parity ─────────────────
 
 it('resolves x-native-text slot text identically to plain text', function () {
-    $component = renderWhitespaceTree(<<<'BLADE'
+    $component = renderEdgeTree(<<<'BLADE'
 <native:column><x-native-text class="whitespace-pre-line">
     Terms apply
     to everyone.
 </x-native-text></native:column>
 BLADE);
-    $plain = renderWhitespaceTree(<<<'BLADE'
+    $plain = renderEdgeTree(<<<'BLADE'
 <native:column><native:text class="whitespace-pre-line">
     Terms apply
     to everyone.
@@ -243,7 +223,7 @@ BLADE);
 });
 
 it('applies whitespace-normal to x-native-text attribute text', function () {
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><x-native-text class="whitespace-normal" :text="$msg" /></native:column>',
         ['msg' => "  Line one \n   Line two  "]
     );
@@ -257,7 +237,7 @@ it('treats a nested self-closing text as a run in document order', function () {
     // now, so the separator keeps its explicit edge spaces too.
     $sep = ' / ';
 
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text>Docs<native:text :text="$sep" />Guides</native:text></native:column>',
         ['sep' => $sep]
     );
@@ -273,7 +253,7 @@ it('treats a nested self-closing text as a run in document order', function () {
 it('lets a run class override the parent whitespace class', function () {
     $msg = "keep\nme";
 
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text class="whitespace-pre-line">head<native:text class="whitespace-normal" :text="$msg"></native:text></native:text></native:column>',
         ['msg' => $msg]
     );
@@ -285,7 +265,7 @@ it('lets a run class override the parent whitespace class', function () {
 it('never collapses non-breaking spaces, matching the browser', function () {
     $msg = "a\u{00A0}\u{00A0}b   c";
 
-    $tree = renderWhitespaceTree(
+    $tree = renderEdgeTree(
         '<native:column><native:text :text="$msg" /></native:column>',
         ['msg' => $msg]
     );

--- a/tests/Feature/Edge/WhitespaceClassesTest.php
+++ b/tests/Feature/Edge/WhitespaceClassesTest.php
@@ -127,7 +127,7 @@ it('keeps attribute text verbatim under whitespace-pre', function () {
     expect($tree['children'][0]['props']['text'])->toBe($msg);
 });
 
-it('keeps attribute text byte-for-byte untouched without a class', function () {
+it('collapses attribute text by default, matching slot text and the browser', function () {
     $msg = "  Line one \n   Line two  ";
 
     $selfClosing = renderWhitespaceTree(
@@ -139,8 +139,25 @@ it('keeps attribute text byte-for-byte untouched without a class', function () {
         ['msg' => $msg]
     );
 
-    expect($selfClosing['children'][0]['props']['text'])->toBe($msg);
-    expect($paired['children'][0]['props']['text'])->toBe($msg);
+    expect($selfClosing['children'][0]['props']['text'])->toBe('Line one Line two');
+    expect($paired['children'][0]['props']['text'])->toBe('Line one Line two');
+});
+
+it('keeps explicit edge spaces on nested separator runs by default', function () {
+    // The browser trims at block boundaries only, so an inline separator
+    // like `:text="' / '"` must keep its spacing when the default
+    // collapse applies. The raw runs around it stay intact too.
+    $sep = ' / ';
+
+    $tree = renderWhitespaceTree(
+        '<native:column><native:text>Docs<native:text :text="$sep"></native:text>Guides</native:text></native:column>',
+        ['sep' => $sep]
+    );
+
+    $runs = $tree['children'][0]['children'];
+    expect($runs[0]['props']['text'])->toBe('Docs');
+    expect($runs[1]['props']['text'])->toBe(' / ');
+    expect($runs[2]['props']['text'])->toBe('Guides');
 });
 
 // ── Hand-wrapped template literals ───────────────────

--- a/tests/Feature/Edge/WhitespaceClassesTest.php
+++ b/tests/Feature/Edge/WhitespaceClassesTest.php
@@ -185,24 +185,6 @@ BLADE);
     expect($text['children'][2]['props']['text'])->toBe(' second line');
 });
 
-it('keeps default run boundaries and spacing unchanged without a class', function () {
-    $tree = renderEdgeTree(<<<'BLADE'
-<native:column>
-    <native:text>
-        <native:text>A </native:text>
-        <native:text class="font-mono">B</native:text>
-        <native:text> C</native:text>
-    </native:text>
-</native:column>
-BLADE);
-
-    $text = collect($tree['children'])->firstWhere('type', 'text');
-    expect($text['children'])->toHaveCount(3);
-    expect($text['children'][0]['props']['text'])->toBe('A ');
-    expect($text['children'][1]['props']['text'])->toBe('B');
-    expect($text['children'][2]['props']['text'])->toBe(' C');
-});
-
 // ── <x-native-text> component parity ─────────────────
 
 it('resolves x-native-text slot text identically to plain text', function () {
@@ -280,12 +262,7 @@ it('never collapses non-breaking spaces, matching the browser', function () {
 // The whitespace policy is what these pin: it resolves the same
 // through a slot as anywhere else, class and default alike.
 it('applies whitespace classes to text rendered through a blade component slot', function () {
-    Blade::anonymousComponentPath(__DIR__.'/views/components');
-    @mkdir(__DIR__.'/views/components', 0755, true);
-    file_put_contents(
-        __DIR__.'/views/components/ws-panel.blade.php',
-        '<native:column class="p-4">{{ $slot }}</native:column>'
-    );
+    app('view')->addLocation(__DIR__.'/../../Fixtures/views');
 
     $msg = "Line one\n   Line two";
 
@@ -294,17 +271,15 @@ it('applies whitespace classes to text rendered through a blade component slot',
         ['msg' => $msg]
     );
 
-    $text = collect($tree['children'])->firstWhere('type', 'text');
-    expect($text['props']['text'])->toBe("Line one\nLine two");
+    // The slot text emits as a sibling BEFORE the panel today; asserting
+    // that placement makes a future capture-order fix flip this test
+    // consciously instead of dying on a null lookup.
+    expect($tree['children'][0]['type'])->toBe('text');
+    expect($tree['children'][0]['props']['text'])->toBe("Line one\nLine two");
 });
 
 it('collapses slot-delivered text by default inside a blade component slot', function () {
-    Blade::anonymousComponentPath(__DIR__.'/views/components');
-    @mkdir(__DIR__.'/views/components', 0755, true);
-    file_put_contents(
-        __DIR__.'/views/components/ws-panel.blade.php',
-        '<native:column class="p-4">{{ $slot }}</native:column>'
-    );
+    app('view')->addLocation(__DIR__.'/../../Fixtures/views');
 
     $msg = "Line one\n   Line two";
 
@@ -313,6 +288,6 @@ it('collapses slot-delivered text by default inside a blade component slot', fun
         ['msg' => $msg]
     );
 
-    $text = collect($tree['children'])->firstWhere('type', 'text');
-    expect($text['props']['text'])->toBe('Line one Line two');
+    expect($tree['children'][0]['type'])->toBe('text');
+    expect($tree['children'][0]['props']['text'])->toBe('Line one Line two');
 });

--- a/tests/Feature/Edge/WhitespaceClassesTest.php
+++ b/tests/Feature/Edge/WhitespaceClassesTest.php
@@ -291,3 +291,54 @@ it('collapses slot-delivered text by default inside a blade component slot', fun
     expect($tree['children'][0]['type'])->toBe('text');
     expect($tree['children'][0]['props']['text'])->toBe('Line one Line two');
 });
+
+// ── Authoring-form parity ────────────────────────────
+
+it('resolves text identically across every form, source and class at top level', function () {
+    $msg = "Line one\n   Line two";
+    $forms = [
+        '<text%s>{{ $msg }}</text>',
+        '<text%s :text="$msg" />',
+        '<native:text%s>{{ $msg }}</native:text>',
+        '<native:text%s :text="$msg" />',
+        '<x-native-text%s>{{ $msg }}</x-native-text>',
+        '<x-native-text%s :text="$msg" />',
+    ];
+
+    foreach (['', ' class="whitespace-pre-line"', ' class="whitespace-pre"'] as $cls) {
+        $texts = collect($forms)->map(function ($tpl) use ($cls, $msg) {
+            $tree = renderEdgeTree('<native:column>'.sprintf($tpl, $cls).'</native:column>', ['msg' => $msg]);
+
+            return collect($tree['children'])->firstWhere('type', 'text')['props']['text'];
+        });
+
+        expect($texts->unique()->count())->toBe(1, "forms diverge under class [{$cls}]: ".$texts->join(' | '));
+    }
+});
+
+it('resolves nested runs identically across every nested form', function () {
+    $msg = "Line one\n   Line two";
+    $nested = [
+        '<text>{{ $msg }}</text>',
+        '<text :text="$msg" />',
+        '<text :text="$msg"></text>',
+        '<native:text>{{ $msg }}</native:text>',
+        '<native:text :text="$msg" />',
+        '<x-native-text>{{ $msg }}</x-native-text>',
+        '<x-native-text :text="$msg" />',
+    ];
+
+    foreach (['', ' class="whitespace-pre-line"'] as $cls) {
+        $runShapes = collect($nested)->map(function ($inner) use ($cls, $msg) {
+            $tree = renderEdgeTree(
+                '<native:column><text'.$cls.'>head '.$inner.' tail</text></native:column>',
+                ['msg' => $msg]
+            );
+            $text = collect($tree['children'])->firstWhere('type', 'text');
+
+            return json_encode(collect($text['children'])->map(fn ($r) => $r['props']['text'] ?? '')->all());
+        });
+
+        expect($runShapes->unique()->count())->toBe(1, "nested forms diverge under class [{$cls}]: ".$runShapes->join(' | '));
+    }
+});

--- a/tests/Feature/Edge/WhitespaceClassesTest.php
+++ b/tests/Feature/Edge/WhitespaceClassesTest.php
@@ -1,0 +1,228 @@
+<?php
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\NativeElementCollector;
+use Native\Mobile\Edge\NativeTagPrecompiler;
+
+/**
+ * The whitespace-* class family governs how text whitespace is resolved
+ * before the text prop is serialized, identically for slot-sourced and
+ * attribute-sourced text. Without a class the per-source defaults hold:
+ * slot text gets the historical trim-and-collapse, attribute text
+ * passes through byte-for-byte untouched.
+ */
+beforeEach(function () {
+    NativeElementCollector::reset();
+    NativeTagPrecompiler::setActive(true);
+
+    $testViewPath = __DIR__.'/views';
+    if (! is_dir($testViewPath)) {
+        mkdir($testViewPath, 0755, true);
+    }
+    app('view')->addLocation($testViewPath);
+});
+
+afterEach(function () {
+    NativeTagPrecompiler::setActive(false);
+    NativeElementCollector::reset();
+
+    $testViewPath = __DIR__.'/views';
+    if (is_dir($testViewPath)) {
+        foreach (glob($testViewPath.'/*.php') as $file) {
+            unlink($file);
+        }
+    }
+});
+
+/** Render a Blade string through the native pipeline and return the tree array. */
+function renderWhitespaceTree(string $blade, array $data = []): array
+{
+    $viewPath = __DIR__.'/views/whitespace-classes.blade.php';
+    file_put_contents($viewPath, $blade);
+
+    NativeElementCollector::reset();
+    view('whitespace-classes', $data)->render();
+
+    return NativeElementCollector::collect()->toArray(new CallbackRegistry);
+}
+
+// ── Slot-sourced text ────────────────────────────────
+
+it('collapses slot text fully under whitespace-normal', function () {
+    $tree = renderWhitespaceTree(
+        '<native:column><native:text class="whitespace-normal">{{ $msg }}</native:text></native:column>',
+        ['msg' => "  Line one \n   Line two  "]
+    );
+
+    expect($tree['children'][0]['props']['text'])->toBe('Line one Line two');
+});
+
+it('preserves newlines in slot text under whitespace-pre-line', function () {
+    $tree = renderWhitespaceTree(
+        '<native:column><native:text class="whitespace-pre-line">{{ $msg }}</native:text></native:column>',
+        ['msg' => "  Line one   \n   Line  two  "]
+    );
+
+    // Newlines survive, horizontal runs collapse, edges trim.
+    expect($tree['children'][0]['props']['text'])->toBe("Line one\nLine two");
+});
+
+it('keeps slot text verbatim under whitespace-pre', function () {
+    $msg = "Line one\n    Line two\n";
+
+    $tree = renderWhitespaceTree(
+        '<native:column><native:text class="whitespace-pre">{{ $msg }}</native:text></native:column>',
+        ['msg' => $msg]
+    );
+
+    expect($tree['children'][0]['props']['text'])->toBe($msg);
+});
+
+it('keeps the exact trim-and-collapse default for slot text without a class', function () {
+    $tree = renderWhitespaceTree(
+        '<native:column><native:text>{{ $msg }}</native:text></native:column>',
+        ['msg' => "  Hello \n  World  "]
+    );
+
+    expect($tree['children'][0]['props']['text'])->toBe('Hello World');
+});
+
+// ── Attribute-sourced text ───────────────────────────
+
+it('collapses attribute text under whitespace-normal on a self-closing tag', function () {
+    $tree = renderWhitespaceTree(
+        '<native:column><native:text class="whitespace-normal" :text="$msg" /></native:column>',
+        ['msg' => "  Line one \n   Line two  "]
+    );
+
+    expect($tree['children'][0]['props']['text'])->toBe('Line one Line two');
+});
+
+it('collapses attribute text under whitespace-normal on a paired tag', function () {
+    $tree = renderWhitespaceTree(
+        '<native:column><native:text class="whitespace-normal" :text="$msg"></native:text></native:column>',
+        ['msg' => "  Line one \n   Line two  "]
+    );
+
+    expect($tree['children'][0]['props']['text'])->toBe('Line one Line two');
+});
+
+it('preserves newlines in attribute text under whitespace-pre-line', function () {
+    $tree = renderWhitespaceTree(
+        '<native:column><native:text class="whitespace-pre-line" :text="$msg" /></native:column>',
+        ['msg' => "  Line one   \n   Line  two  "]
+    );
+
+    expect($tree['children'][0]['props']['text'])->toBe("Line one\nLine two");
+});
+
+it('keeps attribute text verbatim under whitespace-pre', function () {
+    $msg = "  Line one \n   Line two  ";
+
+    $tree = renderWhitespaceTree(
+        '<native:column><native:text class="whitespace-pre" :text="$msg" /></native:column>',
+        ['msg' => $msg]
+    );
+
+    expect($tree['children'][0]['props']['text'])->toBe($msg);
+});
+
+it('keeps attribute text byte-for-byte untouched without a class', function () {
+    $msg = "  Line one \n   Line two  ";
+
+    $selfClosing = renderWhitespaceTree(
+        '<native:column><native:text :text="$msg" /></native:column>',
+        ['msg' => $msg]
+    );
+    $paired = renderWhitespaceTree(
+        '<native:column><native:text :text="$msg"></native:text></native:column>',
+        ['msg' => $msg]
+    );
+
+    expect($selfClosing['children'][0]['props']['text'])->toBe($msg);
+    expect($paired['children'][0]['props']['text'])->toBe($msg);
+});
+
+// ── Hand-wrapped template literals ───────────────────
+
+it('unwraps indented multi-line template prose under whitespace-pre-line', function () {
+    $tree = renderWhitespaceTree(<<<'BLADE'
+<native:column>
+    <native:text class="whitespace-pre-line">
+        Hand wrapped prose line one
+        and the second line here.
+    </native:text>
+</native:column>
+BLADE);
+
+    $text = collect($tree['children'])->firstWhere('type', 'text');
+
+    // The literal newlines survive while the indentation collapses away.
+    expect($text['props']['text'])->toBe("Hand wrapped prose line one\nand the second line here.");
+});
+
+// ── Nested runs under a classed parent ───────────────
+
+it('applies the parent whitespace class to nested runs', function () {
+    $tree = renderWhitespaceTree(<<<'BLADE'
+<native:column><native:text class="whitespace-pre-line">First line
+<native:text class="font-mono">chip</native:text> second line</native:text></native:column>
+BLADE);
+
+    $text = collect($tree['children'])->firstWhere('type', 'text');
+    expect($text['children'])->toHaveCount(3);
+
+    // The raw run keeps its newline; the chip inherits the parent mode;
+    // the tail run keeps its meaningful leading space (runs never trim).
+    expect($text['children'][0]['props']['text'])->toBe("First line\n");
+    expect($text['children'][1]['props']['text'])->toBe('chip');
+    expect($text['children'][1]['props']['font_family'])->toBe(2);
+    expect($text['children'][2]['props']['text'])->toBe(' second line');
+});
+
+it('keeps default run boundaries and spacing unchanged without a class', function () {
+    $tree = renderWhitespaceTree(<<<'BLADE'
+<native:column>
+    <native:text>
+        <native:text>A </native:text>
+        <native:text class="font-mono">B</native:text>
+        <native:text> C</native:text>
+    </native:text>
+</native:column>
+BLADE);
+
+    $text = collect($tree['children'])->firstWhere('type', 'text');
+    expect($text['children'])->toHaveCount(3);
+    expect($text['children'][0]['props']['text'])->toBe('A ');
+    expect($text['children'][1]['props']['text'])->toBe('B');
+    expect($text['children'][2]['props']['text'])->toBe(' C');
+});
+
+// ── <x-native-text> component parity ─────────────────
+
+it('resolves x-native-text slot text identically to plain text', function () {
+    $component = renderWhitespaceTree(<<<'BLADE'
+<native:column><x-native-text class="whitespace-pre-line">
+    Terms apply
+    to everyone.
+</x-native-text></native:column>
+BLADE);
+    $plain = renderWhitespaceTree(<<<'BLADE'
+<native:column><native:text class="whitespace-pre-line">
+    Terms apply
+    to everyone.
+</native:text></native:column>
+BLADE);
+
+    expect($component['children'][0]['props']['text'])->toBe("Terms apply\nto everyone.");
+    expect($component['children'][0]['props']['text'])->toBe($plain['children'][0]['props']['text']);
+});
+
+it('applies whitespace-normal to x-native-text attribute text', function () {
+    $tree = renderWhitespaceTree(
+        '<native:column><x-native-text class="whitespace-normal" :text="$msg" /></native:column>',
+        ['msg' => "  Line one \n   Line two  "]
+    );
+
+    expect($tree['children'][0]['props']['text'])->toBe('Line one Line two');
+});

--- a/tests/Feature/Edge/WhitespaceClassesTest.php
+++ b/tests/Feature/Edge/WhitespaceClassesTest.php
@@ -272,3 +272,36 @@ it('never collapses non-breaking spaces, matching the browser', function () {
 
     expect($tree['children'][0]['props']['text'])->toBe("a\u{00A0}\u{00A0}b c");
 });
+
+// Blade captures slot content before the component template renders, so
+// EDGE elements inside a component slot emit ahead of the component's
+// own wrapper (a pre-existing placement quirk, identical on main).
+// The whitespace policy is what these pin: it resolves the same
+// through a slot as anywhere else, class and default alike.
+it('applies whitespace classes to text rendered through a blade component slot', function () {
+    Illuminate\Support\Facades\Blade::anonymousComponentPath(__DIR__.'/views/components');
+
+    $msg = "Line one\n   Line two";
+
+    $tree = renderEdgeTree(
+        '<native:column><x-ws-panel><native:text class="whitespace-pre-line">{{ $msg }}</native:text></x-ws-panel></native:column>',
+        ['msg' => $msg]
+    );
+
+    $text = collect($tree['children'])->firstWhere('type', 'text');
+    expect($text['props']['text'])->toBe("Line one\nLine two");
+});
+
+it('collapses slot-delivered text by default inside a blade component slot', function () {
+    Illuminate\Support\Facades\Blade::anonymousComponentPath(__DIR__.'/views/components');
+
+    $msg = "Line one\n   Line two";
+
+    $tree = renderEdgeTree(
+        '<native:column><x-ws-panel><native:text>{{ $msg }}</native:text></x-ws-panel></native:column>',
+        ['msg' => $msg]
+    );
+
+    $text = collect($tree['children'])->firstWhere('type', 'text');
+    expect($text['props']['text'])->toBe('Line one Line two');
+});

--- a/tests/Feature/Edge/WhitespaceClassesTest.php
+++ b/tests/Feature/Edge/WhitespaceClassesTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Facades\Blade;
 use Native\Mobile\Edge\NativeElementCollector;
 use Native\Mobile\Edge\NativeTagPrecompiler;
 
@@ -279,7 +280,12 @@ it('never collapses non-breaking spaces, matching the browser', function () {
 // The whitespace policy is what these pin: it resolves the same
 // through a slot as anywhere else, class and default alike.
 it('applies whitespace classes to text rendered through a blade component slot', function () {
-    Illuminate\Support\Facades\Blade::anonymousComponentPath(__DIR__.'/views/components');
+    Blade::anonymousComponentPath(__DIR__.'/views/components');
+    @mkdir(__DIR__.'/views/components', 0755, true);
+    file_put_contents(
+        __DIR__.'/views/components/ws-panel.blade.php',
+        '<native:column class="p-4">{{ $slot }}</native:column>'
+    );
 
     $msg = "Line one\n   Line two";
 
@@ -293,7 +299,12 @@ it('applies whitespace classes to text rendered through a blade component slot',
 });
 
 it('collapses slot-delivered text by default inside a blade component slot', function () {
-    Illuminate\Support\Facades\Blade::anonymousComponentPath(__DIR__.'/views/components');
+    Blade::anonymousComponentPath(__DIR__.'/views/components');
+    @mkdir(__DIR__.'/views/components', 0755, true);
+    file_put_contents(
+        __DIR__.'/views/components/ws-panel.blade.php',
+        '<native:column class="p-4">{{ $slot }}</native:column>'
+    );
 
     $msg = "Line one\n   Line two";
 

--- a/tests/Feature/Edge/views/components/ws-panel.blade.php
+++ b/tests/Feature/Edge/views/components/ws-panel.blade.php
@@ -1,0 +1,1 @@
+<native:column class="p-4">{{ $slot }}</native:column>

--- a/tests/Feature/Edge/views/components/ws-panel.blade.php
+++ b/tests/Feature/Edge/views/components/ws-panel.blade.php
@@ -1,1 +1,0 @@
-<native:column class="p-4">{{ $slot }}</native:column>

--- a/tests/Fixtures/views/components/ws-panel.blade.php
+++ b/tests/Fixtures/views/components/ws-panel.blade.php
@@ -1,0 +1,1 @@
+<native:column class="p-4">{{ $slot }}</native:column>

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\NativeElementCollector;
 use Tests\TestCase;
 
 /*
@@ -43,7 +45,22 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function something()
+/**
+ * Render a Blade string through the native EDGE pipeline and return the
+ * element tree as an array. The view name is unique per render because
+ * the compiler engine caches per path within one app lifecycle, so a
+ * reused name would silently re-render the previous template.
+ */
+function renderEdgeTree(string $blade, array $data = []): array
 {
-    // ..
+    static $sequence = 0;
+    $name = 'edge-tree-'.(++$sequence);
+
+    file_put_contents(__DIR__.'/Feature/Edge/views/'.$name.'.blade.php', $blade);
+
+    NativeElementCollector::reset();
+    view($name, $data)->render();
+
+    return NativeElementCollector::collect()
+        ->toArray(new CallbackRegistry);
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -47,26 +47,36 @@ expect()->extend('toBeOne', function () {
 
 /**
  * Render a Blade string through the native EDGE pipeline and return the
- * element tree as an array. The view name is unique per render because
- * the compiler engine caches per path within one app lifecycle, so a
- * reused name would silently re-render the previous template.
+ * element tree as an array. The helper owns its whole file lifecycle:
+ * it provisions the scratch view, registers the location once, and
+ * removes both the source and the compiled artifact afterwards.
+ * Callers only toggle the precompiler, the thing under test.
+ *
+ * View names are random per call so a name can never collide with an
+ * earlier run's different content inside Blade's compiled cache,
+ * which compares mtimes at one second granularity.
  */
 function renderEdgeTree(string $blade, array $data = []): array
 {
-    static $sequence = 0;
-    static $run = null;
-    $run ??= substr(md5(uniqid('', true)), 0, 8);
+    $viewPath = __DIR__.'/Feature/Edge/views';
+    @mkdir($viewPath, 0755, true);
 
-    // The run token keeps names unique ACROSS pest processes too: a
-    // reused name from an earlier run can hit Blade's compiled cache
-    // within the same mtime second and silently serve stale output.
-    $name = 'edge-tree-'.$run.'-'.(++$sequence);
+    if (! in_array($viewPath, app('view')->getFinder()->getPaths())) {
+        app('view')->addLocation($viewPath);
+    }
 
-    file_put_contents(__DIR__.'/Feature/Edge/views/'.$name.'.blade.php', $blade);
+    $name = 'edge-tree-'.bin2hex(random_bytes(8));
+    $source = $viewPath.'/'.$name.'.blade.php';
+    file_put_contents($source, $blade);
 
-    NativeElementCollector::reset();
-    view($name, $data)->render();
+    try {
+        NativeElementCollector::reset();
+        view($name, $data)->render();
 
-    return NativeElementCollector::collect()
-        ->toArray(new CallbackRegistry);
+        return NativeElementCollector::collect()
+            ->toArray(new CallbackRegistry);
+    } finally {
+        @unlink(app('blade.compiler')->getCompiledPath($source));
+        @unlink($source);
+    }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -54,7 +54,13 @@ expect()->extend('toBeOne', function () {
 function renderEdgeTree(string $blade, array $data = []): array
 {
     static $sequence = 0;
-    $name = 'edge-tree-'.(++$sequence);
+    static $run = null;
+    $run ??= substr(md5(uniqid('', true)), 0, 8);
+
+    // The run token keeps names unique ACROSS pest processes too: a
+    // reused name from an earlier run can hit Blade's compiled cache
+    // within the same mtime second and silently serve stale output.
+    $name = 'edge-tree-'.$run.'-'.(++$sequence);
 
     file_put_contents(__DIR__.'/Feature/Edge/views/'.$name.'.blade.php', $blade);
 


### PR DESCRIPTION
Fixes #336.

The report: `<text>{{ $msg }}</text>` collapses newlines while `:text="$msg"` preserves them, so user-generated text renders differently depending on which authoring form you picked. Reproduced identically on both platforms, and across every form: plain `<text>`, `<native:text>`, `<x-native-text>`, slot and attribute.

Plain Blade never touches whitespace, I checked: slot and prop come through byte-identical. The browser collapses at paint time via CSS white-space, so nothing is ever destroyed and the two sources can't diverge. EDGE collapsed at capture time in PHP instead, and only on the slot path, which is both destructive and asymmetric.

This PR makes the whole thing behave like the web. There is one whitespace policy, applied where slot and attribute text merge, and it treats both sources identically. The default collapses, exactly what CSS white-space normal does. The new whitespace-pre-line and whitespace-pre-wrap classes opt out, and whitespace-normal exists to say the default explicitly. It's pre-wrap rather than pre on purpose: native text always soft-wraps, and per the CSS table pre means no wrapping while pre-wrap means preserve and wrap, which is exactly what this renders. Verified against MDN and measured in a real browser before naming it. In practice:

```blade
{{-- $msg = "Line one\n    Line two" --}}

<text>{{ $msg }}</text>
<text :text="$msg" />
{{-- both render: Line one Line two --}}

<text class="whitespace-pre-line">{{ $msg }}</text>
<text class="whitespace-pre-line" :text="$msg" />
{{-- both render:
     Line one
     Line two          (newlines kept, indentation collapsed) --}}
```

That default is also what keeps hand-wrapped template prose working, the same way a `<p>` does:

```blade
<text>
    A long sentence that was wrapped
    over two lines in the editor.
</text>
{{-- renders as one flowing line --}}
```

Nested runs inherit the closest classed ancestor the way white-space cascades, a run's own class wins, and runs collapse without trimming, the browser trims at block boundaries only. So inline separators keep their spacing:

```blade
<text>Docs<text :text="' / '" />Guides</text>
{{-- renders: Docs / Guides --}}
```

Making every form identical also surfaced two pre-existing bugs. A self-closing `<text />` nested inside a paired `<text>` used to escape the run system entirely and render as a misplaced sibling; it's a proper in-order run now. And `<x-native-text>` had the same escape when nested, which also meant it couldn't inherit a parent's whitespace class; it now runs the exact frame cycle a precompiled `<text>` does. Parity across all seven authoring forms, nested and top-level, prop and slot, is pinned by matrix tests that name the diverging form when they fail.

The policy runs at capture time in PHP, not paint time on the device. Paint time is the browser's model, but SwiftUI and Compose render strings verbatim, so paint time here would mean implementing CSS collapsing twice in Swift and Kotlin plus a wire prop plus cross-run edge logic in both renderers. The split lands where it belongs: content shaping in PHP, layout behaviour native. That's also why whitespace-nowrap, whitespace-pre and break-spaces are left out, all three need a native no-wrap prop before they can exist truthfully.

The breaking part: `:text` no longer preserves newlines by default, and that's what people rely on today to keep them. The migration is one class:

```blade
{{-- before: :text preserved newlines as a side effect --}}
<text :text="$message" />

{{-- after: say it explicitly --}}
<text :text="$message" class="whitespace-pre-wrap" />
{{-- or, for chat-style user content: --}}
<text :text="$message" class="whitespace-pre-line" />
```

The classes and the flip ship together, so the escape hatch exists the moment the default changes. Worth a changelog callout.

Known siblings, deliberately untouched: button labels keep their own inline collapse in the precompiler, programmatic `Text::make()->text(...)` ships strings verbatim with the classes documented as a Blade-only capture policy, and EDGE elements inside a plain Blade component slot emit ahead of the component's wrapper, a pre-existing capture-order quirk. The whitespace policy resolves correctly through such slots (tested); the placement itself, including the inverse case of a native `<text>` inside an `<x-native-text>` slot, predates this branch byte-for-byte and is pinned consciously where tests touch it.

Verification. 21 tests cover every class on every source and form, run inheritance and per-run override, separator runs, nbsp (which must never collapse, and doesn't, in either CSS or this implementation), delivery through Blade component slots, the exact byte shape of the defaults, and the seven-form parity matrix; the original set was proven red on main. Full suite green. On device: a 16-case repro screen rendered identically on the Android emulator and iOS simulator, checked row by row against a plain HTML page rendering the same strings under real CSS white-space.
