### PR TITLE
Merge Info.plist entries structurally so plugins can declare any value type

### DIFF
--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -626,97 +626,34 @@ class IOSPluginCompiler
     }
 
     /**
-     * Merge two plist files
+     * Merge a plugin's Info.plist file into the app's, value types intact.
      */
     protected function mergePlists(string $main, string $plugin): string
     {
-        // Extract key-value pairs from plugin plist
-        preg_match_all('/<key>([^<]+)<\/key>\s*<string>([^<]+)<\/string>/s', $plugin, $matches, PREG_SET_ORDER);
-
-        $entries = [];
-        foreach ($matches as $match) {
-            $entries[$match[1]] = $match[2];
-        }
-
-        return $this->injectPlistEntries($main, $entries);
+        return $this->injectPlistEntries($main, PlistDocument::fromXml($plugin)->all());
     }
 
     /**
-     * Inject entries into plist
+     * Merge entries into the plist, resolving placeholders on the way in.
      */
     protected function injectPlistEntries(string $plist, array $entries): string
     {
-        foreach ($entries as $key => $value) {
-            // Check if key already exists
-            if (str_contains($plist, "<key>{$key}</key>")) {
-                if (is_array($value)) {
-                    $plist = $this->mergeArrayEntry($plist, $key, $value);
-                } elseif (is_string($value)) {
-                    $plist = $this->updateStringEntry($plist, $key, $this->substituteEnvPlaceholders($value));
-                }
+        $document = PlistDocument::fromXml($plist);
+        $document->merge($this->substitutePlaceholdersDeep($entries));
 
-                continue;
-            }
+        return $document->toXml();
+    }
 
-            // Handle array values
-            if (is_array($value)) {
-                $arrayContent = '';
-                foreach ($value as $item) {
-                    $item = $this->substituteEnvPlaceholders($item);
-                    $arrayContent .= "\n\t\t<string>{$item}</string>";
-                }
-                $entry = "\n\t<key>{$key}</key>\n\t<array>{$arrayContent}\n\t</array>";
-            } else {
-                // Handle string values - substitute placeholders
-                $value = $this->substituteEnvPlaceholders($value);
-                $entry = "\n\t<key>{$key}</key>\n\t<string>{$value}</string>";
-            }
-
-            // Add before closing </dict>
-            $plist = preg_replace(
-                '/(\s*<\/dict>\s*<\/plist>)/s',
-                $entry.'$1',
-                $plist,
-                1
-            );
+    /**
+     * Resolve ${ENV_VAR} placeholders in every string of a nested value.
+     */
+    protected function substitutePlaceholdersDeep(mixed $value): mixed
+    {
+        if (is_array($value)) {
+            return array_map(fn ($item) => $this->substitutePlaceholdersDeep($item), $value);
         }
 
-        return $plist;
-    }
-
-    /**
-     * Update an existing string entry's value in the plist
-     */
-    protected function updateStringEntry(string $plist, string $key, string $value): string
-    {
-        $pattern = '/(<key>'.preg_quote($key, '/').'<\/key>\s*<string>)([^<]*)(<\/string>)/';
-
-        return preg_replace_callback($pattern, function ($matches) use ($value) {
-            return $matches[1].htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8').$matches[3];
-        }, $plist, 1);
-    }
-
-    /**
-     * Merge array values into an existing plist array entry
-     */
-    protected function mergeArrayEntry(string $plist, string $key, array $values): string
-    {
-        $pattern = '/(<key>'.preg_quote($key, '/').'<\/key>\s*<array>)(.*?)(<\/array>)/s';
-
-        return preg_replace_callback($pattern, function ($matches) use ($values) {
-            $existingContent = $matches[2];
-            $newItems = '';
-
-            foreach ($values as $item) {
-                $item = $this->substituteEnvPlaceholders($item);
-                // Only add if not already present
-                if (! str_contains($existingContent, "<string>{$item}</string>")) {
-                    $newItems .= "\n\t\t<string>{$item}</string>";
-                }
-            }
-
-            return $matches[1].$existingContent.$newItems.$matches[3];
-        }, $plist);
+        return is_string($value) ? $this->substituteEnvPlaceholders($value) : $value;
     }
 
     /**
@@ -768,17 +705,9 @@ class IOSPluginCompiler
 
             $plist = $this->files->get($plistPath);
 
-            // Check if UIBackgroundModes already exists
-            if (str_contains($plist, '<key>UIBackgroundModes</key>')) {
-                // Merge with existing array
-                $plist = $this->mergeArrayEntry($plist, 'UIBackgroundModes', array_keys($backgroundModes));
-            } else {
-                // Add new UIBackgroundModes array
-                $plist = $this->injectPlistEntries($plist, [
-                    'UIBackgroundModes' => array_keys($backgroundModes),
-                ]);
-            }
-
+            $plist = $this->injectPlistEntries($plist, [
+                'UIBackgroundModes' => array_keys($backgroundModes),
+            ]);
             $this->files->put($plistPath, $plist);
         }
     }

--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -4,6 +4,7 @@ namespace Native\Mobile\Plugins\Compilers;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
+use InvalidArgumentException;
 use Native\Mobile\Exceptions\PluginConflictException;
 use Native\Mobile\Plugins\Plugin;
 use Native\Mobile\Plugins\PluginHookRunner;
@@ -438,7 +439,10 @@ class IOSPluginCompiler
                 }
 
                 $this->mergeIntoPlist($plist, $plugin->getIosInfoPlist());
-                $this->mergeIntoPlist($plist, ['UIBackgroundModes' => $plugin->getIosBackgroundModes()]);
+
+                if ($modes = $plugin->getIosBackgroundModes()) {
+                    $this->mergeIntoPlist($plist, ['UIBackgroundModes' => $modes]);
+                }
             }
 
             $this->mergeIntoPlist($plist, $this->getAppInfoPlistOverrides());
@@ -454,8 +458,8 @@ class IOSPluginCompiler
     {
         try {
             return PlistDocument::fromXml($this->files->get($path));
-        } catch (\InvalidArgumentException $e) {
-            throw new \InvalidArgumentException("{$path}: {$e->getMessage()}", 0, $e);
+        } catch (InvalidArgumentException $e) {
+            throw new InvalidArgumentException("{$path}: {$e->getMessage()}", 0, $e);
         }
     }
 

--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -9,6 +9,7 @@ use Native\Mobile\Plugins\Plugin;
 use Native\Mobile\Plugins\PluginHookRunner;
 use Native\Mobile\Plugins\PluginRegistry;
 use Native\Mobile\Plugins\SwiftSourceFilter;
+use Native\Mobile\Support\PlistDocument;
 use Native\Mobile\Support\Stub;
 
 class IOSPluginCompiler
@@ -176,9 +177,6 @@ class IOSPluginCompiler
 
         // Write per-locale InfoPlist.strings for any localized permission entries
         $this->writeInfoPlistLocalizations($allPlugins);
-
-        // Merge background modes into Info.plist
-        $this->mergeBackgroundModes($allPlugins);
 
         // Merge entitlements from plugins
         $this->mergeEntitlements($allPlugins);
@@ -413,48 +411,66 @@ class IOSPluginCompiler
     }
 
     /**
-     * Merge plugin Info.plist entries into main plist and simulator plist
+     * Merge every plugin's Info.plist contributions into the device and
+     * simulator plists: a resources/ios/Info.plist file, the manifest's
+     * info_plist entries and its background modes, with app-level
+     * overrides applied last so they always win over plugins.
      */
     protected function mergeInfoPlistEntries(Collection $plugins): void
     {
-        // Both device and simulator Info.plist files need plugin entries
         $plistPaths = [
             $this->iosProjectPath.'/NativePHP/Info.plist',
             $this->iosProjectPath.'/NativePHP-simulator-Info.plist',
         ];
-
-        $appOverrides = $this->getAppInfoPlistOverrides();
 
         foreach ($plistPaths as $plistPath) {
             if (! $this->files->exists($plistPath)) {
                 continue;
             }
 
-            $plist = $this->files->get($plistPath);
+            $plist = $this->openPlist($plistPath);
 
             foreach ($plugins as $plugin) {
-                // First check for Info.plist file
                 $pluginPlistPath = $plugin->path.'/resources/ios/Info.plist';
 
                 if ($this->files->exists($pluginPlistPath)) {
-                    $pluginPlist = $this->files->get($pluginPlistPath);
-                    $plist = $this->mergePlists($plist, $pluginPlist);
+                    $this->mergeIntoPlist($plist, $this->openPlist($pluginPlistPath)->all());
                 }
 
-                // Also merge info_plist entries from nativephp.json
-                $infoPlistEntries = $plugin->getIosInfoPlist();
-                if (! empty($infoPlistEntries)) {
-                    $plist = $this->injectPlistEntries($plist, $infoPlistEntries);
-                }
+                $this->mergeIntoPlist($plist, $plugin->getIosInfoPlist());
+                $this->mergeIntoPlist($plist, ['UIBackgroundModes' => $plugin->getIosBackgroundModes()]);
             }
 
-            // Apply app-level overrides last so they always win over plugins.
-            if (! empty($appOverrides)) {
-                $plist = $this->injectPlistEntries($plist, $appOverrides);
-            }
+            $this->mergeIntoPlist($plist, $this->getAppInfoPlistOverrides());
 
-            $this->files->put($plistPath, $plist);
+            $this->files->put($plistPath, $plist->toXml());
         }
+    }
+
+    /**
+     * Open a plist, naming the file when it does not parse.
+     */
+    protected function openPlist(string $path): PlistDocument
+    {
+        try {
+            return PlistDocument::fromXml($this->files->get($path));
+        } catch (\InvalidArgumentException $e) {
+            throw new \InvalidArgumentException("{$path}: {$e->getMessage()}", 0, $e);
+        }
+    }
+
+    /**
+     * Merge entries into a plist, resolving ${ENV_VAR} placeholders on the way in.
+     */
+    protected function mergeIntoPlist(PlistDocument $plist, array $entries): void
+    {
+        array_walk_recursive($entries, function (&$value) {
+            if (is_string($value)) {
+                $value = $this->substituteEnvPlaceholders($value);
+            }
+        });
+
+        $plist->merge($entries);
     }
 
     /**
@@ -626,37 +642,6 @@ class IOSPluginCompiler
     }
 
     /**
-     * Merge a plugin's Info.plist file into the app's, value types intact.
-     */
-    protected function mergePlists(string $main, string $plugin): string
-    {
-        return $this->injectPlistEntries($main, PlistDocument::fromXml($plugin)->all());
-    }
-
-    /**
-     * Merge entries into the plist, resolving placeholders on the way in.
-     */
-    protected function injectPlistEntries(string $plist, array $entries): string
-    {
-        $document = PlistDocument::fromXml($plist);
-        $document->merge($this->substitutePlaceholdersDeep($entries));
-
-        return $document->toXml();
-    }
-
-    /**
-     * Resolve ${ENV_VAR} placeholders in every string of a nested value.
-     */
-    protected function substitutePlaceholdersDeep(mixed $value): mixed
-    {
-        if (is_array($value)) {
-            return array_map(fn ($item) => $this->substitutePlaceholdersDeep($item), $value);
-        }
-
-        return is_string($value) ? $this->substituteEnvPlaceholders($value) : $value;
-    }
-
-    /**
      * Substitute ${ENV_VAR} placeholders with actual environment values
      */
     protected function substituteEnvPlaceholders(string $value): string
@@ -672,44 +657,6 @@ class IOSPluginCompiler
 
             return $envValue;
         }, $value);
