### PR TITLE
fix: don't paint the keyboard's helper windows in UI.SetBackground (iOS)

### DIFF
--- a/resources/xcode/NativePHP/Bridge/Functions/UIFunctions.swift
+++ b/resources/xcode/NativePHP/Bridge/Functions/UIFunctions.swift
@@ -49,14 +49,27 @@ enum UIFunctions {
     /// Returns:
     ///   - success: boolean
     class SetBackground: BridgeFunction {
+        /// The scene's windows MINUS UIKit's keyboard helper windows
+        /// (UITextEffectsWindow / UIRemoteKeyboardWindow). Those overlay
+        /// the app window at a higher level and exist from the first time
+        /// a keyboard is shown until the process dies — painting them
+        /// makes the whole screen an opaque sheet of the background color
+        /// while the app keeps rendering (and receiving taps) underneath.
+        private func appWindows(in windowScene: UIWindowScene) -> [UIWindow] {
+            windowScene.windows.filter { window in
+                let className = String(describing: type(of: window))
+                return !className.contains("TextEffects") && !className.contains("RemoteKeyboard")
+            }
+        }
+
         func execute(parameters: [String: Any]) throws -> [String: Any] {
             let colorStr = parameters["color"] as? String ?? ""
             guard !colorStr.isEmpty else {
-                DispatchQueue.main.async {
+                DispatchQueue.main.async { [self] in
                     WindowBackgroundState.shared.color = nil
                     for scene in UIApplication.shared.connectedScenes {
                         guard let windowScene = scene as? UIWindowScene else { continue }
-                        for window in windowScene.windows {
+                        for window in appWindows(in: windowScene) {
                             window.backgroundColor = nil
                         }
                     }
@@ -69,13 +82,14 @@ enum UIFunctions {
                 return ["success": false, "error": "Invalid color"]
             }
 
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [self] in
                 WindowBackgroundState.shared.color = Color(uiColor)
                 // Also paint the UIKit windows so regions SwiftUI never
-                // covers (keyboard underlap, rotation gaps) match.
+                // covers (keyboard underlap, rotation gaps) match — but
+                // never the keyboard helper windows (see appWindows).
                 for scene in UIApplication.shared.connectedScenes {
                     guard let windowScene = scene as? UIWindowScene else { continue }
-                    for window in windowScene.windows {
+                    for window in appWindows(in: windowScene) {
                         window.backgroundColor = uiColor
                     }
                 }


### PR DESCRIPTION
> Replacement for #373, which was accidentally merged and then reverted. Reopened from the original branch at the maintainer’s request.

## What the user sees

1. You type something in the app — anything, once. The keyboard opens.
2. Later you open a screen that uses `UI.SetBackground`.
3. The whole screen becomes one solid color. Every screen after that too. The only way out is to force-close the app.

The app is not actually frozen: it keeps running, and taps still land on the now-invisible buttons. You just can't see anything.

## What is going on

The first time the keyboard opens, iOS secretly adds an extra, invisible window **on top of** the app's window. It belongs to the keyboard (`UITextEffectsWindow`), and it stays there for the whole life of the app — invisible and harmless.

Until we paint it. `UI.SetBackground` paints its color on **every** window of the app:

```swift
for window in windowScene.windows {
    window.backgroundColor = uiColor   // this also paints the keyboard's window!
}
```

Painting the keyboard's window turns it into a solid colored sheet lying on top of the app. It's like spraying paint on a glass pane standing in front of a TV: the TV keeps playing — you just see paint.

## The fix

Only paint the app's own windows, never the keyboard's:

```swift
windowScene.windows.filter { window in
    let className = String(describing: type(of: window))
    return !className.contains("TextEffects") && !className.contains("RemoteKeyboard")
}
```

The same filter is used when setting a color and when clearing it (`null`).

## Why this is critical

Every app that uses `UI.SetBackground` and has a single text field anywhere will hit this, on the most normal flow there is: type, then navigate. To the user it looks like the app died and their game/data is gone.

It is also very hard to debug: the cause (the keyboard opened once, at any point) and the effect (a solid-color screen somewhere else, later) look completely unrelated.

Android is not affected — it only paints the activity's own view. Verified on an iPhone (iOS 18) and the iOS 26 simulator: with this fix the type-then-navigate flow displays normally, and the background color still fills the safe areas and overscroll like before.
