### PR TITLE
fix: skip the farewell frame when back() answers a system back

### DIFF
--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -91,6 +91,9 @@ abstract class NativeComponent
 
     protected ?NavigationIntent $nativeNavigationIntent = null;
 
+    /** True while dispatching a system back (type 8) — the native pop has already animated. */
+    protected bool $nativeAnsweringSystemBack = false;
+
     protected ?NativeRouter $nativeRouter = null;
 
     protected array $nativeParams = [];
@@ -2019,6 +2022,23 @@ abstract class NativeComponent
         $this->back();
     }
 
+    /**
+     * Dispatch a system back — the hardware button, the system back
+     * chevron, or an edge-swipe pop. While it runs, back() knows the
+     * native pop has ALREADY animated and skips its farewell publish;
+     * see back() for why that matters.
+     */
+    public function handleSystemBack(): void
+    {
+        $this->nativeAnsweringSystemBack = true;
+
+        try {
+            $this->onBackPressed();
+        } finally {
+            $this->nativeAnsweringSystemBack = false;
+        }
+    }
+
     public static function registerDumpHandler(): void
     {
         if (self::$dumpHandlerRegistered) {
@@ -2365,7 +2385,7 @@ abstract class NativeComponent
 
                     continue;
                 }
-                $this->onBackPressed();
+                $this->handleSystemBack();
 
                 continue;
             }
@@ -2528,7 +2548,20 @@ abstract class NativeComponent
         }
 
         $this->nativeNavigationIntent = new NavigationIntent(NavigationIntent::BACK);
-        $this->publishFinalState();
+
+        // The farewell frame keeps a PHP-initiated pop looking fresh while
+        // the native side animates it. Answering a SYSTEM back is the
+        // opposite situation: the native pop has already animated and the
+        // navigation path has already shrunk, so a farewell frame of this
+        // screen reaches the coordinator as an unknown URI — which its
+        // reconciliation can only read as a brand-new push. The screen
+        // flashes back in, then out again once the router publishes the
+        // level below (visible whenever unmount work spans a few frames).
+        // There is nothing on screen left to keep fresh — skip it.
+        if (! $this->nativeAnsweringSystemBack) {
+            $this->publishFinalState();
+        }
+
         $this->stop();
 
         return $this;

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -91,7 +91,7 @@ abstract class NativeComponent
 
     protected ?NavigationIntent $nativeNavigationIntent = null;
 
-    /** True while dispatching a system back (type 8) — the native pop has already animated. */
+    /** True while dispatching a system back (type 8) from native navigation. */
     protected bool $nativeAnsweringSystemBack = false;
 
     protected ?NativeRouter $nativeRouter = null;
@@ -2025,7 +2025,7 @@ abstract class NativeComponent
     /**
      * Dispatch a system back — the hardware button, the system back
      * chevron, or an edge-swipe pop. While it runs, back() knows the
-     * native pop has ALREADY animated and skips its farewell publish;
+     * event came from native navigation and skips its farewell publish;
      * see back() for why that matters.
      */
     public function handleSystemBack(): void
@@ -2551,13 +2551,11 @@ abstract class NativeComponent
 
         // The farewell frame keeps a PHP-initiated pop looking fresh while
         // the native side animates it. Answering a SYSTEM back is the
-        // opposite situation: the native pop has already animated and the
-        // navigation path has already shrunk, so a farewell frame of this
-        // screen reaches the coordinator as an unknown URI — which its
-        // reconciliation can only read as a brand-new push. The screen
-        // flashes back in, then out again once the router publishes the
-        // level below (visible whenever unmount work spans a few frames).
-        // There is nothing on screen left to keep fresh — skip it.
+        // opposite situation: native navigation may already have removed
+        // this screen and shrunk its path, so a farewell frame reaches the
+        // coordinator as an unknown URI — which its reconciliation can only
+        // read as a brand-new push. Skip it to avoid reintroducing a screen
+        // that native navigation is backing away from.
         if (! $this->nativeAnsweringSystemBack) {
             $this->publishFinalState();
         }

--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -497,7 +497,7 @@ class TestableComponent
     {
         $this->startInteraction();
 
-        $this->guard(fn () => $this->component->onBackPressed());
+        $this->guard(fn () => $this->component->handleSystemBack());
 
         return $this->afterInteraction();
     }