-    }
-
-    /**
-     * Merge background modes from plugins into Info.plist UIBackgroundModes array
-     */
-    protected function mergeBackgroundModes(Collection $plugins): void
-    {
-        $backgroundModes = [];
-
-        foreach ($plugins as $plugin) {
-            $modes = $plugin->getIosBackgroundModes();
-            foreach ($modes as $mode) {
-                $backgroundModes[$mode] = true;
-            }
-        }
-
-        if (empty($backgroundModes)) {
-            return;
-        }
-
-        // Both device and simulator Info.plist files need background modes
-        $plistPaths = [
-            $this->iosProjectPath.'/NativePHP/Info.plist',
-            $this->iosProjectPath.'/NativePHP-simulator-Info.plist',
-        ];
-
-        foreach ($plistPaths as $plistPath) {
-            if (! $this->files->exists($plistPath)) {
-                continue;
-            }
-
-            $plist = $this->files->get($plistPath);
-
-            $plist = $this->injectPlistEntries($plist, [
-                'UIBackgroundModes' => array_keys($backgroundModes),
-            ]);
-            $this->files->put($plistPath, $plist);
-        }
     }
 
     /**

--- a/src/Plugins/Compilers/PlistDocument.php
+++ b/src/Plugins/Compilers/PlistDocument.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Native\Mobile\Plugins\Compilers;
+
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+use DOMText;
+use InvalidArgumentException;
+
+/**
+ * Structural read-modify-write access to an Info.plist document.
+ *
+ * Plugin manifests may declare any Info.plist value Apple accepts, so
+ * entries are merged by type: scalars replace, lists union on content,
+ * dicts merge recursively. Untouched keys keep their original markup.
+ */
+class PlistDocument
+{
+    protected DOMDocument $dom;
+
+    protected DOMElement $root;
+
+    protected function __construct(DOMDocument $dom, DOMElement $root)
+    {
+        $this->dom = $dom;
+        $this->root = $root;
+    }
+
+    public static function fromXml(string $xml): static
+    {
+        $dom = new DOMDocument;
+
+        if (! @$dom->loadXML($xml, LIBXML_NONET)) {
+            throw new InvalidArgumentException('Info.plist is not well-formed XML.');
+        }
+
+        $root = $dom->documentElement?->getElementsByTagName('dict')->item(0);
+
+        if (! $root instanceof DOMElement || $root->parentNode !== $dom->documentElement) {
+            throw new InvalidArgumentException('Info.plist has no root <dict>.');
+        }
+
+        return new static($dom, $root);
+    }
+
+    public function toXml(): string
+    {
+        return $this->dom->saveXML();
+    }
+
+    /**
+     * Every top-level entry as PHP values.
+     */
+    public function all(): array
+    {
+        $entries = [];
+
+        foreach ($this->pairs() as $key => $value) {
+            $entries[$key] = static::fromNode($value);
+        }
+
+        return $entries;
+    }
+
+    public function get(string $key): mixed
+    {
+        $value = $this->pairs()[$key] ?? null;
+
+        return $value ? static::fromNode($value) : null;
+    }
+
+    /**
+     * Merge entries into the root dict, replacing or appending each key.
+     */
+    public function merge(array $entries): void
+    {
+        foreach ($entries as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            $this->set($key, static::mergeValues($this->get($key), $value));
+        }
+    }
+
+    public function set(string $key, mixed $value): void
+    {
+        $node = $this->toNode($value, 1);
+        $existing = $this->pairs()[$key] ?? null;
+
+        if ($existing) {
+            $existing->parentNode->replaceChild($node, $existing);
+
+            return;
+        }
+
+        // Keep the closing </dict> on its own line by inserting
+        // ahead of the trailing whitespace the file already has.
+        $anchor = $this->root->lastChild instanceof DOMText && trim($this->root->lastChild->data) === ''
+            ? $this->root->lastChild
+            : $this->root->appendChild($this->dom->createTextNode("\n"));
+
+        $keyNode = $this->dom->createElement('key');
+        $keyNode->appendChild($this->dom->createTextNode($key));
+
+        $this->root->insertBefore($this->dom->createTextNode("\n\t"), $anchor);
+        $this->root->insertBefore($keyNode, $anchor);
+        $this->root->insertBefore($this->dom->createTextNode("\n\t"), $anchor);
+        $this->root->insertBefore($node, $anchor);
+    }
+
+    /**
+     * Combine an existing value with an incoming one. Lists union on
+     * content so a rebuild or a second plugin never duplicates an
+     * item, dicts merge key by key, and anything else is replaced.
+     */
+    public static function mergeValues(mixed $existing, mixed $incoming): mixed
+    {
+        if (! is_array($existing) || ! is_array($incoming)) {
+            return $incoming;
+        }
+
+        $existingIsList = array_is_list($existing);
+
+        if ($existingIsList !== array_is_list($incoming)) {
+            return $incoming;
+        }
+
+        if ($existingIsList) {
+            $seen = array_map([static::class, 'canonical'], $existing);
+
+            foreach ($incoming as $item) {
+                if (! in_array(static::canonical($item), $seen, true)) {
+                    $existing[] = $item;
+                }
+            }
+
+            return $existing;
+        }
+
+        foreach ($incoming as $key => $value) {
+            $existing[$key] = static::mergeValues($existing[$key] ?? null, $value);
+        }
+
+        return $existing;
+    }
+
+    /**
+     * Top-level <key> text mapped to its value element.
+     *
+     * @return array<string, DOMElement>
+     */
+    protected function pairs(): array
+    {
+        $pairs = [];
+        $pendingKey = null;
+
+        foreach ($this->root->childNodes as $child) {
+            if (! $child instanceof DOMElement) {
+                continue;
+            }
+
+            if ($child->tagName === 'key') {
+                $pendingKey = $child->textContent;
+            } elseif ($pendingKey !== null) {
+                $pairs[$pendingKey] = $child;
+                $pendingKey = null;
+            }
+        }
+
+        return $pairs;
+    }
+
+    protected static function fromNode(DOMElement $node): mixed
+    {
+        return match ($node->tagName) {
+            'true' => true,
+            'false' => false,
+            'integer' => (int) $node->textContent,
+            'real' => (float) $node->textContent,
+            'array' => array_map(
+                fn (DOMElement $child) => static::fromNode($child),
+                static::elementChildren($node)
+            ),
+            'dict' => static::dictFromNode($node),
+            default => $node->textContent,
+        };
+    }
+
+    protected static function dictFromNode(DOMElement $node): array
+    {
+        $dict = [];
+        $pendingKey = null;
+
+        foreach (static::elementChildren($node) as $child) {
+            if ($child->tagName === 'key') {
+                $pendingKey = $child->textContent;
+            } elseif ($pendingKey !== null) {
+                $dict[$pendingKey] = static::fromNode($child);
+                $pendingKey = null;
+            }
+        }
+
+        return $dict;
+    }
+
+    protected function toNode(mixed $value, int $depth): DOMNode
+    {
+        if (is_bool($value)) {
+            return $this->dom->createElement($value ? 'true' : 'false');
+        }
+
+        if (is_int($value)) {
+            return $this->dom->createElement('integer', (string) $value);
+        }
+
+        if (is_float($value)) {
+            return $this->dom->createElement('real', (string) $value);
+        }
+
+        if (! is_array($value)) {
+            $node = $this->dom->createElement('string');
+            $node->appendChild($this->dom->createTextNode((string) $value));
+
+            return $node;
+        }
+
+        $isList = array_is_list($value);
+        $node = $this->dom->createElement($isList ? 'array' : 'dict');
+        $indent = "\n".str_repeat("\t", $depth + 1);
+
+        foreach ($value as $key => $item) {
+            if (! $isList) {
+                $keyNode = $this->dom->createElement('key');
+                $keyNode->appendChild($this->dom->createTextNode((string) $key));
+
+                $node->appendChild($this->dom->createTextNode($indent));
+                $node->appendChild($keyNode);
+            }
+
+            $node->appendChild($this->dom->createTextNode($indent));
+            $node->appendChild($this->toNode($item, $depth + 1));
+        }
+
+        if ($value !== []) {
+            $node->appendChild($this->dom->createTextNode("\n".str_repeat("\t", $depth)));
+        }
+
+        return $node;
+    }
+
+    /**
+     * @return array<int, DOMElement>
+     */
+    protected static function elementChildren(DOMElement $node): array
+    {
+        return array_values(array_filter(
+            iterator_to_array($node->childNodes),
+            fn ($child) => $child instanceof DOMElement
+        ));
+    }
+
+    /**
+     * A key-order independent fingerprint, so two dicts with
+     * the same content count as the same list item.
+     */
+    protected static function canonical(mixed $value): string
+    {
+        if (is_array($value) && ! array_is_list($value)) {
+            ksort($value);
+        }
+
+        if (is_array($value)) {
+            $value = array_map([static::class, 'canonical'], $value);
+        }
+
+        return json_encode($value);
+    }
+}

