### PR TITLE
feature: opt-in disabled prop on top-bar actions

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootStackRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootStackRenderer.kt
@@ -384,10 +384,13 @@ fun NativeRootStackRenderer(node: NativeUINode, modifier: Modifier = Modifier) {
 @Composable
 internal fun TopBarActionView(action: NativeUINode) {
     val icon = action.props.getString("icon", "more_vert")
+    val disabled = action.props.getBool("disabled")
     val subItems = action.children.filter { it.type == "top_bar_action" }
 
     if (subItems.isEmpty()) {
-        IconButton(onClick = {
+        // `enabled=false` swallows the tap and swaps LocalContentColor for
+        // the M3 disabled tone, so the icon greys out on its own.
+        IconButton(enabled = !disabled, onClick = {
             if (action.onPress != 0) {
                 NativeElementBridge.sendPressEvent(action.onPress, action.id)
             }
@@ -396,7 +399,7 @@ internal fun TopBarActionView(action: NativeUINode) {
         }
     } else {
         var expanded by remember { mutableStateOf(false) }
-        IconButton(onClick = { expanded = true }) {
+        IconButton(enabled = !disabled, onClick = { expanded = true }) {
             MaterialIcon(name = icon, contentDescription = action.props.getString("label", ""))
         }
         DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
@@ -411,6 +414,7 @@ internal fun TopBarActionView(action: NativeUINode) {
                 val isDestructive = item.props.getBool("destructive")
                 val destructiveColor = MaterialTheme.colorScheme.error
                 DropdownMenuItem(
+                    enabled = !item.props.getBool("disabled"),
                     text = {
                         Text(
                             itemLabel,

--- a/resources/xcode/NativePHP/NativeRender/NativeRootStackRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeRootStackRenderer.swift
@@ -285,6 +285,7 @@ struct NativeRootStackRenderer: View {
     @ViewBuilder
     private func actionView(_ action: NativeUINode, textColor: Color) -> some View {
         let icon = action.props.getString("icon", default: "ellipsis")
+        let disabled = action.props.getBool("disabled")
         let subItems = action.children.filter { $0.type == "top_bar_action" }
 
         if subItems.isEmpty {
@@ -296,7 +297,11 @@ struct NativeRootStackRenderer: View {
                 Image(systemName: getIconForName(icon))
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(textColor)
+                    // Explicit dim: the hard-set foregroundColor above keeps
+                    // SwiftUI's automatic disabled greying from showing.
+                    .opacity(disabled ? 0.4 : 1)
             }
+            .disabled(disabled)
         } else {
             Menu {
                 ForEach(subItems) { item in
@@ -318,6 +323,7 @@ struct NativeRootStackRenderer: View {
                                 Text(itemLabel)
                             }
                         }
+                        .disabled(item.props.getBool("disabled"))
                         // SwiftUI's Menu won't propagate `.foregroundStyle(.red)`
                         // applied inside the Button label down to the Label's
                         // systemImage — the icon stays on the menu's accent color
@@ -331,7 +337,9 @@ struct NativeRootStackRenderer: View {
                 Image(systemName: getIconForName(icon))
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(textColor)
+                    .opacity(disabled ? 0.4 : 1)
             }
+            .disabled(disabled)
         }
     }
 }

--- a/resources/xcode/NativePHP/NativeRender/NativeRootTabsRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeRootTabsRenderer.swift
@@ -643,6 +643,7 @@ private struct TabsActionView: View {
 
     var body: some View {
         let icon = action.props.getString("icon", default: "ellipsis")
+        let disabled = action.props.getBool("disabled")
         let subItems = action.children.filter { $0.type == "top_bar_action" }
 
         if subItems.isEmpty {
@@ -654,7 +655,11 @@ private struct TabsActionView: View {
                 Image(systemName: getIconForName(icon))
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(textColor)
+                    // Explicit dim: the hard-set foregroundColor above keeps
+                    // SwiftUI's automatic disabled greying from showing.
+                    .opacity(disabled ? 0.4 : 1)
             }
+            .disabled(disabled)
         } else {
             Menu {
                 ForEach(subItems) { item in
@@ -675,6 +680,7 @@ private struct TabsActionView: View {
                                 Text(itemLabel)
                             }
                         }
+                        .disabled(item.props.getBool("disabled"))
                         // See NativeRootStackRenderer.swift for the rationale —
                         // .tint on the Button is what SwiftUI's Menu actually
                         // routes to the Label's systemImage in destructive rows.
@@ -685,7 +691,9 @@ private struct TabsActionView: View {
                 Image(systemName: getIconForName(icon))
                     .font(.system(size: 17, weight: .semibold))
                     .foregroundColor(textColor)
+                    .opacity(disabled ? 0.4 : 1)
             }
+            .disabled(disabled)
         }
     }
 }

--- a/src/Edge/Elements/TopBarAction.php
+++ b/src/Edge/Elements/TopBarAction.php
@@ -45,6 +45,9 @@ class TopBarAction extends Element
         if (isset($attrs['destructive'])) {
             $this->props['destructive'] = (bool) $attrs['destructive'];
         }
+        if (isset($attrs['disabled'])) {
+            $this->props['disabled'] = (bool) $attrs['disabled'];
+        }
         if (isset($attrs['divider'])) {
             $this->props['divider'] = (bool) $attrs['divider'];
         }

--- a/src/Edge/Layouts/Builders/NavAction.php
+++ b/src/Edge/Layouts/Builders/NavAction.php
@@ -33,6 +33,8 @@ class NavAction
 
     private bool $destructive = false;
 
+    private bool $disabled = false;
+
     /**
      * Marks this action as a visual divider rather than a tappable row.
      * Use [divider] to construct one — when set, the renderer emits a
@@ -127,6 +129,19 @@ class NavAction
     }
 
     /**
+     * Grey the action out and ignore taps — for actions that are sometimes
+     * unavailable (undo with nothing to undo, save with no changes).
+     * Attributes are reactive, so `->disabled(! $this->canUndo)` updates
+     * live as the screen's state changes.
+     */
+    public function disabled(bool $value = true): self
+    {
+        $this->disabled = $value;
+
+        return $this;
+    }
+
+    /**
      * Attach sub-items so this action renders as a pull-down menu instead
      * of a plain button. Tapping the bar's icon reveals a SwiftUI `Menu`
      * (iOS) / Compose `DropdownMenu` (Android) of these items. Each
@@ -184,6 +199,9 @@ class NavAction
         }
         if ($this->destructive) {
             $attrs['destructive'] = true;
+        }
+        if ($this->disabled) {
+            $attrs['disabled'] = true;
         }
 
         $action->applyAttributes($attrs);

--- a/tests/Unit/Edge/TopBarActionDisabledTest.php
+++ b/tests/Unit/Edge/TopBarActionDisabledTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use Native\Mobile\Edge\CallbackRegistry;
+use Native\Mobile\Edge\Elements\TopBarAction;
+use Native\Mobile\Edge\Layouts\Builders\NavAction;
+
+/**
+ * The opt-in `disabled` prop on top-bar actions: greys the button and
+ * swallows taps on both platforms. Unset keeps today's behavior.
+ */
+it('serializes disabled on a top-bar action', function () {
+    $action = TopBarAction::make();
+    $action->applyAttributes(['id' => 'undo', 'icon' => 'arrow.uturn.backward', 'disabled' => true]);
+
+    expect($action->toArray(new CallbackRegistry)['props']['disabled'])->toBeTrue();
+});
+
+it('coerces disabled to a boolean', function () {
+    $action = TopBarAction::make();
+    $action->applyAttributes(['id' => 'undo', 'disabled' => '1']);
+
+    expect($action->toArray(new CallbackRegistry)['props']['disabled'])->toBeTrue();
+});
+
+it('omits disabled when the attribute is not set', function () {
+    $action = TopBarAction::make();
+    $action->applyAttributes(['id' => 'undo', 'icon' => 'clock']);
+
+    expect($action->toArray(new CallbackRegistry)['props'])->not->toHaveKey('disabled');
+});
+
+it('keeps an explicit disabled=false serialized as false', function () {
+    $action = TopBarAction::make();
+    $action->applyAttributes(['id' => 'undo', 'disabled' => false]);
+
+    expect($action->toArray(new CallbackRegistry)['props']['disabled'])->toBeFalse();
+});
+
+it('builds a disabled action through the NavAction fluent API', function () {
+    $props = NavAction::make('undo')->icon('undo')->disabled()->press('undo')
+        ->toElement()->toArray(new CallbackRegistry)['props'];
+
+    expect($props['disabled'])->toBeTrue();
+});
+
+it('leaves NavAction disabled(false) out of the wire props', function () {
+    $props = NavAction::make('undo')->icon('undo')->disabled(false)->press('undo')
+        ->toElement()->toArray(new CallbackRegistry)['props'];
+
+    expect($props)->not->toHaveKey('disabled');
+});


### PR DESCRIPTION
## What's wrong
A top-bar action can't be greyed out. When an action is sometimes unavailable (undo with nothing to undo, save with no changes), the only option is to hide it — and the bar jumps as icons appear and disappear.

## What this does
One opt-in prop: `disabled`. The button greys out and ignores taps. Unset keeps exactly today's behavior.

```blade
<native:top-bar title="Notes">
    <native:top-bar-action id="undo" icon="arrow.uturn.backward" :disabled="! $this->canUndo" @tap="undo" />
    <native:top-bar-action id="add" icon="plus" @tap="addItem" />
</native:top-bar>
```

Chrome attributes are reactive, so `:disabled="! $this->canUndo"` greys and un-greys live as screen state changes. The `NavAction` builder gets the same: `NavAction::make('undo')->icon('undo')->disabled(! $canUndo)`.

- **iOS**: `.disabled()` on the Button, plus an explicit 0.4 opacity — the action label hard-sets its `foregroundColor`, which keeps SwiftUI's automatic dimming from showing.
- **Android**: `enabled = false` on the `IconButton` — Material 3 swaps in the disabled content tone on its own.
- Menu triggers (actions with sub-items) and menu rows honor it too.

Tests: serialization on the element (set / unset / boolean coercion / explicit false) and through the `NavAction` builder.

## On device (same Blade as above)
Android emulator, API 36 — Undo greyed while there is nothing to undo, live again right after adding a note (the same screen, one tap apart):

<img src="https://raw.githubusercontent.com/SRWieZ/mobile-air/5d7a871d02077d7b950c5cd8e4e269a0c75fed62/pair-disabled-android.png" width="900">

iOS simulator, iPhone 17 — the disabled Undo next to the live Add:

<img src="https://raw.githubusercontent.com/SRWieZ/mobile-air/5d7a871d02077d7b950c5cd8e4e269a0c75fed62/ios-disabled-bar.png" width="450">
