### PR TITLE
Shared-element view transitions (`ref` + `@navigate.viewTransition`)

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeCompositionLocals.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeCompositionLocals.kt
@@ -1,5 +1,8 @@
 package com.nativephp.mobile.ui.nativerender
 
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.runtime.compositionLocalOf
 
 /**
@@ -20,3 +23,20 @@ val LocalAvailableHeight = compositionLocalOf { 844f }
  * layer shows through.
  */
 val LocalBackgroundLayerPresent = compositionLocalOf { false }
+
+/**
+ * Scopes needed to place a shared element (`ref`) into a morph.
+ *
+ * `Modifier.sharedBounds` is declared on `SharedTransitionScope` and needs the
+ * `AnimatedVisibilityScope` of the pane it lives in. `NodeView` is a plain
+ * recursive composable with no receiver, so both arrive through composition
+ * locals — the same route the safe-area values already take.
+ *
+ * Null wherever no host provides them (previews, tests, any tree rendered
+ * outside `NativeUIContent`), which makes the shared-element path an inert
+ * pass-through rather than a crash.
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+val LocalSharedTransitionScope = compositionLocalOf<SharedTransitionScope?> { null }
+
+val LocalAnimatedVisibilityScope = compositionLocalOf<AnimatedVisibilityScope?> { null }

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeUIRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeUIRenderer.kt
@@ -1,6 +1,8 @@
 package com.nativephp.mobile.ui.nativerender
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.tween
@@ -28,6 +30,8 @@ import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -37,6 +41,7 @@ import androidx.core.view.WindowInsetsCompat
  * Captures safe area insets and viewport size, provides them
  * via CompositionLocals, and renders the tree via NodeView.
  */