--- a/src/Plugins/Compilers/PlistDocument.php
+++ b/src/Plugins/Compilers/PlistDocument.php
@@ -11,9 +11,9 @@ use InvalidArgumentException;
 /**
  * Structural read-modify-write access to an Info.plist document.
  *
- * Plugin manifests may declare any Info.plist value Apple accepts, so
- * entries are merged by type: scalars replace, lists union on content,
- * dicts merge recursively. Untouched keys keep their original markup.
+ * Plugins may declare any value Apple accepts, so entries merge by
+ * type: scalars replace, lists union on content, dicts merge key
+ * by key. Keys nobody touches keep their original markup.
  */
 class PlistDocument
 {
@@ -30,9 +30,20 @@ class PlistDocument
     public static function fromXml(string $xml): static
     {
         $dom = new DOMDocument;
+        $previous = libxml_use_internal_errors(true);
 
-        if (! @$dom->loadXML($xml, LIBXML_NONET)) {
-            throw new InvalidArgumentException('Info.plist is not well-formed XML.');
+        try {
+            $loaded = $dom->loadXML($xml, LIBXML_NONET);
+            $error = libxml_get_last_error();
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+
+        if (! $loaded) {
+            throw new InvalidArgumentException(
+                'Info.plist is not well-formed XML'.($error ? ': '.trim($error->message).' (line '.$error->line.')' : '.')
+            );
         }
 
         $root = $dom->documentElement?->getElementsByTagName('dict')->item(0);
@@ -75,11 +86,7 @@ class PlistDocument
      */
     public function merge(array $entries): void
     {
-        foreach ($entries as $key => $value) {
-            if ($value === null) {
-                continue;
-            }
-
+        foreach (static::withoutNulls($entries) as $key => $value) {
             $this->set($key, static::mergeValues($this->get($key), $value));
         }
     }
@@ -95,8 +102,8 @@ class PlistDocument
             return;
         }
 
-        // Keep the closing </dict> on its own line by inserting
-        // ahead of the trailing whitespace the file already has.
+        // Insert ahead of the trailing whitespace the file already
+        // has, so the closing </dict> stays on a line of its own.
         $anchor = $this->root->lastChild instanceof DOMText && trim($this->root->lastChild->data) === ''
             ? $this->root->lastChild
             : $this->root->appendChild($this->dom->createTextNode("\n"));
@@ -111,28 +118,34 @@ class PlistDocument
     }
 
     /**
-     * Combine an existing value with an incoming one. Lists union on
-     * content so a rebuild or a second plugin never duplicates an
-     * item, dicts merge key by key, and anything else is replaced.
+     * Combine an existing value with an incoming one. Lists union on content
+     * so rebuilds and second plugins never duplicate an item, dicts merge
+     * key by key, an empty array contributes nothing, and any other
+     * pairing is replaced outright by the incoming value.
      */
     public static function mergeValues(mixed $existing, mixed $incoming): mixed
     {
-        if (! is_array($existing) || ! is_array($incoming)) {
+        if (! is_array($incoming)) {
             return $incoming;
         }
 
-        $existingIsList = array_is_list($existing);
-
-        if ($existingIsList !== array_is_list($incoming)) {
-            return $incoming;
+        if ($incoming === []) {
+            return $existing ?? [];
         }
 
-        if ($existingIsList) {
+        if (! is_array($existing) || array_is_list($existing) !== array_is_list($incoming)) {
+            return array_is_list($incoming) ? static::mergeValues([], $incoming) : $incoming;
+        }
+
+        if (array_is_list($existing)) {
             $seen = array_map([static::class, 'canonical'], $existing);
 
             foreach ($incoming as $item) {
-                if (! in_array(static::canonical($item), $seen, true)) {
+                $fingerprint = static::canonical($item);
+
+                if (! in_array($fingerprint, $seen, true)) {
                     $existing[] = $item;
+                    $seen[] = $fingerprint;
                 }
             }
 
@@ -259,6 +272,22 @@ class PlistDocument
             iterator_to_array($node->childNodes),
             fn ($child) => $child instanceof DOMElement
         ));
+    }
+
+    /**
+     * Drop null entries at every depth, since a plist has no
+     * way to express one and JSON manifests may carry them.
+     */
+    protected static function withoutNulls(array $values): array
+    {
+        $wasList = array_is_list($values);
+
+        $values = array_map(
+            fn ($value) => is_array($value) ? static::withoutNulls($value) : $value,
+            array_filter($values, fn ($value) => $value !== null)
+        );
+
+        return $wasList ? array_values($values) : $values;
     }
 
     /**

--- a/src/Support/PlistDocument.php
+++ b/src/Support/PlistDocument.php
@@ -1,11 +1,12 @@
 <?php
 
-namespace Native\Mobile\Plugins\Compilers;
+namespace Native\Mobile\Support;
 
 use DOMDocument;
 use DOMElement;
 use DOMNode;
 use DOMText;
+use DOMXPath;
 use InvalidArgumentException;
 
 /**
@@ -17,15 +18,10 @@ use InvalidArgumentException;
  */
 class PlistDocument
 {
-    protected DOMDocument $dom;
-
-    protected DOMElement $root;
-
-    protected function __construct(DOMDocument $dom, DOMElement $root)
-    {
-        $this->dom = $dom;
-        $this->root = $root;
-    }
+    protected function __construct(
+        protected DOMDocument $dom,
+        protected DOMElement $root,
+    ) {}
 
     public static function fromXml(string $xml): static
     {
@@ -42,14 +38,14 @@ class PlistDocument
 
         if (! $loaded) {
             throw new InvalidArgumentException(
-                'Info.plist is not well-formed XML'.($error ? ': '.trim($error->message).' (line '.$error->line.')' : '.')
+                'Plist is not well-formed XML'.($error ? ': '.trim($error->message).' (line '.$error->line.')' : '.')
             );
         }
 
-        $root = $dom->documentElement?->getElementsByTagName('dict')->item(0);
+        $root = (new DOMXPath($dom))->query('/*/dict[1]')->item(0);
 
-        if (! $root instanceof DOMElement || $root->parentNode !== $dom->documentElement) {
-            throw new InvalidArgumentException('Info.plist has no root <dict>.');
+        if (! $root instanceof DOMElement) {
+            throw new InvalidArgumentException('Plist has no root <dict>.');
         }
 
         return new static($dom, $root);
@@ -65,18 +61,12 @@ class PlistDocument
      */
     public function all(): array
     {
-        $entries = [];
-
-        foreach ($this->pairs() as $key => $value) {
-            $entries[$key] = static::fromNode($value);
-        }
-
-        return $entries;
+        return static::fromNode($this->root);
     }
 
     public function get(string $key): mixed
     {
-        $value = $this->pairs()[$key] ?? null;
+        $value = static::pairsOf($this->root)[$key] ?? null;
 
         return $value ? static::fromNode($value) : null;
     }
@@ -94,7 +84,7 @@ class PlistDocument
     public function set(string $key, mixed $value): void
     {
         $node = $this->toNode($value, 1);
-        $existing = $this->pairs()[$key] ?? null;
+        $existing = static::pairsOf($this->root)[$key] ?? null;
 
         if ($existing) {
             $existing->parentNode->replaceChild($node, $existing);
@@ -108,11 +98,8 @@ class PlistDocument
             ? $this->root->lastChild
             : $this->root->appendChild($this->dom->createTextNode("\n"));
 
-        $keyNode = $this->dom->createElement('key');
-        $keyNode->appendChild($this->dom->createTextNode($key));
-
         $this->root->insertBefore($this->dom->createTextNode("\n\t"), $anchor);
-        $this->root->insertBefore($keyNode, $anchor);
+        $this->root->insertBefore($this->textElement('key', $key), $anchor);
         $this->root->insertBefore($this->dom->createTextNode("\n\t"), $anchor);
         $this->root->insertBefore($node, $anchor);
     }
@@ -123,7 +110,7 @@ class PlistDocument
      * key by key, an empty array contributes nothing, and any other
      * pairing is replaced outright by the incoming value.
      */
-    public static function mergeValues(mixed $existing, mixed $incoming): mixed
+    protected static function mergeValues(mixed $existing, mixed $incoming): mixed
     {
         if (! is_array($incoming)) {
             return $incoming;
@@ -160,20 +147,16 @@ class PlistDocument
     }
 
     /**
-     * Top-level <key> text mapped to its value element.
+     * A dict's <key> text mapped to the value element that follows it.
      *
      * @return array<string, DOMElement>
      */
-    protected function pairs(): array
+    protected static function pairsOf(DOMElement $dict): array
     {
         $pairs = [];
         $pendingKey = null;
 
-        foreach ($this->root->childNodes as $child) {
-            if (! $child instanceof DOMElement) {
-                continue;
-            }
-
+        foreach (static::elementChildren($dict) as $child) {
             if ($child->tagName === 'key') {
                 $pendingKey = $child->textContent;
             } elseif ($pendingKey !== null) {
@@ -192,30 +175,10 @@ class PlistDocument
             'false' => false,
             'integer' => (int) $node->textContent,
             'real' => (float) $node->textContent,
-            'array' => array_map(
-                fn (DOMElement $child) => static::fromNode($child),
-                static::elementChildren($node)
-            ),
-            'dict' => static::dictFromNode($node),
+            'array' => array_map([static::class, 'fromNode'], static::elementChildren($node)),
+            'dict' => array_map([static::class, 'fromNode'], static::pairsOf($node)),
             default => $node->textContent,
         };
-    }
-
-    protected static function dictFromNode(DOMElement $node): array
-    {
-        $dict = [];
-        $pendingKey = null;
-
-        foreach (static::elementChildren($node) as $child) {
-            if ($child->tagName === 'key') {
-                $pendingKey = $child->textContent;
-            } elseif ($pendingKey !== null) {
-                $dict[$pendingKey] = static::fromNode($child);
-                $pendingKey = null;
-            }
-        }
-
-        return $dict;
     }
 
     protected function toNode(mixed $value, int $depth): DOMNode
@@ -225,18 +188,15 @@ class PlistDocument
         }
 
         if (is_int($value)) {
-            return $this->dom->createElement('integer', (string) $value);
+            return $this->textElement('integer', (string) $value);
         }
 
         if (is_float($value)) {
-            return $this->dom->createElement('real', (string) $value);
+            return $this->textElement('real', (string) $value);
         }
 
         if (! is_array($value)) {
-            $node = $this->dom->createElement('string');
-            $node->appendChild($this->dom->createTextNode((string) $value));
-
-            return $node;
+            return $this->textElement('string', (string) $value);
         }
 
         $isList = array_is_list($value);
@@ -245,11 +205,8 @@ class PlistDocument
 
         foreach ($value as $key => $item) {
             if (! $isList) {
-                $keyNode = $this->dom->createElement('key');
-                $keyNode->appendChild($this->dom->createTextNode((string) $key));
-
                 $node->appendChild($this->dom->createTextNode($indent));
-                $node->appendChild($keyNode);
+                $node->appendChild($this->textElement('key', (string) $key));
             }
 
             $node->appendChild($this->dom->createTextNode($indent));
@@ -261,6 +218,18 @@ class PlistDocument
         }
 
         return $node;
+    }
+
+    /**
+     * An element whose text is escaped, which createElement's
+     * value argument would not do for characters like "&".
+     */
+    protected function textElement(string $tag, string $text): DOMElement
+    {
+        $element = $this->dom->createElement($tag);
+        $element->appendChild($this->dom->createTextNode($text));
+
+        return $element;
     }
 
     /**
@@ -296,11 +265,11 @@ class PlistDocument
      */
     protected static function canonical(mixed $value): string
     {
-        if (is_array($value) && ! array_is_list($value)) {
-            ksort($value);
-        }
-
         if (is_array($value)) {
+            if (! array_is_list($value)) {
+                ksort($value);
+            }
+
             $value = array_map([static::class, 'canonical'], $value);
         }
 

--- a/src/Support/PlistDocument.php
+++ b/src/Support/PlistDocument.php
@@ -37,9 +37,9 @@ class PlistDocument
         }
 
         if (! $loaded) {
-            throw new InvalidArgumentException(
-                'Plist is not well-formed XML'.($error ? ': '.trim($error->message).' (line '.$error->line.')' : '.')
-            );
+            $reason = $error ? ': '.trim($error->message).' (line '.$error->line.')' : '.';
+
+            throw new InvalidArgumentException('Plist is not well-formed XML'.$reason);
         }
 
         $root = (new DOMXPath($dom))->query('/*/dict[1]')->item(0);
@@ -68,7 +68,7 @@ class PlistDocument
     {
         $value = static::pairsOf($this->root)[$key] ?? null;
 
-        return $value ? static::fromNode($value) : null;
+        return $value === null ? null : static::fromNode($value);
     }
 
     /**
@@ -87,7 +87,7 @@ class PlistDocument
         $existing = static::pairsOf($this->root)[$key] ?? null;
 
         if ($existing) {
-            $existing->parentNode->replaceChild($node, $existing);
+            $this->root->replaceChild($node, $existing);
 
             return;
         }
@@ -121,26 +121,39 @@ class PlistDocument
         }
 
         if (! is_array($existing) || array_is_list($existing) !== array_is_list($incoming)) {
-            return array_is_list($incoming) ? static::mergeValues([], $incoming) : $incoming;
+            // There is nothing of the same shape to merge onto, so the
+            // incoming value stands alone. A list is still unioned
+            // against itself to drop repeats it declared twice.
+            return array_is_list($incoming) ? static::union([], $incoming) : $incoming;
         }
 
         if (array_is_list($existing)) {
-            $seen = array_map([static::class, 'canonical'], $existing);
-
-            foreach ($incoming as $item) {
-                $fingerprint = static::canonical($item);
-
-                if (! in_array($fingerprint, $seen, true)) {
-                    $existing[] = $item;
-                    $seen[] = $fingerprint;
-                }
-            }
-
-            return $existing;
+            return static::union($existing, $incoming);
         }
 
         foreach ($incoming as $key => $value) {
             $existing[$key] = static::mergeValues($existing[$key] ?? null, $value);
+        }
+
+        return $existing;
+    }
+
+    /**
+     * Append the incoming items an existing list does not already
+     * hold. Items compare on content, so a dict counts as
+     * present whatever order its keys arrived in.
+     */
+    protected static function union(array $existing, array $incoming): array
+    {
+        $seen = array_map(static::canonical(...), $existing);
+
+        foreach ($incoming as $item) {
+            $fingerprint = static::canonical($item);
+
+            if (! in_array($fingerprint, $seen, true)) {
+                $existing[] = $item;
+                $seen[] = $fingerprint;
+            }
         }
 
         return $existing;
@@ -175,8 +188,8 @@ class PlistDocument
             'false' => false,
             'integer' => (int) $node->textContent,
             'real' => (float) $node->textContent,
-            'array' => array_map([static::class, 'fromNode'], static::elementChildren($node)),
-            'dict' => array_map([static::class, 'fromNode'], static::pairsOf($node)),
+            'array' => array_map(static::fromNode(...), static::elementChildren($node)),
+            'dict' => array_map(static::fromNode(...), static::pairsOf($node)),
             default => $node->textContent,
         };
     }
@@ -270,7 +283,7 @@ class PlistDocument
                 ksort($value);
             }
 
-            $value = array_map([static::class, 'canonical'], $value);
+            $value = array_map(static::canonical(...), $value);
         }
 
         return json_encode($value);

--- a/tests/Feature/Plugins/IOSCompilerTest.php
+++ b/tests/Feature/Plugins/IOSCompilerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Plugins;
 use Illuminate\Filesystem\Filesystem;
 use Mockery;
 use Native\Mobile\Plugins\Compilers\IOSPluginCompiler;
+use Native\Mobile\Plugins\Compilers\PlistDocument;
 use Native\Mobile\Plugins\Plugin;
 use Native\Mobile\Plugins\PluginManifest;
 use Native\Mobile\Plugins\PluginRegistry;
@@ -1077,6 +1078,211 @@ class NestedClass {}');
     /**
      * Helper method to create a test Plugin instance.
      */
+    /**
+     * @test
+     *
+     * Apple keys such as SKAdNetworkItems are arrays of dicts. They must
+     * land with their structure intact, and a rebuild must not duplicate.
+     */
+    public function it_merges_arrays_of_dicts_into_info_plist(): void
+    {
+        $items = [
+            ['SKAdNetworkIdentifier' => 'cstr6suwn9.skadnetwork'],
+            ['SKAdNetworkIdentifier' => '4fzdc2evr5.skadnetwork'],
+        ];
+        $plugin = $this->createTestPlugin([
+            'ios' => ['info_plist' => ['SKAdNetworkItems' => $items]],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+        $this->compiler->compile();
+
+        $plist = PlistDocument::fromXml($this->files->get($this->testBasePath.'/ios/NativePHP/Info.plist'));
+
+        $this->assertSame($items, $plist->get('SKAdNetworkItems'));
+    }
+
+    /**
+     * @test
+     *
+     * Bools and integers keep their plist type, and a value the old text
+     * merge wrote with the wrong type is corrected on the next build.
+     */
+    public function it_writes_typed_plist_values(): void
+    {
+        $plistPath = $this->testBasePath.'/ios/NativePHP/Info.plist';
+        $this->files->put($plistPath, str_replace(
+            '<dict>',
+            "<dict>\n\t<key>FirebaseAppDelegateProxyEnabled</key>\n\t<string></string>",
+            $this->files->get($plistPath)
+        ));
+
+        $plugin = $this->createTestPlugin([
+            'ios' => ['info_plist' => [
+                'FirebaseAppDelegateProxyEnabled' => false,
+                'UIFileSharingEnabled' => true,
+                'ITSAppUsesNonExemptEncryption' => 0,
+            ]],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $content = $this->files->get($plistPath);
+        $plist = PlistDocument::fromXml($content);
+
+        $this->assertFalse($plist->get('FirebaseAppDelegateProxyEnabled'));
+        $this->assertTrue($plist->get('UIFileSharingEnabled'));
+        $this->assertSame(0, $plist->get('ITSAppUsesNonExemptEncryption'));
+        $this->assertStringNotContainsString('<string></string>', $content);
+    }
+
+    /**
+     * @test
+     *
+     * A plugin contributing to a key the base plist already nests, like
+     * CFBundleURLTypes, adds a sibling entry rather than corrupting the
+     * inner array, and dict keys merge instead of being dropped.
+     */
+    public function it_merges_into_nested_plist_structures(): void
+    {
+        $plistPath = $this->testBasePath.'/ios/NativePHP/Info.plist';
+        $this->files->put($plistPath, file_get_contents(__DIR__.'/../../../resources/xcode/NativePHP/Info.plist'));
+
+        $plugin = $this->createTestPlugin([
+            'ios' => ['info_plist' => [
+                'CFBundleURLTypes' => [['CFBundleURLSchemes' => ['probe']]],
+                'NSAppTransportSecurity' => ['NSAllowsArbitraryLoads' => true],
+            ]],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $plist = PlistDocument::fromXml($this->files->get($plistPath));
+
+        $types = $plist->get('CFBundleURLTypes');
+        $this->assertCount(2, $types);
+        $this->assertSame(['nativephp'], $types[0]['CFBundleURLSchemes']);
+        $this->assertSame(['probe'], $types[1]['CFBundleURLSchemes']);
+        $this->assertTrue($plist->get('NSAppTransportSecurity')['NSAllowsArbitraryLoadsInWebContent']);
+        $this->assertTrue($plist->get('NSAppTransportSecurity')['NSAllowsArbitraryLoads']);
+    }
+
+    /**
+     * @test
+     *
+     * A plugin's resources/ios/Info.plist is merged with every value type,
+     * and keys nested inside it never surface at the top level.
+     */
+    public function it_merges_plugin_info_plist_files_structurally(): void
+    {
+        $pluginPath = $this->testBasePath.'/plugins/test-plugin';
+        $this->files->ensureDirectoryExists($pluginPath.'/resources/ios');
+        $this->files->put($pluginPath.'/resources/ios/Info.plist', '<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>UIFileSharingEnabled</key>
+    <true/>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Any file</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>public.data</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>');
+
+        $plugin = $this->createTestPlugin([
+            'ios' => ['info_plist' => ['NSCameraUsageDescription' => 'Camera access']],
+        ], $pluginPath);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $plist = PlistDocument::fromXml($this->files->get($this->testBasePath.'/ios/NativePHP/Info.plist'));
+
+        $this->assertTrue($plist->get('UIFileSharingEnabled'));
+        $this->assertSame([[
+            'CFBundleTypeName' => 'Any file',
+            'LSItemContentTypes' => ['public.data'],
+        ]], $plist->get('CFBundleDocumentTypes'));
+        $this->assertNull($plist->get('CFBundleTypeName'));
+    }
+
+    /**
+     * @test
+     *
+     * ${ENV_VAR} placeholders resolve inside nested values too, and markup
+     * characters in any string are escaped so the plist stays well-formed.
+     */
+    public function it_substitutes_placeholders_and_escapes_inside_nested_values(): void
+    {
+        putenv('NATIVEPHP_TEST_SKAN=4fzdc2evr5.skadnetwork');
+        $_ENV['NATIVEPHP_TEST_SKAN'] = '4fzdc2evr5.skadnetwork';
+
+        try {
+            $plugin = $this->createTestPlugin([
+                'ios' => ['info_plist' => [
+                    'SKAdNetworkItems' => [['SKAdNetworkIdentifier' => '${NATIVEPHP_TEST_SKAN}']],
+                    'NSCameraUsageDescription' => 'Photos & <video>',
+                ]],
+            ]);
+
+            $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+            $this->compiler->compile();
+
+            $content = $this->files->get($this->testBasePath.'/ios/NativePHP/Info.plist');
+            $plist = PlistDocument::fromXml($content);
+
+            $this->assertSame('4fzdc2evr5.skadnetwork', $plist->get('SKAdNetworkItems')[0]['SKAdNetworkIdentifier']);
+            $this->assertSame('Photos & <video>', $plist->get('NSCameraUsageDescription'));
+            $this->assertStringContainsString('&amp; &lt;video&gt;', $content);
+        } finally {
+            putenv('NATIVEPHP_TEST_SKAN');
+            unset($_ENV['NATIVEPHP_TEST_SKAN']);
+        }
+    }
+
+    /**
+     * @test
+     *
+     * Background modes share the plist merge, so they union with what
+     * the base plist already declares and never duplicate on rebuild.
+     */
+    public function it_unions_background_modes_with_the_base_plist(): void
+    {
+        $plistPath = $this->testBasePath.'/ios/NativePHP/Info.plist';
+        $this->files->put($plistPath, file_get_contents(__DIR__.'/../../../resources/xcode/NativePHP/Info.plist'));
+
+        $plugin = $this->createTestPlugin([
+            'ios' => [
+                'info_plist' => ['NSLocationWhenInUseUsageDescription' => 'Location access'],
+                'background_modes' => ['remote-notification', 'location'],
+            ],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+        $this->compiler->compile();
+
+        $plist = PlistDocument::fromXml($this->files->get($plistPath));
+
+        $this->assertSame(['remote-notification', 'location'], $plist->get('UIBackgroundModes'));
+    }
+
     private function createTestPlugin(array $manifestData = [], ?string $path = null): Plugin
     {
         $defaultData = [

--- a/tests/Feature/Plugins/IOSCompilerTest.php
+++ b/tests/Feature/Plugins/IOSCompilerTest.php
@@ -5,10 +5,10 @@ namespace Tests\Feature\Plugins;
 use Illuminate\Filesystem\Filesystem;
 use Mockery;
 use Native\Mobile\Plugins\Compilers\IOSPluginCompiler;
-use Native\Mobile\Plugins\Compilers\PlistDocument;
 use Native\Mobile\Plugins\Plugin;
 use Native\Mobile\Plugins\PluginManifest;
 use Native\Mobile\Plugins\PluginRegistry;
+use Native\Mobile\Support\PlistDocument;
 use Tests\TestCase;
 
 /**
@@ -1091,14 +1091,18 @@ class NestedClass {}');
             'ios' => ['info_plist' => ['SKAdNetworkItems' => $items]],
         ]);
 
+        $this->files->copy(
+            $this->testBasePath.'/ios/NativePHP/Info.plist',
+            $this->testBasePath.'/ios/NativePHP-simulator-Info.plist'
+        );
+
         $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
 
         $this->compiler->compile();
         $this->compiler->compile();
 
-        $plist = PlistDocument::fromXml($this->files->get($this->testBasePath.'/ios/NativePHP/Info.plist'));
-
-        $this->assertSame($items, $plist->get('SKAdNetworkItems'));
+        $this->assertSame($items, $this->readPlist()->get('SKAdNetworkItems'));
+        $this->assertSame($items, $this->readPlist('NativePHP-simulator-Info.plist')->get('SKAdNetworkItems'));
     }
 
     /**
@@ -1140,39 +1144,6 @@ class NestedClass {}');
     /**
      * @test
      *
-     * A plugin contributing to a key the base plist already nests, like
-     * CFBundleURLTypes, adds a sibling entry rather than corrupting the
-     * inner array, and dict keys merge instead of being dropped.
-     */
-    public function it_merges_into_nested_plist_structures(): void
-    {
-        $plistPath = $this->testBasePath.'/ios/NativePHP/Info.plist';
-        $this->files->put($plistPath, file_get_contents(__DIR__.'/../../../resources/xcode/NativePHP/Info.plist'));
-
-        $plugin = $this->createTestPlugin([
-            'ios' => ['info_plist' => [
-                'CFBundleURLTypes' => [['CFBundleURLSchemes' => ['probe']]],
-                'NSAppTransportSecurity' => ['NSAllowsArbitraryLoads' => true],
-            ]],
-        ]);
-
-        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
-
-        $this->compiler->compile();
-
-        $plist = PlistDocument::fromXml($this->files->get($plistPath));
-
-        $types = $plist->get('CFBundleURLTypes');
-        $this->assertCount(2, $types);
-        $this->assertSame(['nativephp'], $types[0]['CFBundleURLSchemes']);
-        $this->assertSame(['probe'], $types[1]['CFBundleURLSchemes']);
-        $this->assertTrue($plist->get('NSAppTransportSecurity')['NSAllowsArbitraryLoadsInWebContent']);
-        $this->assertTrue($plist->get('NSAppTransportSecurity')['NSAllowsArbitraryLoads']);
-    }
-
-    /**
-     * @test
-     *
      * A plugin's resources/ios/Info.plist is merged with every value type,
      * and keys nested inside it never surface at the top level.
      */
@@ -1207,7 +1178,7 @@ class NestedClass {}');
 
         $this->compiler->compile();
 
-        $plist = PlistDocument::fromXml($this->files->get($this->testBasePath.'/ios/NativePHP/Info.plist'));
+        $plist = $this->readPlist();
 
         $this->assertTrue($plist->get('UIFileSharingEnabled'));
         $this->assertSame([[
@@ -1220,10 +1191,9 @@ class NestedClass {}');
     /**
      * @test
      *
-     * ${ENV_VAR} placeholders resolve inside nested values too, and markup
-     * characters in any string are escaped so the plist stays well-formed.
+     * ${ENV_VAR} placeholders resolve inside nested values too.
      */
-    public function it_substitutes_placeholders_and_escapes_inside_nested_values(): void
+    public function it_substitutes_placeholders_inside_nested_values(): void
     {
         putenv('NATIVEPHP_TEST_SKAN=4fzdc2evr5.skadnetwork');
         $_ENV['NATIVEPHP_TEST_SKAN'] = '4fzdc2evr5.skadnetwork';
@@ -1232,7 +1202,6 @@ class NestedClass {}');
             $plugin = $this->createTestPlugin([
                 'ios' => ['info_plist' => [
                     'SKAdNetworkItems' => [['SKAdNetworkIdentifier' => '${NATIVEPHP_TEST_SKAN}']],
-                    'NSCameraUsageDescription' => 'Photos & <video>',
                 ]],
             ]);
 
@@ -1240,12 +1209,7 @@ class NestedClass {}');
 
             $this->compiler->compile();
 
-            $content = $this->files->get($this->testBasePath.'/ios/NativePHP/Info.plist');
-            $plist = PlistDocument::fromXml($content);
-
-            $this->assertSame('4fzdc2evr5.skadnetwork', $plist->get('SKAdNetworkItems')[0]['SKAdNetworkIdentifier']);
-            $this->assertSame('Photos & <video>', $plist->get('NSCameraUsageDescription'));
-            $this->assertStringContainsString('&amp; &lt;video&gt;', $content);
+            $this->assertSame('4fzdc2evr5.skadnetwork', $this->readPlist()->get('SKAdNetworkItems')[0]['SKAdNetworkIdentifier']);
         } finally {
             putenv('NATIVEPHP_TEST_SKAN');
             unset($_ENV['NATIVEPHP_TEST_SKAN']);
@@ -1275,9 +1239,14 @@ class NestedClass {}');
         $this->compiler->compile();
         $this->compiler->compile();
 
-        $plist = PlistDocument::fromXml($this->files->get($plistPath));
+        $plist = $this->readPlist();
 
         $this->assertSame(['remote-notification', 'location'], $plist->get('UIBackgroundModes'));
+    }
+
+    private function readPlist(string $file = 'NativePHP/Info.plist'): PlistDocument
+    {
+        return PlistDocument::fromXml($this->files->get($this->testBasePath.'/ios/'.$file));
     }
 
     /**

--- a/tests/Feature/Plugins/IOSCompilerTest.php
+++ b/tests/Feature/Plugins/IOSCompilerTest.php
@@ -1103,6 +1103,7 @@ class NestedClass {}');
 
         $this->assertSame($items, $this->readPlist()->get('SKAdNetworkItems'));
         $this->assertSame($items, $this->readPlist('NativePHP-simulator-Info.plist')->get('SKAdNetworkItems'));
+        $this->assertNull($this->readPlist('NativePHP-simulator-Info.plist')->get('UIBackgroundModes'));
     }
 
     /**
@@ -1132,13 +1133,12 @@ class NestedClass {}');
 
         $this->compiler->compile();
 
-        $content = $this->files->get($plistPath);
-        $plist = PlistDocument::fromXml($content);
+        $plist = $this->readPlist();
 
         $this->assertFalse($plist->get('FirebaseAppDelegateProxyEnabled'));
         $this->assertTrue($plist->get('UIFileSharingEnabled'));
         $this->assertSame(0, $plist->get('ITSAppUsesNonExemptEncryption'));
-        $this->assertStringNotContainsString('<string></string>', $content);
+        $this->assertStringNotContainsString('<string></string>', $this->files->get($plistPath));
     }
 
     /**
@@ -1225,7 +1225,7 @@ class NestedClass {}');
     public function it_unions_background_modes_with_the_base_plist(): void
     {
         $plistPath = $this->testBasePath.'/ios/NativePHP/Info.plist';
-        $this->files->put($plistPath, file_get_contents(__DIR__.'/../../../resources/xcode/NativePHP/Info.plist'));
+        $this->files->put($plistPath, $this->files->get(__DIR__.'/../../../resources/xcode/NativePHP/Info.plist'));
 
         $plugin = $this->createTestPlugin([
             'ios' => [

--- a/tests/Feature/Plugins/IOSCompilerTest.php
+++ b/tests/Feature/Plugins/IOSCompilerTest.php
@@ -1076,9 +1076,6 @@ class NestedClass {}');
     }
 
     /**
-     * Helper method to create a test Plugin instance.
-     */
-    /**
      * @test
      *
      * Apple keys such as SKAdNetworkItems are arrays of dicts. They must
@@ -1283,6 +1280,9 @@ class NestedClass {}');
         $this->assertSame(['remote-notification', 'location'], $plist->get('UIBackgroundModes'));
     }
 
+    /**
+     * Helper method to create a test Plugin instance.
+     */
     private function createTestPlugin(array $manifestData = [], ?string $path = null): Plugin
     {
         $defaultData = [

--- a/tests/Unit/Plugins/PlistDocumentTest.php
+++ b/tests/Unit/Plugins/PlistDocumentTest.php
@@ -7,17 +7,13 @@ use Native\Mobile\Plugins\Compilers\PlistDocument;
  * and the base Info.plist already nests arrays of dicts, so the merge
  * has to be aware of structure rather than treat the file as text.
  */
-function plist(string $dict = ''): string
-{
-    return '<?xml version="1.0" encoding="UTF-8"?>'."\n"
+beforeEach(function () {
+    $this->base = file_get_contents(__DIR__.'/../../../resources/xcode/NativePHP/Info.plist');
+
+    $this->plist = fn (string $dict = '') => '<?xml version="1.0" encoding="UTF-8"?>'."\n"
         .'<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'."\n"
         .'<plist version="1.0">'."\n<dict>{$dict}\n</dict>\n</plist>\n";
-}
-
-function basePlist(): string
-{
-    return file_get_contents(__DIR__.'/../../../resources/xcode/NativePHP/Info.plist');
-}
+});
 
 it('renders every value type and reads it back', function () {
     $entries = [
@@ -29,7 +25,7 @@ it('renders every value type and reads it back', function () {
         'ADict' => ['Inner' => true, 'Items' => [['Id' => 'x']]],
     ];
 
-    $doc = PlistDocument::fromXml(plist());
+    $doc = PlistDocument::fromXml(($this->plist)());
     $doc->merge($entries);
 
     $xml = $doc->toXml();
@@ -39,9 +35,9 @@ it('renders every value type and reads it back', function () {
 
 it('unions lists on content so rebuilds and second plugins never duplicate', function () {
     $item = ['SKAdNetworkIdentifier' => 'cstr6suwn9.skadnetwork'];
-    $doc = PlistDocument::fromXml(plist());
+    $doc = PlistDocument::fromXml(($this->plist)());
 
-    $doc->merge(['SKAdNetworkItems' => [$item]]);
+    $doc->merge(['SKAdNetworkItems' => [$item, $item]]);
     $doc->merge(['SKAdNetworkItems' => [$item]]);
     expect($doc->get('SKAdNetworkItems'))->toBe([$item]);
 
@@ -51,7 +47,7 @@ it('unions lists on content so rebuilds and second plugins never duplicate', fun
 });
 
 it('merges dicts key by key', function () {
-    $doc = PlistDocument::fromXml(basePlist());
+    $doc = PlistDocument::fromXml($this->base);
     $doc->merge(['NSAppTransportSecurity' => ['NSAllowsArbitraryLoads' => true]]);
 
     expect($doc->get('NSAppTransportSecurity'))->toBe([
@@ -60,10 +56,25 @@ it('merges dicts key by key', function () {
     ]);
 });
 
+it('treats an empty array as contributing nothing', function () {
+    // JSON {} and [] both decode to [], so neither may wipe an existing value.
+    $doc = PlistDocument::fromXml($this->base);
+    $doc->merge(['NSAppTransportSecurity' => [], 'UIBackgroundModes' => []]);
+
+    expect($doc->toXml())->toBe($this->base);
+});
+
+it('drops null entries at any depth', function () {
+    $doc = PlistDocument::fromXml(($this->plist)());
+    $doc->merge(['Skipped' => null, 'AList' => ['a', null, 'b'], 'ADict' => ['Keep' => 1, 'Gone' => null]]);
+
+    expect($doc->all())->toBe(['AList' => ['a', 'b'], 'ADict' => ['Keep' => 1]]);
+});
+
 it('replaces a value whose type changed', function () {
     // The old text-based merge left <string></string> for a false bool in
     // scaffolds that already exist, so the typed value must win on rebuild.
-    $doc = PlistDocument::fromXml(plist('<key>FirebaseAppDelegateProxyEnabled</key><string></string>'));
+    $doc = PlistDocument::fromXml(($this->plist)('<key>FirebaseAppDelegateProxyEnabled</key><string></string>'));
     $doc->merge(['FirebaseAppDelegateProxyEnabled' => false]);
 
     expect($doc->get('FirebaseAppDelegateProxyEnabled'))->toBeFalse();
@@ -71,7 +82,7 @@ it('replaces a value whose type changed', function () {
 });
 
 it('appends array-of-dict items beside existing ones, never inside a nested array', function () {
-    $doc = PlistDocument::fromXml(basePlist());
+    $doc = PlistDocument::fromXml($this->base);
     $doc->merge(['CFBundleURLTypes' => [['CFBundleURLSchemes' => ['probe']]]]);
 
     $types = $doc->get('CFBundleURLTypes');
@@ -82,7 +93,7 @@ it('appends array-of-dict items beside existing ones, never inside a nested arra
 
 it('only matches keys at the top level', function () {
     // CFBundleTypeRole exists inside CFBundleURLTypes in the base plist.
-    $doc = PlistDocument::fromXml(basePlist());
+    $doc = PlistDocument::fromXml($this->base);
     $doc->merge(['CFBundleTypeRole' => 'Editor']);
 
     expect($doc->get('CFBundleTypeRole'))->toBe('Editor');
@@ -90,7 +101,7 @@ it('only matches keys at the top level', function () {
 });
 
 it('escapes markup in strings', function () {
-    $doc = PlistDocument::fromXml(plist());
+    $doc = PlistDocument::fromXml(($this->plist)());
     $doc->merge(['NSCameraUsageDescription' => "Foto's & <video>"]);
 
     expect($doc->toXml())->toContain('&amp; &lt;video&gt;');
@@ -98,11 +109,15 @@ it('escapes markup in strings', function () {
 });
 
 it('leaves untouched entries byte for byte', function () {
-    $doc = PlistDocument::fromXml(basePlist());
+    $doc = PlistDocument::fromXml($this->base);
     $doc->merge([]);
 
-    expect($doc->toXml())->toBe(basePlist());
+    expect($doc->toXml())->toBe($this->base);
 });
+
+it('names the parse error and line for malformed XML', function () {
+    PlistDocument::fromXml(($this->plist)("\n<key>X</key>\n<string>a & b</string>"));
+})->throws(InvalidArgumentException::class, 'line 6');
 
 it('rejects input without a root dict', function () {
     PlistDocument::fromXml('<plist version="1.0"><array/></plist>');

--- a/tests/Unit/Plugins/PlistDocumentTest.php
+++ b/tests/Unit/Plugins/PlistDocumentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Native\Mobile\Plugins\Compilers\PlistDocument;
+use Native\Mobile\Support\PlistDocument;
 
 /**
  * Structural plist merging. Plugins may declare any value Apple accepts,
@@ -106,13 +106,6 @@ it('escapes markup in strings', function () {
 
     expect($doc->toXml())->toContain('&amp; &lt;video&gt;');
     expect(PlistDocument::fromXml($doc->toXml())->get('NSCameraUsageDescription'))->toBe("Foto's & <video>");
-});
-
-it('leaves untouched entries byte for byte', function () {
-    $doc = PlistDocument::fromXml($this->base);
-    $doc->merge([]);
-
-    expect($doc->toXml())->toBe($this->base);
 });
 
 it('names the parse error and line for malformed XML', function () {

--- a/tests/Unit/Plugins/PlistDocumentTest.php
+++ b/tests/Unit/Plugins/PlistDocumentTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use Native\Mobile\Plugins\Compilers\PlistDocument;
+
+/**
+ * Structural plist merging. Plugins may declare any value Apple accepts,
+ * and the base Info.plist already nests arrays of dicts, so the merge
+ * has to be aware of structure rather than treat the file as text.
+ */
+function plist(string $dict = ''): string
+{
+    return '<?xml version="1.0" encoding="UTF-8"?>'."\n"
+        .'<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'."\n"
+        .'<plist version="1.0">'."\n<dict>{$dict}\n</dict>\n</plist>\n";
+}
+
+function basePlist(): string
+{
+    return file_get_contents(__DIR__.'/../../../resources/xcode/NativePHP/Info.plist');
+}
+
+it('renders every value type and reads it back', function () {
+    $entries = [
+        'AString' => 'text',
+        'ABool' => false,
+        'AnInt' => 42,
+        'AReal' => 1.5,
+        'AList' => ['a', 'b'],
+        'ADict' => ['Inner' => true, 'Items' => [['Id' => 'x']]],
+    ];
+
+    $doc = PlistDocument::fromXml(plist());
+    $doc->merge($entries);
+
+    $xml = $doc->toXml();
+    expect($xml)->toContain('<false/>', '<integer>42</integer>', '<real>1.5</real>');
+    expect(PlistDocument::fromXml($xml)->all())->toBe($entries);
+});
+
+it('unions lists on content so rebuilds and second plugins never duplicate', function () {
+    $item = ['SKAdNetworkIdentifier' => 'cstr6suwn9.skadnetwork'];
+    $doc = PlistDocument::fromXml(plist());
+
+    $doc->merge(['SKAdNetworkItems' => [$item]]);
+    $doc->merge(['SKAdNetworkItems' => [$item]]);
+    expect($doc->get('SKAdNetworkItems'))->toBe([$item]);
+
+    $other = ['SKAdNetworkIdentifier' => '4fzdc2evr5.skadnetwork'];
+    $doc->merge(['SKAdNetworkItems' => [$other]]);
+    expect($doc->get('SKAdNetworkItems'))->toBe([$item, $other]);
+});
+
+it('merges dicts key by key', function () {
+    $doc = PlistDocument::fromXml(basePlist());
+    $doc->merge(['NSAppTransportSecurity' => ['NSAllowsArbitraryLoads' => true]]);
+
+    expect($doc->get('NSAppTransportSecurity'))->toBe([
+        'NSAllowsArbitraryLoadsInWebContent' => true,
+        'NSAllowsArbitraryLoads' => true,
+    ]);
+});
+
+it('replaces a value whose type changed', function () {
+    // The old text-based merge left <string></string> for a false bool in
+    // scaffolds that already exist, so the typed value must win on rebuild.
+    $doc = PlistDocument::fromXml(plist('<key>FirebaseAppDelegateProxyEnabled</key><string></string>'));
+    $doc->merge(['FirebaseAppDelegateProxyEnabled' => false]);
+
+    expect($doc->get('FirebaseAppDelegateProxyEnabled'))->toBeFalse();
+    expect(substr_count($doc->toXml(), 'FirebaseAppDelegateProxyEnabled'))->toBe(1);
+});
+
+it('appends array-of-dict items beside existing ones, never inside a nested array', function () {
+    $doc = PlistDocument::fromXml(basePlist());
+    $doc->merge(['CFBundleURLTypes' => [['CFBundleURLSchemes' => ['probe']]]]);
+
+    $types = $doc->get('CFBundleURLTypes');
+    expect($types)->toHaveCount(2);
+    expect($types[0]['CFBundleURLSchemes'])->toBe(['nativephp']);
+    expect($types[1])->toBe(['CFBundleURLSchemes' => ['probe']]);
+});
+
+it('only matches keys at the top level', function () {
+    // CFBundleTypeRole exists inside CFBundleURLTypes in the base plist.
+    $doc = PlistDocument::fromXml(basePlist());
+    $doc->merge(['CFBundleTypeRole' => 'Editor']);
+
+    expect($doc->get('CFBundleTypeRole'))->toBe('Editor');
+    expect($doc->get('CFBundleURLTypes')[0]['CFBundleTypeRole'])->toBe('Viewer');
+});
+
+it('escapes markup in strings', function () {
+    $doc = PlistDocument::fromXml(plist());
+    $doc->merge(['NSCameraUsageDescription' => "Foto's & <video>"]);
+
+    expect($doc->toXml())->toContain('&amp; &lt;video&gt;');
+    expect(PlistDocument::fromXml($doc->toXml())->get('NSCameraUsageDescription'))->toBe("Foto's & <video>");
+});
+
+it('leaves untouched entries byte for byte', function () {
+    $doc = PlistDocument::fromXml(basePlist());
+    $doc->merge([]);
+
+    expect($doc->toXml())->toBe(basePlist());
+});
+
+it('rejects input without a root dict', function () {
+    PlistDocument::fromXml('<plist version="1.0"><array/></plist>');
+})->throws(InvalidArgumentException::class);


### PR DESCRIPTION
Fixes #368.

Thanks to @CodyPChristian for the thorough report. A plugin declaring `SKAdNetworkItems` (an array of dicts, required by every ad network) aborted `native:run ios` with a TypeError, because `injectPlistEntries` built the plist by string concatenation and assumed every value is a string or a list of strings. Tracing that assumption turned up more than the crash:

- arrays of dicts threw on both the new-key and existing-key paths
- bools and ints were written as strings; mobile-firebase's `FirebaseAppDelegateProxyEnabled: false` ships as `<string></string>` today and only works because Firebase happens to read an empty string as NO
- merging into a key the base plist already nests (`CFBundleURLTypes`) landed inside the inner `CFBundleURLSchemes` array, since the regex stopped at the first nested `</array>`
- a dict onto `NSAppTransportSecurity`, or a bool onto any existing key, was silently ignored
- a plugin's `resources/ios/Info.plist` lost its bools and arrays, and nested keys were hoisted to the top level
- new string values were not escaped, so `Photos & video` produced a plist Xcode rejects

### The fix

`PlistDocument` reads the plist through the DOM and merges by type: scalars replace, lists union on content, dicts merge key by key, empty arrays and nulls contribute nothing, a type mismatch is replaced by the incoming value. Keys nobody touches keep their original markup byte for byte, and strings are escaped by the DOM.

The compiler opens each plist once and merges every source into it in one pass: the plugin's `resources/ios/Info.plist`, its `info_plist` entries, its background modes, and the app-level overrides last so they still win. The regex helpers are gone. Cody's suggestion to emit by type is the direction taken; the regex merge had to go with it, because once plugins can contribute nested structures its non-greedy `.*?</array>` corrupts them.

This is the second run at the problem. #6 went stale with Shane's review open, and that review doubles as the checklist here: indentation follows depth, bools render as Apple's `<true/>`, empty arrays stay arrays, integers and reals get their own tags, everything is type-hinted, and the tests assert structure by parsing the output back rather than grepping for key names. Placeholders still only resolve in values, not keys, as before.

Two consequences of the union semantics worth knowing. A list never loses items, so a `${PLACEHOLDER}` that changes between builds keeps both values until the scaffold is regenerated, the same way an unregistered plugin's keys already linger. And an app-level override replaces a plugin's scalar but unions with its list.

### Verification

Probe plugin manifest, built on the simulator:

```json
"info_plist": {
    "SKAdNetworkItems": [
        { "SKAdNetworkIdentifier": "cstr6suwn9.skadnetwork" },
        { "SKAdNetworkIdentifier": "${PROBE_NETWORK}" }
    ],
    "FirebaseAppDelegateProxyEnabled": false,
    "NSAppTransportSecurity": { "NSAllowsArbitraryLoads": true },
    "CFBundleURLTypes": [{ "CFBundleURLName": "probe", "CFBundleURLSchemes": ["probe"] }],
    "NSCameraUsageDescription": "Probe: photos & <video>"
}
```

`plutil -p` on the installed bundle's Info.plist:

```
"SKAdNetworkItems" => [
  0 => { "SKAdNetworkIdentifier" => "cstr6suwn9.skadnetwork" }
  1 => { "SKAdNetworkIdentifier" => "4fzdc2evr5.skadnetwork" }
]
"FirebaseAppDelegateProxyEnabled" => 0
"NSAppTransportSecurity" => {
  "NSAllowsArbitraryLoads" => 1
  "NSAllowsArbitraryLoadsInWebContent" => 1
}
"CFBundleURLTypes" => [ 0 => { app entry }, 1 => { "CFBundleURLName" => "probe" ... } ]
"NSCameraUsageDescription" => "Probe: photos & <video>"
```

A second build produced the same plist, so nothing duplicates on rebuild. Unit tests pin the merge rules on `PlistDocument`; compiler tests pin that each source reaches both the device and simulator plists. Suite green.

### Decisions for Simon and Shane

Things the trace surfaced that I left alone because they change behaviour beyond this issue:

- Keys from an unregistered plugin stay in the scaffold plist and ship with the app until `native:install --force`, and a changed `.env` value for such a plugin never lands either. Pre-existing on main. Either track plugin-contributed keys and drop the ones no longer declared, or document `--force` as the way to remove a plugin.
- `compile()` returns early unless a plugin has Swift sources, `info_plist` entries or dependencies, so a plugin whose only iOS data is `background_modes`, `entitlements` or a `resources/ios/Info.plist` file contributes nothing, silently. This PR makes that plist file meaningful for the first time, so the gate bites harder now. Widening it is a few lines; happy to fold it in here.
- A provider class in `plugins()` that matches no installed package is accepted without a word, since `isPluginAllowed` compares strings. A warning at discovery time would turn "my plugin does nothing" into a two-minute fix.
- The entitlements emitters still build XML by hand, keep the first value for a key that already exists, and do not escape. #174 rewrites that path onto its own `PropertyList` codec, so merging both as they stand leaves two plist codecs in the package. Whichever lands second should sit on the other's class; `PlistDocument` can take the entitlements merge as-is if first wins is not something you want to keep.
