### PR TITLE
fix: Android bottom-bar draws under the system navigation bar

### DIFF
--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootStackRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootStackRenderer.kt
@@ -7,11 +7,17 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.exclude
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
@@ -297,7 +303,34 @@ fun NativeRootStackRenderer(node: NativeUINode, modifier: Modifier = Modifier) {
             // Render the bar's inner content (its first child). Kept in the
             // Scaffold slot so content insets above it and `imePadding` lifts
             // it over the keyboard.
-            bottomBarNode?.children?.firstOrNull()?.let { NodeView(node = it) }
+            //
+            // Unlike M3's NavigationBar, custom slot content handles no
+            // insets of its own — unpadded, the bar draws flush with the
+            // window edge, UNDER the system navigation bar (gesture pill /
+            // 3-button strip). Pad it above the nav-bar inset and bleed the
+            // bar's own background color through the inset so that strip
+            // matches the bar instead of showing the window background —
+            // mirroring iOS's home-indicator bleed
+            // (`StackBottomBarInsetModifier.barContent`). The IME inset is
+            // excluded because the root `imePadding` already lifts the whole
+            // Scaffold above the keyboard — keeping the nav-bar inset while
+            // the keyboard covers that region would float the bar a
+            // nav-bar height too high.
+            bottomBarNode?.children?.firstOrNull()?.let { inner ->
+                val darkBg = if (isSystemInDarkTheme()) inner.props.getColor("dark_bg_color", 0) else 0
+                val barBg = if (darkBg != 0) darkBg else (inner.style?.bgColor ?: 0)
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(
+                            if (barBg != 0) Modifier.background(argbToComposeColor(barBg))
+                            else Modifier
+                        )
+                        .windowInsetsPadding(WindowInsets.navigationBars.exclude(WindowInsets.ime))
+                ) {
+                    NodeView(node = inner)
+                }
+            }
         },
         // With the TopAppBar composed, it consumes the status-bar inset
         // itself. With the bar hidden, Scaffold's default contentWindowInsets


### PR DESCRIPTION
> Replacement for #375, which was accidentally merged and then reverted. Reopened from the original branch at the maintainer’s request.

## What's wrong
On Android, `<native:bottom-bar>` content draws **underneath the system navigation bar** (gesture pill or 3-button strip). Material's own `NavigationBar` pads itself above the system bar, but the stack renderer drops custom bottom-bar content into the Scaffold slot raw — no insets — so it sits flush with the window edge, and the home button lands on top of your buttons.

Minimum repro:

```blade
<native:bottom-bar>
    <native:row class="w-full items-center justify-between px-5 py-3 bg-white">
        <native:column class="w-12 h-12 rounded-full bg-zinc-200 items-center justify-center"><native:text font="bold" class="font-bold">1</native:text></native:column>
        <native:pressable class="px-8 h-[44] rounded-full bg-blue-600 items-center justify-center"><native:text font="semibold" class="font-semibold text-white">Primary</native:text></native:pressable>
        <native:column class="w-12 h-12 rounded-full bg-zinc-200 items-center justify-center"><native:text font="bold" class="font-bold">2</native:text></native:column>
    </native:row>
</native:bottom-bar>
```

## What this does
- Pads the bottom-bar slot with the navigation-bar inset and paints the bar's own background color through the inset — the same "bleed" treatment the iOS renderer gives the home-indicator strip, so the strip matches the bar instead of showing the window background.
- The IME inset is excluded: the root `imePadding` already lifts the bar above the keyboard, so keeping the nav-bar inset there would float it too high.
- The tabs renderer needs no change (its bottom bar already sits inside the Scaffold padding). No iOS or PHP changes.

## Before / after (Android emulator, API 36, 3-button navigation, same Blade)
Before: the bar is flush with the window edge — the home button sits ON the Primary button. After: the bar rides above the nav strip and its background bleeds through it.

<img src="https://raw.githubusercontent.com/SRWieZ/mobile-air/0d05a4774f750a69cf8b106a15ff47b24aa57780/pair-bottombar.png" width="900">
