### PR TITLE
fix(ios): let pre-Xcode-26 toolchains compile the Liquid Glass surfaces

### DIFF
--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -186,13 +186,26 @@ struct HotReloadIndicator: View {
 /// Wraps the glass / thin-material material lookup behind an iOS-26
 /// availability check. iOS 26+ gets the real Liquid Glass capsule;
 /// earlier versions fall back to a Capsule-shaped `.thinMaterial`.
+///
+/// The `#if` keeps `.glassEffect` out of the compilation entirely on
+/// pre-Xcode-26 toolchains, whose SDK has no such symbol — see
+/// `LiquidGlassAvailability.swift`.
 private struct GlassPillBackground: ViewModifier {
     func body(content: Content) -> some View {
+        #if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             content.glassEffect(in: .capsule)
         } else {
-            content.background(.thinMaterial, in: .capsule)
+            fallback(content)
         }
+        #else
+        fallback(content)
+        #endif
+    }
+
+    @ViewBuilder
+    private func fallback(_ content: Content) -> some View {
+        content.background(.thinMaterial, in: .capsule)
     }
 }
 

--- a/resources/xcode/NativePHP/LiquidGlassAvailability.swift
+++ b/resources/xcode/NativePHP/LiquidGlassAvailability.swift
@@ -1,0 +1,66 @@
+//
+//  LiquidGlassAvailability.swift
+//  NativePHP
+//
+//  Why the renderer's iOS 26 surfaces are wrapped in `#if compiler(>=6.2)`.
+//
+//  A `#available(iOS 26.0, *)` check is a RUNTIME gate: it keeps the app from
+//  calling a symbol on a device too old to have it. It does nothing at compile
+//  time — the symbol still has to exist in the SDK being built against, or the
+//  file doesn't type-check at all. Building the renderer with Xcode 16 (iOS 18
+//  SDK) therefore failed outright on the iOS 26 API it uses:
+//
+//      value of type 'TabBarAccessoryModifier.Content'
+//      has no member 'tabViewBottomAccessory'
+//
+//  So each iOS 26 call site needs a second, COMPILE-time gate around the
+//  runtime one. Swift has no direct "which SDK am I building against?"
+//  condition, but the toolchain and the SDK ship together, so the compiler
+//  version stands in for it:
+//
+//      Xcode 16.0–16.4  →  Swift 6.0–6.1.2  →  iOS 18 SDK
+//      Xcode 26.x       →  Swift 6.2+       →  iOS 26 SDK
+//
+//  `#if compiler(>=6.2)` therefore reads as "the iOS 26 SDK is present". The
+//  one way to fool it is a hand-installed swift.org 6.2 toolchain driving an
+//  Xcode 16 SDK — not a configuration iOS app builds use.
+//
+//  The shape at every call site is:
+//
+//      #if compiler(>=6.2)
+//      if #available(iOS 26.0, *) {
+//          content.someIOS26Modifier()      // compiled only on Xcode 26+,
+//      } else {                             // run only on iOS 26+ devices
+//          fallback(content)
+//      }
+//      #else
+//      fallback(content)                    // Xcode 16: iOS 26 path is gone
+//      #endif
+//
+//  with the pre-26 branch factored into a `fallback` helper so the two
+//  `#if` arms can't drift apart. Call sites:
+//
+//    • ContentView.GlassPillBackground              — .glassEffect(in:)
+//    • NodeStyleModifier.GlassModifier              — .glassEffect(_:in:)
+//    • NodeStyleModifier.WithGlassContainer         — GlassEffectContainer
+//    • NativeRootStackRenderer                      — .safeAreaBar(edge:)
+//    • NativeRootStackRenderer                      — .navigationSubtitle(_:)
+//    • NativeRootTabsRenderer                       — .tabViewBottomAccessory
+//
+//  Neither gate changes the deployment target: the app targets iOS 18.2 and
+//  runs there either way. A binary built with Xcode 16 simply never shows the
+//  Liquid Glass treatments, even on an iOS 26 device — it renders the same
+//  material/inset fallbacks an iOS 18 device gets. Ship builds should use
+//  Xcode 26 — App Store Connect has rejected uploads built against anything
+//  older than the iOS 26 SDK since 28 April 2026.
+//
+
+#if !compiler(>=6.2)
+#warning("""
+Building with a pre-Xcode-26 toolchain: the iOS 26 Liquid Glass surfaces \
+(glass effects, .safeAreaBar, .navigationSubtitle, tab bottom accessory) are \
+compiled out and fall back to their pre-26 equivalents on every device. Build \
+with Xcode 26 or later for the full native rendering — and for App Store \
+submission, which requires the iOS 26 SDK.
+""")
+#endif

--- a/resources/xcode/NativePHP/NativeRender/NativeRootStackRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeRootStackRenderer.swift
@@ -351,17 +351,32 @@ private struct StackBottomBarInsetModifier: ViewModifier {
             // the input floats mid-screen over a giant empty bar, and on the
             // `.safeAreaBar` path the bar's scroll-edge effect then dims the
             // whole content region behind it.
+            //
+            // The `#if` keeps `.safeAreaBar` out of the compilation entirely
+            // on pre-Xcode-26 toolchains, whose SDK has no such symbol — see
+            // `LiquidGlassAvailability.swift`.
+            #if compiler(>=6.2)
             if #available(iOS 26.0, *) {
                 content.safeAreaBar(edge: .bottom) {
                     barContent(inner)
                 }
             } else {
-                content.safeAreaInset(edge: .bottom, spacing: 0) {
-                    barContent(inner)
-                }
+                fallback(content, inner)
             }
+            #else
+            fallback(content, inner)
+            #endif
         } else {
             content
+        }
+    }
+
+    /// Pre-26 placement: a plain bottom safe-area inset, no floating glass
+    /// bar primitive.
+    @ViewBuilder
+    private func fallback(_ content: Content, _ inner: NativeUINode) -> some View {
+        content.safeAreaInset(edge: .bottom, spacing: 0) {
+            barContent(inner)
         }
     }
 
@@ -447,13 +462,22 @@ private struct NavigationSubtitleModifier: ViewModifier {
     let subtitle: String
     let showsAsPrincipal: Bool
 
+    /// The `#if` keeps `.navigationSubtitle` out of the compilation entirely
+    /// on pre-Xcode-26 toolchains, whose SDK has no such symbol — see
+    /// `LiquidGlassAvailability.swift`.
     func body(content: Content) -> some View {
         if subtitle.isEmpty || showsAsPrincipal {
             content
-        } else if #available(iOS 26.0, *) {
-            content.navigationSubtitle(subtitle)
         } else {
+            #if compiler(>=6.2)
+            if #available(iOS 26.0, *) {
+                content.navigationSubtitle(subtitle)
+            } else {
+                content
+            }
+            #else
             content
+            #endif
         }
     }
 }

--- a/resources/xcode/NativePHP/NativeRender/NativeRootTabsRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeRootTabsRenderer.swift
@@ -899,10 +899,15 @@ private struct TabBarLabelVisibilityModifier: ViewModifier {
     }
 }
 
+/// The `#if` keeps `.tabViewBottomAccessory` out of the compilation entirely
+/// on pre-Xcode-26 toolchains, whose SDK has no such symbol — see
+/// `LiquidGlassAvailability.swift`. This is the call site that broke the
+/// build outright on Xcode 16 ("has no member 'tabViewBottomAccessory'").
 private struct TabBarAccessoryModifier: ViewModifier {
     let accessory: NativeUINode?
 
     func body(content: Content) -> some View {
+        #if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             if let inner = accessory?.children.first {
                 content
@@ -915,6 +920,9 @@ private struct TabBarAccessoryModifier: ViewModifier {
         } else {
             content
         }
+        #else
+        content
+        #endif
     }
 }
 

--- a/resources/xcode/NativePHP/NativeRender/NodeStyleModifier.swift
+++ b/resources/xcode/NativePHP/NativeRender/NodeStyleModifier.swift
@@ -216,24 +216,38 @@ private struct GlassModifier: ViewModifier {
     private var interactive: Bool  { (flags & 4) != 0 }
     private var clear: Bool        { (flags & 8) != 0 }
 
+    /// The `#if` keeps `.glassEffect` out of the compilation entirely on
+    /// pre-Xcode-26 toolchains, whose SDK has no such symbol — see
+    /// `LiquidGlassAvailability.swift`.
     func body(content: Content) -> some View {
         if !enabled {
             content
-        } else if #available(iOS 26.0, *) {
-            if clear {
-                content.glassEffect(.clear.interactive(interactive), in: glassShape)
-            } else {
-                content.glassEffect(.regular.interactive(interactive), in: glassShape)
-            }
         } else {
-            // Older-iOS fallback can't simulate touch-highlight — drop the
-            // interactive flag silently. `.ultraThinMaterial` is the closest
-            // analogue for `.clear`; `.regularMaterial` for the default.
-            content.background(
-                clear ? AnyShapeStyle(.ultraThinMaterial) : AnyShapeStyle(.regularMaterial),
-                in: glassShape
-            )
+            #if compiler(>=6.2)
+            if #available(iOS 26.0, *) {
+                if clear {
+                    content.glassEffect(.clear.interactive(interactive), in: glassShape)
+                } else {
+                    content.glassEffect(.regular.interactive(interactive), in: glassShape)
+                }
+            } else {
+                fallback(content)
+            }
+            #else
+            fallback(content)
+            #endif
         }
+    }
+
+    /// Older-iOS fallback can't simulate touch-highlight — drop the
+    /// interactive flag silently. `.ultraThinMaterial` is the closest
+    /// analogue for `.clear`; `.regularMaterial` for the default.
+    @ViewBuilder
+    private func fallback(_ content: Content) -> some View {
+        content.background(
+            clear ? AnyShapeStyle(.ultraThinMaterial) : AnyShapeStyle(.regularMaterial),
+            in: glassShape
+        )
     }
 
     /// Infer the glass shape from the element's borderRadius. The
@@ -286,13 +300,21 @@ extension UIColor {
 /// Apply this once at the screen root in each root renderer (Stack, Tabs,
 /// etc.) — the container's effects are scoped to the subtree it wraps, so
 /// one container per screen is the right granularity.
+///
+/// The `#if` keeps `GlassEffectContainer` out of the compilation entirely on
+/// pre-Xcode-26 toolchains, whose SDK has no such symbol — see
+/// `LiquidGlassAvailability.swift`.
 struct WithGlassContainer: ViewModifier {
     func body(content: Content) -> some View {
+        #if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             GlassEffectContainer { content }
         } else {
             content
         }
+        #else
+        content
+        #endif
     }
 }
 


### PR DESCRIPTION
Fixes the compile failure reported in NativePHP/nativephp.com#450, where a fresh v4 app built with Xcode 16.4 (iOS 18.5 SDK) fails in the native renderer:

> value of type 'TabBarAccessoryModifier.Content' has no member 'tabViewBottomAccessory'

## Why the existing guards weren't enough

`#available(iOS 26.0, *)` is a **runtime** gate — it stops the call on old devices, but the symbol still has to exist in the SDK being compiled against. So the linked PR was right that `#available` alone can't save it, but wrong that Xcode 26 is therefore mandatory: each iOS 26 call site just needs a second, **compile-time** gate wrapped around the runtime one.

Swift has no direct "which SDK am I building against?" condition, but the toolchain and the SDK ship together, so the compiler version stands in for it:

| Xcode | Swift | SDK |
|---|---|---|
| 16.0–16.4 | 6.0–6.1.2 | iOS 18 |
| 26.x | 6.2+ | iOS 26 |

`#if compiler(>=6.2)` therefore reads as "the iOS 26 SDK is present".

## What changed

`tabViewBottomAccessory` was just the first error hit — there were **six** iOS 26 call sites, all now gated:

- `ContentView.GlassPillBackground` — `.glassEffect(in:)`
- `NodeStyleModifier.GlassModifier` — `.glassEffect(_:in:)`
- `NodeStyleModifier.WithGlassContainer` — `GlassEffectContainer`
- `NativeRootStackRenderer` — `.safeAreaBar(edge:)`
- `NativeRootStackRenderer` — `.navigationSubtitle(_:)`
- `NativeRootTabsRenderer` — `.tabViewBottomAccessory`

Each keeps its `#available` check *inside* the `#if`, with the pre-26 branch factored into a `fallback` helper so the two `#if` arms can't drift apart. New `LiquidGlassAvailability.swift` documents the rationale in one place and emits a `#warning` on pre-Xcode-26 toolchains, so it's obvious in the build log that Liquid Glass was compiled out.

## Device support is unchanged

The iOS 18 side already worked — `IPHONEOS_DEPLOYMENT_TARGET` is already `18.2` and every iOS 26 API was already runtime-guarded, so an iPad stuck on iOS 18 was never the blocked case. The compile was the only failure. Real floor is Xcode **16.2**, not 16.0 — 16.0/16.1 ship the iOS 18.0/18.1 SDK, below the 18.2 deployment target.

## Two things to flag

1. **A binary built with Xcode 16 shows the fallbacks even on iOS 26 hardware.** The gate is per-build, not per-device: no Liquid Glass, no bottom accessory, no `.navigationSubtitle`.
2. **Xcode 26 is still required to ship.** App Store Connect has rejected uploads built against anything older than the iOS 26 SDK [since 28 April 2026](https://developer.apple.com/news/upcoming-requirements/). This buys back local dev and CI on older Xcode; full-fidelity rendering still needs 26. NativePHP/nativephp.com#450 should probably say "Xcode 26 to submit and for Liquid Glass; 16.2+ compiles and runs" rather than hard-requiring 26.

## Verification

Built both paths with Xcode 26.3 against a clean derived-data dir. Error set is identical to the pre-change baseline (10 pre-existing `php_embed` errors — the PHP headers aren't vendored into a bare clone) with no new warnings. Then forced the `#else` arm via a temporary `compiler(>=9.9)` flip and rebuilt: still no new errors, and the `#warning` fires as expected. That proves the fallbacks type-check with zero iOS 26 symbols in scope at a 18.2 deployment target.

Only Xcode 26.3 was available here, so the flip is a *simulation* of Xcode 16 rather than the real thing — **worth one confirming build on 16.4 before merge.**

PHP suite: 854 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)