### PR TITLE
Deliver native events to webview screens on Android

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
@@ -124,10 +124,7 @@ class MainActivity : FragmentActivity(), WebViewProvider, NativeElementBridge.We
         super.onCreate(savedInstanceState)
         instance = this
 
-        // Web delivery arm for device events (appearance, shake, thermal…):
-        // sendNativeEvent only feeds the EDGE element queue, which nothing
-        // drains on a webview screen, so it also hands each event here to
-        // be injected into the page (see onNativeEvent below).
+        // Claim the web delivery arm for device events (see onNativeEvent).
         NativeElementBridge.installWebEventSink(this)
 
         // Seed the appearance tracker so a later config change (e.g. rotation)
@@ -801,11 +798,9 @@ class MainActivity : FragmentActivity(), WebViewProvider, NativeElementBridge.We
 
     /**
      * Web delivery arm for device events (NativeElementBridge.WebEventSink).
-     * While an EDGE screen owns the UI its runloop already drains the element
-     * queue, so injecting into the hidden page would deliver the same event
-     * twice — once live and once as a deferred POST replay when the web page
-     * returns. On a webview screen the injection is the only delivery path.
-     * Skips silently when no WebView exists yet (native-first boot).
+     * While an EDGE screen owns the UI its runloop already drains the queue,
+     * and injecting into the page behind it would deliver the same event a
+     * second time when that page returns. Skips when no WebView exists yet.
      */
     override fun onNativeEvent(eventName: String, payloadJson: String) {
         runOnUiThread {

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
@@ -62,7 +62,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class MainActivity : FragmentActivity(), WebViewProvider {
+class MainActivity : FragmentActivity(), WebViewProvider, NativeElementBridge.WebEventSink {
     // Native-first boot: no WebView exists until a web response actually
     // needs painting. Compose state so MainScreen recomposes and attaches
     // the WebView the moment a renderer is lazily created.
@@ -123,6 +123,12 @@ class MainActivity : FragmentActivity(), WebViewProvider {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         instance = this
+
+        // Web delivery arm for device events (appearance, shake, thermal…):
+        // sendNativeEvent only feeds the EDGE element queue, which nothing
+        // drains on a webview screen, so it also hands each event here to
+        // be injected into the page (see onNativeEvent below).
+        NativeElementBridge.installWebEventSink(this)
 
         // Seed the appearance tracker so a later config change (e.g. rotation)
         // only emits AppearanceChanged when the theme genuinely differs.
@@ -792,6 +798,24 @@ class MainActivity : FragmentActivity(), WebViewProvider {
     }
 
     override fun getWebViewOrNull(): WebView? = webRenderer?.webView
+
+    /**
+     * Web delivery arm for device events (NativeElementBridge.WebEventSink).
+     * While an EDGE screen owns the UI its runloop already drains the element
+     * queue, so injecting into the hidden page would deliver the same event
+     * twice — once live and once as a deferred POST replay when the web page
+     * returns. On a webview screen the injection is the only delivery path.
+     * Skips silently when no WebView exists yet (native-first boot).
+     */
+    override fun onNativeEvent(eventName: String, payloadJson: String) {
+        runOnUiThread {
+            if (NativeUIBridge.isActive.value) return@runOnUiThread
+
+            webRenderer?.webView?.let {
+                NativeActionCoordinator.dispatchToWebView(it, eventName, payloadJson)
+            }
+        }
+    }
 
     override fun onRequestPermissionsResult(
         requestCode: Int,

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeElementBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeElementBridge.kt
@@ -41,10 +41,8 @@ import java.util.concurrent.locks.LockSupport
 class NativeElementBridge private constructor() {
 
     /**
-     * Delivery arm for the web surface. MainActivity implements this and
-     * installs itself; it injects the event into the current WebView
-     * page (CustomEvent + Livewire + POST /_native/api/events) whenever
-     * a webview screen — not an EDGE runloop — is the active surface.
+     * Delivery arm for the web surface, implemented by MainActivity.
+     * See sendNativeEvent for why it exists.
      */
     fun interface WebEventSink {
         fun onNativeEvent(eventName: String, payloadJson: String)

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeElementBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeElementBridge.kt
@@ -876,7 +876,9 @@ class NativeElementBridge private constructor() {
 
         /** Held weakly so a destroyed activity is never kept alive. The
          *  implementor must therefore be an object with its own lifecycle
-         *  (the activity), not a lambda owned only by this reference. */
+         *  (the activity), not a lambda owned only by this reference.
+         *  Volatile because plugin threads emit events off the main thread. */
+        @Volatile
         private var webEventSink: java.lang.ref.WeakReference<WebEventSink>? = null
 
         fun installWebEventSink(sink: WebEventSink) {

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeElementBridge.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeElementBridge.kt
@@ -39,6 +39,17 @@ import java.util.concurrent.locks.LockSupport
  * 154: prop_offset       158: prop_size (u16)
  */
 class NativeElementBridge private constructor() {
+
+    /**
+     * Delivery arm for the web surface. MainActivity implements this and
+     * installs itself; it injects the event into the current WebView
+     * page (CustomEvent + Livewire + POST /_native/api/events) whenever
+     * a webview screen — not an EDGE runloop — is the active surface.
+     */
+    fun interface WebEventSink {
+        fun onNativeEvent(eventName: String, payloadJson: String)
+    }
+
     companion object {
         private const val TAG = "NativeElementBridge"
         // Wire-format node stride. Mirrors iOS's `nodeSize` and the
@@ -842,6 +853,12 @@ class NativeElementBridge private constructor() {
          * Inject a native event into the element event queue.
          * This wakes up nativephp_element_wait_event() on the PHP side.
          * Data format: two length-prefixed UTF-8 strings (event name, payload JSON).
+         *
+         * The queue is only drained by an EDGE screen's PHP runloop, so the
+         * event is ALSO offered to the web delivery sink — on a webview
+         * screen nothing else would ever carry it to the page or to PHP.
+         * Internal control signals (`__`-prefixed, e.g. __deeplink) exist
+         * solely to wake the runloop and stay off the web arm.
          */
         fun sendNativeEvent(eventName: String, payloadJson: String) {
             val nameBytes = eventName.toByteArray(Charsets.UTF_8)
@@ -853,6 +870,19 @@ class NativeElementBridge private constructor() {
             buf.putInt(payloadBytes.size)
             buf.put(payloadBytes)
             nativeElementWriteEvent(EventType.NATIVE, 0, 0, buf.array())
+
+            if (!eventName.startsWith("__")) {
+                webEventSink?.get()?.onNativeEvent(eventName, payloadJson)
+            }
+        }
+
+        /** Held weakly so a destroyed activity is never kept alive. The
+         *  implementor must therefore be an object with its own lifecycle
+         *  (the activity), not a lambda owned only by this reference. */
+        private var webEventSink: java.lang.ref.WeakReference<WebEventSink>? = null
+
+        fun installWebEventSink(sink: WebEventSink) {
+            webEventSink = java.lang.ref.WeakReference(sink)
         }
 
         /* ── Tree Diff — reuse unchanged node references ── */

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/utils/NativeActionCoordinator.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/utils/NativeActionCoordinator.kt
@@ -62,29 +62,22 @@ class NativeActionCoordinator : Fragment() {
     }
 
     /**
-     * Route the event through NativeElementBridge.sendNativeEvent — the
-     * single dispatch channel. It feeds the EDGE element queue and hands
-     * the event to the web sink MainActivity installs, so each screen
-     * mode hears it exactly once through its own delivery arm.
+     * Hand the event to the one dispatch channel, which reaches both
+     * surfaces. See NativeElementBridge.sendNativeEvent.
      */
     private fun dispatch(event: String, payloadJson: String) {
         Log.d("NativeActionCoordinator", "📢 Dispatching event: $event")
 
-        try {
-            NativeElementBridge.sendNativeEvent(event, payloadJson)
-        } catch (e: Exception) {
-            Log.d("NativeActionCoordinator", "Event dispatch failed: ${e.message}")
-        }
+        NativeElementBridge.sendNativeEvent(event, payloadJson)
     }
 
 
     companion object {
 
         /**
-         * Deliver a native event to the current web page: a `native-event`
-         * CustomEvent, a Livewire dispatch, and a POST to /_native/api/events
-         * so PHP-side listeners fire. Called by MainActivity's web event
-         * sink; must run on the main thread.
+         * Deliver an event to the current page: a `native-event` CustomEvent,
+         * a Livewire dispatch, and a POST to /_native/api/events so PHP-side
+         * listeners fire. Must run on the main thread.
          */
         fun dispatchToWebView(webView: WebView, event: String, payloadJson: String) {
             val eventForJs = event.replace("\\", "\\\\")

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/utils/NativeActionCoordinator.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/utils/NativeActionCoordinator.kt
@@ -61,9 +61,32 @@ class NativeActionCoordinator : Fragment() {
         }
     }
 
+    /**
+     * Route the event through NativeElementBridge.sendNativeEvent — the
+     * single dispatch channel. It feeds the EDGE element queue and hands
+     * the event to the web sink MainActivity installs, so each screen
+     * mode hears it exactly once through its own delivery arm.
+     */
     private fun dispatch(event: String, payloadJson: String) {
-            Log.d("JSFUNC", "native:$event");
-            Log.d("JSFUNC", "$payloadJson");
+        Log.d("NativeActionCoordinator", "📢 Dispatching event: $event")
+
+        try {
+            NativeElementBridge.sendNativeEvent(event, payloadJson)
+        } catch (e: Exception) {
+            Log.d("NativeActionCoordinator", "Event dispatch failed: ${e.message}")
+        }
+    }
+
+
+    companion object {
+
+        /**
+         * Deliver a native event to the current web page: a `native-event`
+         * CustomEvent, a Livewire dispatch, and a POST to /_native/api/events
+         * so PHP-side listeners fire. Called by MainActivity's web event
+         * sink; must run on the main thread.
+         */
+        fun dispatchToWebView(webView: WebView, event: String, payloadJson: String) {
             val eventForJs = event.replace("\\", "\\\\")
             val js = """
                 (function () {
@@ -99,20 +122,10 @@ class NativeActionCoordinator : Fragment() {
                 })();
             """.trimIndent()
 
-            Log.d("NativeActionCoordinator", "📢 Dispatching JS event: $event")
+            Log.d("NativeActionCoordinator", "📢 Injecting JS event: $event")
 
-            (activity as? WebViewProvider)?.getWebViewOrNull()?.evaluateJavascript(js, null)
-
-            // Also inject into the element event queue for #[OnNative] listeners
-            try {
-                NativeElementBridge.sendNativeEvent(event, payloadJson)
-            } catch (e: Exception) {
-                Log.d("NativeActionCoordinator", "Element event injection skipped (no active region)")
-            }
+            webView.evaluateJavascript(js, null)
         }
-
-
-    companion object {
         fun install(activity: FragmentActivity): NativeActionCoordinator =
             activity.supportFragmentManager.findFragmentByTag("NativeActionCoordinator") as? NativeActionCoordinator
                 ?: NativeActionCoordinator().also {

--- a/resources/xcode/NativePHP/ShakeDetector.swift
+++ b/resources/xcode/NativePHP/ShakeDetector.swift
@@ -5,7 +5,7 @@ import UIKit
 /// UIKit delivers a shake as a motion event up the responder chain; if no
 /// responder consumes it, it reaches the key `UIWindow`. Overriding
 /// `motionEnded` here catches the shake regardless of which view is first
-/// responder, and forwards it to PHP over the native-event channel as
+/// responder, and forwards it to PHP as
 /// `Native\Mobile\Events\Motion\ShakeDetected`.
 ///
 /// On the PHP side, handle it in a NativeComponent:
@@ -13,16 +13,21 @@ import UIKit
 ///     #[On(ShakeDetected::class)]
 ///     public function onShake(): void { ... }
 ///
-/// This rides the same `sendNativeEvent` path as camera/gallery events — no
-/// node, no binary wire-format change.
+/// …or anywhere via `Event::listen(ShakeDetected::class, ...)`.
+///
+/// This rides `LaravelBridge.send` like every other device event, so it
+/// reaches the page and PHP on webview screens (coordinator: JS CustomEvent
+/// + POST) and the element queue on EDGE screens — a raw
+/// `NativeElementBridge.sendNativeEvent` would only feed the queue, which
+/// nothing drains while a webview screen is showing.
 extension UIWindow {
     open override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
         super.motionEnded(motion, with: event)
 
         if motion == .motionShake {
-            NativeElementBridge.sendNativeEvent(
-                eventName: "Native\\Mobile\\Events\\Motion\\ShakeDetected",
-                payloadJson: "{}"
+            LaravelBridge.shared.send?(
+                "Native\\Mobile\\Events\\Motion\\ShakeDetected",
+                [:]
             )
         }
     }

--- a/src/Events/Motion/ShakeDetected.php
+++ b/src/Events/Motion/ShakeDetected.php
@@ -4,6 +4,7 @@ namespace Native\Mobile\Events\Motion;
 
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Native\Mobile\Events\Concerns\BroadcastsGlobally;
 
 /**
  * Device shake detected.
@@ -15,10 +16,15 @@ use Illuminate\Queue\SerializesModels;
  *     #[On(ShakeDetected::class)]
  *     public function onShake(): void { ... }
  *
+ * …or anywhere via `Event::listen(ShakeDetected::class, ...)`. A shake is a
+ * system-level signal with no owning component, so it broadcasts globally —
+ * webview screens already did this through POST /_native/api/events, and
+ * the BroadcastsGlobally tag gives EDGE screens the same reach.
+ *
  * A shake carries no reliable magnitude on iOS, so the payload is minimal —
  * `id` is an optional correlation token if a future emitter wants to set one.
  */
-class ShakeDetected
+class ShakeDetected implements BroadcastsGlobally
 {
     use Dispatchable, SerializesModels;
 

--- a/tests/Unit/Events/Motion/ShakeDetectedTest.php
+++ b/tests/Unit/Events/Motion/ShakeDetectedTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use Native\Mobile\Events\Concerns\BroadcastsGlobally;
+use Native\Mobile\Events\Motion\ShakeDetected;
+
+it('marks ShakeDetected for global dispatch', function () {
+    // A shake has no owning component, and webview screens already reach
+    // app-wide listeners through POST /_native/api/events. The marker gives
+    // Event::listen the same reach on edge screens.
+    expect(is_subclass_of(ShakeDetected::class, BroadcastsGlobally::class))->toBeTrue();
+});

--- a/tests/Unit/System/AppearanceTest.php
+++ b/tests/Unit/System/AppearanceTest.php
@@ -15,6 +15,13 @@ it('marks AppearanceChanged for global dispatch', function () {
     expect(is_subclass_of(AppearanceChanged::class, BroadcastsGlobally::class))->toBeTrue();
 });
 
+it('marks ShakeDetected for global dispatch', function () {
+    // A shake has no owning component, and webview screens already reach
+    // app-wide listeners through POST /_native/api/events — the marker
+    // gives Event::listen the same reach on EDGE screens.
+    expect(is_subclass_of(\Native\Mobile\Events\Motion\ShakeDetected::class, BroadcastsGlobally::class))->toBeTrue();
+});
+
 it('caches appearance and answers isDark/isLight off it', function () {
     System::rememberAppearance('dark');
     $sys = new System;

--- a/tests/Unit/System/AppearanceTest.php
+++ b/tests/Unit/System/AppearanceTest.php
@@ -15,13 +15,6 @@ it('marks AppearanceChanged for global dispatch', function () {
     expect(is_subclass_of(AppearanceChanged::class, BroadcastsGlobally::class))->toBeTrue();
 });
 
-it('marks ShakeDetected for global dispatch', function () {
-    // A shake has no owning component, and webview screens already reach
-    // app-wide listeners through POST /_native/api/events — the marker
-    // gives Event::listen the same reach on EDGE screens.
-    expect(is_subclass_of(\Native\Mobile\Events\Motion\ShakeDetected::class, BroadcastsGlobally::class))->toBeTrue();
-});
-
 it('caches appearance and answers isDark/isLight off it', function () {
     System::rememberAppearance('dark');
     $sys = new System;


### PR DESCRIPTION
Fixes #360.

`AppearanceChanged` and `ShakeDetected` were sent with `NativeElementBridge.sendNativeEvent`, which only feeds the EDGE element queue. Nothing drains that queue on a webview screen, so neither PHP nor the page's JS listener ever heard them. `System::appearance()` froze on its first read for the life of the process, and shakes vanished entirely.

- **Android webview**: appearance stuck at its first value, no `#[On]`, no `Event::listen`, no `native-event` in the page
- **Android EDGE**: both worked, so the bug looked Android-specific when it is about the surface
- **iOS**: appearance worked, shake did not, for a different reason (below)

### The fix

`sendNativeEvent` becomes the one dispatch channel. It writes the element queue as before, then hands the event to an installable `WebEventSink`:

```kotlin
nativeElementWriteEvent(EventType.NATIVE, 0, 0, buf.array())

if (!eventName.startsWith("__")) {
    webEventSink?.get()?.onNativeEvent(eventName, payloadJson)
}
```

`MainActivity` implements the sink and injects into the page through `NativeActionCoordinator.dispatchToWebView` (CustomEvent, Livewire dispatch, POST to `/_native/api/events`). It skips while `NativeUIBridge.isActive`, because an EDGE screen's runloop is already draining the queue and injecting into the page behind it would deliver the same event twice when that page returns.

Fixing the channel rather than the two call sites is deliberate. Every future emitter gets web delivery, and calling the primitive directly can no longer skip the page. `__`-prefixed signals (`__deeplink`) stay queue-only, since they exist purely to wake the runloop and carry no PHP event class.

`NativeActionCoordinator.dispatch` now just calls the channel, so alert and file-picker events stop doing their own separate injection and deliver once instead of twice.

### Two smaller pieces

`ShakeDetected` now implements `BroadcastsGlobally`, like `AppearanceChanged` already did. Webview screens reached `Event::listen` through the POST; EDGE screens only reached `#[On]` handlers. A shake has no owning component, so the marker closes that gap without relying on the page injection.

On iOS, `ShakeDetector` called `NativeElementBridge.sendNativeEvent` directly instead of going through `LaravelBridge.send`, which `ContentView` upgrades to the web-injecting closure once a WebView exists. So iOS shake never reached webview screens either. It now routes like every other device event.

### Verification

Rig with probes on both surfaces, logging one line per delivery arm with the PHP pid, so a process restart can't be mistaken for a fix.

Android webview, appearance flipped with `adb shell cmd uimode night yes` then `no`:

```
read      pid=25538 api=light raw=light
js-event  pid=25538 event=...AppearanceChanged payload={"mode":"dark"}
php-event pid=25538 source=global-listen mode_payload=dark
read      pid=25538 api=dark  raw=dark
js-event  pid=25538 event=...AppearanceChanged payload={"mode":"light"}
php-event pid=25538 source=global-listen mode_payload=light
read      pid=25538 api=light raw=light
```

Same pid throughout, so the API tracked the OS rather than being reseeded by a relaunch. Every shake delivers exactly once per arm, on both platforms:

```
Android  php-events: 1   js-events: 1   (per detection)
iOS      php-events: 1   js-events: 1
```

EDGE screens are unchanged, verified in the hybrid case too (an EDGE screen over a cached WebView): one `#[On]` call, no page injection, no duplicate POST. `__deeplink` still navigates and never reaches the web arm.

Suite is green, 58 passed.

### Merge order with #359

Larry's thermal monitor in #359 calls the same primitive, so it inherits this fix without changes to his branch. #359 merges onto this one with no conflicts (`MainActivity.kt` is the only shared file and it auto-merges), and the combined tree's suite is green including his new thermal tests. Built with both applied, a thermal override now reaches every arm and the cached read follows:

```
js-event  pid=25861 event=...ThermalStateChanged payload={"state":"hot","previous":"normal"}
php-event pid=25861 source=global-listen
read      pid=25861 api=hot
js-event  pid=25861 event=...ThermalStateChanged payload={"state":"critical","previous":"hot"}
read      pid=25861 api=critical
js-event  pid=25861 event=...ThermalStateChanged payload={"state":"normal","previous":"critical"}
read      pid=25861 api=normal
```

Before this fix nothing arrived on a webview screen at all. The enum 500 I reported on #359 is gone since his `48074ed`. Suggested order: this PR first, then #359 on top.