+@OptIn(ExperimentalSharedTransitionApi::class, androidx.compose.ui.ExperimentalComposeUiApi::class)
 @Composable
 fun NativeUIContent() {
     val tree by NativeUIBridge.currentTree
@@ -57,6 +62,11 @@ fun NativeUIContent() {
     BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
+            // Publishes every `testTag` in this tree as a resource-id, which
+            // is the only way UiAutomator — and therefore a Maestro `id:`
+            // selector — can see a Compose test tag. Set once at the root
+            // rather than per node.
+            .semantics { testTagsAsResourceId = true }
             .imePadding()
             .clickable(
                 indication = null,
@@ -95,27 +105,45 @@ fun NativeUIContent() {
             // exiting pane keeps the last tree it showed and releases it
             // when its exit animation completes.
             val treesByKey = remember { HashMap<Int, NativeUITree>() }
-            AnimatedContent(
-                targetState = screenKey,
-                transitionSpec = { transitionFor(pendingTransition) },
-                label = "screen-transition"
-            ) { key ->
-                DisposableEffect(key) {
-                    onDispose { treesByKey.remove(key) }
-                }
-                val paneTree = if (key == screenKey) {
-                    tree?.also { treesByKey[key] = it }
-                } else {
-                    treesByKey[key]
-                }
-                paneTree?.let { t ->
-                    // Fold any plugin-registered root hosts (side drawers,
-                    // global overlays, …) around the rendered tree. A host
-                    // pulls its own sentinel child out of `t.root` and renders
-                    // nothing when absent. A no-op pass-through when none are
-                    // registered, so trees using no plugin chrome pay nothing.
-                    NativeRootHostRegistry.Wrap(root = t.root) {
-                        NodeView(node = t.root)
+
+            // SharedTransitionLayout wraps the swap so elements sharing a
+            // `ref` across the two panes morph between them. Compose matches
+            // and animates these itself — unlike iOS, which has no equivalent
+            // and needs the source/slave roles driven by hand.
+            //
+            // A ref present on only one pane simply never matches and renders
+            // normally, so no pairing set is needed here.
+            SharedTransitionLayout {
+                AnimatedContent(
+                    targetState = screenKey,
+                    transitionSpec = { transitionFor(pendingTransition) },
+                    label = "screen-transition"
+                ) { key ->
+                    DisposableEffect(key) {
+                        onDispose { treesByKey.remove(key) }
+                    }
+                    val paneTree = if (key == screenKey) {
+                        tree?.also { treesByKey[key] = it }
+                    } else {
+                        treesByKey[key]
+                    }
+                    paneTree?.let { t ->
+                        // Publish both scopes down the tree: `NodeView` is a
+                        // plain recursive composable and cannot receive them
+                        // any other way.
+                        CompositionLocalProvider(
+                            LocalSharedTransitionScope provides this@SharedTransitionLayout,
+                            LocalAnimatedVisibilityScope provides this@AnimatedContent
+                        ) {
+                            // Fold any plugin-registered root hosts (side drawers,
+                            // global overlays, …) around the rendered tree. A host
+                            // pulls its own sentinel child out of `t.root` and renders
+                            // nothing when absent. A no-op pass-through when none are
+                            // registered, so trees using no plugin chrome pay nothing.
+                            NativeRootHostRegistry.Wrap(root = t.root) {
+                                NodeView(node = t.root)
+                            }
+                        }
                     }
                 }
             }
@@ -168,6 +196,12 @@ internal fun transitionFor(type: String?): ContentTransform {
         // staying visible beneath the incoming screen for a layered depth cue.
         "parallax_push" -> (slideInHorizontally(intSpec) { it }) togetherWith
             slideOutHorizontally(intSpec) { -it / 3 }
+        // Shared-element swap: the screens only cross-fade, because the motion
+        // the user reads comes from elements morphing across (see
+        // `Modifier.heroMorph`). Duration matches iOS's
+        // `nativeViewTransitionAnimation` so a morph is paced the same on both
+        // platforms.
+        "view_transition" -> fadeIn(tween(350)) togetherWith fadeOut(tween(350))
         "none" -> fadeIn(tween(0)) togetherWith fadeOut(tween(0))
         else -> fadeIn(spec) togetherWith fadeOut(spec)
     }

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeHeroMorph.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeHeroMorph.kt
@@ -1,0 +1,101 @@
+package com.nativephp.mobile.ui.nativerender
+
+import androidx.compose.animation.BoundsTransform
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.core.Easing
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.LinearOutSlowInEasing
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.FiniteAnimationSpec
+import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.core.VisibilityThreshold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
+
+/**
+ * Shared-element morph for nodes carrying a `ref` — the Android half of the
+ * feature iOS implements in `NodeHeroModifier`.
+ *
+ * Identity is the element's `ref`. Two screens naming an element the same
+ * thing morph it between them during a `view_transition` navigation. A ref
+ * that exists only as a test handle and must never travel opts out with
+ * `morph="none"`.
+ *
+ * Compose does the heavy lifting here that iOS does not: `SharedTransitionLayout`
+ * wrapped around the screen-swapping `AnimatedContent` matches keys across the
+ * two panes and animates the bounds itself. There is no source/slave role to
+ * assign, no arming, and no timing race — all of which the iOS side needs.
+ *
+ * A ref present on only one pane never matches and renders normally, so
+ * unmatched elements are inert without any pairing set.
+ *
+ * ## Parity note: `morph="position"` / `morph="size"`
+ *
+ * iOS maps these onto `MatchedGeometryProperties.position` / `.size`, which
+ * share only half the geometry. Compose's shared-element API always animates
+ * the full bounds and exposes no equivalent, so both values fall back to the
+ * default full-bounds morph here. That is a real behavioural difference
+ * between the platforms, not an oversight — the alternative was to invent an
+ * approximation that looks like the iOS one without matching it.
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+fun Modifier.heroMorph(node: NativeUINode): Modifier {
+    val ref = node.props.getString("ref", "")
+    val mode = node.props.getString("morph", "frame")
+
+    // Fast path — the overwhelming majority of nodes. No ref, an explicit
+    // opt-out, or no host providing the scopes (previews, tests, any tree
+    // rendered outside NativeUIContent).
+    if (ref.isEmpty() || mode == "none") return this
+
+    val sharedScope = LocalSharedTransitionScope.current ?: return this
+    val animatedScope = LocalAnimatedVisibilityScope.current ?: return this
+
+    val spec = node.boundsSpec()
+
+    return with(sharedScope) {
+        this@heroMorph.sharedBounds(
+            sharedContentState = rememberSharedContentState(key = ref),
+            animatedVisibilityScope = animatedScope,
+            boundsTransform = BoundsTransform { _, _ -> spec }
+        )
+    }
+}
+
+/**
+ * `morph-duration` (ms) and `morph-easing` for one element, falling back to a
+ * 350ms ease-in-out that matches iOS's shared view-transition pace so an
+ * untuned morph looks the same on both platforms.
+ *
+ * Deliberately distinct from `animate-duration` / `animate-easing`, which
+ * drive state-change transforms: an element may want a 200ms press response
+ * and a 600ms morph.
+ */
+@OptIn(ExperimentalSharedTransitionApi::class)
+private fun NativeUINode.boundsSpec(): FiniteAnimationSpec<Rect> {
+    val duration = props.getFloat("morph_duration", 0f)
+    val easing = props.getString("morph_easing", "")
+
+    if (easing == "spring") {
+        return spring(
+            dampingRatio = Spring.DampingRatioLowBouncy,
+            stiffness = Spring.StiffnessMediumLow,
+            visibilityThreshold = Rect.VisibilityThreshold
+        )
+    }
+
+    return tween(
+        durationMillis = if (duration > 0f) duration.toInt() else 350,
+        easing = when (easing) {
+            "linear" -> LinearEasing
+            "ease-in" -> FastOutLinearInEasing
+            "ease-out" -> LinearOutSlowInEasing
+            else -> FastOutSlowInEasing
+        }
+    )
+}

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeView.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeView.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.unit.dp
 
 /**
@@ -246,6 +248,8 @@ fun NodeView(node: NativeUINode, overrideModifier: Modifier? = null) {
         // ── Modifier chain ───────────────────────────────────────────
         // Outer to inner:
         //   base (sizing)
+        //   → heroMorph                     (shared-element bounds; must wrap
+        //                                    the background, not sit inside it)
         //   → press feedback graphicsLayer  (wraps everything for visual scale/alpha on press)
         //   → animation graphicsLayer       (wraps bg too so translate/alpha affect the box, not just inner content)
         //   → nodeStyle                     (background + border)
@@ -253,6 +257,20 @@ fun NodeView(node: NativeUINode, overrideModifier: Modifier? = null) {
         //   → nodeGestures                  (clickable; ripple now lives inside the scaled visual)
         //   → nodeLayout                    (padding)
         var modifier: Modifier = base
+
+        // Shared-element morph goes FIRST, i.e. outermost.
+        //
+        // Compose modifiers wrap outer→inner, so anything applied before
+        // `sharedBounds` is measured and drawn OUTSIDE the animated bounds.
+        // Applied last it moved only the node's children: on the three-hop
+        // chain the number travelled while its coloured box stayed put.
+        // Outermost, the background, border, clip, padding and content all
+        // ride the animated bounds together.
+        //
+        // Note this is the OPPOSITE order from iOS, where the equivalent
+        // modifier sits late in the chain — SwiftUI applies modifiers
+        // outward, so "last" there means the same thing "first" means here.
+        modifier = modifier.heroMorph(node)
 
         if (hasPressFeedback) {
             modifier = modifier.graphicsLayer {
@@ -290,6 +308,21 @@ fun NodeView(node: NativeUINode, overrideModifier: Modifier? = null) {
         modifier = modifier
             .nodeGestures(node, interactionSource)
             .nodeLayout(node.layout, safeAreaTop, safeAreaBottom, availableWidth, availableHeight)
+
+        // `ref` is both the test-targeting handle (Maestro / Compose UI tests)
+        // AND the shared-element identity: two screens naming an element the
+        // same thing morph it between them under a `view_transition`.
+        val ref = node.props.getString("ref", "")
+        if (ref.isNotEmpty()) {
+            // testTag ONLY — deliberately not contentDescription. Overwriting
+            // the description with an internal handle makes TalkBack announce
+            // "photo-1" in place of whatever the element actually is, which
+            // trades a real accessibility affordance for a test convenience.
+            // The tag reaches UiAutomator (and therefore Maestro `id:`) via
+            // `testTagsAsResourceId` set once at the root in NativeUIContent.
+            modifier = modifier.semantics { testTag = ref }
+        }
+
 
         // In-place text change animation (`content_transition` — numeric
         // roll / crossfade). Wraps the content in AnimatedContent keyed on

--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -15,11 +15,6 @@ struct ContentView: View {
     // platform default. Shows behind screens and during transitions.
     @ObservedObject private var windowBackground = WindowBackgroundState.shared
     @Environment(\.colorScheme) private var colorScheme
-    /// Namespace shared-element (`ref`) morphs are matched in.
-    /// Declared here because ContentView owns the screen stack — both the
-    /// outgoing and incoming screen must sit inside ONE namespace for
-    /// `matchedGeometryEffect` to pair their heroes at all.
-    @Namespace private var heroNamespace
 
     /// The base color native screens render over — the PHP override when
     /// set, otherwise the system default.
@@ -69,11 +64,10 @@ struct ContentView: View {
                                 x: -10
                             )
                             .transition(nativeScreenTransition(for: nativeUIBridge.pendingTransition))
-                            // Shared-element plumbing. `isOutgoing` tells
-                            // NodeHeroModifier which side of a matched pair
-                            // this screen is, which is what decides the
-                            // geometry source during the morph.
-                            .environment(\.heroNamespace, heroNamespace)
+                            // Shared-element plumbing. A screen on its way
+                            // out must stop reporting frames — the store
+                            // captured them at the swap and is flying from
+                            // them right now.
                             .environment(\.heroIsOutgoing, screen.isOutgoing)
                             // Each new screen sits above the previous one
                             // (keys increment), so slides cover in push
@@ -91,6 +85,12 @@ struct ContentView: View {
                 // WebKit processes for nothing.
                 screenBackground.ignoresSafeArea()
             }
+        }
+        // Shared elements in transit, drawn ABOVE both screens so a morph is
+        // never occluded by the incoming screen fading in over it. Renders
+        // nothing at all when no element is flying.
+        .overlay {
+            HeroFlightOverlay()
         }
         .overlay(alignment: .top) {
             // Hot-reload indicator. Mirrors iOS 26's Liquid Glass pill

--- a/resources/xcode/NativePHP/ContentView.swift
+++ b/resources/xcode/NativePHP/ContentView.swift
@@ -15,6 +15,11 @@ struct ContentView: View {
     // platform default. Shows behind screens and during transitions.
     @ObservedObject private var windowBackground = WindowBackgroundState.shared
     @Environment(\.colorScheme) private var colorScheme
+    /// Namespace shared-element (`ref`) morphs are matched in.
+    /// Declared here because ContentView owns the screen stack — both the
+    /// outgoing and incoming screen must sit inside ONE namespace for
+    /// `matchedGeometryEffect` to pair their heroes at all.
+    @Namespace private var heroNamespace
 
     /// The base color native screens render over — the PHP override when
     /// set, otherwise the system default.
@@ -64,6 +69,12 @@ struct ContentView: View {
                                 x: -10
                             )
                             .transition(nativeScreenTransition(for: nativeUIBridge.pendingTransition))
+                            // Shared-element plumbing. `isOutgoing` tells
+                            // NodeHeroModifier which side of a matched pair
+                            // this screen is, which is what decides the
+                            // geometry source during the morph.
+                            .environment(\.heroNamespace, heroNamespace)
+                            .environment(\.heroIsOutgoing, screen.isOutgoing)
                             // Each new screen sits above the previous one
                             // (keys increment), so slides cover in push
                             // order and a fade has a defined front/back.

--- a/resources/xcode/NativePHP/NativeRender/HeroFlightOverlay.swift
+++ b/resources/xcode/NativePHP/NativeRender/HeroFlightOverlay.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+import UIKit
+
+/// Renders shared elements in transit, ABOVE both screens.
+///
+/// This is the layer that makes the morph read cleanly. While the two screens
+/// cross-fade, a copy of each travelling element is drawn here at full opacity
+/// for the whole journey, so nothing is occluded by the screen fading in over
+/// it. See `HeroFlightStore` for why SwiftUI needs this done by hand.
+///
+/// Inert whenever nothing is flying — the overwhelming majority of the time —
+/// and never interactive: the copy is a picture of an element, and taps belong
+/// to the real one underneath it.
+struct HeroFlightOverlay: View {
+    @ObservedObject private var store = HeroFlightStore.shared
+
+    var body: some View {
+        if store.flights.isEmpty {
+            // No ZStack, no GeometryReader, nothing in the hierarchy at all.
+            Color.clear.frame(width: 0, height: 0).hidden()
+        } else {
+            GeometryReader { geo in
+                // Same environment the real tree renders with, so a copied
+                // subtree lays out identically to the original — a node that
+                // sizes itself against the viewport or safe area would
+                // otherwise measure differently up here.
+                let insets = Self.windowSafeAreaInsets
+                ZStack(alignment: .topLeading) {
+                    ForEach(store.flights) { flight in
+                        HeroFlightView(flight: flight)
+                            // Without this the copy hides itself: its ref is
+                            // the one in flight, and NodeHeroModifier hides
+                            // every element whose ref is mid-flight.
+                            .environment(\.heroIsFlyingCopy, true)
+                            .environment(\.nativeSafeAreaTop, insets.top)
+                            .environment(\.nativeSafeAreaBottom, insets.bottom)
+                            .environment(\.availableWidth, geo.size.width)
+                            .environment(\.availableHeight, geo.size.height)
+                    }
+                }
+                .frame(width: geo.size.width, height: geo.size.height, alignment: .topLeading)
+            }
+            .ignoresSafeArea(.container, edges: .all)
+            .allowsHitTesting(false)
+        }
+    }
+
+    /// Read from the window rather than a nested reader: the overlay ignores
+    /// the safe area, so a `GeometryReader` here reports zero insets and a
+    /// copied node would sit at a different offset than its original.
+    private static var windowSafeAreaInsets: (top: CGFloat, bottom: CGFloat) {
+        guard let insets = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first?.windows.first?.safeAreaInsets else {
+            return (0, 0)
+        }
+        return (insets.top, insets.bottom)
+    }
+}
+
+/// One element in transit: mounts at its origin frame, then animates to its
+/// destination.
+private struct HeroFlightView: View {
+    let flight: HeroFlightStore.Flight
+
+    @State private var arrived = false
+
+    var body: some View {
+        let rect = arrived ? flight.to : flight.from
+
+        NodeView(node: flight.node)
+            .frame(width: rect.width, height: rect.height)
+            .position(x: rect.midX, y: rect.midY)
+            // Declared on the value that moves, NOT wrapped around the
+            // mutation. `withAnimation` around an @Published change does not
+            // reliably carry its transaction into observing views — measured
+            // on device as the frame snapping while the state flipped
+            // correctly.
+            .animation(flight.animation, value: arrived)
+            .onAppear {
+                // A LATER runloop turn than the mount. Setting this inline
+                // coalesces with the insertion, so the copy appears already at
+                // its destination and never travels.
+                DispatchQueue.main.async { arrived = true }
+            }
+    }
+}

--- a/resources/xcode/NativePHP/NativeRender/HeroFlightStore.swift
+++ b/resources/xcode/NativePHP/NativeRender/HeroFlightStore.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+
+/// Owns the shared-element ("hero") flights for `view_transition` navigations.
+///
+/// ## Why a flight store rather than `matchedGeometryEffect`
+///
+/// `matchedGeometryEffect` can only slave one view's frame to another's, and
+/// both views stay inside their own screen layer. During a swap the incoming
+/// screen is cross-fading in over the outgoing one, so a hero travelling
+/// inside either layer is subject to that layer's opacity — measured on device
+/// as "animates most of the way, then fades", because the tail of the journey
+/// is progressively occluded.
+///
+/// Compose has no such problem: `SharedTransitionLayout` lifts the shared
+/// element into its own layer ABOVE both panes. This store gives SwiftUI the
+/// same model by hand — the FLIP approach (First, Last, Invert, Play):
+///
+///   1. **First** — every element carrying a `ref` continuously reports its
+///      on-screen frame here.
+///   2. **Last** — at the swap we snapshot those frames, then wait for the
+///      incoming screen to report where the same refs landed.
+///   3. **Play** — a *copy* of the element is rendered in
+///      `HeroFlightOverlay`, above both screens, and animated from the old
+///      frame to the new one. The real elements on both screens stay hidden
+///      for the duration, so nothing double-draws and nothing is occluded.
+///
+/// Only refs present on BOTH screens fly. A grid has six tagged tiles and one
+/// partner; the other five never had anywhere to go.
+@MainActor
+final class HeroFlightStore: ObservableObject {
+    static let shared = HeroFlightStore()
+
+    private init() {}
+
+    /// One element in transit.
+    struct Flight: Identifiable, Equatable {
+        /// The element's `ref` — unique per screen, so it doubles as identity.
+        let id: String
+        let node: NativeUINode
+        let from: CGRect
+        let to: CGRect
+        let animation: Animation
+        let duration: Double
+
+        static func == (a: Flight, b: Flight) -> Bool {
+            a.id == b.id && a.from == b.from && a.to == b.to
+        }
+    }
+
+    /// Live frames of ref'd elements on the screen currently on top.
+    private var liveFrames: [String: CGRect] = [:]
+
+    /// Frames captured at the instant of a swap — each flight's origin.
+    private var pendingFrom: [String: CGRect] = [:]
+
+    /// Incoming-tree nodes keyed by ref, so the overlay can render a copy.
+    private var pendingNodes: [String: NativeUINode] = [:]
+
+    /// Bumped per swap so a late safety sweep can tell whether it still owns
+    /// the navigation it was scheduled for.
+    private var swapToken = 0
+
+    @Published private(set) var flights: [Flight] = []
+
+    /// Refs whose real elements must stay hidden — set at the swap so the
+    /// incoming hero never flashes at its destination before taking off.
+    @Published private(set) var hidden: Set<String> = []
+
+    // MARK: - Reporting
+
+    /// Record where a ref'd element currently sits, in global coordinates.
+    ///
+    /// Outgoing screens are ignored: their frames were already captured at the
+    /// swap, and letting a screen that is on its way out keep reporting would
+    /// overwrite the origin we are about to fly from.
+    func report(ref: String, rect: CGRect, isOutgoing: Bool) {
+        guard !isOutgoing, !rect.isEmpty else { return }
+
+        liveFrames[ref] = rect
+
+        // The incoming screen has just told us where this ref landed, which is
+        // the last thing a flight was waiting for.
+        guard let from = pendingFrom.removeValue(forKey: ref),
+              let node = pendingNodes.removeValue(forKey: ref) else { return }
+
+        launch(ref: ref, node: node, from: from, to: rect)
+    }
+
+    // MARK: - Swap lifecycle
+
+    /// Begin a `view_transition`. Called synchronously from the publish path,
+    /// before the incoming tree is handed to SwiftUI.
+    func beginSwap(incomingNodes: [String: NativeUINode]) {
+        let matched = Set(incomingNodes.keys).intersection(liveFrames.keys)
+
+        pendingFrom = liveFrames.filter { matched.contains($0.key) }
+        pendingNodes = incomingNodes.filter { matched.contains($0.key) }
+        liveFrames.removeAll()
+
+        // Hide the pair NOW. The incoming copy mounts hidden and only becomes
+        // visible when its flight lands; without this it paints once at its
+        // destination before the overlay copy has taken off.
+        hidden = matched
+
+        swapToken += 1
+        let token = swapToken
+
+        // Safety net: a ref that never reports back (destination removed from
+        // the tree, screen swapped again mid-flight) would otherwise stay
+        // hidden forever. Unstick anything still pending.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
+            guard let self, self.swapToken == token else { return }
+            for ref in self.pendingFrom.keys { self.land(ref) }
+        }
+    }
+
+    /// Abandon any in-flight state — a non-hero navigation, or teardown.
+    func cancelAll() {
+        pendingFrom.removeAll()
+        pendingNodes.removeAll()
+        liveFrames.removeAll()
+        flights.removeAll()
+        hidden.removeAll()
+        swapToken += 1
+    }
+
+    // MARK: - Flights
+
+    private func launch(ref: String, node: NativeUINode, from: CGRect, to: CGRect) {
+        let mode = node.props.getString("morph", default: "frame")
+        let (start, end) = Self.rects(mode: mode, from: from, to: to)
+
+        // Nothing actually moves — skip the overlay entirely rather than
+        // paying for a copy that renders one frame and lands.
+        guard !start.equalTo(end) else {
+            land(ref)
+            return
+        }
+
+        let duration = Self.duration(for: node)
+        flights.append(Flight(
+            id: ref,
+            node: node,
+            from: start,
+            to: end,
+            animation: Self.animation(for: node, duration: duration),
+            duration: duration
+        ))
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration) { [weak self] in
+            self?.land(ref)
+        }
+    }
+
+    /// Drop a flight and reveal the real element again.
+    private func land(_ ref: String) {
+        flights.removeAll { $0.id == ref }
+        hidden.remove(ref)
+        pendingFrom.removeValue(forKey: ref)
+        pendingNodes.removeValue(forKey: ref)
+    }
+
+    // MARK: - Geometry
+
+    /// `morph` decides which half of the geometry is actually shared.
+    ///
+    ///   frame    — travels AND resizes (the default).
+    ///   position — travels at its destination size; only the move animates.
+    ///   size     — resizes in place at the destination; only the size animates.
+    ///
+    /// Interpolating the rect ourselves means these are exact here, unlike the
+    /// Compose side, whose shared-element API always animates the full bounds.
+    static func rects(mode: String, from: CGRect, to: CGRect) -> (CGRect, CGRect) {
+        switch mode {
+        case "position":
+            return (CGRect(center: from.center, size: to.size), to)
+        case "size":
+            return (CGRect(center: to.center, size: from.size), to)
+        default:
+            return (from, to)
+        }
+    }
+
+    private static func duration(for node: NativeUINode) -> Double {
+        let ms = Double(node.props.getFloat("morph_duration", default: 0))
+        return ms > 0 ? ms / 1000.0 : 0.35
+    }
+
+    private static func animation(for node: NativeUINode, duration: Double) -> Animation {
+        let easing = node.props.getString("morph_easing", default: "")
+        guard !easing.isEmpty else {
+            return nativeEasedAnimation("ease-in-out", durationMs: duration * 1000)
+        }
+        return nativeEasedAnimation(easing, durationMs: duration * 1000)
+    }
+}
+
+extension CGRect {
+    var center: CGPoint { CGPoint(x: midX, y: midY) }
+
+    init(center: CGPoint, size: CGSize) {
+        self.init(
+            x: center.x - size.width / 2,
+            y: center.y - size.height / 2,
+            width: size.width,
+            height: size.height
+        )
+    }
+}

--- a/resources/xcode/NativePHP/NativeRender/NativeElementBridge.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeElementBridge.swift
@@ -517,29 +517,20 @@ final class NativeElementBridge {
                             }
                         }
                     }
-                    // Shared-element morph (`view_transition`): hand the
-                    // geometry to the OUTGOING hero for one tick so the
-                    // incoming one mounts at the old screen's frame, then
-                    // flip the source back inside an animation. That flip is
-                    // the whole mechanism — see `NodeHeroModifier`.
-                    //
-                    // asyncAfter(0) rather than a plain async: the flip has
-                    // to land in a LATER transaction than the insertion, or
-                    // SwiftUI coalesces the two and the hero appears already
-                    // at its destination with no motion.
+                    // Shared elements: hand the incoming tree's ref'd nodes to
+                    // the flight store. It already holds the outgoing screen's
+                    // frames (reported while that screen was live), so it can
+                    // pair the two sides and fly a copy of each match in the
+                    // overlay above both screens. Done synchronously here so
+                    // matched elements are hidden before the incoming screen's
+                    // very first layout — otherwise they paint once at their
+                    // destination before taking off.
                     if bridge.pendingTransition == "view_transition" {
-                        bridge.heroSourceIsIncoming = false
-                        DispatchQueue.main.asyncAfter(deadline: .now()) {
-                            withAnimation(nativeViewTransitionAnimation) {
-                                bridge.heroSourceIsIncoming = true
-                            }
-                        }
-                    } else if !bridge.heroSourceIsIncoming {
-                        // A non-hero navigation interrupting a view
-                        // transition must not leave the flag parked false,
-                        // or the next screen's heroes would mount slaved to
-                        // a screen that is long gone.
-                        bridge.heroSourceIsIncoming = true
+                        HeroFlightStore.shared.beginSwap(
+                            incomingNodes: Self.collectRefNodes(finalTree.root)
+                        )
+                    } else {
+                        HeroFlightStore.shared.cancelAll()
                     }
                     bridge.screenKey += 1
                 }
@@ -552,6 +543,29 @@ final class NativeElementBridge {
                 if bridge.isReloading { bridge.isReloading = false }
             }
         }
+    }
+
+    /// Every ref'd node in a tree, keyed by ref. The flight store pairs these
+    /// against the outgoing screen's reported frames and renders a copy of the
+    /// matched ones in flight. Walks the incoming tree once per navigation — the
+    /// trees are already in memory and this runs on the same publish that
+    /// builds them, so it costs a single traversal per swap rather than any
+    /// per-frame work.
+    static func collectRefNodes(_ node: NativeUINode) -> [String: NativeUINode] {
+        var found: [String: NativeUINode] = [:]
+
+        func walk(_ n: NativeUINode) {
+            let ref = n.props.getString("ref", default: "")
+            // First wins. A duplicated ref on one screen is malformed markup —
+            // a name identifies ONE element — and picking deterministically
+            // beats letting the last one silently take over.
+            if !ref.isEmpty, found[ref] == nil { found[ref] = n }
+            for child in n.children { walk(child) }
+        }
+
+        walk(node)
+
+        return found
     }
 
     // MARK: - Event Sending

--- a/resources/xcode/NativePHP/NativeRender/NativeElementBridge.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeElementBridge.swift
@@ -1,5 +1,6 @@
 
 import Foundation
+import SwiftUI // withAnimation, for the view_transition hero source flip
 import UIKit // needed for UIScreen.main, UIApplication
 import os
 import Bridge // C prototypes: nphp_get_format_version / nphp_get_runtime_flags (Phase 0 format check)
@@ -515,6 +516,30 @@ final class NativeElementBridge {
                                 bridge.outgoingScreen = nil
                             }
                         }
+                    }
+                    // Shared-element morph (`view_transition`): hand the
+                    // geometry to the OUTGOING hero for one tick so the
+                    // incoming one mounts at the old screen's frame, then
+                    // flip the source back inside an animation. That flip is
+                    // the whole mechanism — see `NodeHeroModifier`.
+                    //
+                    // asyncAfter(0) rather than a plain async: the flip has
+                    // to land in a LATER transaction than the insertion, or
+                    // SwiftUI coalesces the two and the hero appears already
+                    // at its destination with no motion.
+                    if bridge.pendingTransition == "view_transition" {
+                        bridge.heroSourceIsIncoming = false
+                        DispatchQueue.main.asyncAfter(deadline: .now()) {
+                            withAnimation(nativeViewTransitionAnimation) {
+                                bridge.heroSourceIsIncoming = true
+                            }
+                        }
+                    } else if !bridge.heroSourceIsIncoming {
+                        // A non-hero navigation interrupting a view
+                        // transition must not leave the flag parked false,
+                        // or the next screen's heroes would mount slaved to
+                        // a screen that is long gone.
+                        bridge.heroSourceIsIncoming = true
                     }
                     bridge.screenKey += 1
                 }

--- a/resources/xcode/NativePHP/NativeRender/NativeUIBridge.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeUIBridge.swift
@@ -55,17 +55,7 @@ final class NativeUIBridge: ObservableObject {
 
     @Published var outgoingScreen: OutgoingScreen?
 
-    /// Which side of a shared-element (`ref`) pair currently owns
-    /// the geometry, for `view_transition` navigations.
-    ///
-    /// Normally true: the screen on top is the source, which is the only
-    /// sensible answer when there is no navigation in flight. It is driven
-    /// false for exactly one runloop tick at the start of a view transition
-    /// so the incoming hero mounts at the OUTGOING screen's frame, then
-    /// flipped back inside `withAnimation` — and that flip is what makes
-    /// `matchedGeometryEffect` interpolate. See `NodeHeroModifier` for the
-    /// full rationale.
-    @Published var heroSourceIsIncoming: Bool = true
+
 
     /// Flag set by UI.SetTransition bridge function
     var navigationPending = false

--- a/resources/xcode/NativePHP/NativeRender/NativeUIBridge.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeUIBridge.swift
@@ -55,6 +55,18 @@ final class NativeUIBridge: ObservableObject {
 
     @Published var outgoingScreen: OutgoingScreen?
 
+    /// Which side of a shared-element (`ref`) pair currently owns
+    /// the geometry, for `view_transition` navigations.
+    ///
+    /// Normally true: the screen on top is the source, which is the only
+    /// sensible answer when there is no navigation in flight. It is driven
+    /// false for exactly one runloop tick at the start of a view transition
+    /// so the incoming hero mounts at the OUTGOING screen's frame, then
+    /// flipped back inside `withAnimation` — and that flip is what makes
+    /// `matchedGeometryEffect` interpolate. See `NodeHeroModifier` for the
+    /// full rationale.
+    @Published var heroSourceIsIncoming: Bool = true
+
     /// Flag set by UI.SetTransition bridge function
     var navigationPending = false
 

--- a/resources/xcode/NativePHP/NativeRender/NodeAnimationModifier.swift
+++ b/resources/xcode/NativePHP/NativeRender/NodeAnimationModifier.swift
@@ -119,16 +119,11 @@ struct NodeAnimationModifier: ViewModifier {
         !props.getString("\(prop)_sv", default: "").isEmpty
     }
 
+    /// Delegates to the shared table in ScreenTransitions.swift so the
+    /// easing vocabulary cannot drift between animation, content transitions
+    /// and shared-element morphs.
     private func animationFor(easing: String, durationMs: Float) -> Animation {
-        let duration = Double(durationMs) / 1000.0
-        switch easing {
-        case "linear":        return .linear(duration: duration)
-        case "ease-in":       return .easeIn(duration: duration)
-        case "ease-out":      return .easeOut(duration: duration)
-        case "ease-in-out":   return .easeInOut(duration: duration)
-        case "spring":        return .spring(duration: duration)
-        default:              return .easeInOut(duration: duration)
-        }
+        nativeEasedAnimation(easing, durationMs: Double(durationMs))
     }
 }
 

--- a/resources/xcode/NativePHP/NativeRender/NodeContentTransitionModifier.swift
+++ b/resources/xcode/NativePHP/NativeRender/NodeContentTransitionModifier.swift
@@ -56,13 +56,10 @@ struct NodeContentTransitionModifier: ViewModifier {
         let durationMs = props.getFloat("animate-duration", default: 0)
         guard durationMs > 0 else { return .default }
 
-        let duration = Double(durationMs) / 1000.0
-        switch props.getString("animate-easing", default: "ease-in-out") {
-        case "linear":      return .linear(duration: duration)
-        case "ease-in":     return .easeIn(duration: duration)
-        case "ease-out":    return .easeOut(duration: duration)
-        case "spring":      return .spring(duration: duration)
-        default:            return .easeInOut(duration: duration)
-        }
+        // Shared table — see nativeEasedAnimation in ScreenTransitions.swift.
+        return nativeEasedAnimation(
+            props.getString("animate-easing", default: "ease-in-out"),
+            durationMs: Double(durationMs)
+        )
     }
 }

--- a/resources/xcode/NativePHP/NativeRender/NodeHeroModifier.swift
+++ b/resources/xcode/NativePHP/NativeRender/NodeHeroModifier.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+/// Shared-element morph for nodes carrying a `ref` — the native analogue of
+/// CSS `view-transition-name`, keyed off the element's own name.
+///
+/// Identity is the element's `ref`, which already existed as a test-targeting
+/// handle. Two screens naming an element the same thing is exactly what a
+/// shared element IS, so there is no second naming concept to learn. A ref
+/// that exists only for tests and must never travel opts out with
+/// `morph="none"`.
+///
+/// Motion is shaped by three optional props:
+///   - `morph`          — frame (default) | position | size | none
+///   - `morph_duration` — ms; overrides the shared view-transition pace
+///   - `morph_easing`   — linear / ease-in / ease-out / ease-in-out / spring
+///
+/// ## Why this isn't the textbook `matchedGeometryEffect` usage
+///
+/// The canonical SwiftUI hero animation relies on one view being REMOVED and
+/// its partner INSERTED in the same animated transaction; SwiftUI then
+/// interpolates the inserted view's frame from the removed one's. That
+/// handoff cannot happen here: the router's two-layer swap deliberately keeps
+/// the outgoing screen mounted (see `NativeUIBridge.OutgoingScreen`) and drops
+/// it a beat later, so at swap time both heroes coexist and nothing is ever
+/// removed. Left alone, that yields two `isSource: true` views sharing one id —
+/// undefined behaviour — and no motion at all.
+///
+/// ## What drives the morph instead
+///
+/// The geometry source is flipped between the two coexisting heroes inside an
+/// animated transaction, which `matchedGeometryEffect` does interpolate:
+///
+///   1. At the swap the outgoing hero is the source, so the freshly-inserted
+///      incoming hero is slaved to it and renders at the OLD screen's frame —
+///      the detail image appears at the grid thumbnail's position.
+///   2. One runloop tick later `heroSourceIsIncoming` flips inside
+///      `withAnimation`, making the incoming hero the source. It is now
+///      driven by its own natural layout, so it animates out of the
+///      thumbnail's frame and into its destination — the fly.
+///
+/// The outgoing hero, now the non-source, is slaved to the destination frame
+/// for the rest of the window. It would otherwise render a duplicate flying
+/// underneath, so it is hidden once it loses source status; the screen above
+/// it is cross-fading in and covers the gap.
+///
+/// A name that appears on only one screen never has a partner to match, so the
+/// effect resolves to that single view and is inert — the intended graceful
+/// degradation rather than an error.
+struct NodeHeroModifier: ViewModifier {
+    let props: GenericProps
+
+    @Environment(\.heroNamespace) private var namespace
+    @Environment(\.heroIsOutgoing) private var isOutgoing
+    @ObservedObject private var bridge = NativeUIBridge.shared
+
+    func body(content: Content) -> some View {
+        let name = props.getString("ref", default: "")
+        let mode = props.getString("morph", default: "frame")
+
+        // Fast path — the overwhelming majority of nodes. No ref, an explicit
+        // opt-out, or no host providing a namespace (plain tree rendering,
+        // previews, tests).
+        guard !name.isEmpty, mode != "none", let namespace else {
+            return AnyView(content)
+        }
+
+        let isSource = isOutgoing ? !bridge.heroSourceIsIncoming
+                                  : bridge.heroSourceIsIncoming
+
+        return AnyView(
+            content
+                // Hiding the outgoing copy only once it stops being the
+                // source keeps the OLD screen looking untouched right up to
+                // the moment the morph starts — hiding it unconditionally
+                // would blank the thumbnail a frame early, which reads as a
+                // flicker on the screen the user is still looking at.
+                .opacity(isOutgoing && !isSource ? 0 : 1)
+                .matchedGeometryEffect(
+                    id: name,
+                    in: namespace,
+                    properties: Self.properties(for: mode),
+                    isSource: isSource
+                )
+                // Per-element pacing. A SCOPED animation keyed on the same
+                // value the source flip changes overrides the ambient
+                // withAnimation transaction for this view only, which is what
+                // lets two heroes in one navigation arrive at different
+                // moments. Absent props leave the ambient pace untouched.
+                .animation(customAnimation, value: bridge.heroSourceIsIncoming)
+        )
+    }
+
+    /// `morph` → which geometry the pair shares.
+    ///
+    ///   frame    — position AND size: the element travels and resizes.
+    ///   position — travels but keeps its own size (a fly, not a grow).
+    ///   size     — resizes in place without travelling.
+    private static func properties(for mode: String) -> MatchedGeometryProperties {
+        switch mode {
+        case "position": return .position
+        case "size":     return .size
+        default:         return .frame
+        }
+    }
+
+    /// nil when the node sets no timing props, which leaves the ambient
+    /// `nativeViewTransitionAnimation` in charge — the common case, and the
+    /// one where every hero should stay in step with the screen cross-fade.
+    private var customAnimation: Animation? {
+        let duration = Double(props.getFloat("morph_duration", default: 0))
+        let easing = props.getString("morph_easing", default: "")
+
+        guard duration > 0 || !easing.isEmpty else { return nil }
+
+        return nativeEasedAnimation(
+            easing.isEmpty ? "ease-in-out" : easing,
+            // Match the shared view-transition pace when only an easing was
+            // named, so `morph-easing="spring"` alone is a sensible thing to
+            // write.
+            durationMs: duration > 0 ? duration : 350
+        )
+    }
+}

--- a/resources/xcode/NativePHP/NativeRender/NodeHeroModifier.swift
+++ b/resources/xcode/NativePHP/NativeRender/NodeHeroModifier.swift
@@ -1,123 +1,58 @@
 import SwiftUI
 
-/// Shared-element morph for nodes carrying a `ref` — the native analogue of
-/// CSS `view-transition-name`, keyed off the element's own name.
+/// Marks a node as a shared element and keeps its on-screen frame reported.
 ///
-/// Identity is the element's `ref`, which already existed as a test-targeting
-/// handle. Two screens naming an element the same thing is exactly what a
-/// shared element IS, so there is no second naming concept to learn. A ref
-/// that exists only for tests and must never travel opts out with
-/// `morph="none"`.
+/// Identity is the element's `ref` — the same handle used for test targeting.
+/// Two screens naming an element the same thing morph it between them during a
+/// `view_transition` navigation. A ref that exists only as a test handle and
+/// must never travel opts out with `morph="none"`.
 ///
-/// Motion is shaped by three optional props:
+/// This modifier does NOT animate anything. The flight itself is rendered by
+/// `HeroFlightOverlay`, above both screens, from frames collected here — see
+/// `HeroFlightStore` for why SwiftUI needs the element lifted out of the screen
+/// layers rather than animated in place.
+///
+/// Its two jobs:
+///   - **Report** the element's global frame, which is the origin of the next
+///     flight and the destination of the current one.
+///   - **Hide** the element while its copy is in transit, so the real one does
+///     not double-draw beneath the overlay or leave a ghost at the origin.
+///
+/// Motion is shaped by props read on the far side, in the store:
 ///   - `morph`          — frame (default) | position | size | none
-///   - `morph_duration` — ms; overrides the shared view-transition pace
+///   - `morph_duration` — ms; overrides the shared 350ms view-transition pace
 ///   - `morph_easing`   — linear / ease-in / ease-out / ease-in-out / spring
-///
-/// ## Why this isn't the textbook `matchedGeometryEffect` usage
-///
-/// The canonical SwiftUI hero animation relies on one view being REMOVED and
-/// its partner INSERTED in the same animated transaction; SwiftUI then
-/// interpolates the inserted view's frame from the removed one's. That
-/// handoff cannot happen here: the router's two-layer swap deliberately keeps
-/// the outgoing screen mounted (see `NativeUIBridge.OutgoingScreen`) and drops
-/// it a beat later, so at swap time both heroes coexist and nothing is ever
-/// removed. Left alone, that yields two `isSource: true` views sharing one id —
-/// undefined behaviour — and no motion at all.
-///
-/// ## What drives the morph instead
-///
-/// The geometry source is flipped between the two coexisting heroes inside an
-/// animated transaction, which `matchedGeometryEffect` does interpolate:
-///
-///   1. At the swap the outgoing hero is the source, so the freshly-inserted
-///      incoming hero is slaved to it and renders at the OLD screen's frame —
-///      the detail image appears at the grid thumbnail's position.
-///   2. One runloop tick later `heroSourceIsIncoming` flips inside
-///      `withAnimation`, making the incoming hero the source. It is now
-///      driven by its own natural layout, so it animates out of the
-///      thumbnail's frame and into its destination — the fly.
-///
-/// The outgoing hero, now the non-source, is slaved to the destination frame
-/// for the rest of the window. It would otherwise render a duplicate flying
-/// underneath, so it is hidden once it loses source status; the screen above
-/// it is cross-fading in and covers the gap.
-///
-/// A name that appears on only one screen never has a partner to match, so the
-/// effect resolves to that single view and is inert — the intended graceful
-/// degradation rather than an error.
 struct NodeHeroModifier: ViewModifier {
     let props: GenericProps
 
-    @Environment(\.heroNamespace) private var namespace
     @Environment(\.heroIsOutgoing) private var isOutgoing
-    @ObservedObject private var bridge = NativeUIBridge.shared
+    @Environment(\.heroIsFlyingCopy) private var isFlyingCopy
+    @ObservedObject private var store = HeroFlightStore.shared
 
     func body(content: Content) -> some View {
-        let name = props.getString("ref", default: "")
+        let ref = props.getString("ref", default: "")
         let mode = props.getString("morph", default: "frame")
 
-        // Fast path — the overwhelming majority of nodes. No ref, an explicit
-        // opt-out, or no host providing a namespace (plain tree rendering,
-        // previews, tests).
-        guard !name.isEmpty, mode != "none", let namespace else {
+        // Fast path — the overwhelming majority of nodes carry no ref at all.
+        guard !ref.isEmpty, mode != "none" else {
             return AnyView(content)
         }
 
-        let isSource = isOutgoing ? !bridge.heroSourceIsIncoming
-                                  : bridge.heroSourceIsIncoming
+        // The overlay's own copy renders through this same modifier. It must
+        // stay visible — it IS the flight — and must not report its mid-air
+        // position as the element's real geometry.
+        guard !isFlyingCopy else {
+            return AnyView(content)
+        }
 
         return AnyView(
             content
-                // Hiding the outgoing copy only once it stops being the
-                // source keeps the OLD screen looking untouched right up to
-                // the moment the morph starts — hiding it unconditionally
-                // would blank the thumbnail a frame early, which reads as a
-                // flicker on the screen the user is still looking at.
-                .opacity(isOutgoing && !isSource ? 0 : 1)
-                .matchedGeometryEffect(
-                    id: name,
-                    in: namespace,
-                    properties: Self.properties(for: mode),
-                    isSource: isSource
-                )
-                // Per-element pacing. A SCOPED animation keyed on the same
-                // value the source flip changes overrides the ambient
-                // withAnimation transaction for this view only, which is what
-                // lets two heroes in one navigation arrive at different
-                // moments. Absent props leave the ambient pace untouched.
-                .animation(customAnimation, value: bridge.heroSourceIsIncoming)
-        )
-    }
-
-    /// `morph` → which geometry the pair shares.
-    ///
-    ///   frame    — position AND size: the element travels and resizes.
-    ///   position — travels but keeps its own size (a fly, not a grow).
-    ///   size     — resizes in place without travelling.
-    private static func properties(for mode: String) -> MatchedGeometryProperties {
-        switch mode {
-        case "position": return .position
-        case "size":     return .size
-        default:         return .frame
-        }
-    }
-
-    /// nil when the node sets no timing props, which leaves the ambient
-    /// `nativeViewTransitionAnimation` in charge — the common case, and the
-    /// one where every hero should stay in step with the screen cross-fade.
-    private var customAnimation: Animation? {
-        let duration = Double(props.getFloat("morph_duration", default: 0))
-        let easing = props.getString("morph_easing", default: "")
-
-        guard duration > 0 || !easing.isEmpty else { return nil }
-
-        return nativeEasedAnimation(
-            easing.isEmpty ? "ease-in-out" : easing,
-            // Match the shared view-transition pace when only an easing was
-            // named, so `morph-easing="spring"` alone is a sensible thing to
-            // write.
-            durationMs: duration > 0 ? duration : 350
+                .opacity(store.hidden.contains(ref) ? 0 : 1)
+                .onGeometryChange(for: CGRect.self) { proxy in
+                    proxy.frame(in: .global)
+                } action: { rect in
+                    store.report(ref: ref, rect: rect, isOutgoing: isOutgoing)
+                }
         )
     }
 }

--- a/resources/xcode/NativePHP/NativeRender/NodeIdentityModifier.swift
+++ b/resources/xcode/NativePHP/NativeRender/NodeIdentityModifier.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Exposes a node's `ref` to the accessibility tree as its identifier, which
+/// is how UI drivers (Maestro, XCUITest) target an element by name.
+///
+/// `ref` is the element's public handle — the same one that pairs shared
+/// elements across a view transition — so a driver targeting `id: "photo-1"`
+/// and a morph matching `ref="photo-1"` are naming the same thing. Without
+/// this the identifier never leaves PHP: nothing in the iOS renderer read
+/// `ref` at all, so every `tapOn: id:` failed with "Element with Id matching
+/// regex not found" even though the ref was present in the tree.
+///
+/// Applied to every node, so it deliberately does the cheapest possible thing
+/// when the prop is absent.
+///
+/// Note: `a11y_label` / `a11y_hint` are emitted by PHP (see `HasA11y`) but no
+/// iOS renderer consumes them yet — that gap is untouched here.
+struct NodeIdentityModifier: ViewModifier {
+    let props: GenericProps
+
+    func body(content: Content) -> some View {
+        let ref = props.getString("ref", default: "")
+
+        if ref.isEmpty {
+            content
+        } else {
+            content
+                // `.contain` keeps this node's DESCENDANTS as separate
+                // accessibility elements. Without it, naming a container
+                // collapses everything inside it into one element: the full
+                // player exposed only its outermost `player-surface` and hid
+                // `player-art`, `player-title` and the close control, so a UI
+                // driver could open the screen and then had nothing to tap.
+                //
+                // It also matters beyond testing — a screen reader would have
+                // lost the same content.
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier(ref)
+        }
+    }
+}

--- a/resources/xcode/NativePHP/NativeRender/ScreenTransitions.swift
+++ b/resources/xcode/NativePHP/NativeRender/ScreenTransitions.swift
@@ -71,6 +71,35 @@ struct ScreenExitModifier: ViewModifier {
 /// what actually drives `.move`, so it must be computed per staged
 /// transition rather than hardcoded. Effects with scoped animations
 /// (`ScreenExitModifier`'s recede, `value: isExiting`) are unaffected.
+/// The single animation shared by a `view_transition` swap: the screen
+/// cross-fade, and the `matchedGeometryEffect` source flip that drives the
+/// shared-element morph (`NodeHeroModifier`).
+///
+/// Deliberately ONE constant used by both. The morph and the cross-fade
+/// beneath it have to finish together — if the screens settle first the hero
+/// is left flying over a static background, and if the hero settles first it
+/// sits at its destination while the old screen is still visibly fading.
+let nativeViewTransitionAnimation: Animation = .easeInOut(duration: 0.35)
+
+/// The one string→`Animation` table for the whole renderer.
+///
+/// This mapping was independently duplicated in `NodeAnimationModifier` and
+/// `NodeContentTransitionModifier`; the shared-element morph would have made a
+/// third copy, so it lives here instead and those two call in. Vocabulary is
+/// the existing one PHP already emits for `animate-easing`, so nothing new has
+/// to be learned to tune a morph.
+func nativeEasedAnimation(_ easing: String, durationMs: Double) -> Animation {
+    let duration = durationMs / 1000.0
+    switch easing {
+    case "linear":      return .linear(duration: duration)
+    case "ease-in":     return .easeIn(duration: duration)
+    case "ease-out":    return .easeOut(duration: duration)
+    case "ease-in-out": return .easeInOut(duration: duration)
+    case "spring":      return .spring(duration: duration)
+    default:            return .easeInOut(duration: duration)
+    }
+}
+
 func nativeScreenSwapAnimation(for type: String?) -> Animation {
     switch type {
     case "parallax_push":
@@ -79,6 +108,8 @@ func nativeScreenSwapAnimation(for type: String?) -> Animation {
         return .easeInOut(duration: 0.40).delay(0.10)
     case "none":
         return .linear(duration: 0)
+    case "view_transition":
+        return nativeViewTransitionAnimation
     case "fade", "fade_from_bottom", "scale_from_center":
         return .easeInOut(duration: 0.3)
     default:
@@ -168,6 +199,15 @@ func nativeScreenTransition(for type: String?) -> AnyTransition {
             removal:   .identity
         )
         .animation(.easeInOut(duration: 0.55).delay(0.15))
+    case "view_transition":
+        // Shared-element swap. The screens themselves only cross-fade — the
+        // motion the user reads comes from the elements morphing across
+        // (`NodeHeroModifier`), and a directional slide underneath would
+        // fight it. Same held-outgoing/`.identity`-removal shape as `fade`,
+        // so the old screen stays opaque beneath for the whole window and
+        // the morphing element never flies over a bare background.
+        return .asymmetric(insertion: .opacity, removal: .identity)
+            .animation(nativeViewTransitionAnimation)
     case "none":
         // Instant cut. The incoming screen renders fully opaque on the same
         // frame (zIndexed above), so nothing flashes.

--- a/resources/xcode/NativePHP/NativeRender/SwiftUINodeRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/SwiftUINodeRenderer.swift
@@ -15,6 +15,19 @@ private struct AvailableWidthKey: EnvironmentKey {
 private struct AvailableHeightKey: EnvironmentKey {
     static let defaultValue: CGFloat = 844
 }
+/// Namespace that shared-element (`ref`) morphs are matched in.
+/// Owned by `ContentView`, which declares the `@Namespace` and injects it
+/// around the screen stack; nil wherever no host provides one, which makes
+/// `NodeHeroModifier` an inert pass-through rather than a crash.
+private struct HeroNamespaceKey: EnvironmentKey {
+    static let defaultValue: Namespace.ID? = nil
+}
+/// True for the screen being covered during a router-level swap. Decides
+/// which side of a `matchedGeometryEffect` pair is the geometry source —
+/// see `NodeHeroModifier`.
+private struct HeroIsOutgoingKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
 
 extension EnvironmentValues {
     var nativeSafeAreaTop: CGFloat {
@@ -32,6 +45,14 @@ extension EnvironmentValues {
     var availableHeight: CGFloat {
         get { self[AvailableHeightKey.self] }
         set { self[AvailableHeightKey.self] = newValue }
+    }
+    var heroNamespace: Namespace.ID? {
+        get { self[HeroNamespaceKey.self] }
+        set { self[HeroNamespaceKey.self] = newValue }
+    }
+    var heroIsOutgoing: Bool {
+        get { self[HeroIsOutgoingKey.self] }
+        set { self[HeroIsOutgoingKey.self] = newValue }
     }
 }
 
@@ -186,6 +207,12 @@ struct NodeView: View, Equatable {
             // opacity. No-op when `animate-duration` is not set, so the
             // hot path is unchanged for non-animated nodes.
             .modifier(NodeAnimationModifier(style: node.style, props: node.props))
+            // Shared-element morph (`ref`). Sits AFTER style and
+            // layout so the geometry it hands to `matchedGeometryEffect` is
+            // the node's final frame — padding and background included —
+            // rather than its bare content box, which would make the element
+            // visibly jump as it lands. No-op when the prop is absent.
+            .modifier(NodeHeroModifier(props: node.props))
             // Gesture FIRST (inner) — onTapGesture must be attached
             // before any simultaneousGesture wrapper or the tap is
             // starved by SwiftUI's gesture composition.

--- a/resources/xcode/NativePHP/NativeRender/SwiftUINodeRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/SwiftUINodeRenderer.swift
@@ -15,17 +15,20 @@ private struct AvailableWidthKey: EnvironmentKey {
 private struct AvailableHeightKey: EnvironmentKey {
     static let defaultValue: CGFloat = 844
 }
-/// Namespace that shared-element (`ref`) morphs are matched in.
-/// Owned by `ContentView`, which declares the `@Namespace` and injects it
-/// around the screen stack; nil wherever no host provides one, which makes
-/// `NodeHeroModifier` an inert pass-through rather than a crash.
-private struct HeroNamespaceKey: EnvironmentKey {
-    static let defaultValue: Namespace.ID? = nil
-}
 /// True for the screen being covered during a router-level swap. Decides
 /// which side of a `matchedGeometryEffect` pair is the geometry source —
 /// see `NodeHeroModifier`.
 private struct HeroIsOutgoingKey: EnvironmentKey {
+    static let defaultValue: Bool = false
+}
+/// True only inside `HeroFlightOverlay`'s copy of a travelling element.
+///
+/// The copy is rendered with the same `NodeView` as the original, so it runs
+/// through `NodeHeroModifier` as well — and would obediently hide itself,
+/// because its ref is exactly the one currently in flight. It must also not
+/// report frames, or it would overwrite the real element's geometry with its
+/// own mid-flight position.
+private struct HeroIsFlyingCopyKey: EnvironmentKey {
     static let defaultValue: Bool = false
 }
 
@@ -46,13 +49,13 @@ extension EnvironmentValues {
         get { self[AvailableHeightKey.self] }
         set { self[AvailableHeightKey.self] = newValue }
     }
-    var heroNamespace: Namespace.ID? {
-        get { self[HeroNamespaceKey.self] }
-        set { self[HeroNamespaceKey.self] = newValue }
-    }
     var heroIsOutgoing: Bool {
         get { self[HeroIsOutgoingKey.self] }
         set { self[HeroIsOutgoingKey.self] = newValue }
+    }
+    var heroIsFlyingCopy: Bool {
+        get { self[HeroIsFlyingCopyKey.self] }
+        set { self[HeroIsFlyingCopyKey.self] = newValue }
     }
 }
 
@@ -213,6 +216,9 @@ struct NodeView: View, Equatable {
             // rather than its bare content box, which would make the element
             // visibly jump as it lands. No-op when the prop is absent.
             .modifier(NodeHeroModifier(props: node.props))
+            // Test-targeting identity. Same `ref` the morph pairs on, so a
+            // Maestro `id:` selector and a shared element name the same thing.
+            .modifier(NodeIdentityModifier(props: node.props))
             // Gesture FIRST (inner) — onTapGesture must be attached
             // before any simultaneousGesture wrapper or the tap is
             // starved by SwiftUI's gesture composition.

--- a/src/Edge/Element.php
+++ b/src/Edge/Element.php
@@ -34,11 +34,15 @@ abstract class Element
     protected ?string $key = null;
 
     /**
-     * Test-targeting handle, set via `->ref('save-btn')` or a Blade
-     * `ref="save-btn"` attribute. Emitted on the wire node so the
-     * testing harness can locate elements without depending on visible
-     * text or method names (the `data-testid` equivalent). Renderers
-     * ignore it.
+     * The element's name, set via `->ref('save-btn')` or a Blade
+     * `ref="save-btn"` attribute. Emitted on the wire node so the testing
+     * harness can locate elements without depending on visible text or method
+     * names (the `data-testid` equivalent).
+     *
+     * It is ALSO the shared-element identity: two elements on different
+     * screens sharing a ref morph into each other during a `view_transition`
+     * navigation (see NodeHeroModifier on iOS). A ref that exists purely as a
+     * test handle and must never travel can opt out with `morph="none"`.
      */
     protected ?string $elementRef = null;
 
@@ -729,11 +733,17 @@ abstract class Element
      * the docblock on `$key` and Phase 1 in the perf refactor doc.
      */
     /**
-     * Set the test-targeting ref for this node (see $elementRef).
+     * Name this node (see $elementRef).
      */
     public function ref(string $ref): static
     {
         $this->elementRef = $ref;
+
+        // Also carried as a generic prop. The node-level `ref` field is NOT
+        // serialized — no native node model parses it — so the prop bag is
+        // what actually reaches the renderer, and the shared-element morph
+        // reads it from there. Same value, two carriers, one authored name.
+        $this->setProp('ref', $ref);
 
         return $this;
     }

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -1533,6 +1533,32 @@ class NativeElementCollector
         if (isset($attrs['scroll-anchor'])) {
             $element->setProp('scroll_anchor', (string) $attrs['scroll-anchor']);
         }
+        // Shared-element motion controls. The element's IDENTITY is its
+        // `ref` (applied generically in applyCallbacks → Element::ref), so
+        // these only shape HOW a matched pair travels.
+        //
+        // Here rather than in `buildAnimationProps()` because that helper only
+        // runs on the builtin path, which would leave plugin elements
+        // (`<image>`, `<text>`) unable to be tuned.
+        //
+        //   morph          — frame (default: travel + resize) | position
+        //                    (travel, keep own size) | size (resize in place)
+        //                    | none (opt out; keeps `ref` as a plain handle)
+        //   morph-duration — ms; overrides the shared view-transition pace
+        //   morph-easing   — linear | ease-in | ease-out | ease-in-out | spring
+        //
+        // Deliberately distinct from `animate-duration` / `animate-easing`,
+        // which drive state-change transforms: an element may want a 200ms
+        // press response and a 600ms morph.
+        if (isset($attrs['morph'])) {
+            $element->setProp('morph', (string) $attrs['morph']);
+        }
+        if (isset($attrs['morph-duration'])) {
+            $element->setProp('morph_duration', (float) $attrs['morph-duration']);
+        }
+        if (isset($attrs['morph-easing'])) {
+            $element->setProp('morph_easing', (string) $attrs['morph-easing']);
+        }
     }
 
     protected static function applyCallbacks(Element $element, array $attrs): void

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -358,7 +358,8 @@ class NativeElementCollector
             $props = static::buildDarkProps($attrs)
                 + static::buildGradientProps($attrs)
                 + static::buildCornerRadiusProps($attrs)
-                + static::buildAnimationProps($attrs);
+                + static::buildAnimationProps($attrs)
+                + static::buildHeroProps($attrs);
             $onPress = static::resolveOnPress($attrs);
             $onLongPress = static::resolveOnLongPress($attrs);
 
@@ -453,7 +454,8 @@ class NativeElementCollector
             $props = static::buildDarkProps($attrs)
                 + static::buildGradientProps($attrs)
                 + static::buildCornerRadiusProps($attrs)
-                + static::buildAnimationProps($attrs);
+                + static::buildAnimationProps($attrs)
+                + static::buildHeroProps($attrs);
             $onPress = static::resolveOnPress($attrs);
             $onLongPress = static::resolveOnLongPress($attrs);
 
@@ -757,6 +759,33 @@ class NativeElementCollector
         }
         if (isset($attrs['press-translate-y'])) {
             $props['press-translate-y'] = (float) $attrs['press-translate-y'];
+        }
+
+        return $props;
+    }
+
+    /**
+     * Shared-element identity + motion props for the builtin streaming path.
+     *
+     * `ref` is the public identity (test handle AND morph id). Morph shape/timing
+     * ride alongside it. The Element-tree path already applies these via
+     * applyCallbacks/applyStyle; streaming builtins used to drop them.
+     */
+    public static function buildHeroProps(array $attrs): array
+    {
+        $props = [];
+
+        if (isset($attrs['ref']) && $attrs['ref'] !== '') {
+            $props['ref'] = (string) $attrs['ref'];
+        }
+        if (isset($attrs['morph'])) {
+            $props['morph'] = (string) $attrs['morph'];
+        }
+        if (isset($attrs['morph-duration'])) {
+            $props['morph_duration'] = (float) $attrs['morph-duration'];
+        }
+        if (isset($attrs['morph-easing'])) {
+            $props['morph_easing'] = (string) $attrs['morph-easing'];
         }
 
         return $props;

--- a/src/Edge/NativeTagPrecompiler.php
+++ b/src/Edge/NativeTagPrecompiler.php
@@ -38,6 +38,7 @@ class NativeTagPrecompiler
         'fadeFromBottom' => 'fade_from_bottom',
         'scaleFromCenter' => 'scale_from_center',
         'parallaxPush' => 'parallax_push',
+        'viewTransition' => 'view_transition',
         'none' => 'none',
     ];
 

--- a/src/Edge/Transition.php
+++ b/src/Edge/Transition.php
@@ -18,5 +18,21 @@ enum Transition: string
      */
     case ParallaxPush = 'parallax_push';
 
+    /**
+     * Shared-element swap, the native analogue of the CSS View Transitions
+     * API: the two screens cross-fade while every pair of elements sharing a
+     * `ref` morphs between its outgoing and incoming frame.
+     *
+     * A cross-fade rather than a directional slide on purpose — a screen
+     * sliding past an element that is simultaneously morphing across it reads
+     * as two unrelated animations fighting each other. Holding the screens
+     * still is what lets the morph carry the motion, which is the same reason
+     * the web API cross-fades its root while named elements animate.
+     *
+     * Elements sharing a `ref` still morph best-effort under the
+     * other transitions; this case is the one tuned for them.
+     */
+    case ViewTransition = 'view_transition';
+
     case None = 'none';
 }

--- a/tests/Feature/__snapshots__/TestingSuiteV2Test/after-two-taps.json
+++ b/tests/Feature/__snapshots__/TestingSuiteV2Test/after-two-taps.json
@@ -22,6 +22,7 @@
         {
             "type": "button",
             "props": {
+                "ref": "increment-btn",
                 "label": "Increment"
             },
             "on_press": "@increment",
@@ -50,6 +51,7 @@
         {
             "type": "text_input",
             "props": {
+                "ref": "query-input",
                 "on_change": "@__syncProperty('query')"
             },
             "ref": "query-input"

--- a/tests/Feature/__snapshots__/TestingSuiteV2Test/it-matches-the-wire-tree-snapshot.json
+++ b/tests/Feature/__snapshots__/TestingSuiteV2Test/it-matches-the-wire-tree-snapshot.json
@@ -22,6 +22,7 @@
         {
             "type": "button",
             "props": {
+                "ref": "increment-btn",
                 "label": "Increment"
             },
             "on_press": "@increment",
@@ -50,6 +51,7 @@
         {
             "type": "text_input",
             "props": {
+                "ref": "query-input",
                 "on_change": "@__syncProperty('query')"
             },
             "ref": "query-input"

--- a/tests/Unit/Edge/ViewTransitionTest.php
+++ b/tests/Unit/Edge/ViewTransitionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Elements\Column;
+use Native\Mobile\Edge\NativeElementCollector;
+use Native\Mobile\Edge\NativeTagPrecompiler;
+use Native\Mobile\Edge\Transition;
+
+/**
+ * Shared-element transitions — the native analogue of CSS view transitions.
+ *
+ * Identity is the element's `ref`, which already existed as a test-targeting
+ * handle: two screens naming an element the same thing is what a shared
+ * element is, so there is no second naming concept. Motion is shaped by the
+ * optional `morph` / `morph-duration` / `morph-easing` props.
+ *
+ * All of it rides the fallback (string-key) wire path, so there is no PropKey
+ * table change and no C-extension rebuild involved.
+ */
+beforeEach(function () {
+    $this->precompiler = new NativeTagPrecompiler;
+    NativeTagPrecompiler::setActive(true);
+});
+
+afterEach(function () {
+    NativeTagPrecompiler::setActive(false);
+});
+
+// ── Identity ─────────────────────────────────────────────────────
+
+it('carries ref as a prop as well as a node field', function () {
+    $node = Column::make()->ref('album-3')->toArray(new CallbackRegistry);
+
+    // The node-level field is what the test harness reads...
+    expect($node['ref'])->toBe('album-3');
+    // ...and the prop is what actually reaches the renderer, since no native
+    // node model parses the node-level field.
+    expect($node['props']['ref'])->toBe('album-3');
+});
+
+// The `ref="…"` attribute → Element::ref() wiring runs through the collector's
+// protected applyCallbacks(); it is covered end-to-end by the demo app's
+// HeroTransitionsTest (which renders real Blade and asserts props.ref), rather
+// than by widening visibility here just to reach it.
+
+it('emits no ref prop by default', function () {
+    expect(Column::make()->toArray(new CallbackRegistry)['props'] ?? [])
+        ->not->toHaveKey('ref');
+});
+
+it('no longer recognises the old transition-name attribute', function () {
+    $element = Column::make();
+    NativeElementCollector::applyStyle($element, ['transition-name' => 'album-3']);
+
+    $props = $element->toArray(new CallbackRegistry)['props'] ?? [];
+    expect($props)->not->toHaveKey('transition_name');
+    expect($props)->not->toHaveKey('ref');
+});
+
+// ── Motion controls ──────────────────────────────────────────────
+
+it('emits the morph style', function () {
+    foreach (['frame', 'position', 'size', 'none'] as $mode) {
+        $element = Column::make();
+        NativeElementCollector::applyStyle($element, ['morph' => $mode]);
+
+        expect($element->toArray(new CallbackRegistry)['props']['morph'])->toBe($mode);
+    }
+});
+
+it('emits per-element timing', function () {
+    $element = Column::make();
+    NativeElementCollector::applyStyle($element, [
+        'morph-duration' => '600',
+        'morph-easing' => 'spring',
+    ]);
+
+    $props = $element->toArray(new CallbackRegistry)['props'];
+    expect($props['morph_duration'])->toBe(600.0);
+    expect($props['morph_easing'])->toBe('spring');
+});
+
+it('leaves timing unset so the shared view-transition pace applies', function () {
+    $element = Column::make();
+    NativeElementCollector::applyStyle($element, ['morph' => 'position']);
+
+    $props = $element->toArray(new CallbackRegistry)['props'];
+    expect($props)->not->toHaveKey('morph_duration');
+    expect($props)->not->toHaveKey('morph_easing');
+});
+
+// ── Blade + directive plumbing ───────────────────────────────────
+
+it('survives the blade precompiler as static attributes', function () {
+    $result = ($this->precompiler)(
+        '<native:column ref="album-3" morph="position" morph-easing="spring" />'
+    );
+
+    expect($result)->toContain("'ref' => 'album-3'");
+    expect($result)->toContain("'morph' => 'position'");
+    expect($result)->toContain("'morph-easing' => 'spring'");
+});
+
+it('compiles @navigate.viewTransition to the view_transition intent', function () {
+    expect(($this->precompiler)("<native:column @navigate.viewTransition('/album/3') />"))
+        ->toContain('view_transition');
+});
+
+it('lets back navigation carry the transition too', function () {
+    expect(($this->precompiler)('<native:column @navigate.back.viewTransition />'))
+        ->toContain('view_transition');
+});
+
+it('exposes ViewTransition on the Transition enum', function () {
+    expect(Transition::ViewTransition->value)->toBe('view_transition');
+    expect(Transition::from('view_transition'))->toBe(Transition::ViewTransition);
+});


### PR DESCRIPTION
Elements that morph between screens — the native analogue of the CSS View
Transitions API — on **iOS and Android**.

```blade
<column @navigate.viewTransition('/album/3')>
    <column ref="album-3" class="w-16 h-16 rounded-xl">…</column>
</column>

{{-- destination --}}
<column ref="album-3" class="w-full h-80">…</column>

<row @navigate.back.viewTransition>…</row>
```

Two elements sharing a `ref` across two screens morph between them. Motion is
shaped by three optional props: `morph="frame|position|size|none"`,
`morph-duration` (ms) and `morph-easing`
(`linear|ease-in|ease-out|ease-in-out|spring`).

## Why `ref`

`ref` already existed as a per-element name, used as a test-targeting handle.
Two screens naming an element the same thing is exactly what a shared element
*is*, so there is no second naming concept to learn. `id` was rejected because
it is already the node's numeric wire identity and what event dispatch routes
on; `key` was rejected because it is scoped to a parent key-path and the docs
encourage domain ids, so `key="3"` on unrelated things would pair constantly.

Consequence worth reviewing: a `ref` that exists only as a test handle and
repeats across two screens will now morph under a `view_transition`. The opt-out
is `morph="none"`.

`ref` costs nothing extra on the wire — the node-level field is dropped by
`npui_serialize_node`, so only the generic prop is transmitted, and it replaced
`transition_name`.

## How it works, per platform

**Android** — `SharedTransitionLayout` wraps the screen-swapping
`AnimatedContent`; Compose matches refs across panes and animates the bounds
itself. Scopes reach the recursive `NodeView` through composition locals.

**iOS** — SwiftUI has no equivalent. `matchedGeometryEffect` only slaves one
view's frame to another's, and both stay inside their own screen layer, so a
hero travelling while the screens cross-fade is progressively occluded ("moves
most of the way, then fades"). Instead a FLIP overlay renders a *copy* of each
travelling element above both screens: frames are reported continuously, the
swap snapshots them, and the copy animates between them while both real
elements stay hidden.

## Known parity gap

`morph="position"` / `"size"` are exact on iOS (the rect is interpolated
directly) but fall back to a full-bounds morph on Android — Compose's
shared-element API always animates the full bounds and exposes no equivalent.
Documented in `NodeHeroMorph.kt` rather than approximated.

## Also in here

- `ref` reaches UI drivers on both platforms: an `accessibilityIdentifier` on
  iOS (nothing read `ref` at all before) and `testTagsAsResourceId` on Android
  (a Compose test tag is otherwise invisible to UiAutomator). On iOS this needs
  `.accessibilityElement(children: .contain)`, or naming a container collapses
  its descendants out of the tree — which hid content from screen readers too,
  not just tests.
- `ref` sets `testTag` only on Android, not `contentDescription` — writing an
  internal handle there made TalkBack announce "photo-1" in place of the
  element's real description.
- `ref` and the morph props now survive the streaming builtin path, which
  bypasses `applyStyle`/`applyCallbacks` and dropped them silently. Unit tests
  could not catch this; they use the Element path.

## Testing

Pest 58 passed / 0 failed (3041 assertions), including a new
`tests/Unit/Edge/ViewTransitionTest.php`. Pint clean.

Verified frame-by-frame from screen recordings on an iPhone 14 simulator and a
Pixel 9 emulator across twelve demo screens, forward and back — automated flows
prove taps land and destinations render, never that a morph played.

> **Pre-existing CI note:** PHPStan reports 17 errors in
> `src/Commands/Concerns/*` (`native:watch` argument/option signatures). They
> are untouched by this branch and present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
