### PR TITLE
feature: OrientationChanged event + System::orientation() — react to device rotation from PHP

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/BridgeFunctionRegistration.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/BridgeFunctionRegistration.kt
@@ -29,6 +29,7 @@ fun registerBridgeFunctions(activity: FragmentActivity, context: Context) {
     // plugin). iOS twin: Bridge/Functions/SystemFunctions.swift.
     registry.register("System.OpenAppSettings", SystemFunctions.OpenAppSettings(context))
     registry.register("System.GetAppearance", SystemFunctions.GetAppearance(context))
+    registry.register("System.GetOrientation", SystemFunctions.GetOrientation(context))
     registry.register("System.MinimizeApp", SystemFunctions.MinimizeApp(activity))
 
     // Dialog.* — core built-in (migrated from the nativephp/mobile-dialog

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/functions/SystemFunctions.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/functions/SystemFunctions.kt
@@ -80,7 +80,8 @@ object SystemFunctions {
     }
 
     /**
-     * Current screen orientation (portrait / landscape). Backs
+     * Current app-window orientation (portrait / landscape), which may differ
+     * from the physical device orientation in multi-window mode. Backs
      * `System::orientation()` / `isLandscape()` for the cold read before the
      * first OrientationChanged push.
      * Returns:

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/functions/SystemFunctions.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/functions/SystemFunctions.kt
@@ -78,4 +78,19 @@ object SystemFunctions {
             return mapOf("appearance" to if (night) "dark" else "light")
         }
     }
+
+    /**
+     * Current screen orientation (portrait / landscape). Backs
+     * `System::orientation()` / `isLandscape()` for the cold read before the
+     * first OrientationChanged push.
+     * Returns:
+     *   - orientation: string - "portrait" or "landscape"
+     */
+    class GetOrientation(private val context: Context) : BridgeFunction {
+        override fun execute(parameters: Map<String, Any>): Map<String, Any> {
+            val landscape = context.resources.configuration.orientation ==
+                Configuration.ORIENTATION_LANDSCAPE
+            return mapOf("orientation" to if (landscape) "landscape" else "portrait")
+        }
+    }
 }

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
@@ -95,6 +95,9 @@ class MainActivity : FragmentActivity(), WebViewProvider {
     // Last appearance pushed to PHP, so onConfigurationChanged (which also fires
     // on rotation) only emits AppearanceChanged when the theme actually flips.
     private var lastAppearance: String? = null
+    // Last orientation pushed to PHP, so onConfigurationChanged (which also fires
+    // on theme flips) only emits OrientationChanged when the device rotates.
+    private var lastOrientation: String? = null
     private var showSplash by mutableStateOf(true)
     // Gates composition of the heavy MainScreen tree (Scaffold + WebView)
     // until the runtime is booted and the WebView is ready. Until then the first
@@ -128,6 +131,11 @@ class MainActivity : FragmentActivity(), WebViewProvider {
         // only emits AppearanceChanged when the theme genuinely differs.
         lastAppearance = if ((resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
                 Configuration.UI_MODE_NIGHT_YES) "dark" else "light"
+
+        // Seed the orientation tracker so a later config change (e.g. theme flip)
+        // only emits OrientationChanged when the device genuinely rotated.
+        lastOrientation = if (resources.configuration.orientation ==
+                Configuration.ORIENTATION_LANDSCAPE) "landscape" else "portrait"
 
         // Android 15 edge-to-edge compatibility fix
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -459,6 +467,19 @@ class MainActivity : FragmentActivity(), WebViewProvider {
             NativeElementBridge.sendNativeEvent(
                 "Native\\Mobile\\Events\\System\\AppearanceChanged",
                 org.json.JSONObject().put("mode", mode).toString()
+            )
+        }
+
+        // Push a native OrientationChanged event to PHP when the device rotates.
+        // Same guard as above: only emit when the orientation actually changed.
+        // Drives reactive System::orientation() / #[On(OrientationChanged)].
+        val orientation = if (newConfig.orientation ==
+                Configuration.ORIENTATION_LANDSCAPE) "landscape" else "portrait"
+        if (orientation != lastOrientation) {
+            lastOrientation = orientation
+            NativeElementBridge.sendNativeEvent(
+                "Native\\Mobile\\Events\\System\\OrientationChanged",
+                org.json.JSONObject().put("orientation", orientation).toString()
             )
         }
     }

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
@@ -95,9 +95,7 @@ class MainActivity : FragmentActivity(), WebViewProvider {
     // Last appearance pushed to PHP, so onConfigurationChanged (which also fires
     // on rotation) only emits AppearanceChanged when the theme actually flips.
     private var lastAppearance: String? = null
-    // Last orientation pushed to PHP, so onConfigurationChanged (which also fires
-    // on theme flips) only emits OrientationChanged when the device rotates.
-    private var lastOrientation: String? = null
+
     private var showSplash by mutableStateOf(true)
     // Gates composition of the heavy MainScreen tree (Scaffold + WebView)
     // until the runtime is booted and the WebView is ready. Until then the first
@@ -117,6 +115,11 @@ class MainActivity : FragmentActivity(), WebViewProvider {
         var instance: MainActivity? = null
             private set
 
+        // Survives activity recreation so a multi-window resize that Android
+        // does not route through onConfigurationChanged can still refresh PHP's
+        // process cache from the new activity's window configuration.
+        private var lastOrientation: String? = null
+
         // Delay before the background queue worker boots. The worker spins up a
         // second full Laravel runtime; deferring it keeps that off the cold-start
         // critical path so it doesn't steal CPU from the first paint.
@@ -132,10 +135,16 @@ class MainActivity : FragmentActivity(), WebViewProvider {
         lastAppearance = if ((resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
                 Configuration.UI_MODE_NIGHT_YES) "dark" else "light"
 
-        // Seed the orientation tracker so a later config change (e.g. theme flip)
-        // only emits OrientationChanged when the device genuinely rotated.
-        lastOrientation = if (resources.configuration.orientation ==
+        // Compare before reseeding: some multi-window changes recreate the
+        // activity rather than calling onConfigurationChanged. The companion
+        // tracker survives that recreation, so PHP still receives the change.
+        val currentOrientation = if (resources.configuration.orientation ==
                 Configuration.ORIENTATION_LANDSCAPE) "landscape" else "portrait"
+        val previousOrientation = lastOrientation
+        lastOrientation = currentOrientation
+        if (previousOrientation != null && previousOrientation != currentOrientation) {
+            sendOrientationChanged(currentOrientation)
+        }
 
         // Android 15 edge-to-edge compatibility fix
         WindowCompat.setDecorFitsSystemWindows(window, false)
@@ -470,18 +479,23 @@ class MainActivity : FragmentActivity(), WebViewProvider {
             )
         }
 
-        // Push a native OrientationChanged event to PHP when the device rotates.
+        // Push when the app window's orientation changes. In multi-window mode
+        // this can differ from the physical device's orientation.
         // Same guard as above: only emit when the orientation actually changed.
         // Drives reactive System::orientation() / #[On(OrientationChanged)].
         val orientation = if (newConfig.orientation ==
                 Configuration.ORIENTATION_LANDSCAPE) "landscape" else "portrait"
         if (orientation != lastOrientation) {
             lastOrientation = orientation
-            NativeElementBridge.sendNativeEvent(
-                "Native\\Mobile\\Events\\System\\OrientationChanged",
-                org.json.JSONObject().put("orientation", orientation).toString()
-            )
+            sendOrientationChanged(orientation)
         }
+    }
+
+    private fun sendOrientationChanged(orientation: String) {
+        NativeElementBridge.sendNativeEvent(
+            "Native\\Mobile\\Events\\System\\OrientationChanged",
+            org.json.JSONObject().put("orientation", orientation).toString()
+        )
     }
 
     @Suppress("DEPRECATION")

--- a/resources/xcode/NativePHP/Bridge/BridgeFunctionRegistration.swift
+++ b/resources/xcode/NativePHP/Bridge/BridgeFunctionRegistration.swift
@@ -18,6 +18,7 @@ func registerBridgeFunctions() {
     // plugin). Android twin: bridge/functions/SystemFunctions.kt.
     registry.register("System.OpenAppSettings", function: SystemFunctions.OpenAppSettings())
     registry.register("System.GetAppearance", function: SystemFunctions.GetAppearance())
+    registry.register("System.GetOrientation", function: SystemFunctions.GetOrientation())
 
     // UI.* — core built-in. Android twin: bridge/functions/UIFunctions.kt
     // (which also registers UI.SetTransition; iOS transitions ride the

--- a/resources/xcode/NativePHP/Bridge/Functions/SystemFunctions.swift
+++ b/resources/xcode/NativePHP/Bridge/Functions/SystemFunctions.swift
@@ -11,6 +11,17 @@ import UIKit
 /// Namespace: "System.*"
 enum SystemFunctions {
 
+    /// The current app window orientation. This intentionally describes the
+    /// window, not the physical device: iPad multitasking can make a window
+    /// landscape while the device itself is portrait (and vice versa).
+    static func currentWindowOrientation() -> String {
+        let size = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.windows.first?.bounds.size
+            ?? UIScreen.main.bounds.size
+        return size.width > size.height ? "landscape" : "portrait"
+    }
+
     // MARK: - System.OpenAppSettings
 
     /// Open the app's settings screen in the device settings
@@ -53,7 +64,7 @@ enum SystemFunctions {
 
     // MARK: - System.GetOrientation
 
-    /// Current screen orientation (portrait / landscape), derived from the key
+    /// Current app window orientation (portrait / landscape), derived from the
     /// window's aspect — the same signal the OrientationChanged push uses.
     /// Backs `System::orientation()` / `isLandscape()` for the cold read before
     /// the first OrientationChanged push.
@@ -62,11 +73,7 @@ enum SystemFunctions {
     class GetOrientation: BridgeFunction {
         func execute(parameters: [String: Any]) throws -> [String: Any] {
             func read() -> String {
-                let size = UIApplication.shared.connectedScenes
-                    .compactMap { $0 as? UIWindowScene }
-                    .first?.windows.first?.bounds.size
-                    ?? UIScreen.main.bounds.size
-                return size.width > size.height ? "landscape" : "portrait"
+                SystemFunctions.currentWindowOrientation()
             }
             // Bridge functions may run off the main thread; UIKit window reads
             // must be on main.

--- a/resources/xcode/NativePHP/Bridge/Functions/SystemFunctions.swift
+++ b/resources/xcode/NativePHP/Bridge/Functions/SystemFunctions.swift
@@ -50,4 +50,28 @@ enum SystemFunctions {
             return ["appearance": mode]
         }
     }
+
+    // MARK: - System.GetOrientation
+
+    /// Current screen orientation (portrait / landscape), derived from the key
+    /// window's aspect — the same signal the OrientationChanged push uses.
+    /// Backs `System::orientation()` / `isLandscape()` for the cold read before
+    /// the first OrientationChanged push.
+    /// Returns:
+    ///   - orientation: string - "portrait" or "landscape"
+    class GetOrientation: BridgeFunction {
+        func execute(parameters: [String: Any]) throws -> [String: Any] {
+            func read() -> String {
+                let size = UIApplication.shared.connectedScenes
+                    .compactMap { $0 as? UIWindowScene }
+                    .first?.windows.first?.bounds.size
+                    ?? UIScreen.main.bounds.size
+                return size.width > size.height ? "landscape" : "portrait"
+            }
+            // Bridge functions may run off the main thread; UIKit window reads
+            // must be on main.
+            let orientation = Thread.isMainThread ? read() : DispatchQueue.main.sync { read() }
+            return ["orientation": orientation]
+        }
+    }
 }

--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -15,6 +15,9 @@ struct ContentView: View {
     // platform default. Shows behind screens and during transitions.
     @ObservedObject private var windowBackground = WindowBackgroundState.shared
     @Environment(\.colorScheme) private var colorScheme
+    // Last orientation pushed to PHP (seeded from the first layout), so window
+    // size changes only emit OrientationChanged when the aspect actually flips.
+    @State private var lastOrientation: String?
 
     /// The base color native screens render over — the PHP override when
     /// set, otherwise the system default.
@@ -120,6 +123,26 @@ struct ContentView: View {
             let mode = newScheme == .dark ? "dark" : "light"
             LaravelBridge.shared.send?("Native\\Mobile\\Events\\System\\AppearanceChanged", ["mode": mode])
         }
+        // Push a native OrientationChanged event to PHP when the device
+        // rotates. Orientation is derived from the window's aspect
+        // (width > height) — the signal layout actually cares about. Seeded
+        // on first layout so only a real flip emits. Drives the reactive
+        // `System::orientation()` / `#[On(OrientationChanged)]` path.
+        .background(
+            GeometryReader { geometry in
+                Color.clear
+                    .onAppear {
+                        lastOrientation = geometry.size.width > geometry.size.height
+                            ? "landscape" : "portrait"
+                    }
+                    .onChange(of: geometry.size) { size in
+                        let orientation = size.width > size.height ? "landscape" : "portrait"
+                        guard orientation != lastOrientation else { return }
+                        lastOrientation = orientation
+                        LaravelBridge.shared.send?("Native\\Mobile\\Events\\System\\OrientationChanged", ["orientation": orientation])
+                    }
+            }
+        )
     }
 
     /// One layer of the two-layer native screen swap. `id` is the screen's

--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -15,8 +15,8 @@ struct ContentView: View {
     // platform default. Shows behind screens and during transitions.
     @ObservedObject private var windowBackground = WindowBackgroundState.shared
     @Environment(\.colorScheme) private var colorScheme
-    // Last orientation pushed to PHP (seeded from the first layout), so window
-    // size changes only emit OrientationChanged when the aspect actually flips.
+    // Last app-window orientation pushed to PHP (seeded from the first layout),
+    // so size changes only emit when the window aspect actually flips.
     @State private var lastOrientation: String?
 
     /// The base color native screens render over — the PHP override when
@@ -119,29 +119,30 @@ struct ContentView: View {
         // flips (Control Center toggle, sunset auto-switch). Drives the
         // reactive `System::appearance()` / `#[On(AppearanceChanged)]` path.
         // ContentView is always mounted, so this observes every change.
-        .onChange(of: colorScheme) { newScheme in
+        .onChange(of: colorScheme) { _, newScheme in
             let mode = newScheme == .dark ? "dark" : "light"
             LaravelBridge.shared.send?("Native\\Mobile\\Events\\System\\AppearanceChanged", ["mode": mode])
         }
-        // Push a native OrientationChanged event to PHP when the device
-        // rotates. Orientation is derived from the window's aspect
-        // (width > height) — the signal layout actually cares about. Seeded
+        // Push a native OrientationChanged event to PHP when the app window's
+        // aspect flips. Read the actual window on both the push and query paths:
+        // GeometryReader's safe-area frame can become landscape-shaped when an
+        // iPad keyboard appears even though the window remains portrait. Seeded
         // on first layout so only a real flip emits. Drives the reactive
         // `System::orientation()` / `#[On(OrientationChanged)]` path.
         .background(
             GeometryReader { geometry in
                 Color.clear
                     .onAppear {
-                        lastOrientation = geometry.size.width > geometry.size.height
-                            ? "landscape" : "portrait"
+                        lastOrientation = SystemFunctions.currentWindowOrientation()
                     }
-                    .onChange(of: geometry.size) { size in
-                        let orientation = size.width > size.height ? "landscape" : "portrait"
+                    .onChange(of: geometry.size) { _, _ in
+                        let orientation = SystemFunctions.currentWindowOrientation()
                         guard orientation != lastOrientation else { return }
                         lastOrientation = orientation
                         LaravelBridge.shared.send?("Native\\Mobile\\Events\\System\\OrientationChanged", ["orientation": orientation])
                     }
             }
+            .ignoresSafeArea(.keyboard)
         )
     }
 

--- a/src/Events/System/OrientationChanged.php
+++ b/src/Events/System/OrientationChanged.php
@@ -7,10 +7,11 @@ use Illuminate\Queue\SerializesModels;
 use Native\Mobile\Events\Concerns\BroadcastsGlobally;
 
 /**
- * The screen orientation (portrait / landscape) changed while the app was
- * running — the user rotated the device. Only fires when the app allows more
- * than one orientation (`nativephp.orientation` config). Fired from native
- * (iOS window size change / Android `onConfigurationChanged` orientation).
+ * The app window orientation (portrait / landscape) changed while the app was
+ * running. This describes the window's aspect, not the physical device, so it
+ * also covers iPad/Android multi-window resizing. Only fires when the app
+ * allows more than one orientation (`nativephp.orientation` config). Fired
+ * from native window/configuration changes.
  *
  * React in a component:
  *

--- a/src/Events/System/OrientationChanged.php
+++ b/src/Events/System/OrientationChanged.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Native\Mobile\Events\System;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Native\Mobile\Events\Concerns\BroadcastsGlobally;
+
+/**
+ * The screen orientation (portrait / landscape) changed while the app was
+ * running — the user rotated the device. Only fires when the app allows more
+ * than one orientation (`nativephp.orientation` config). Fired from native
+ * (iOS window size change / Android `onConfigurationChanged` orientation).
+ *
+ * React in a component:
+ *
+ *     #[On(OrientationChanged::class)]
+ *     public function rotated(string $orientation): void { ... } // 'portrait' | 'landscape'
+ *
+ * …or anywhere in the app (it also dispatches globally — see
+ * [[BroadcastsGlobally]]):
+ *
+ *     Event::listen(OrientationChanged::class, fn ($e) => ...);
+ *
+ * The query side (`System::orientation()` / `System::isLandscape()`) is kept
+ * in sync off this event, so reads stay fresh without a bridge round-trip.
+ */
+class OrientationChanged implements BroadcastsGlobally
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        /** 'portrait' | 'landscape' */
+        public string $orientation,
+    ) {}
+}

--- a/src/Facades/System.php
+++ b/src/Facades/System.php
@@ -14,6 +14,10 @@ use Illuminate\Support\Facades\Facade;
  * @method static bool isDarkMode()
  * @method static bool isLightMode()
  * @method static void rememberAppearance(string $mode)
+ * @method static string orientation()
+ * @method static bool isPortrait()
+ * @method static bool isLandscape()
+ * @method static void rememberOrientation(string $orientation)
  */
 class System extends Facade
 {

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -44,6 +44,7 @@ use Native\Mobile\Edge\NativeComponent;
 use Native\Mobile\Edge\NativeRouter;
 use Native\Mobile\Edge\NativeTagPrecompiler;
 use Native\Mobile\Events\System\AppearanceChanged;
+use Native\Mobile\Events\System\OrientationChanged;
 use Native\Mobile\Http\Middleware\HonorsRequestedNativeScreen;
 use Native\Mobile\Plugins\Compilers\AndroidPluginCompiler;
 use Native\Mobile\Plugins\Compilers\IOSPluginCompiler;
@@ -147,6 +148,11 @@ class NativeServiceProvider extends PackageServiceProvider
         Event::listen(
             AppearanceChanged::class,
             fn (AppearanceChanged $e) => System::rememberAppearance($e->mode),
+        );
+
+        Event::listen(
+            OrientationChanged::class,
+            fn (OrientationChanged $e) => System::rememberOrientation($e->orientation),
         );
     }
 

--- a/src/System.php
+++ b/src/System.php
@@ -16,6 +16,13 @@ class System
      */
     private static ?string $appearance = null;
 
+    /**
+     * Process-cached current orientation. Same lifecycle as $appearance:
+     * seeded on first read via `System.GetOrientation`, kept fresh by the
+     * OrientationChanged event.
+     */
+    private static ?string $orientation = null;
+
     public function isIos(): bool
     {
         $info = Device::getInfo();
@@ -87,6 +94,48 @@ class System
     {
         if ($mode === 'light' || $mode === 'dark') {
             self::$appearance = $mode;
+        }
+    }
+
+    /**
+     * Current screen orientation: 'portrait' or 'landscape'. Off the device
+     * (tests, web preview) the bridge is absent and this returns 'portrait'.
+     */
+    public function orientation(): string
+    {
+        if (self::$orientation !== null) {
+            return self::$orientation;
+        }
+
+        if (function_exists('nativephp_call')) {
+            $result = nativephp_call('System.GetOrientation', '{}');
+            $orientation = json_decode($result ?: '{}', true)['orientation'] ?? null;
+            if ($orientation === 'portrait' || $orientation === 'landscape') {
+                return self::$orientation = $orientation;
+            }
+        }
+
+        return 'portrait';
+    }
+
+    public function isPortrait(): bool
+    {
+        return $this->orientation() === 'portrait';
+    }
+
+    public function isLandscape(): bool
+    {
+        return $this->orientation() === 'landscape';
+    }
+
+    /**
+     * Update the process-cached orientation. Called by the OrientationChanged
+     * listener so `orientation()` stays fresh without re-probing the bridge.
+     */
+    public static function rememberOrientation(string $orientation): void
+    {
+        if ($orientation === 'portrait' || $orientation === 'landscape') {
+            self::$orientation = $orientation;
         }
     }
 

--- a/src/System.php
+++ b/src/System.php
@@ -17,7 +17,7 @@ class System
     private static ?string $appearance = null;
 
     /**
-     * Process-cached current orientation. Same lifecycle as $appearance:
+     * Process-cached current app-window orientation. Same lifecycle as $appearance:
      * seeded on first read via `System.GetOrientation`, kept fresh by the
      * OrientationChanged event.
      */
@@ -98,8 +98,10 @@ class System
     }
 
     /**
-     * Current screen orientation: 'portrait' or 'landscape'. Off the device
-     * (tests, web preview) the bridge is absent and this returns 'portrait'.
+     * Current app-window orientation: 'portrait' or 'landscape'. This describes
+     * the window aspect rather than the physical device, which matters in
+     * multi-window modes. Off device (tests, web preview), the bridge is absent
+     * and this returns 'portrait'.
      */
     public function orientation(): string
     {

--- a/tests/Unit/System/AppearanceTest.php
+++ b/tests/Unit/System/AppearanceTest.php
@@ -33,6 +33,14 @@ it('ignores a bogus appearance value', function () {
     expect((new System)->appearance())->toBe('dark');
 });
 
+it('updates the appearance cache through the service provider listener', function () {
+    System::rememberAppearance('light');
+
+    AppearanceChanged::dispatch('dark');
+
+    expect((new System)->appearance())->toBe('dark');
+});
+
 it('rebuilds a marked event from its native payload', function () {
     $comp = new class extends NativeComponent {};
     $build = new ReflectionMethod(NativeComponent::class, 'buildEventInstance');

--- a/tests/Unit/System/OrientationTest.php
+++ b/tests/Unit/System/OrientationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Events\Concerns\BroadcastsGlobally;
+use Native\Mobile\Events\System\OrientationChanged;
+use Native\Mobile\System;
+
+/**
+ * Reactive orientation: the query side (System cache) + the event that keeps
+ * it fresh, mirroring the AppearanceChanged pattern.
+ */
+it('marks OrientationChanged for global dispatch', function () {
+    expect(is_subclass_of(OrientationChanged::class, BroadcastsGlobally::class))->toBeTrue();
+});
+
+it('caches orientation and answers isPortrait/isLandscape off it', function () {
+    System::rememberOrientation('landscape');
+    $sys = new System;
+    expect($sys->orientation())->toBe('landscape');
+    expect($sys->isLandscape())->toBeTrue();
+    expect($sys->isPortrait())->toBeFalse();
+
+    System::rememberOrientation('portrait');
+    expect($sys->orientation())->toBe('portrait');
+    expect($sys->isLandscape())->toBeFalse();
+});
+
+it('ignores a bogus orientation value', function () {
+    System::rememberOrientation('landscape');
+    System::rememberOrientation('diagonal'); // not portrait/landscape → no change
+    expect((new System)->orientation())->toBe('landscape');
+});
+
+it('rebuilds a marked event from its native payload', function () {
+    $comp = new class extends NativeComponent {};
+    $build = new ReflectionMethod(NativeComponent::class, 'buildEventInstance');
+    $build->setAccessible(true);
+
+    $ev = $build->invoke($comp, OrientationChanged::class, ['orientation' => 'landscape']);
+
+    expect($ev)->toBeInstanceOf(OrientationChanged::class);
+    expect($ev->orientation)->toBe('landscape');
+});

--- a/tests/Unit/System/OrientationTest.php
+++ b/tests/Unit/System/OrientationTest.php
@@ -31,6 +31,14 @@ it('ignores a bogus orientation value', function () {
     expect((new System)->orientation())->toBe('landscape');
 });
 
+it('updates the orientation cache through the service provider listener', function () {
+    System::rememberOrientation('portrait');
+
+    OrientationChanged::dispatch('landscape');
+
+    expect((new System)->orientation())->toBe('landscape');
+});
+
 it('rebuilds a marked event from its native payload', function () {
     $comp = new class extends NativeComponent {};
     $build = new ReflectionMethod(NativeComponent::class, 'buildEventInstance');


### PR DESCRIPTION
## What this does

When the app window changes between portrait and landscape, PHP is notified, so a screen can render a different layout for each orientation.

Until now, an app that allows both orientations would reflow natively when its window changed, but the PHP side never knew it happened. There was no way to say "in landscape, put the score tiles side by side".

## How you use it

React to an orientation change in any screen:

```php
use Native\Mobile\Events\System\OrientationChanged;

#[On(OrientationChanged::class)]
public function rotated(string $orientation): void
{
    // 'portrait' or 'landscape' — state changed, screen re-renders
}
```

Or ask at any time:

```php
System::orientation();  // 'portrait' | 'landscape'
System::isLandscape();  // bool
System::isPortrait();   // bool
```

## How it works

It follows the existing `AppearanceChanged` pattern end to end:

- **Native pushes an event when the app window's aspect changes.**
  - Android emits from `onConfigurationChanged`. The last orientation lives in the companion object, so an activity recreation caused by multi-window resizing compares the fresh configuration in `onCreate()` and emits when PHP's process cache would otherwise remain stale.
  - iOS watches layout changes but reads the actual app-window bounds for both push and query paths. Keyboard safe-area changes therefore cannot create false iPad orientation events. It uses the current iOS 17+ `onChange` form.
- **A listener in `NativeServiceProvider` keeps `System`'s cached value fresh**, so reads avoid another bridge round-trip after the first one.
- **`System.GetOrientation` backs the first read**, before any orientation event has arrived.

## Good to know

- Orientation describes the **app window**, not necessarily the physical device. They can differ in iPad and Android multi-window modes.
- The event only fires if the app enables a second orientation in `config/nativephp.php`.
- The payload is deliberately minimal: `'portrait' | 'landscape'`.
- Because the event implements `BroadcastsGlobally`, it also reaches app-wide `Event::listen()` listeners.
- Android webview screens depend on [#379](https://github.com/NativePHP/mobile-air/pull/379) to route native events into PHP.
- The documentation site needs a follow-up orientation page; it does not live in this repository.

## Tests

- Orientation event/global-dispatch and cache behaviour.
- Invalid-value guard and native-payload rebuild.
- Explicit service-provider listener coverage for both orientation and appearance events.

Full suite: 902 passed. Pint and PHPStan clean.
