### PR TITLE
feat: opt-in RTL support across iOS, Android, and the WebView

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -82,6 +82,45 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | RTL Support
+    |--------------------------------------------------------------------------
+    |
+    | Enables opt-in right-to-left (RTL) support for Arabic, Hebrew,
+    | Persian/Farsi, Urdu and other RTL languages.
+    |
+    | Enabling this does NOT force the app into RTL — it only gives
+    | NativePHP permission to mirror the native shell (top bar, side nav,
+    | bottom nav, gestures) and the WebView when the device's active
+    | language is an RTL language. On LTR devices (or when this is false)
+    | the app behaves exactly as before.
+    |
+    | Defaults to false for full backward compatibility.
+    |
+    */
+
+    'rtl_support' => env('NATIVEPHP_RTL_SUPPORT', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Localizations
+    |--------------------------------------------------------------------------
+    |
+    | The list of languages your application supports, as BCP 47 language
+    | codes (e.g. 'en', 'ar', 'he', 'fa', 'ur'). For iOS these are written
+    | into the generated Info.plist as CFBundleLocalizations so the system
+    | correctly recognizes the languages the app ships.
+    |
+    | Leave empty to keep the existing build behavior unchanged.
+    |
+    */
+
+    'localizations' => [
+        // 'en',
+        // 'ar',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Appearance
     |--------------------------------------------------------------------------
     |

--- a/docs/rtl-support.md
+++ b/docs/rtl-support.md
@@ -1,0 +1,139 @@
+# Opt-in RTL Support
+
+NativePHP Mobile supports first-class **right-to-left (RTL)** layouts for
+Arabic, Hebrew, Persian/Farsi, Urdu, and other RTL languages across the iOS
+native UI, the Android native UI, and the embedded WebView.
+
+The feature is **fully backward-compatible**: existing applications remain LTR
+unless the developer explicitly enables RTL support.
+
+## How direction is decided
+
+The effective layout direction is:
+
+```
+isRTL = rtl_support && device language is RTL
+```
+
+| `rtl_support` | Device language | Effective direction |
+| ------------- | --------------- | ------------------- |
+| `false`       | English         | LTR                 |
+| `false`       | Arabic          | LTR                 |
+| `true`        | English         | LTR                 |
+| `true`        | Arabic          | RTL                 |
+| `true`        | Hebrew          | RTL                 |
+| `true`        | Persian         | RTL                 |
+| `true`        | Urdu            | RTL                 |
+
+> **Enabling `rtl_support` does not force the application into RTL.** It allows
+> NativePHP to automatically choose RTL or LTR based on the device language.
+> `rtl_support = false` is the default for backward compatibility.
+
+## Configuration
+
+Enable RTL and declare the languages your app supports in
+`config/nativephp.php`:
+
+```php
+'rtl_support' => true,
+
+'localizations' => [
+    'en',
+    'ar',
+],
+```
+
+- `rtl_support` — defaults to `false`. When `true`, the native shell and
+  WebView may switch to RTL based on the device locale. When `false`, the app
+  always behaves LTR regardless of the device locale.
+- `localizations` — the BCP 47 language codes your app supports. On iOS these
+  are written into the generated `Info.plist` as `CFBundleLocalizations`:
+
+  ```xml
+  <key>CFBundleLocalizations</key>
+  <array>
+      <string>en</string>
+      <string>ar</string>
+  </array>
+  ```
+
+## Blade usage
+
+### `@nativeHead`
+
+Outputs HTML language metadata for the `<html>` tag:
+
+```blade
+<html @nativeHead>
+```
+
+Renders to:
+
+```html
+<html lang="ar" dir="rtl">
+```
+
+or:
+
+```html
+<html lang="en" dir="ltr">
+```
+
+The language comes from `app()->getLocale()`; the direction is derived from
+the shared RTL language list.
+
+### `@rtl`
+
+A server-rendered conditional that evaluates the current Laravel locale:
+
+```blade
+@rtl
+    {{-- RTL-specific content --}}
+@else
+    {{-- LTR-specific content --}}
+@endrtl
+```
+
+`@rtl` is for server-rendered application content. It does **not** replace
+native device-locale detection — the native shell always follows the device.
+
+## Runtime behavior
+
+The **Laravel locale** (`app()->getLocale()`) and the **device locale** are two
+distinct concepts:
+
+- The Laravel locale drives `@nativeHead`, `@rtl`, and Laravel-rendered content.
+- The **native operating system locale** is the authoritative source for the
+  actual mobile shell direction: the top bar, side navigation, bottom
+  navigation, native gestures, and the WebView document direction.
+
+This matters when Laravel reports `en` but the device language is `ar-SA` —
+the native runtime still lays out the shell RTL, and the WebView is set to
+`<html lang="en" dir="rtl">`.
+
+## Supported RTL languages
+
+The shared RTL list includes `ar`, `he`, `fa`, `ur` (and others). Locale
+variants resolve through their base language:
+
+```
+ar-SA -> ar -> RTL
+en-SA -> en -> LTR
+```
+
+## No native code required
+
+After this feature, enabling RTL is a single config change:
+
+```php
+'rtl_support' => true,
+
+'localizations' => [
+    'en',
+    'ar',
+],
+```
+
+No application-specific Swift or Kotlin modifications are required. The native
+shell mirrors the top bar, side navigation, bottom navigation, and WebView
+automatically according to the device language.

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/BridgeFunctionRegistration.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/BridgeFunctionRegistration.kt
@@ -43,6 +43,7 @@ fun registerBridgeFunctions(activity: FragmentActivity, context: Context) {
 
     registry.register("UI.SetTransition", UIFunctions.SetTransition())
     registry.register("UI.SetBackground", UIFunctions.SetBackground(activity))
+    registry.register("UI.SetRtlSupport", UIFunctions.SetRtlSupport())
 
     // Performance tracking
     registry.register("Perf.Enable", PerfFunctions.Enable())

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/functions/UIFunctions.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/functions/UIFunctions.kt
@@ -7,6 +7,7 @@ import android.os.Looper
 import androidx.fragment.app.FragmentActivity
 import com.nativephp.mobile.bridge.BridgeFunction
 import com.nativephp.mobile.ui.nativerender.NativeUIBridge
+import com.nativephp.mobile.ui.nativerender.NativeUIState
 
 /**
  * Functions related to native UI control
@@ -73,6 +74,40 @@ object UIFunctions {
             } catch (e: Exception) {
                 mapOf("success" to false, "error" to (e.message ?: "Invalid color"))
             }
+        }
+    }
+
+    /**
+     * Receive the developer's `nativephp.rtl_support` flag from the Laravel
+     * layer at boot. The payload carries framework metadata:
+     *
+     *     { "_meta": { "rtl_support": true } }
+     *
+     * `_meta` is NativePHP framework metadata (not application state). This
+     * updates the shared [NativeUIState], which then recomputes the
+     * effective layout direction from the device locale. iOS twin:
+     * `Bridge/Functions/UIFunctions.swift`.
+     */
+    class SetRtlSupport : BridgeFunction {
+        override fun execute(parameters: Map<String, Any>): Map<String, Any> {
+            val meta = parameters["_meta"] as? Map<*, *>
+            val enabled = (meta?.get("rtl_support") as? Boolean)
+                ?: (parameters["rtl_support"] as? Boolean)
+                ?: false
+
+            // Compute the effective direction deterministically for the
+            // return value (before the async state update lands on main).
+            val effective = enabled && NativeUIState.deviceLanguageIsRTL()
+
+            Handler(Looper.getMainLooper()).post {
+                NativeUIState.setRtlSupport(enabled)
+            }
+
+            return mapOf(
+                "success" to true,
+                "rtl_support" to enabled,
+                "is_rtl" to effective,
+            )
         }
     }
 }

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebViewManager.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebViewManager.kt
@@ -16,6 +16,7 @@ import android.os.Message
 import com.acsbendi.requestinspectorwebview.RequestInspectorWebViewClient
 import com.nativephp.mobile.bridge.PHPBridge
 import com.nativephp.mobile.ui.MainActivity
+import com.nativephp.mobile.ui.nativerender.NativeUIState
 import org.json.JSONObject
 import com.nativephp.mobile.security.LaravelSecurity
 
@@ -388,6 +389,11 @@ class WebViewManager(
                     // Inject safe area insets IMMEDIATELY when page starts loading
                     // This ensures CSS variables are available before DOM parsing
                     activity?.injectSafeAreaInsetsToWebView()
+
+                    // Apply the runtime document direction early (the native
+                    // device direction overrides a server-rendered dir="ltr"
+                    // when the device is actually RTL).
+                    injectDirection(view)
                 }
             }
 
@@ -401,6 +407,8 @@ class WebViewManager(
                     activity.pendingWebSwap = false
                     com.nativephp.mobile.ui.nativerender.NativeUIBridge.isActive.value = false
                 }
+                // Re-assert the document direction at first visible commit.
+                injectDirection(view)
                 // Renderer-agnostic first-content signal (web renderer):
                 // the page's first visible commit is honest TTFD.
                 activity?.onFirstContent("web-commit")
@@ -412,6 +420,9 @@ class WebViewManager(
 
                 // Inject safe area insets again to ensure they're set
                 (context as? MainActivity)?.injectSafeAreaInsetsToWebView()
+
+                // Re-apply the document direction (navigation can reset it).
+                injectDirection(view)
 
                 // Inject JavaScript to capture form submissions and AJAX requests
                 injectJavaScript(view)
@@ -570,6 +581,19 @@ class WebViewManager(
         view.evaluateJavascript(jsCode) { result ->
             Log.d(TAG, "JavaScript injection result: $result")
         }
+    }
+
+    /**
+     * Set the document `dir` attribute to the native device direction. This
+     * intentionally lets the native runtime override a server-rendered
+     * `<html lang="en" dir="ltr">` when the device environment is RTL.
+     */
+    private fun injectDirection(view: WebView) {
+        val dir = if (NativeUIState.isRTL.value) "rtl" else "ltr"
+        view.evaluateJavascript(
+            "document.documentElement.setAttribute('dir', '$dir');",
+            null
+        )
     }
 
 

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
@@ -26,6 +26,7 @@ import androidx.activity.addCallback
 import com.nativephp.mobile.ui.nativerender.NativeElementBridge
 import com.nativephp.mobile.ui.nativerender.NativeUIBridge
 import com.nativephp.mobile.ui.nativerender.NativeUIContent
+import com.nativephp.mobile.ui.nativerender.NativeUIState
 import com.nativephp.mobile.ui.nativerender.PerformanceTracker
 import com.nativephp.mobile.utils.NativeActionCoordinator
 import com.nativephp.mobile.utils.WebViewProvider
@@ -50,6 +51,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -167,30 +169,38 @@ class MainActivity : FragmentActivity(), WebViewProvider {
         // uninterruptible I/O sleep on the main thread + Chromium init on the critical path.)
         setContent {
             val isDark = isSystemInDarkTheme()
-            MaterialTheme(
-                colorScheme = nativeUiMaterialColorScheme(isDark),
-                typography = NativeUIThemeProvider.resolveTypography(),
-            ) {
-                Box(modifier = Modifier.fillMaxSize()) {
-                    // The heavy MainScreen tree (Scaffold + drawer + WebView) is gated on
-                    // showContent; until boot is ready the first frame is just the splash.
-                    if (showContent) {
-                        MainScreen()
+            // RTL support: the Compose hierarchy receives the effective
+            // layout direction (rtlSupport && device locale is RTL). System
+            // components (TopAppBar, ModalDrawer, NavigationBar, …) and all
+            // start/end-aligned content mirror automatically. Explicit
+            // left/right math that LocalLayoutDirection doesn't cover is
+            // mirrored in the renderers themselves.
+            CompositionLocalProvider(LocalLayoutDirection provides NativeUIState.layoutDirection) {
+                MaterialTheme(
+                    colorScheme = nativeUiMaterialColorScheme(isDark),
+                    typography = NativeUIThemeProvider.resolveTypography(),
+                ) {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        // The heavy MainScreen tree (Scaffold + drawer + WebView) is gated on
+                        // showContent; until boot is ready the first frame is just the splash.
+                        if (showContent) {
+                            MainScreen()
+                        }
+                        // Splash overlay with fade animation (full screen, no insets).
+                        // Lives here — NOT inside the showContent gate — so it paints on the
+                        // first frame and covers the boot; MainScreen composes beneath it.
+                        AnimatedVisibility(
+                            visible = showSplash,
+                            exit = fadeOut(animationSpec = tween(300))
+                        ) {
+                            SplashScreen()
+                        }
+                        // Dev-mode perf overlay (top-right pill: fps / p99 / jank).
+                        // Driven by Choreographer via FrameTracker. Recomposes at
+                        // 4Hz only — no per-frame render cost. Toggle off in
+                        // production via FrameTracker.enabled = false.
+                        com.nativephp.mobile.ui.nativerender.PerfOverlay()
                     }
-                    // Splash overlay with fade animation (full screen, no insets).
-                    // Lives here — NOT inside the showContent gate — so it paints on the
-                    // first frame and covers the boot; MainScreen composes beneath it.
-                    AnimatedVisibility(
-                        visible = showSplash,
-                        exit = fadeOut(animationSpec = tween(300))
-                    ) {
-                        SplashScreen()
-                    }
-                    // Dev-mode perf overlay (top-right pill: fps / p99 / jank).
-                    // Driven by Choreographer via FrameTracker. Recomposes at
-                    // 4Hz only — no per-frame render cost. Toggle off in
-                    // production via FrameTracker.enabled = false.
-                    com.nativephp.mobile.ui.nativerender.PerfOverlay()
                 }
             }
         }

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeUIState.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeUIState.kt
@@ -1,0 +1,77 @@
+package com.nativephp.mobile.ui.nativerender
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.unit.LayoutDirection
+import java.util.Locale
+
+/**
+ * Shared native UI state for opt-in RTL support. Mirrors iOS
+ * `NativeUIState` and the PHP `Native\Mobile\Support\Rtl` language list.
+ *
+ * Holds the developer's opt-in `rtlSupport` flag (pushed from PHP via
+ * `_meta.rtl_support` in the `UI.SetRtlSupport` bridge call) and the
+ * derived effective `isRTL`, which is:
+ *
+ *     isRTL = rtlSupport && deviceLanguageIsRTL
+ *
+ * The device locale is authoritative for the native shell; this is what
+ * allows the shell to follow `ar-SA` even when the Laravel locale is `en`.
+ */
+object NativeUIState {
+
+    /** RTL languages by base ISO 639-1 code (kept in lockstep with PHP). */
+    private val rtlLanguages = setOf(
+        "ar", // Arabic
+        "he", // Hebrew
+        "fa", // Persian / Farsi
+        "ur", // Urdu
+        "dv", // Divehi / Maldivian
+        "ku", // Kurdish
+        "ps", // Pashto
+        "sd", // Sindhi
+        "ug", // Uyghur
+        "yi", // Yiddish
+    )
+
+    /** Developer opt-in from `nativephp.rtl_support`. */
+    val rtlSupport = mutableStateOf(false)
+
+    /** Effective layout direction for the native shell. */
+    val isRTL = mutableStateOf(false)
+
+    /** Update the opt-in flag from the `UI.SetRtlSupport` bridge call. */
+    fun setRtlSupport(enabled: Boolean) {
+        rtlSupport.value = enabled
+        recompute()
+    }
+
+    /** Recompute the effective direction from the current device locale. */
+    fun recompute() {
+        isRTL.value = rtlSupport.value && deviceLanguageIsRTL()
+    }
+
+    /** Compose layout direction for the effective RTL state. */
+    val layoutDirection: LayoutDirection
+        get() = if (isRTL.value) LayoutDirection.Rtl else LayoutDirection.Ltr
+
+    /** Whether the device's active language is an RTL language. */
+    fun deviceLanguageIsRTL(): Boolean {
+        return isRtlLanguage(deviceLanguage())
+    }
+
+    /** The device's active language, as a base ISO 639-1 code. */
+    fun deviceLanguage(): String {
+        return Locale.getDefault().language.ifEmpty { "en" }.lowercase(Locale.ROOT)
+    }
+
+    /** Whether a locale (or BCP 47 tag) is an RTL language, resolving
+     *  through its base language. Pure and deterministic — testable. */
+    fun isRtlLanguage(locale: String): Boolean {
+        return rtlLanguages.contains(baseLanguage(locale))
+    }
+
+    /** Extract the base language from a BCP 47 tag (e.g. `ar-SA` -> `ar`). */
+    fun baseLanguage(locale: String): String {
+        return locale.substringBefore('-').substringBefore('_').lowercase(Locale.ROOT)
+    }
+}

--- a/resources/androidstudio/app/src/test/java/com/nativephp/mobile/ui/nativerender/NativeUIStateTest.kt
+++ b/resources/androidstudio/app/src/test/java/com/nativephp/mobile/ui/nativerender/NativeUIStateTest.kt
@@ -1,0 +1,48 @@
+package com.nativephp.mobile.ui.nativerender
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeUIStateTest {
+
+    @Test
+    fun baseLanguageExtractsTheIsoCodeFromAVariant() {
+        assertEquals("ar", NativeUIState.baseLanguage("ar-SA"))
+        assertEquals("ar", NativeUIState.baseLanguage("ar-AE"))
+        assertEquals("he", NativeUIState.baseLanguage("he-IL"))
+        assertEquals("fa", NativeUIState.baseLanguage("fa-IR"))
+        assertEquals("ur", NativeUIState.baseLanguage("ur-PK"))
+        assertEquals("en", NativeUIState.baseLanguage("en-US"))
+        assertEquals("fr", NativeUIState.baseLanguage("fr-FR"))
+        assertEquals("ar", NativeUIState.baseLanguage("ar"))
+        assertEquals("ar", NativeUIState.baseLanguage("AR-sa"))
+    }
+
+    @Test
+    fun rtlLocalesAreDetectedThroughTheirBaseLanguage() {
+        listOf("ar", "ar-SA", "ar-AE", "he", "he-IL", "fa", "fa-IR", "ur", "ur-PK")
+            .forEach { assertTrue(it, NativeUIState.isRtlLanguage(it)) }
+    }
+
+    @Test
+    fun ltrLocalesAreNotRtl() {
+        listOf("en", "en-US", "fr-FR", "en-SA", "de", "es")
+            .forEach { assertFalse(it, NativeUIState.isRtlLanguage(it)) }
+    }
+
+    @Test
+    fun effectiveRtlRequiresBothOptInAndAnRtlLocale() {
+        // Scenario A: enabled + Arabic -> RTL
+        assertTrue(NativeUIState.isRtlLanguage("ar-SA"))
+        // Scenario B: enabled + English -> LTR (the locale is not RTL)
+        assertFalse(NativeUIState.isRtlLanguage("en-US"))
+        // Scenario C: the opt-in flag is applied by setRtlSupport; without it
+        // the state stays LTR regardless of locale.
+        NativeUIState.setRtlSupport(false)
+        assertFalse(NativeUIState.isRTL.value)
+        NativeUIState.setRtlSupport(true)
+        assertEquals(NativeUIState.deviceLanguageIsRTL(), NativeUIState.isRTL.value)
+    }
+}

--- a/resources/xcode/NativePHP/Bridge/BridgeFunctionRegistration.swift
+++ b/resources/xcode/NativePHP/Bridge/BridgeFunctionRegistration.swift
@@ -23,6 +23,7 @@ func registerBridgeFunctions() {
     // (which also registers UI.SetTransition; iOS transitions ride the
     // tree publish path, so only SetBackground is implemented here).
     registry.register("UI.SetBackground", function: UIFunctions.SetBackground())
+    registry.register("UI.SetRtlSupport", function: UIFunctions.SetRtlSupport())
 
     // Dialog.* — core built-in (migrated from the nativephp/mobile-dialog
     // plugin). Android twin: bridge/functions/DialogFunctions.kt.

--- a/resources/xcode/NativePHP/Bridge/Functions/UIFunctions.swift
+++ b/resources/xcode/NativePHP/Bridge/Functions/UIFunctions.swift
@@ -84,6 +84,36 @@ enum UIFunctions {
             return ["success": true]
         }
     }
+
+    // MARK: - UI.SetRtlSupport
+
+    /// Receive the developer's `nativephp.rtl_support` flag from the
+    /// Laravel layer at boot. The payload carries framework metadata:
+    ///
+    ///     { "_meta": { "rtl_support": true } }
+    ///
+    /// `_meta` is NativePHP framework metadata (not application state).
+    /// This updates the shared `NativeUIState`, which then recomputes the
+    /// effective layout direction from the device locale. Android twin:
+    /// `bridge/functions/UIFunctions.kt`.
+    class SetRtlSupport: BridgeFunction {
+        func execute(parameters: [String: Any]) throws -> [String: Any] {
+            let meta = parameters["_meta"] as? [String: Any]
+            let enabled = (meta?["rtl_support"] as? Bool)
+                ?? (parameters["rtl_support"] as? Bool)
+                ?? false
+
+            // Compute the effective direction deterministically for the
+            // return value (before the async state update lands on main).
+            let effective = enabled && NativeUIState.deviceLanguageIsRTL()
+
+            DispatchQueue.main.async {
+                NativeUIState.shared.setRtlSupport(enabled)
+            }
+
+            return ["success": true, "rtl_support": enabled, "is_rtl": effective]
+        }
+    }
 }
 
 extension UIColor {

--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -209,11 +209,16 @@ class SharedWebView: ObservableObject {
 /// (NativeRootStack / NativeRootTabs), so this is just the full-bleed page.
 struct WebViewLayoutContainer: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @ObservedObject private var nativeUIState = NativeUIState.shared
 
     var body: some View {
-        WebView(shared: SharedWebView.shared, horizontalSizeClass: horizontalSizeClass)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .ignoresSafeArea()
+        WebView(
+            shared: SharedWebView.shared,
+            horizontalSizeClass: horizontalSizeClass,
+            isRTL: nativeUIState.isRTL
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .ignoresSafeArea()
     }
 }
 
@@ -221,6 +226,7 @@ struct WebView: UIViewRepresentable {
     static let dataStore = WKWebsiteDataStore.default()
     let shared: SharedWebView
     let horizontalSizeClass: UserInterfaceSizeClass?
+    let isRTL: Bool
 
     func makeCoordinator() -> Coordinator {
         // Reuse existing coordinator if available to maintain LaravelBridge connection
@@ -307,6 +313,11 @@ struct WebView: UIViewRepresentable {
             // Inject safe area insets IMMEDIATELY when navigation commits (before rendering)
             // This is the iOS equivalent of Android's onPageStarted
             injectSafeAreaInsets(webView)
+
+            // Apply the runtime document direction. This intentionally lets the
+            // native device direction override a server-rendered
+            // <html lang="en" dir="ltr"> when the device is actually RTL.
+            injectDirection(webView)
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -327,6 +338,16 @@ struct WebView: UIViewRepresentable {
 
             // Re-inject safe area insets to ensure they're set (like Android does)
             injectSafeAreaInsets(webView)
+
+            // Re-apply the runtime document direction (navigation can reset it).
+            injectDirection(webView)
+        }
+
+        /// Set `dir` on the document element to the native device direction.
+        func injectDirection(_ webView: WKWebView) {
+            let dir = NativeUIState.shared.isRTL ? "rtl" : "ltr"
+            let js = "document.documentElement.setAttribute('dir', '\(dir)');"
+            webView.evaluateJavaScript(js, completionHandler: nil)
         }
 
         private func injectSafeAreaInsets(_ webView: WKWebView) {
@@ -724,6 +745,15 @@ struct WebView: UIViewRepresentable {
     func updateUIView(_ uiView: WKWebView, context: Context) {
         // No manual insets needed - safeAreaInset handles topbar automatically
         // Bottom nav uses its own safeAreaInset in WebViewLayoutContainer
+
+        // RTL is applied reactively here (not only at creation): keep the
+        // WebView's semantic direction in sync with the effective runtime
+        // direction and re-assert the document `dir` attribute.
+        let semantic: UISemanticContentAttribute = isRTL ? .forceRightToLeft : .forceLeftToRight
+        if uiView.semanticContentAttribute != semantic {
+            uiView.semanticContentAttribute = semantic
+        }
+        context.coordinator.injectDirection(uiView)
     }
 }
 

--- a/resources/xcode/NativePHP/NativePHPApp.swift
+++ b/resources/xcode/NativePHP/NativePHPApp.swift
@@ -17,6 +17,7 @@ public func pipe_php_output(_ cString: UnsafePointer<CChar>?) {
 struct NativePHPApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @StateObject private var appState = AppState.shared
+    @ObservedObject private var nativeUIState = NativeUIState.shared
 
     static var shared: NativePHPApp?
 
@@ -240,6 +241,26 @@ struct NativePHPApp: App {
                                 performDeferredInitialization()
                             }
                         }
+                }
+            }
+            // The effective layout direction for the WHOLE native shell —
+            // top bar, side nav, bottom nav, gestures, and any UIKit
+            // chrome — follows the device locale when the developer opted
+            // into RTL support. SwiftUI flips logical leading/trailing
+            // placements (and system components) automatically.
+            .environment(\.layoutDirection, nativeUIState.layoutDirection)
+            .onChange(of: nativeUIState.isRTL) { isRTL in
+                // UIKit hosting views read semanticContentAttribute for
+                // chrome SwiftUI doesn't own (window-level gestures, edge
+                // insets). Keep the key windows in sync reactively.
+                for scene in UIApplication.shared.connectedScenes {
+                    guard let windowScene = scene as? UIWindowScene else { continue }
+                    for window in windowScene.windows {
+                        let semantic: UISemanticContentAttribute = isRTL ? .forceRightToLeft : .forceLeftToRight
+                        if window.semanticContentAttribute != semantic {
+                            window.semanticContentAttribute = semantic
+                        }
+                    }
                 }
             }
             // Dev-mode perf overlay (top-right pill: fps / p99 / jank).

--- a/resources/xcode/NativePHP/NativeUI/NativeUIState.swift
+++ b/resources/xcode/NativePHP/NativeUI/NativeUIState.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+/// Shared native UI state for opt-in RTL support.
+///
+/// Holds the developer's opt-in `rtlSupport` flag (pushed from PHP via
+/// `_meta.rtl_support` in the `UI.SetRtlSupport` bridge call) and the
+/// derived effective `isRTL`, which is:
+///
+///     isRTL = rtlSupport && deviceLanguageIsRTL
+///
+/// This mirrors Android's `NativeUIState` and the PHP-side `Support\Rtl`
+/// language list. The *device* locale is authoritative here — the native
+/// shell always follows the OS, even when the Laravel locale is `en`.
+///
+/// All mutations happen on the main queue (see `UIFunctions.SetRtlSupport`),
+/// so `@Published` updates drive SwiftUI re-renders safely.
+final class NativeUIState: ObservableObject {
+    static let shared = NativeUIState()
+
+    /// RTL languages by base ISO 639-1 code. Kept in lockstep with the
+    /// PHP `Native\Mobile\Support\Rtl::LANGUAGES` list.
+    static let rtlLanguages: Set<String> = [
+        "ar", // Arabic
+        "he", // Hebrew
+        "fa", // Persian / Farsi
+        "ur", // Urdu
+        "dv", // Divehi / Maldivian
+        "ku", // Kurdish
+        "ps", // Pashto
+        "sd", // Sindhi
+        "ug", // Uyghur
+        "yi", // Yiddish
+    ]
+
+    /// Developer opt-in from `nativephp.rtl_support`. Enabling this does
+    /// NOT force RTL — it only permits RTL when the device is RTL.
+    @Published var rtlSupport: Bool = false {
+        didSet { recompute() }
+    }
+
+    /// Effective layout direction for the native shell.
+    @Published private(set) var isRTL: Bool = false
+
+    private init() {
+        recompute()
+    }
+
+    /// Update the opt-in flag from the `UI.SetRtlSupport` bridge call.
+    func setRtlSupport(_ enabled: Bool) {
+        rtlSupport = enabled
+    }
+
+    /// SwiftUI layout direction for the effective RTL state.
+    var layoutDirection: LayoutDirection {
+        isRTL ? .rightToLeft : .leftToRight
+    }
+
+    /// UIKit semantic content attribute for the effective RTL state.
+    var semanticContentAttribute: UISemanticContentAttribute {
+        isRTL ? .forceRightToLeft : .forceLeftToRight
+    }
+
+    private func recompute() {
+        isRTL = rtlSupport && Self.deviceLanguageIsRTL()
+    }
+
+    // MARK: - Device language
+
+    /// Whether the device's active language is an RTL language.
+    static func deviceLanguageIsRTL() -> Bool {
+        guard let preferred = Locale.preferredLanguages.first else { return false }
+        return isRtlLanguage(preferred)
+    }
+
+    /// Whether a locale (or BCP 47 tag) is an RTL language, resolving
+    /// through its base language. Pure and deterministic — testable.
+    static func isRtlLanguage(_ locale: String) -> Bool {
+        return rtlLanguages.contains(baseLanguage(of: locale))
+    }
+
+    /// Extract the base language from a BCP 47 tag (e.g. `ar-SA` -> `ar`).
+    static func baseLanguage(of locale: String) -> String {
+        let first = locale.split(whereSeparator: { $0 == "-" || $0 == "_" }).first
+        return (first.map { String($0) } ?? locale).lowercased()
+    }
+}

--- a/resources/xcode/NativePHPTests/NativePHPTests.swift
+++ b/resources/xcode/NativePHPTests/NativePHPTests.swift
@@ -7,4 +7,38 @@ struct NativePHPTests {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
     }
 
+    // MARK: - RTL language detection (NativeUIState)
+
+    @Test func baseLanguageExtractsTheIsoCodeFromAVariant() {
+        #expect(NativeUIState.baseLanguage(of: "ar-SA") == "ar")
+        #expect(NativeUIState.baseLanguage(of: "ar-AE") == "ar")
+        #expect(NativeUIState.baseLanguage(of: "he-IL") == "he")
+        #expect(NativeUIState.baseLanguage(of: "fa-IR") == "fa")
+        #expect(NativeUIState.baseLanguage(of: "ur-PK") == "ur")
+        #expect(NativeUIState.baseLanguage(of: "en-US") == "en")
+        #expect(NativeUIState.baseLanguage(of: "fr-FR") == "fr")
+        #expect(NativeUIState.baseLanguage(of: "AR-sa") == "ar")
+    }
+
+    @Test func rtlLocalesAreDetectedThroughTheirBaseLanguage() {
+        for locale in ["ar", "ar-SA", "ar-AE", "he", "he-IL", "fa", "fa-IR", "ur", "ur-PK"] {
+            #expect(NativeUIState.isRtlLanguage(locale))
+        }
+    }
+
+    @Test func ltrLocalesAreNotRtl() {
+        for locale in ["en", "en-US", "fr-FR", "en-SA", "de", "es"] {
+            #expect(!NativeUIState.isRtlLanguage(locale))
+        }
+    }
+
+    @Test func effectiveRtlRequiresBothOptInAndAnRtlLocale() {
+        // Without opt-in, an RTL device still evaluates to LTR.
+        NativeUIState.shared.setRtlSupport(false)
+        #expect(!NativeUIState.shared.isRTL)
+
+        // With opt-in, the direction follows the device language.
+        NativeUIState.shared.setRtlSupport(true)
+        #expect(NativeUIState.shared.isRTL == NativeUIState.deviceLanguageIsRTL())
+    }
 }

--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -515,6 +515,9 @@ class BuildIosAppCommand extends Command
             // Handle UIUserInterfaceStyle
             $this->updateInterfaceStyle($dom, $rootDict, $plistData);
 
+            // Handle CFBundleLocalizations (nativephp.localizations)
+            $this->updateLocalizations($dom, $rootDict, $plistData);
+
             // Handle BIFROST_APP_ID
             $bifrostAppId = env('BIFROST_APP_ID');
             if ($bifrostAppId) {
@@ -717,6 +720,55 @@ class BuildIosAppCommand extends Command
         }
 
         $this->addPlistKeyValue($dom, $rootDict, 'UIUserInterfaceStyle', 'string', $style);
+    }
+
+    /**
+     * Write `nativephp.localizations` into the Info.plist as
+     * CFBundleLocalizations so iOS recognizes the languages the app
+     * supports. When no localizations are configured, the key is removed
+     * so existing build behavior is unchanged.
+     *
+     * @param  array<string, array{keyNode: \DOMElement, valueNode: \DOMElement}>  $plistData
+     */
+    private function updateLocalizations(\DOMDocument $dom, \DOMElement $rootDict, array &$plistData): void
+    {
+        $localizations = array_values(array_filter(array_map(
+            static fn ($lang) => trim((string) $lang),
+            (array) config('nativephp.localizations', [])
+        )));
+
+        if (empty($localizations)) {
+            if (isset($plistData['CFBundleLocalizations'])) {
+                $this->removePlistKeyValue(
+                    $rootDict,
+                    $plistData['CFBundleLocalizations']['keyNode'],
+                    $plistData['CFBundleLocalizations']['valueNode']
+                );
+                unset($plistData['CFBundleLocalizations']);
+            }
+
+            return;
+        }
+
+        if (isset($plistData['CFBundleLocalizations'])) {
+            $arrayNode = $plistData['CFBundleLocalizations']['valueNode'];
+            while ($arrayNode->firstChild) {
+                $arrayNode->removeChild($arrayNode->firstChild);
+            }
+            foreach ($localizations as $lang) {
+                $arrayNode->appendChild($arrayNode->ownerDocument->createElement('string', $lang));
+            }
+
+            return;
+        }
+
+        $keyNode = $dom->createElement('key', 'CFBundleLocalizations');
+        $arrayNode = $dom->createElement('array');
+        foreach ($localizations as $lang) {
+            $arrayNode->appendChild($dom->createElement('string', $lang));
+        }
+        $rootDict->appendChild($keyNode);
+        $rootDict->appendChild($arrayNode);
     }
 
     /**

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -251,6 +251,7 @@ class NativeServiceProvider extends PackageServiceProvider
         $this->registerBladeDirectives();
         $this->configureViteHotFile();
         $this->applyFpsOverlayConfig();
+        $this->applyRtlSupportConfig();
         $this->registerScreenIntentMiddleware();
 
         if (config('nativephp-internal.running')) {
@@ -448,6 +449,29 @@ class NativeServiceProvider extends PackageServiceProvider
                 }
             ?>";
         });
+
+        // @nativeHead — outputs HTML language metadata for the <html> tag:
+        //   <html @nativeHead>  →  <html lang="ar" dir="rtl">
+        // The language comes from the Laravel locale; the direction is
+        // derived from the shared RTL language list.
+        Blade::directive('nativeHead', function () {
+            return '<?php
+                $__nativeLocale = app()->getLocale();
+                $__nativeDir = \Native\Mobile\Support\Rtl::isRtlLocale($__nativeLocale) ? "rtl" : "ltr";
+                echo "lang=\"".e($__nativeLocale)."\" dir=\"".$__nativeDir."\"";
+            ?>';
+        });
+
+        // @rtl ... @else ... @endrtl — server-rendered conditional based on
+        // the current Laravel locale. `@else` is the standard Blade keyword,
+        // so this composes naturally with a plain conditional block.
+        Blade::directive('rtl', function () {
+            return '<?php if (\Native\Mobile\Support\Rtl::isRtlLocale(app()->getLocale())): ?>';
+        });
+
+        Blade::directive('endrtl', function () {
+            return '<?php endif; ?>';
+        });
     }
 
     protected function registerFilesystems(): void
@@ -555,6 +579,33 @@ class NativeServiceProvider extends PackageServiceProvider
         $enabled = (bool) config('nativephp.fps_overlay', false);
 
         nativephp_call('Perf.SetFpsOverlayEnabled', json_encode(['enabled' => $enabled]));
+    }
+
+    /**
+     * Push the `nativephp.rtl_support` config flag to the native side at
+     * boot so the iOS/Android shell knows whether RTL is permitted. The
+     * `_meta` object is NativePHP framework metadata (not application
+     * state); both platforms read `_meta.rtl_support` and combine it with
+     * the device locale to compute the effective layout direction.
+     */
+    private function applyRtlSupportConfig(): void
+    {
+        if (! function_exists('nativephp_call')) {
+            return;
+        }
+
+        // Never at test boot (same rationale as applyFpsOverlayConfig).
+        if ($this->app->runningUnitTests()) {
+            return;
+        }
+
+        $enabled = (bool) config('nativephp.rtl_support', false);
+
+        nativephp_call('UI.SetRtlSupport', json_encode([
+            '_meta' => [
+                'rtl_support' => $enabled,
+            ],
+        ]));
     }
 
     /**

--- a/src/Support/Rtl.php
+++ b/src/Support/Rtl.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Native\Mobile\Support;
+
+/**
+ * Opt-in right-to-left (RTL) language detection shared by the Laravel
+ * layer (`@nativeHead`, `@rtl`) and any server-rendered content.
+ *
+ * The device locale (not the Laravel locale) is still the authoritative
+ * source for the *native* shell direction on iOS/Android; this class is
+ * what keeps the language list consistent everywhere it is needed in PHP.
+ */
+class Rtl
+{
+    /**
+     * Common RTL languages, keyed by their base ISO 639-1 code.
+     *
+     * This list is intentionally small and explicit (ar / he / fa / ur are
+     * the guaranteed set); it is easy to extend with any additional RTL
+     * language as required.
+     */
+    public const LANGUAGES = [
+        'ar', // Arabic
+        'he', // Hebrew
+        'fa', // Persian / Farsi
+        'ur', // Urdu
+        'dv', // Divehi / Maldivian
+        'ku', // Kurdish
+        'ps', // Pashto
+        'sd', // Sindhi
+        'ug', // Uyghur
+        'yi', // Yiddish
+    ];
+
+    /**
+     * Return the base language for a locale, stripping any region /
+     * script / variant tags. e.g. `ar-SA` -> `ar`, `he-IL` -> `he`,
+     * `zh-Hans-CN` -> `zh`.
+     */
+    public static function baseLanguage(string $locale): string
+    {
+        $locale = trim($locale);
+
+        if ($locale === '') {
+            return '';
+        }
+
+        // Split on the first '-' or '_' (both are common separators in
+        // BCP 47 tags and POSIX locales respectively).
+        $parts = preg_split('/[-_]/', $locale, 2);
+
+        return strtolower($parts[0] ?? '');
+    }
+
+    /**
+     * Whether the given locale's base language is an RTL language.
+     *
+     * Variants such as `ar`, `ar-SA`, `ar-AE`, `fa-IR`, `he-IL` and
+     * `ur-PK` all resolve through their base language, so `ar-SA` is RTL
+     * while `en-SA` is LTR.
+     */
+    public static function isRtlLanguage(string $locale): bool
+    {
+        return in_array(self::baseLanguage($locale), self::LANGUAGES, true);
+    }
+
+    /**
+     * Alias of {@see isRtlLanguage()} for readability at call sites that
+     * work with a Laravel locale value.
+     */
+    public static function isRtlLocale(string $locale): bool
+    {
+        return self::isRtlLanguage($locale);
+    }
+}

--- a/tests/Feature/IosLocalizationsTest.php
+++ b/tests/Feature/IosLocalizationsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\File;
+use Native\Mobile\Commands\BuildIosAppCommand;
+use ReflectionClass;
+use Tests\TestCase;
+
+/**
+ * `nativephp.localizations` is written into the generated Info.plist as
+ * CFBundleLocalizations so iOS recognizes the languages the app supports.
+ * When unset, the key is left out entirely so existing builds don't change.
+ */
+class IosLocalizationsTest extends TestCase
+{
+    protected string $plistPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->plistPath = sys_get_temp_dir().'/nativephp_localizations_test_'.uniqid().'.plist';
+    }
+
+    protected function tearDown(): void
+    {
+        File::delete($this->plistPath);
+
+        parent::tearDown();
+    }
+
+    public function test_configured_localizations_are_written_to_the_plist(): void
+    {
+        config(['nativephp.localizations' => ['en', 'ar']]);
+
+        $this->updatePlist($this->writePlist());
+
+        $this->assertStringContainsString('<key>CFBundleLocalizations</key>', $this->plist());
+        $this->assertStringContainsString('<string>en</string>', $this->plist());
+        $this->assertStringContainsString('<string>ar</string>', $this->plist());
+    }
+
+    public function test_no_localizations_leaves_the_key_out(): void
+    {
+        config(['nativephp.localizations' => []]);
+
+        $this->updatePlist($this->writePlist());
+
+        $this->assertStringNotContainsString('CFBundleLocalizations', $this->plist());
+    }
+
+    public function test_unset_localizations_leaves_the_key_out(): void
+    {
+        config(['nativephp.localizations' => null]);
+
+        $this->updatePlist($this->writePlist());
+
+        $this->assertStringNotContainsString('CFBundleLocalizations', $this->plist());
+    }
+
+    public function test_an_existing_key_is_replaced_rather_than_duplicated(): void
+    {
+        config(['nativephp.localizations' => ['en', 'ar']]);
+
+        $this->updatePlist($this->writePlist(
+            "\t<key>CFBundleLocalizations</key>\n\t<array>\n\t\t<string>fr</string>\n\t</array>\n"
+        ));
+
+        $this->assertSame(1, substr_count($this->plist(), 'CFBundleLocalizations'));
+        $this->assertStringContainsString('<string>en</string>', $this->plist());
+        $this->assertStringContainsString('<string>ar</string>', $this->plist());
+        $this->assertStringNotContainsString('<string>fr</string>', $this->plist());
+    }
+
+    public function test_clearing_localizations_removes_a_previously_written_key(): void
+    {
+        config(['nativephp.localizations' => []]);
+
+        $this->updatePlist($this->writePlist(
+            "\t<key>CFBundleLocalizations</key>\n\t<array>\n\t\t<string>en</string>\n\t\t<string>ar</string>\n\t</array>\n"
+        ));
+
+        $this->assertStringNotContainsString('CFBundleLocalizations', $this->plist());
+    }
+
+    /** Write a minimal Info.plist, optionally with extra keys already in it. */
+    protected function writePlist(string $extraKeys = ''): string
+    {
+        File::put($this->plistPath, <<<PLIST
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+        \t<key>CFBundleURLTypes</key>
+        \t<array>
+        \t\t<dict>
+        \t\t\t<key>CFBundleTypeRole</key>
+        \t\t\t<string>Viewer</string>
+        \t\t\t<key>CFBundleURLName</key>
+        \t\t\t<string>com.nativephp.app</string>
+        \t\t\t<key>CFBundleURLSchemes</key>
+        \t\t\t<array>
+        \t\t\t\t<string>nativephp</string>
+        \t\t\t</array>
+        \t\t</dict>
+        \t</array>
+        {$extraKeys}</dict>
+        </plist>
+        PLIST);
+
+        return $this->plistPath;
+    }
+
+    protected function updatePlist(string $path): void
+    {
+        $command = new BuildIosAppCommand;
+
+        (new ReflectionClass($command))
+            ->getMethod('updateInfoPlistFile')
+            ->invoke($command, $path, 'com.nativephp.test', 'nativephp');
+    }
+
+    protected function plist(): string
+    {
+        return File::get($this->plistPath);
+    }
+}

--- a/tests/Feature/RtlBladeDirectivesTest.php
+++ b/tests/Feature/RtlBladeDirectivesTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Blade;
+use Tests\TestCase;
+
+class RtlBladeDirectivesTest extends TestCase
+{
+    public function test_native_head_outputs_language_and_direction_for_an_rtl_locale(): void
+    {
+        app()->setLocale('ar');
+
+        $html = Blade::render('<html @nativeHead><head></head><body></body></html>');
+
+        $this->assertStringContainsString('lang="ar" dir="rtl"', $html);
+    }
+
+    public function test_native_head_outputs_ltr_for_an_ltr_locale(): void
+    {
+        app()->setLocale('en');
+
+        $html = Blade::render('<html @nativeHead></html>');
+
+        $this->assertStringContainsString('lang="en" dir="ltr"', $html);
+    }
+
+    public function test_native_head_uses_the_base_language_for_variant_locales(): void
+    {
+        app()->setLocale('ar-SA');
+
+        $html = Blade::render('<html @nativeHead></html>');
+
+        $this->assertStringContainsString('lang="ar-SA" dir="rtl"', $html);
+    }
+
+    public function test_rtl_directive_renders_the_rtl_branch_for_an_rtl_locale(): void
+    {
+        app()->setLocale('ar');
+
+        $html = Blade::render(<<<'BLADE'
+        @rtl
+        RTL
+        @else
+        LTR
+        @endrtl
+        BLADE);
+
+        $this->assertStringContainsString('RTL', $html);
+        $this->assertStringNotContainsString('LTR', $html);
+    }
+
+    public function test_rtl_directive_renders_the_else_branch_for_an_ltr_locale(): void
+    {
+        app()->setLocale('en');
+
+        $html = Blade::render(<<<'BLADE'
+        @rtl
+        RTL
+        @else
+        LTR
+        @endrtl
+        BLADE);
+
+        $this->assertStringContainsString('LTR', $html);
+        $this->assertStringNotContainsString('RTL', $html);
+    }
+}

--- a/tests/Unit/RtlSupportTest.php
+++ b/tests/Unit/RtlSupportTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit;
+
+use Native\Mobile\Support\Rtl;
+use Tests\TestCase;
+
+class RtlSupportTest extends TestCase
+{
+    public function test_rtl_support_defaults_to_false()
+    {
+        $this->assertFalse(config('nativephp.rtl_support'));
+    }
+
+    public function test_localizations_defaults_to_an_empty_array()
+    {
+        $this->assertSame([], config('nativephp.localizations'));
+    }
+
+    /**
+     * @testWith ["ar", true]
+     *           ["ar-SA", true]
+     *           ["ar-AE", true]
+     *           ["he", true]
+     *           ["he-IL", true]
+     *           ["fa", true]
+     *           ["fa-IR", true]
+     *           ["ur", true]
+     *           ["ur-PK", true]
+     *           ["en", false]
+     *           ["en-US", false]
+     *           ["fr-FR", false]
+     *           ["en-SA", false]
+     */
+    public function test_rtl_language_detection(string $locale, bool $expected): void
+    {
+        $this->assertSame($expected, Rtl::isRtlLanguage($locale));
+        $this->assertSame($expected, Rtl::isRtlLocale($locale));
+    }
+
+    /**
+     * @testWith ["ar-SA", "ar"]
+     *           ["ar-AE", "ar"]
+     *           ["he-IL", "he"]
+     *           ["fa-IR", "fa"]
+     *           ["ur-PK", "ur"]
+     *           ["en-US", "en"]
+     *           ["fr-FR", "fr"]
+     *           ["zh-Hans-CN", "zh"]
+     *           ["ar_SA", "ar"]
+     *           ["ar", "ar"]
+     */
+    public function test_base_language_extraction(string $locale, string $expected): void
+    {
+        $this->assertSame($expected, Rtl::baseLanguage($locale));
+    }
+
+    public function test_empty_locale_has_no_base_language(): void
+    {
+        $this->assertSame('', Rtl::baseLanguage(''));
+        $this->assertFalse(Rtl::isRtlLanguage(''));
+    }
+
+    public function test_base_language_is_case_insensitive(): void
+    {
+        $this->assertSame('ar', Rtl::baseLanguage('AR-SA'));
+        $this->assertTrue(Rtl::isRtlLanguage('AR-sa'));
+    }
+}


### PR DESCRIPTION
## Summary

First-class, **opt-in** right-to-left (RTL) support for Arabic, Hebrew, Persian/Farsi, Urdu, and other RTL languages — across the iOS native UI, the Android native UI, and the embedded WebView.

The effective layout direction is:

```
isRTL = rtl_support && device language is RTL
```

> Enabling `rtl_support` does **not** force RTL. It only permits RTL when the device's active language is an RTL language. `rtl_support = false` is the default, so existing applications are fully backward-compatible.

## Configuration

```php
// config/nativephp.php
'rtl_support' => true,

'localizations' => [
    'en',
    'ar',
],
```

- `rtl_support` — defaults to `false`. When `false`, the app always behaves LTR regardless of device locale.
- `localizations` — written into the generated iOS `Info.plist` as `CFBundleLocalizations`.

## Blade

```blade
<html @nativeHead>   {{-- <html lang="ar" dir="rtl"> --}}
```

```blade
@rtl
    {{-- RTL content --}}
@else
    {{-- LTR content --}}
@endrtl
```

## Runtime behavior

The **Laravel locale** (`app()->getLocale()`) drives `@nativeHead`, `@rtl`, and server-rendered content. The **device locale** is authoritative for the native shell (top bar, side nav, bottom nav, gestures) and the WebView document direction — so a device at `ar-SA` still lays out RTL even when Laravel reports `en`, yielding `<html lang="en" dir="rtl">`.

## Implementation

- **PHP** — `config/nativephp.php`; `Support\Rtl` (shared RTL list + base-language resolution, so `ar-SA` → `ar` → RTL); `@nativeHead` / `@rtl` directives; boot-time `UI.SetRtlSupport` bridge call carrying `_meta.rtl_support`.
- **iOS** — `NativeUIState` (rtlSupport + derived `isRTL`) fed by `UI.SetRtlSupport`; root `.environment(\.layoutDirection, …)`; reactive `semanticContentAttribute`; WebView `dir` injection at `didCommit`/`didFinish`; `BuildIosAppCommand` writes `CFBundleLocalizations`.
- **Android** — `NativeUIState` (Compose state) + `UI.SetRtlSupport`; root `CompositionLocalProvider(LocalLayoutDirection provides …)` so `TopAppBar`/`ModalDrawer`/`NavigationBar`/`NavigationDrawerItem` mirror; WebView `dir` injection at page lifecycle events.
- **Docs** — `docs/rtl-support.md`.

## Tests

- PHP: config defaults, language detection (ar/ar-SA/he/fa/ur/… vs en/en-US/fr-FR/en-SA), `@nativeHead` + `@rtl` rendering, and `CFBundleLocalizations` plist generation (write/update/remove).
- Android: `NativeUIStateTest` (base-language + RTL detection).
- iOS: `NativePHPTests` additions (base-language + RTL detection).

Existing test suite passes; `pint` and `phpstan` are clean.

## Backward compatibility

No `rtl_support` (or `rtl_support: false`) keeps every app LTR on English, Arabic, Hebrew, and Persian devices — no layout, gesture, navigation, WebView, or build regression. No localizations config leaves the iOS `Info.plist` unchanged.
