### PR TITLE
Allow x86_64 simulator builds for Intel Macs

### DIFF
--- a/resources/xcode/NativePHP.xcodeproj/project.pbxproj
+++ b/resources/xcode/NativePHP.xcodeproj/project.pbxproj
@@ -2009,7 +2009,6 @@
 				DEVELOPMENT_ASSET_PATHS = "\"NativePHP/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				EXCLUDED_RECURSIVE_SEARCH_PATH_SUBDIRECTORIES = "*.nib *.lproj *.framework *.gch *.xcode* *.xcassets (*) .DS_Store CVS .svn .git .hg *.pbproj *.pbxproj node_modules";
 				EXCLUDED_SOURCE_FILE_NAMES = (
 					.editorconfig,
@@ -2061,7 +2060,6 @@
 				DEVELOPMENT_ASSET_PATHS = "\"NativePHP/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				EXCLUDED_RECURSIVE_SEARCH_PATH_SUBDIRECTORIES = "*.nib *.lproj *.framework *.gch *.xcode* *.xcassets (*) .DS_Store CVS .svn .git .hg *.pbproj *.pbxproj node_modules";
 				EXCLUDED_SOURCE_FILE_NAMES = (
 					.editorconfig,


### PR DESCRIPTION
## What

Removes `EXCLUDED_ARCHS[sdk=iphonesimulator*] = x86_64` from both the Debug and Release build configurations in the bundled Xcode project.

## Why

The exclusion forced simulator builds to arm64 only, so the app could not be built or run on the iOS Simulator on Intel Macs.

This pairs with the companion work in `nativephp/php-bin-mobile` that ships x86_64 simulator slices — now that the PHP runtime has an x86_64 simulator slice, there's no reason for the Xcode project to keep excluding that arch.

## Notes

Apple Silicon builds are unaffected: Xcode still picks arm64 for the simulator there. On Intel Macs, the simulator now resolves to x86_64 instead of failing to find a valid architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)