### PR TITLE
fix(android): serve the embedded app as https://127.0.0.1, not http

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/bridge/LaravelEnvironment.kt
@@ -842,8 +842,10 @@ class LaravelEnvironment(private val context: Context) {
 
             setEnvironmentVariables(
                 // Laravel environment settings
-                "APP_URL" to "http://127.0.0.1",
-                "ASSET_URL" to "http://127.0.0.1/_assets",
+                // https: 127.0.0.1 must be a secure context (#148); fully
+                // intercepted below, so generated URLs never hit real TLS.
+                "APP_URL" to "https://127.0.0.1",
+                "ASSET_URL" to "https://127.0.0.1/_assets",
                 "DB_CONNECTION" to "sqlite",
                 "DB_DATABASE" to "${appStorageDir.absolutePath}/persisted_data/database/database.sqlite",
                 "CACHE_DRIVER" to "file",

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebRenderer.kt
@@ -43,7 +43,7 @@ class WebRenderer(
         WebCookieMirror.markWebViewAvailable()
         val jar = CookieManager.getInstance()
         LaravelCookieStore.all().forEach { (name, value) ->
-            jar.setCookie("http://127.0.0.1", "$name=$value")
+            jar.setCookie("https://127.0.0.1", "$name=$value")
         }
         jar.flush()
 

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebViewManager.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/network/WebViewManager.kt
@@ -248,7 +248,7 @@ class WebViewManager(
                 // Handle relative URLs (convert to php://)
                 if (url.startsWith("/")) {
                     val uri = request.url
-                    val fullUrl = "http://127.0.0.1${uri.encodedPath}" +
+                    val fullUrl = "https://127.0.0.1${uri.encodedPath}" +
                         (uri.encodedQuery?.let { "?$it" } ?: "")
 
                     Log.d(TAG, "🛠️ Rewriting relative URL with query: $fullUrl")
@@ -277,7 +277,7 @@ class WebViewManager(
                 if (url.startsWith("http://") && !url.contains(".") && !url.contains("127.0.0.1") && !url.contains("localhost")) {
                     val host = url.substring("http://".length).substringBefore("/")
                     val path = if (url.contains("/")) "/${url.substringAfter("/")}" else "/"
-                    val correctedUrl = "http://127.0.0.1/$host$path"
+                    val correctedUrl = "https://127.0.0.1/$host$path"
 
                     Log.d(TAG, "🔄 Correcting malformed URL from $url to $correctedUrl")
 

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/security/WebCookieMirror.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/security/WebCookieMirror.kt
@@ -22,7 +22,9 @@ object WebCookieMirror {
 
     fun set(cookieHeaderValue: String) {
         if (!available) return
-        CookieManager.getInstance().setCookie("http://127.0.0.1", cookieHeaderValue)
+        // Must match the WebView's real origin (now https, see #148/#381) or
+        // Secure-flagged cookies silently fail to write (see #334).
+        CookieManager.getInstance().setCookie("https://127.0.0.1", cookieHeaderValue)
     }
 
     fun flush() {

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
@@ -225,7 +225,9 @@ class MainActivity : FragmentActivity(), WebViewProvider {
                         // drive the first request through webView.loadUrl. First
                         // content fires on the page's first commit.
                         val renderer = ensureWebRenderer()
-                        val fullUrl = "http://127.0.0.1$target"
+                        // https, not http: 127.0.0.1 must be a secure context (mobile-air#148) —
+                        // fully intercepted below, so no real TLS handshake is needed.
+                        val fullUrl = "https://127.0.0.1$target"
                         Log.d("DeepLink", "🚀 Loading final URL after WebView setup: $fullUrl")
                         renderer.webView.loadUrl(fullUrl)
                     }
@@ -324,7 +326,7 @@ class MainActivity : FragmentActivity(), WebViewProvider {
                 runOnUiThread {
                     if (!isFinishing && !isDestroyed) {
                         // Fall back to the legacy path rather than wedge on splash.
-                        ensureWebRenderer().webView.loadUrl("http://127.0.0.1$uri")
+                        ensureWebRenderer().webView.loadUrl("https://127.0.0.1$uri")
                     }
                 }
             }
@@ -377,7 +379,7 @@ class MainActivity : FragmentActivity(), WebViewProvider {
         Log.d("NativeBoot", "⇄ EXIT_WEB → $path")
         pendingWebSwap = true
         val renderer = ensureWebRenderer()
-        renderer.webView.loadUrl("http://127.0.0.1$path")
+        renderer.webView.loadUrl("https://127.0.0.1$path")
     }
 
     /**
@@ -429,7 +431,7 @@ class MainActivity : FragmentActivity(), WebViewProvider {
             if (!firstContentReported && !isFinishing && !isDestroyed) {
                 Log.w("MainActivity", "⏰ No content 10s after native boot — falling back to WebView")
                 val target = LaravelEnvironment.getStartURL(this)
-                ensureWebRenderer().webView.loadUrl("http://127.0.0.1$target")
+                ensureWebRenderer().webView.loadUrl("https://127.0.0.1$target")
                 onFirstContent("watchdog")
             }
         }, 10_000L)
@@ -628,7 +630,7 @@ class MainActivity : FragmentActivity(), WebViewProvider {
             Log.d("DeepLink", "🚀 native-ui: dispatching __deeplink event: $route")
             NativeElementBridge.sendNativeEvent("__deeplink", "{\"uri\":\"$escaped\"}")
         } else {
-            val fullUrl = "http://127.0.0.1$route"
+            val fullUrl = "https://127.0.0.1$route"
             Log.d("DeepLink", "🚀 Loading deep link immediately (app already running): $fullUrl")
             ensureWebRenderer().webView.loadUrl(fullUrl)
         }
@@ -1026,7 +1028,7 @@ class MainActivity : FragmentActivity(), WebViewProvider {
                                 web.clearHistory()
                                 web.clearFormData()
 
-                                val currentUrl = web.url ?: "http://127.0.0.1/"
+                                val currentUrl = web.url ?: "https://127.0.0.1/"
                                 val separator = if (currentUrl.contains("?")) "&" else "?"
                                 val cacheBustUrl = "${currentUrl}${separator}_cb=${System.currentTimeMillis()}"
 


### PR DESCRIPTION
Fixes #148 (secure-context break) and the Android side of #381 (password-manager "unprotected site" warning).

## What

Android's WebView loads the embedded app at `http://127.0.0.1`, a genuinely insecure origin. iOS avoids this with a `php://` scheme handler; Android had no equivalent, so anything gated on a secure context (Maps JS SDK, password-manager autofill checks, `isSecureContext`) treats the app as insecure.

Every `127.0.0.1` request is already fully intercepted in `shouldInterceptRequest` and dispatched in-process to the embedded PHP runtime by path alone — no real socket, no TLS handshake. So flipping the scheme to `https` needs no new networking layer (no `WebViewAssetLoader`, no cert, no new dependency) — just consistent URL construction across the existing call sites. 12 lines, 5 files.

Also updates `WebCookieMirror`/`WebRenderer` to mirror cookies against the new `https://127.0.0.1` origin — otherwise `Secure`-flagged cookies silently fail to write (same root cause as #334; that PR's cookie-scheme patch becomes redundant once this lands, cc @inoha-kudo).

## What this doesn't touch

- iOS — already unaffected (untouched here).
- The Jump remote-dev-forward path (`WebViewManager`'s `JumpWebViewSession` branch, `PHPWebViewClient.forwardToRemote`) — left on `http` deliberately, dev-only tooling, out of scope.
- Laravel's own `$request->secure()` (no `HTTPS`/`X-Forwarded-Proto` server var threaded through) — `APP_URL`/`ASSET_URL` cover URL generation, but framework-level secure-request detection may still need a follow-up if anything depends on it.

## Testing

**I have not been able to test this on a device or emulator** — no Android environment available where this was written. The change is a straightforward scheme substitution over an already-fully-intercepted request path, but this needs real-device verification before merge:

- [ ] Cold boot reaches login/home without errors
- [ ] Login/session/CSRF flow works end-to-end (the exact path #334 found breaking)
- [ ] Google Maps SDK / other secure-context-gated API from #148 now works
- [ ] Password manager no longer shows "unprotected website"
- [ ] Jump dev/hot-reload flow still works unaffected

Opening as a draft for that reason — happy to iterate based on device testing from anyone who can run it, or reviewer feedback on the approach itself.
