### PR TITLE
Split the query string off a native route URI before resolving it

### DIFF
--- a/src/Edge/NativeRouter.php
+++ b/src/Edge/NativeRouter.php
@@ -174,25 +174,60 @@ class NativeRouter
         static::$currentGroupLayout = null;
     }
 
-    public static function resolve(string $uri): ?array
+    /**
+     * Split a navigation URI into its path and its decoded query parameters.
+     *
+     * Route patterns are registered as paths, so anything after `?` has to come
+     * off before matching or `/auth/callback?code=x` misses `/auth/callback`.
+     * `parse_str` is what gives array syntax (`tag[]=a&tag[]=b`, the shape a
+     * Livewire array `#[Url]` prop serialises to) the same meaning it has in a
+     * web request.
+     *
+     * @return array{0: string, 1: array<string, mixed>}
+     */
+    protected static function splitQuery(string $uri): array
     {
         $uri = '/'.ltrim($uri, '/');
 
-        // Match on the path alone. A query string would otherwise be swallowed
-        // by the last route parameter — "/docs/{page}?utm_source=x" matched with
-        // page = "installation?utm_source=x", so a tagged link resolved to a
-        // screen that then found nothing. Tagged links are the common case for
-        // anything shared publicly.
-        $uri = explode('?', $uri, 2)[0];
+        // A fragment addresses somewhere within a document. It is never part of
+        // a route or its parameters, and the hosts pass it through untouched.
+        if (($hash = strpos($uri, '#')) !== false) {
+            $uri = substr($uri, 0, $hash);
+        }
+
+        if (($mark = strpos($uri, '?')) === false) {
+            return [$uri, []];
+        }
+
+        parse_str(substr($uri, $mark + 1), $query);
+
+        // `?a=1` on its own leaves an empty path, and no route is registered
+        // under ''. Root is what a bare query string addresses.
+        $path = substr($uri, 0, $mark);
+
+        return [$path === '' ? '/' : $path, $query];
+    }
+
+    /**
+     * Resolve a navigation URI to the screen registered for it.
+     *
+     * `query` is the URI's query string, parsed. Callers merge it into the
+     * component's navigation data, so a deep link's parameters reach the screen
+     * through `$this->data()` the same way an in-app `navigate()` payload does.
+     */
+    public static function resolve(string $uri): ?array
+    {
+        [$path, $query] = static::splitQuery($uri);
 
         // Exact match first
-        if (isset(static::$routes[$uri])) {
-            $entry = static::$routes[$uri];
+        if (isset(static::$routes[$path])) {
+            $entry = static::$routes[$path];
 
             return [
                 'class' => $entry['class'],
                 'layout' => $entry['layout'] ?? null,
                 'params' => [],
+                'query' => $query,
             ];
         }
 
@@ -201,13 +236,14 @@ class NativeRouter
             $regex = preg_replace('/\{(\w+)\}/', '(?P<$1>[^/]+)', $pattern);
             $regex = '#^'.$regex.'$#';
 
-            if (preg_match($regex, $uri, $matches)) {
+            if (preg_match($regex, $path, $matches)) {
                 $params = array_filter($matches, fn ($key) => is_string($key), ARRAY_FILTER_USE_KEY);
 
                 return [
                     'class' => $entry['class'],
                     'layout' => $entry['layout'] ?? null,
                     'params' => $params,
+                    'query' => $query,
                 ];
             }
         }
@@ -353,6 +389,7 @@ class NativeRouter
                 $component = $this->createComponent(
                     $resolved['class'],
                     $resolved['params'] ?: ($entry['params'] ?? []),
+                    $resolved['query'],
                 );
                 if (! empty($resolved['layout'])) {
                     $component->setLayout($resolved['layout']);
@@ -378,9 +415,13 @@ class NativeRouter
      * Entry point. Init shared memory, run the navigation loop,
      * shutdown when done.
      *
+     * `$data` is the launch screen's navigation data — on a cold deep link the
+     * request's query parameters, so `$this->data()` answers the same on the
+     * first screen as it does on every screen navigated to after it.
+     *
      * @return string|null Exit URI for redirect, or null
      */
-    public function start(string $class, array $params = [], string $uri = ''): ?string
+    public function start(string $class, array $params = [], string $uri = '', array $data = []): ?string
     {
         NativeComponent::registerDumpHandler();
 
@@ -388,7 +429,7 @@ class NativeRouter
 
         try {
             static::debugLog("start: class=$class uri=$uri");
-            $component = $this->createComponent($class, $params);
+            $component = $this->createComponent($class, $params, $data);
 
             // Hydrate layout from the registered route entry so the
             // component knows its chrome before mount() runs.
@@ -494,7 +535,9 @@ class NativeRouter
                     $next = $this->createComponent(
                         $resolved['class'],
                         $resolved['params'],
-                        $intent->data
+                        // An explicit navigate() payload is more specific than
+                        // the URI it travelled on, so it wins a key collision.
+                        array_merge($resolved['query'], $intent->data)
                     );
                     if (! empty($resolved['layout'])) {
                         $next->setLayout($resolved['layout']);
@@ -550,7 +593,7 @@ class NativeRouter
                         $next = $this->createComponent(
                             $resolved['class'],
                             $resolved['params'],
-                            $intent->data
+                            array_merge($resolved['query'], $intent->data)
                         );
                         if (! empty($resolved['layout'])) {
                             $next->setLayout($resolved['layout']);

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -377,7 +377,11 @@ class NativeServiceProvider extends PackageServiceProvider
                     }
                 }
 
-                $exitUri = $router->start($componentClass, $params, $path);
+                // A cold deep link arrives as a real request, so its query
+                // parameters are on it rather than in the URI the router sees
+                // ($path is already stripped). Hand them to the launch screen as
+                // navigation data — the same place a warm deep link puts them.
+                $exitUri = $router->start($componentClass, $params, $path, request()->query->all());
 
                 if ($exitUri !== null) {
                     return redirect($exitUri);

--- a/src/Testing/TestableComponent.php
+++ b/src/Testing/TestableComponent.php
@@ -143,7 +143,7 @@ class TestableComponent
 
     /**
      * Mount the component registered for a native route URI, with the
-     * route's params and layout resolved exactly as navigation would.
+     * route's params, query and layout resolved exactly as navigation would.
      * Requires the app's Route::native() registrations to be loaded.
      */
     public static function visit(string $uri, array $data = [], ?string $platform = null): static
@@ -155,7 +155,9 @@ class TestableComponent
             "No native route registered for [{$uri}]. Register it with Route::native() or test the component class directly."
         );
 
-        return new static($resolved['class'], $resolved['params'], $data, $resolved['layout'], $platform, $uri);
+        // Visiting '/detail?tab=2' must put `tab` where the device puts it.
+        // An explicit $data argument still wins — the test said so directly.
+        return new static($resolved['class'], $resolved['params'], array_merge($resolved['query'], $data), $resolved['layout'], $platform, $uri);
     }
 
     protected function __construct(string $componentClass, array $params, array $data, ?string $layout, ?string $platform = null, ?string $uri = null)
@@ -617,7 +619,7 @@ class TestableComponent
         // re-fire it (NativeRouter::loop does exactly this).
         $this->component->resetNavigationIntent();
 
-        $next = new static($resolved['class'], $resolved['params'], $intent->data, $resolved['layout'], $this->platform, $intent->uri);
+        $next = new static($resolved['class'], $resolved['params'], array_merge($resolved['query'], $intent->data), $resolved['layout'], $this->platform, $intent->uri);
 
         if ($intent->type === NavigationIntent::REPLACE) {
             // Replaced screens leave the stack entirely.

--- a/tests/Feature/DeepLinkQueryTest.php
+++ b/tests/Feature/DeepLinkQueryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Native\Mobile\Edge\NativeRouter;
+use Native\Mobile\Testing\Native;
+use Tests\Fixtures\Edge\CounterScreen;
+use Tests\Fixtures\Edge\DetailScreen;
+
+/*
+ * A deep link arriving while the app is already running is delivered as a
+ * `__deeplink` native event, becomes a NAVIGATE intent, and is resolved by
+ * NativeRouter like any in-app navigation. Everything below the resolver
+ * already preserved the query string; the resolver is where it was lost.
+ *
+ * Reported as #290: an OAuth callback (`myapp://auth/callback?authCode=...`)
+ * reached the screen with no code on it.
+ */
+
+beforeEach(fn () => NativeRouter::clearRoutes());
+afterEach(fn () => NativeRouter::clearRoutes());
+
+it('gives a warm deep link its query parameters as navigation data', function () {
+    Route::native('/detail/{id}', DetailScreen::class);
+
+    Native::test(CounterScreen::class)
+        ->emitNative('__deeplink', ['uri' => '/detail/7?from=deeplink'])
+        ->assertNavigatedTo('/detail/7?from=deeplink')
+        ->followNavigation()
+        ->assertScreen(DetailScreen::class)
+        ->assertSee('Detail 7 from deeplink');
+});
+
+it('lands the OAuth callback shape from the report', function () {
+    Route::native('/auth/callback', DetailScreen::class);
+
+    // `myapp://auth/callback?authCode=example`, normalised by DeepLinkRouter.
+    $screen = Native::test(CounterScreen::class)
+        ->emitNative('__deeplink', ['uri' => '/auth/callback?authCode=example'])
+        ->followNavigation();
+
+    expect($screen->instance()->data('authCode'))->toBe('example');
+});
+
+it('prefers an explicit navigate() payload over the query string', function () {
+    Route::native('/detail/{id}', DetailScreen::class);
+
+    // The URI is where the value came from; the payload is what the caller
+    // asked for. The caller is more specific, so it wins.
+    Native::test(CounterScreen::class)
+        ->call('navigate', '/detail/7?from=query', ['from' => 'payload'])
+        ->followNavigation()
+        ->assertSee('Detail 7 from payload');
+});
+
+it('exposes the query to Native::visit() the way the device does', function () {
+    Route::native('/detail/{id}', DetailScreen::class);
+
+    Native::visit('/detail/9?from=visit')
+        ->assertSee('Detail 9 from visit');
+});
+
+it('restores query data onto a hot-reloaded stack', function () {
+    Route::native('/detail/{id}', DetailScreen::class);
+
+    // preloadStack replays the entries below the top after a PHP reboot. It
+    // reads the same stored URIs, so it needs the query off them too —
+    // otherwise a save while deep-linked drops back a screen with no data.
+    $router = new class extends NativeRouter
+    {
+        public function restored(): array
+        {
+            return $this->stack;
+        }
+    };
+
+    $router->preloadStack([['uri' => '/detail/3?from=restored']]);
+
+    expect($router->stackDepth())->toBe(1);
+
+    $component = $router->restored()[0]['component'];
+
+    expect($component->param('id'))->toBe('3')
+        ->and($component->data('from'))->toBe('restored');
+});

--- a/tests/Unit/Edge/NativeRouterQueryTest.php
+++ b/tests/Unit/Edge/NativeRouterQueryTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use Native\Mobile\Edge\NativeRouter;
+use Tests\Fixtures\Edge\CounterScreen;
+use Tests\Fixtures\Edge\DetailScreen;
+
+/*
+ * Route patterns are registered as paths. Until this split existed, resolve()
+ * matched the whole URI, so `/auth/callback?code=x` missed `/auth/callback` and
+ * a deep link carrying any query string resolved to no screen at all — the app
+ * either exited to the web or, on a warm link, went nowhere.
+ *
+ * The parsed query rides back on the resolution so callers can hand it to the
+ * screen as navigation data.
+ */
+
+beforeEach(fn () => NativeRouter::clearRoutes());
+afterEach(fn () => NativeRouter::clearRoutes());
+
+it('matches an exact route when the URI carries a query string', function () {
+    NativeRouter::register('/auth/callback', CounterScreen::class);
+
+    $resolved = NativeRouter::resolve('/auth/callback?authCode=example');
+
+    expect($resolved)->not->toBeNull()
+        ->and($resolved['class'])->toBe(CounterScreen::class)
+        ->and($resolved['query'])->toBe(['authCode' => 'example']);
+});
+
+it('matches a pattern route and keeps route params and query apart', function () {
+    NativeRouter::register('/detail/{id}', DetailScreen::class);
+
+    $resolved = NativeRouter::resolve('/detail/7?from=deeplink');
+
+    // A query parameter must not be able to pose as a route segment: `param()`
+    // and `data()` answer different questions and the URI says which is which.
+    expect($resolved['params'])->toBe(['id' => '7'])
+        ->and($resolved['query'])->toBe(['from' => 'deeplink']);
+});
+
+it('returns the query parsed rather than as a raw string', function () {
+    NativeRouter::register('/search', CounterScreen::class);
+
+    expect(NativeRouter::resolve('/search?q=laravel&page=2')['query'])
+        ->toBe(['q' => 'laravel', 'page' => '2']);
+});
+
+it('keeps repeated and bracketed parameters as arrays', function () {
+    NativeRouter::register('/filter', CounterScreen::class);
+
+    // The shape a Livewire array #[Url] prop serialises to. #143 and #327 both
+    // exist because this collapsed to a single value somewhere down the stack.
+    expect(NativeRouter::resolve('/filter?tag[]=alpha&tag[]=beta')['query'])
+        ->toBe(['tag' => ['alpha', 'beta']]);
+});
+
+it('decodes a percent-encoded value exactly once', function () {
+    NativeRouter::register('/auth/callback', CounterScreen::class);
+
+    // `%252F` is an encoded `%2F`. Decoding twice would hand the app a `/` and
+    // silently corrupt any token that contains one.
+    expect(NativeRouter::resolve('/auth/callback?code=a%20b%252Fc')['query'])
+        ->toBe(['code' => 'a b%2Fc']);
+});
+
+it('reports an empty query when the URI has none', function () {
+    NativeRouter::register('/auth/callback', CounterScreen::class);
+
+    expect(NativeRouter::resolve('/auth/callback')['query'])->toBe([]);
+});
+
+it('ignores a fragment, on its own or after a query', function () {
+    NativeRouter::register('/auth/callback', CounterScreen::class);
+
+    expect(NativeRouter::resolve('/auth/callback#section')['query'])->toBe([])
+        ->and(NativeRouter::resolve('/auth/callback#section'))->not->toBeNull()
+        ->and(NativeRouter::resolve('/auth/callback?code=x#section')['query'])->toBe(['code' => 'x']);
+});
+
+it('treats a bare query string as addressing the root route', function () {
+    NativeRouter::register('/', CounterScreen::class);
+
+    $resolved = NativeRouter::resolve('?ref=email');
+
+    expect($resolved)->not->toBeNull()
+        ->and($resolved['class'])->toBe(CounterScreen::class)
+        ->and($resolved['query'])->toBe(['ref' => 'email']);
+});
+
+it('answers isNativeRoute for a URI with a query string', function () {
+    NativeRouter::register('/auth/callback', CounterScreen::class);
+
+    // BootPlanner asks this to decide the boot mode. Answering false here is
+    // what sent a deep-linked launch to the WebView instead of the screen.
+    expect(NativeRouter::isNativeRoute('/auth/callback?authCode=example'))->toBeTrue();
+});
+
+it('still resolves nothing for a path that is not registered', function () {
+    NativeRouter::register('/auth/callback', CounterScreen::class);
+
+    // The query must not become a way to match a route that does not exist.
+    expect(NativeRouter::resolve('/auth/other?authCode=example'))->toBeNull();
+});


### PR DESCRIPTION
NativeRouter::resolve() matched the whole URI against patterns registered as paths, so a deep link with a query string could not find its screen. The parsed query now reaches the screen as `$this->data()`.

Fixes #290.