### PR TITLE
Resolve relative image src for the device under Jump

### DIFF
--- a/src/Edge/Elements/Image.php
+++ b/src/Edge/Elements/Image.php
@@ -4,6 +4,7 @@ namespace Native\Mobile\Edge\Elements;
 
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\ImageSource;
 
 class Image extends Element
 {
@@ -15,7 +16,7 @@ class Image extends Element
     {
         $el = new static;
         if ($src !== '') {
-            $el->imageProps['src'] = $src;
+            $el->imageProps['src'] = ImageSource::forDevice($src);
         }
 
         return $el;
@@ -24,7 +25,7 @@ class Image extends Element
     public function applyAttributes(array $attrs): void
     {
         if (isset($attrs['src'])) {
-            $this->imageProps['src'] = $attrs['src'];
+            $this->imageProps['src'] = ImageSource::forDevice($attrs['src']);
         }
         if (isset($attrs['fit'])) {
             $this->fit((int) $attrs['fit']);

--- a/src/Edge/ImageSource.php
+++ b/src/Edge/ImageSource.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Native\Mobile\Edge;
+
+use Native\Mobile\System;
+
+/**
+ * Turns a developer-authored image `src` into something the DEVICE can load.
+ *
+ * `src` reads like a web URL to whoever writes it, so a relative path means
+ * "an asset I shipped in `public/`". Who resolves that depends on where PHP is
+ * running:
+ *
+ * - ON DEVICE, PHP and the renderer share a filesystem, so the path travels
+ *   over the wire untouched and the native renderer resolves it against the
+ *   app's `public/` directory.
+ * - UNDER JUMP, PHP is on the developer's machine and the renderer is on a
+ *   phone. `public/` only exists here, but `native:jump` is already serving it
+ *   over HTTP and the router forwards the phone-reachable `Host` header to
+ *   Laravel — so `asset()` yields a URL the device can fetch, and the renderer
+ *   treats it as any other remote image.
+ *
+ * Plugins that accept an image path should route it through here so a `src`
+ * means the same thing wherever it's written. Anything already absolute — a
+ * device file path, or a value carrying a URL scheme — is passed through
+ * untouched: camera captures and gallery picks arrive that way, and rewriting
+ * them would break them.
+ */
+class ImageSource
+{
+    /** Leading URI scheme per RFC 3986 — `https:`, `file:`, `data:`. */
+    private const SCHEME = '#^[a-zA-Z][a-zA-Z0-9+.\-]*:#';
+
+    public static function forDevice(string $src): string
+    {
+        if ($src === '' || str_starts_with($src, '/') || preg_match(self::SCHEME, $src) === 1) {
+            return $src;
+        }
+
+        if (! System::runningInJump()) {
+            return $src;
+        }
+
+        return asset(str_starts_with($src, './') ? substr($src, 2) : $src);
+    }
+}

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -30,6 +30,7 @@ use Native\Mobile\Events\Concerns\BroadcastsGlobally;
 use Native\Mobile\JumpBridge;
 use Native\Mobile\Platform;
 use Native\Mobile\Support\NativeCallbacks;
+use Native\Mobile\System;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
 use Symfony\Component\VarDumper\VarDumper;
@@ -2217,13 +2218,8 @@ abstract class NativeComponent
         // Claim this runloop as the current native session; the check at the top
         // of the loop makes any older, superseded runloop bail out so exactly one
         // ever drives the device.
-        //
-        // Gate on JUMP_BRIDGE_PORT (set only by `native:jump`). NOT on
-        // `function_exists('nativephp_call')` — in Jump mode the PHP fallback
-        // DEFINES that function, so it exists on both device and dev server and
-        // would gate this off everywhere.
         $jumpSessionToken = null;
-        if (getenv('JUMP_BRIDGE_PORT') !== false) {
+        if (System::runningInJump()) {
             $jumpSessionToken = $this->claimJumpSession();
         }
 

--- a/src/Facades/System.php
+++ b/src/Facades/System.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static bool isAndroid()
  * @method static bool isIos()
  * @method static bool isMobile()
+ * @method static bool runningInJump()
  * @method static void appSettings()
  * @method static string appearance()
  * @method static bool isDarkMode()

--- a/src/System.php
+++ b/src/System.php
@@ -49,6 +49,31 @@ class System
     }
 
     /**
+     * Is this process running under `native:jump`?
+     *
+     * In Jump hybrid mode PHP runs on the DEVELOPER'S MACHINE and only bridge
+     * calls cross to the phone. Anything the app hands the device that resolves
+     * locally — a filesystem path, a `localhost` URL — is meaningless over
+     * there, because "there" is a different computer. Code that builds
+     * device-bound values (core and plugins alike) checks this to hand over
+     * something the device can actually reach.
+     *
+     * Gated on `JUMP_BRIDGE_PORT`, which `native:jump` exports into the Laravel
+     * server it spawns. NOT on `function_exists('nativephp_call')` — in Jump
+     * mode the PHP fallback DEFINES that function (see
+     * NativeServiceProvider::registerJumpBridgeFallback()), so it exists on the
+     * dev server as well as on device and would report true everywhere.
+     *
+     * Static, and a bare env read, because callers include per-element render
+     * paths that also run on device, where this must not cost a facade resolve
+     * or a bridge round-trip.
+     */
+    public static function runningInJump(): bool
+    {
+        return getenv('JUMP_BRIDGE_PORT') !== false;
+    }
+
+    /**
      * Current system appearance: 'light' or 'dark'. Off the device (tests, web
      * preview) the bridge is absent and this returns 'light'.
      */

--- a/tests/Unit/Edge/ImageSourceTest.php
+++ b/tests/Unit/Edge/ImageSourceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Elements\Image;
+use Native\Mobile\Edge\ImageSource;
+
+/**
+ * A relative `src` means "an asset in `public/`". On device the native
+ * renderer resolves that against the app's public directory, so the value
+ * travels untouched; under Jump `public/` lives on the developer's machine
+ * and only reaches the phone over HTTP, so it has to become a URL before it
+ * goes over the wire.
+ */
+afterEach(function () {
+    putenv('JUMP_BRIDGE_PORT');
+});
+
+function jumping(bool $active): void
+{
+    $active ? putenv('JUMP_BRIDGE_PORT=3002') : putenv('JUMP_BRIDGE_PORT');
+}
+
+it('leaves a relative path alone on device — the renderer resolves it', function () {
+    jumping(false);
+
+    expect(ImageSource::forDevice('img/logo.png'))->toBe('img/logo.png');
+});
+
+it('rewrites a relative path to a fetchable URL under Jump', function () {
+    jumping(true);
+
+    expect(ImageSource::forDevice('img/logo.png'))->toBe(asset('img/logo.png'));
+});
+
+it('drops a leading ./ before building the URL', function () {
+    jumping(true);
+
+    expect(ImageSource::forDevice('./img/logo.png'))->toBe(asset('img/logo.png'));
+});
+
+it('passes through values that already point somewhere real', function (string $src) {
+    jumping(true);
+
+    expect(ImageSource::forDevice($src))->toBe($src);
+})->with([
+    'empty' => '',
+    // Absolute device path — a camera capture. Rewriting it would break it.
+    'device file' => '/var/mobile/Containers/Data/Application/x/tmp/photo.jpg',
+    'file url' => 'file:///var/mobile/photo.jpg',
+    'remote' => 'https://example.com/logo.png',
+    'data uri' => 'data:image/png;base64,iVBORw0KGgo=',
+    'content uri' => 'content://media/external/images/media/42',
+]);
+
+it('applies to the image element, from both the tag and the fluent API', function () {
+    jumping(true);
+
+    $fromTag = new Image;
+    $fromTag->applyAttributes(['src' => 'img/logo.png']);
+
+    $tagSrc = $fromTag->toArray(new CallbackRegistry)['props']['src'];
+    $fluentSrc = Image::make('img/logo.png')->toArray(new CallbackRegistry)['props']['src'];
+
+    expect($tagSrc)->toBe(asset('img/logo.png'))
+        ->and($fluentSrc)->toBe(asset('img/logo.png'));
+});


### PR DESCRIPTION
## What

A relative image `src` — `img/logo.png` — means "an asset I shipped in `public/`". Who resolves that depends on where PHP is running, and until now we assumed it was always the device:

- **On device**, PHP and the renderer share a filesystem, so the path travels over the wire untouched and the native renderer resolves it against the app's `public/` directory.
- **Under `native:jump`**, PHP is on the developer's machine and the renderer is on a phone. `public/` only exists on the dev machine, so the path resolves to nothing on the device and the image silently fails to load.

`native:jump` is already serving `public/` over HTTP, and the router forwards the phone-reachable `Host` header to Laravel — so `asset()` yields a URL the device can actually fetch, and the renderer treats it as any other remote image.

## How

New `Edge\ImageSource::forDevice()` centralises the rule, wired into both entry points on the `Image` element (the `<native:image src="...">` tag path and the fluent `Image::make()` path). Plugins that accept an image path should route through it too, so a `src` means the same thing wherever it's written.

Anything already pointing somewhere real is passed through untouched:

- absolute paths (`/var/mobile/.../photo.jpg`) — camera captures arrive this way
- anything carrying a URI scheme (`https:`, `file:`, `data:`, `content:`) — gallery picks arrive this way

Rewriting either would break them.

## `System::runningInJump()`

The Jump-mode check needed a home. It landed on `System`, alongside the other "where am I running" methods (`isIos()`, `isAndroid()`, `isMobile()`) — it's the same question one scope out: after "which platform", "which *machine*". Being on the facade also makes it discoverable for plugin authors, who are part of the intended audience.

It's `static` and a bare `getenv()` deliberately: `ImageSource::forDevice()` runs per image on the device render path, where this must not cost a container resolve or a bridge round-trip.

`NativeComponent::runLoop()` had the same check inlined, along with a copy of the reasoning. Both now collapse into the one method, so the `JUMP_BRIDGE_PORT` gate — and the non-obvious note about why it can't be `function_exists('nativephp_call')`, which is defined on *both* sides in Jump mode — is documented in exactly one place.

## Testing

10 new tests in `tests/Unit/Edge/ImageSourceTest.php` covering both modes, the `./` prefix, every pass-through case, and both `Image` entry points. Full suite green: 904 passed.

## Noticed while here — not addressed

Two pre-existing issues in untouched files, flagged for a separate look:

- `composer analyse` crashes at the default 128M memory limit. `./vendor/bin/phpstan analyse --memory-limit=2G` gets a real result; may be worth baking into the composer script.
- With the limit raised, 6 errors surface in `Concerns/ChecksLatestBuildNumber.php` and `Concerns/RunsAndroid.php` — references to command options/arguments that aren't declared (`api-key-path`, `api-key-id`, `api-issuer-id`, `watch`, `udid`). They read as real bugs rather than false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)