### PR TITLE
Apply the review nits from #391 and #392

### DIFF
--- a/resources/xcode/NativePHP/AppUpdateManager.swift
+++ b/resources/xcode/NativePHP/AppUpdateManager.swift
@@ -126,8 +126,9 @@ class AppUpdateManager {
             let utf8Path = entry.path(using: .utf8)
             let rawPath = utf8Path.isEmpty ? entry.path : utf8Path
 
-            // Normalize to NFC: macOS sources may emit NFD filenames; iOS APFS stores
-            // bytes verbatim, but PHP autoloaders look up the NFC form.
+            // Retained but inert: appendingPathComponent() re-decomposes the
+            // component, so the name still lands on disk as NFD. Lookups match
+            // anyway — the filesystem compares normalisation-insensitively.
             let normalizedPath = (rawPath as NSString).precomposedStringWithCanonicalMapping
             let destinationPath = destinationURL.appendingPathComponent(normalizedPath)
 

--- a/src/Concerns/WatchesIos.php
+++ b/src/Concerns/WatchesIos.php
@@ -109,9 +109,15 @@ trait WatchesIos
             if ($viteRunning) {
                 $this->info('Vite dev server detected - syncing hot file to simulator');
                 $hotFileDestination = $derivedDataPath.'/Documents/app/public/ios-hot';
-                @mkdir(dirname($hotFileDestination), 0755, true);
-                copy($viteHotFile, $hotFileDestination);
-                $this->triggerIosReload();
+                $hotFileDirectory = dirname($hotFileDestination);
+
+                if (! is_dir($hotFileDirectory) && ! @mkdir($hotFileDirectory, 0755, true) && ! is_dir($hotFileDirectory)) {
+                    $this->warn("Could not create {$hotFileDirectory} - the app will not find the Vite dev server.");
+                } elseif (! @copy($viteHotFile, $hotFileDestination)) {
+                    $this->warn("Could not copy the hot file to {$hotFileDestination} - the app will not find the Vite dev server.");
+                } else {
+                    $this->triggerIosReload();
+                }
             }
 
             $this->startIosWatching($derivedDataPath, $viteHotFile);


### PR DESCRIPTION
Follow-up housekeeping from the review nits on #391 and #392.

- `WatchesIos`: the hot file seed reports a failed mkdir or copy instead of swallowing it, from the nit on #391.
- `AppUpdateManager`: the NFC comment now says the normalisation is retained but inert, which is what the probe in #392 showed.
