### PR TITLE
fix: scrolling gets stuck on elements with press-* feedback (iOS 18)

### DIFF
--- a/resources/xcode/NativePHP/NativeRender/NodePressFeedbackModifier.swift
+++ b/resources/xcode/NativePHP/NativeRender/NodePressFeedbackModifier.swift
@@ -9,10 +9,16 @@ import SwiftUI
 ///   - `press-opacity`      — opacity while pressed (e.g. 0.7).
 ///   - `press-translate-y`  — Y offset while pressed (points).
 ///
-/// Press detection uses a zero-distance `DragGesture` attached via
-/// `simultaneousGesture` so it composes with the existing tap and
-/// long-press handlers — the visual feedback happens immediately on
-/// press-in, `@tap` still fires on tap, and scrolls aren't blocked.
+/// Press detection uses SwiftUI's button recognizer
+/// (`_onButtonGesture(pressing:)`) — the same one `Button` uses — so a
+/// scroll view treats the element like a button: a pan that starts on it
+/// still scrolls, and the press highlight only engages once the system
+/// decides the touch is a press, not a drag. The previous implementation
+/// (zero-distance `DragGesture` via `simultaneousGesture`) claimed every
+/// touch immediately, which on iOS 18 prevents an enclosing ScrollView
+/// from ever starting its pan — screens whose content is mostly
+/// pressables became near-unscrollable. The tap itself still fires via
+/// the separate `@tap` handler; `perform` here is deliberately empty.
 ///
 /// Multiplies / adds onto the base `NodeAnimationModifier` transforms,
 /// so `<column :scale="1.2" :press-scale="0.95">` shows a base scale
@@ -47,15 +53,9 @@ struct NodePressFeedbackModifier: ViewModifier {
                 .opacity(opacity)
                 .offset(y: ty)
                 .animation(.spring(response: 0.22, dampingFraction: 0.7), value: isPressed)
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 0)
-                        .onChanged { _ in
-                            if !isPressed { isPressed = true }
-                        }
-                        .onEnded { _ in
-                            isPressed = false
-                        }
-                )
+                ._onButtonGesture(pressing: { pressing in
+                    isPressed = pressing
+                }, perform: {})
         )
     }
 }


### PR DESCRIPTION
> Replacement for #374, which was accidentally merged and then reverted. Reopened from the original branch at the maintainer’s request.

## What's wrong
**On iOS 18, a scroll that starts on any element with `press-scale` (or any `press-*` prop) never scrolls.** The press feedback watched for touch contact with a zero-distance `DragGesture` attached via `simultaneousGesture`; on iOS 18 that drag claims the touch before the surrounding ScrollView can begin its pan. On a screen made mostly of pressable cards, the only way to scroll is to aim for the gaps between them.

Minimum repro (fill a screen with these — swipes that start on a card don't scroll):

```blade
<native:scroll-view class="w-full flex-1">
    <native:column class="w-full p-5 gap-3">
        @for ($i = 0; $i < 20; $i++)
            <native:pressable :press-scale="0.97" class="w-full h-[80] rounded-2xl bg-white items-center justify-center">
                <native:text font="semibold" class="font-semibold">Card {{ $i }}</native:text>
            </native:pressable>
        @endfor
    </native:column>
</native:scroll-view>
```

## What this does
- Swaps the drag for `_onButtonGesture(pressing:)` — the recognizer SwiftUI's own `Button` uses. A ScrollView already knows how to share touches with buttons: pans win, taps still land, and the pressed effect engages only once the system resolves the touch as a press.
- `@tap` is untouched (it fires through its own handler). Android is untouched.

No screenshot — the bug is a gesture, not pixels; the repro above shows it in seconds on an iOS 18 device.
