### PR TITLE
fix(async): allow Symfony Process 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "laravel/prompts": "^0.1.1|^0.2|^0.3",
         "laravel/serializable-closure": "^1.3|^2.0",
-        "symfony/process": "^6.2|^7.0",
+        "symfony/process": "^6.2|^7.0|^8.0",
         "endroid/qr-code": "^6.0.9",
         "react/datagram": "^1.10",
         "spatie/laravel-package-tools": "^1.14.0"


### PR DESCRIPTION
## Summary
- allow `symfony/process` 8.x alongside the existing 6.x and 7.x support
- let applications on a secure Symfony 8 lock consume AsyncTask without disabling Composer security advisory blocking

## Why
The current `^6.2|^7.0` constraint prevents Composer from resolving #228 in consumers whose policy blocks all matching Symfony 6/7 releases for advisories, even when they already run Symfony Process 8.

The package requires PHP `^8.4`, which satisfies Symfony Process 8. Direct Process usage on this branch stays within APIs available in Symfony 8.

## Verification
- `composer validate --strict`
- reviewed all direct `Symfony\Component\Process` usage against Symfony 8

A full upstream `composer update --dry-run` remains blocked locally by an unrelated PHP 8.5 / legacy test dependency conflict (`orchestra/testbench` / Pest / PHPUnit), not this constraint.