### PR TITLE
Revert "Decode zip entry names as UTF-8 when extracting the app bundle (#331)"

### DIFF
--- a/resources/xcode/NativePHP/AppUpdateManager.swift
+++ b/resources/xcode/NativePHP/AppUpdateManager.swift
@@ -118,18 +118,7 @@ class AppUpdateManager {
         var fileDataMap: [(path: URL, data: Data)] = []
 
         for entry in archive {
-            // ZIPFoundation 0.9.19's `entry.path` decodes as CP437 unless the EFS bit
-            // is set on the entry — and macOS `zip` often omits that flag even for
-            // UTF-8 names, producing mojibake (⚡️ → ΓÜí∩╕Å). Force UTF-8 decode via
-            // path(using:); fall back to `entry.path` only if the bytes aren't valid
-            // UTF-8 (which shouldn't happen for archives we build).
-            let utf8Path = entry.path(using: .utf8)
-            let rawPath = utf8Path.isEmpty ? entry.path : utf8Path
-
-            // Normalize to NFC: macOS sources may emit NFD filenames; iOS APFS stores
-            // bytes verbatim, but PHP autoloaders look up the NFC form.
-            let normalizedPath = (rawPath as NSString).precomposedStringWithCanonicalMapping
-            let destinationPath = destinationURL.appendingPathComponent(normalizedPath)
+            let destinationPath = destinationURL.appendingPathComponent(entry.path)
 
             switch entry.type {
             case .directory:


### PR DESCRIPTION
Revert unauthorized merge of #331.