@@ -647,7 +647,7 @@ class TestableComponent
     public function goBack(): TestableComponent
     {
         if ($this->component->getNavigationIntent() === null) {
-            $this->guard(fn () => $this->component->onBackPressed());
+            $this->guard(fn () => $this->component->handleSystemBack());
         }
 
         $intent = $this->component->getNavigationIntent();

--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -1423,8 +1423,8 @@ class TestableComponent
 
     /**
      * Post-interaction re-render, mirroring the runloop: a component that
-     * set a navigation intent has stopped (its final state was already
-     * published by publishFinalState()); otherwise render the next frame.
+     * set a navigation intent has stopped (and may have published a farewell
+     * frame as part of that navigation); otherwise render the next frame.
      */
     protected function afterInteraction(): static
     {

--- a/tests/Feature/SystemBackFarewellTest.php
+++ b/tests/Feature/SystemBackFarewellTest.php
@@ -1,93 +1,107 @@
 <?php
 
-namespace Tests\Feature;
-
 use Native\Mobile\Edge\Element;
 use Native\Mobile\Edge\Elements\Column;
 use Native\Mobile\Edge\NativeComponent;
 use Native\Mobile\Edge\NavigationIntent;
-use Tests\TestCase;
+use Native\Mobile\Testing\Native;
+use Tests\Fixtures\Edge\DetailScreen;
 
 /**
  * back() publishes one farewell frame so a PHP-initiated pop has fresh
- * content to show while the native side animates it. A SYSTEM back
+ * content to show while the native side animates it. A system back
  * (hardware button, back chevron, edge-swipe pop) is the opposite case:
- * the native pop has already animated, the coordinator's path has already
- * shrunk, and a farewell frame of the departing screen arrives as an
- * unknown URI — reconciled as a brand-new push. The screen flashes back
- * in, then out again. These tests pin the split: farewell for
+ * native navigation may already have removed the departing screen and
+ * shrunk its path, so its farewell frame can arrive as an unknown URI —
+ * reconciled as a brand-new push. These tests pin the split: farewell for
  * PHP-initiated backs, none when answering a system back.
  */
-class SystemBackFarewellTest extends TestCase
+function farewellScreen(): NativeComponent
 {
-    private function screen(): NativeComponent
+    return new class extends NativeComponent
     {
-        return new class extends NativeComponent
+        public int $farewellFrames = 0;
+
+        public function render(): Element
         {
-            public int $farewellFrames = 0;
-
-            public function render(): Element
-            {
-                return Column::make();
-            }
-
-            protected function publishFinalState(): void
-            {
-                $this->farewellFrames++;
-            }
-        };
-    }
-
-    public function test_a_php_initiated_back_still_publishes_a_farewell_frame(): void
-    {
-        $screen = $this->screen();
-
-        $screen->back();
-
-        $this->assertSame(NavigationIntent::BACK, $screen->getNavigationIntent()?->type);
-        $this->assertSame(1, $screen->farewellFrames);
-    }
-
-    public function test_answering_a_system_back_skips_the_farewell_frame(): void
-    {
-        $screen = $this->screen();
-
-        $screen->handleSystemBack();
-
-        $this->assertSame(NavigationIntent::BACK, $screen->getNavigationIntent()?->type);
-        $this->assertSame(0, $screen->farewellFrames);
-    }
-
-    public function test_the_flag_resets_even_when_the_back_handler_throws(): void
-    {
-        $screen = new class extends NativeComponent
-        {
-            public int $farewellFrames = 0;
-
-            public function render(): Element
-            {
-                return Column::make();
-            }
-
-            protected function publishFinalState(): void
-            {
-                $this->farewellFrames++;
-            }
-
-            public function onBackPressed(): void
-            {
-                throw new \RuntimeException('boom');
-            }
-        };
-
-        try {
-            $screen->handleSystemBack();
-        } catch (\RuntimeException) {
-            // expected
+            return Column::make();
         }
 
-        $screen->back();
-
-        $this->assertSame(1, $screen->farewellFrames);
-    }
+        protected function publishFinalState(): void
+        {
+            $this->farewellFrames++;
+        }
+    };
 }
+
+it('publishes a farewell frame for a PHP-initiated back', function () {
+    $screen = farewellScreen();
+
+    $screen->back();
+
+    expect($screen->getNavigationIntent()?->type)->toBe(NavigationIntent::BACK)
+        ->and($screen->farewellFrames)->toBe(1);
+});
+
+it('skips the farewell frame when answering a system back', function () {
+    $screen = farewellScreen();
+
+    $screen->handleSystemBack();
+
+    expect($screen->getNavigationIntent()?->type)->toBe(NavigationIntent::BACK)
+        ->and($screen->farewellFrames)->toBe(0);
+});
+
+it('resets the system-back flag when the back handler throws', function () {
+    $screen = new class extends NativeComponent
+    {
+        public int $farewellFrames = 0;
+
+        public function render(): Element
+        {
+            return Column::make();
+        }
+
+        protected function publishFinalState(): void
+        {
+            $this->farewellFrames++;
+        }
+
+        public function onBackPressed(): void
+        {
+            throw new RuntimeException('boom');
+        }
+    };
+
+    try {
+        $screen->handleSystemBack();
+    } catch (RuntimeException) {
+        // expected
+    }
+
+    $screen->back();
+
+    expect($screen->farewellFrames)->toBe(1);
+});
+
+it('skips the farewell frame for a harness back press', function () {
+    $bridge = Native::fakeBridge();
+
+    $screen = Native::test(DetailScreen::class);
+    $mounted = count($bridge->publishes);
+
+    $screen->pressBack()->assertWentBack();
+
+    expect($bridge->publishes)->toHaveCount($mounted);
+});
+
+it('publishes a farewell frame for a PHP-initiated harness back', function () {
+    $bridge = Native::fakeBridge();
+
+    $screen = Native::test(DetailScreen::class);
+    $mounted = count($bridge->publishes);
+
+    $screen->tap('Go back')->assertWentBack();
+
+    expect($bridge->publishes)->toHaveCount($mounted + 1);
+});

--- a/tests/Feature/SystemBackFarewellTest.php
+++ b/tests/Feature/SystemBackFarewellTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use Native\Mobile\Edge\Element;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Edge\NavigationIntent;
+use Tests\TestCase;
+
+/**
+ * back() publishes one farewell frame so a PHP-initiated pop has fresh
+ * content to show while the native side animates it. A SYSTEM back
+ * (hardware button, back chevron, edge-swipe pop) is the opposite case:
+ * the native pop has already animated, the coordinator's path has already
+ * shrunk, and a farewell frame of the departing screen arrives as an
+ * unknown URI — reconciled as a brand-new push. The screen flashes back
+ * in, then out again. These tests pin the split: farewell for
+ * PHP-initiated backs, none when answering a system back.
+ */
+class SystemBackFarewellTest extends TestCase
+{
+    private function screen(): NativeComponent
+    {
+        return new class extends NativeComponent
+        {
+            public int $farewellFrames = 0;
+
+            public function render(): Element
+            {
+                return Column::make();
+            }
+
+            protected function publishFinalState(): void
+            {
+                $this->farewellFrames++;
+            }
+        };
+    }
+
+    public function test_a_php_initiated_back_still_publishes_a_farewell_frame(): void
+    {
+        $screen = $this->screen();
+
+        $screen->back();
+
+        $this->assertSame(NavigationIntent::BACK, $screen->getNavigationIntent()?->type);
+        $this->assertSame(1, $screen->farewellFrames);
+    }
+
+    public function test_answering_a_system_back_skips_the_farewell_frame(): void
+    {
+        $screen = $this->screen();
+
+        $screen->handleSystemBack();
+
+        $this->assertSame(NavigationIntent::BACK, $screen->getNavigationIntent()?->type);
+        $this->assertSame(0, $screen->farewellFrames);
+    }
+
+    public function test_the_flag_resets_even_when_the_back_handler_throws(): void
+    {
+        $screen = new class extends NativeComponent
+        {
+            public int $farewellFrames = 0;
+
+            public function render(): Element
+            {
+                return Column::make();
+            }
+
+            protected function publishFinalState(): void
+            {
+                $this->farewellFrames++;
+            }
+
+            public function onBackPressed(): void
+            {
+                throw new \RuntimeException('boom');
+            }
+        };
+
+        try {
+            $screen->handleSystemBack();
+        } catch (\RuntimeException) {
+            // expected
+        }
+
+        $screen->back();
+
+        $this->assertSame(1, $screen->farewellFrames);
+    }
+}


### PR DESCRIPTION
## The bug

With shared-stack chrome, backing out of a screen via the **system** back (back chevron, edge-swipe, hardware button) can flash the screen back in and immediately out again. It shows when the departing screen's farewell tree differs from its last publish and teardown spans a few frames. A byte-identical republish is dropped by the bridge diff, so that case never re-pushes.

## Why

Three pieces, each fine on its own:

1. `back()` publishes a **farewell frame** of the departing screen before setting the BACK intent, so a *PHP-initiated* pop has fresh content to show while the native side animates it.
2. On a *system* back, native navigation initiated the pop and its path may already have shrunk before PHP receives `sendSystemBackEvent`.
3. The coordinator reconciles a publish whose URI is no longer in the path as a **brand-new push**.

So for affected system backs: native navigation starts backing away → PHP answers with a changed farewell frame of the departing screen → the coordinator pushes it back on → the router publishes the level below → it disappears again.

## The fix

The type-8 dispatch now goes through `handleSystemBack()`, which flags the native-system-back context. `back()` skips the farewell frame while that flag is set; PHP-initiated backs are untouched and keep their farewell frame. `pressBack()` in the test harness mirrors the production dispatch.

`navigate()` from `onBackPressed()` deliberately keeps its farewell publish because that re-push is what aligns the native path with PHP's resulting stack. On Android plain screens, the previous frame remains visible during teardown instead of publishing a fresh one; this affects only state mutated in `onBackPressed()` immediately before `back()`, for the teardown interval plus the next screen's `onResume()`.

## Tests

`SystemBackFarewellTest` now uses the EDGE suite's Pest style and pins five cases:

- PHP-initiated back publishes one farewell frame.
- A production system back publishes none.
- The system-back flag resets if `onBackPressed()` throws.
- Harness `pressBack()` publishes no farewell frame.
- A PHP-initiated harness back still publishes one.

Full suite: 901 passed. Pint and PHPStan clean.
