### PR TITLE
Let apps scope which paths open on Android app links

### DIFF
--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -88,10 +88,10 @@ return [
     |
     */
 
-    'deeplink_paths' => array_values(array_filter(array_map(
-        'trim',
-        explode(',', (string) env('NATIVEPHP_DEEPLINK_PATHS', ''))
-    ))),
+    'deeplink_paths' => array_values(array_filter(
+        array_map('trim', explode(',', (string) env('NATIVEPHP_DEEPLINK_PATHS', ''))),
+        fn ($path) => $path !== '',
+    )),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/nativephp.php
+++ b/config/nativephp.php
@@ -69,6 +69,32 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Deeplink Paths
+    |--------------------------------------------------------------------------
+    |
+    | Restrict which paths on the deeplink host open your app. By default the
+    | app claims the WHOLE domain, so every link to it — marketing pages, blog
+    | posts, anything you never routed — is taken away from the browser and
+    | dead-ends inside the app.
+    |
+    | List the path prefixes your app actually handles to claim only those:
+    |
+    |     'deeplink_paths' => ['/docs/', '/orders/'],
+    |
+    | On iOS this is already handled server-side by the `components` block of
+    | your apple-app-site-association file, so these values are Android-only:
+    | Android's assetlinks.json has no path component, which means the scoping
+    | has to live in the manifest instead. Keep the two lists in sync.
+    |
+    */
+
+    'deeplink_paths' => array_values(array_filter(array_map(
+        'trim',
+        explode(',', (string) env('NATIVEPHP_DEEPLINK_PATHS', ''))
+    ))),
+
+    /*
+    |--------------------------------------------------------------------------
     | Start URL
     |--------------------------------------------------------------------------
     |

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/MainActivity.kt
@@ -622,11 +622,18 @@ class MainActivity : FragmentActivity(), WebViewProvider {
      * and NativeRouter pushes the screen (same path as an in-app @tap navigate).
      * WebView/Inertia apps keep the direct loadUrl().
      */
-    private fun navigateWarm(route: String) {
+    private fun navigateWarm(route: String, externalUrl: String? = null) {
         if (NativeUIBridge.isActive.value) {
             val escaped = route.replace("\\", "\\\\").replace("\"", "\\\"")
+            // Carry the original https URL too. If PHP finds no route for the
+            // path it hands this straight back to the browser rather than
+            // dropping the user on a local 404.
+            val url = externalUrl
+                ?.replace("\\", "\\\\")?.replace("\"", "\\\"")
+                ?.let { ",\"url\":\"$it\"" }
+                ?: ""
             Log.d("DeepLink", "🚀 native-ui: dispatching __deeplink event: $route")
-            NativeElementBridge.sendNativeEvent("__deeplink", "{\"uri\":\"$escaped\"}")
+            NativeElementBridge.sendNativeEvent("__deeplink", "{\"uri\":\"$escaped\"$url}")
         } else {
             val fullUrl = "http://127.0.0.1$route"
             Log.d("DeepLink", "🚀 Loading deep link immediately (app already running): $fullUrl")
@@ -713,11 +720,15 @@ class MainActivity : FragmentActivity(), WebViewProvider {
             }
         }
 
+        // Only a real web URL can be handed back to the browser; a custom-scheme
+        // link (jump://…) has nowhere else to go.
+        val externalUrl = if (uri.scheme == "https" || uri.scheme == "http") uri.toString() else null
+
         Log.d("DeepLink", "📦 Saving deep link for later: $laravelUrl")
         pendingDeepLink = laravelUrl
         if (::laravelEnv.isInitialized && bootReady) {
             // Only navigate immediately once the boot pipeline is ready
-            navigateWarm(laravelUrl)
+            navigateWarm(laravelUrl, externalUrl)
         } else {
             Log.d("DeepLink", "⏳ Deep link saved, waiting for app initialization to complete")
         }

--- a/resources/xcode/NativePHP/DeepLinkRouter.swift
+++ b/resources/xcode/NativePHP/DeepLinkRouter.swift
@@ -161,7 +161,11 @@ final class DeepLinkRouter {
                 // the target route; NativeComponent::dispatchNativeEvent turns
                 // it into a NavigationIntent::NAVIGATE and NativeRouter pushes
                 // the screen — the same path an in-app @tap navigate uses.
-                dispatchNativeUIDeepLink(normalizedRoute)
+                // Hand the original https URL along; PHP gives it back to
+                // Safari when the app has no route for the path, instead of
+                // exiting to the WebView and serving a local 404.
+                let externalURL = (url.scheme == "https" || url.scheme == "http") ? url.absoluteString : nil
+                dispatchNativeUIDeepLink(normalizedRoute, externalURL: externalURL)
             } else {
                 // Inertia/WebView SPA: use the SPA router to preserve state.
                 // This prevents Inertia from returning raw JSON on subsequent
@@ -178,11 +182,18 @@ final class DeepLinkRouter {
 
     /// Wake the blocked native-ui PHP loop with the deep-link route (the
     /// same path an in-app @tap navigate uses).
-    private func dispatchNativeUIDeepLink(_ route: String) {
+    private func dispatchNativeUIDeepLink(_ route: String, externalURL: String? = nil) {
         let escaped = route
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
-        let json = "{\"uri\":\"\(escaped)\"}"
+        var urlField = ""
+        if let externalURL {
+            let escapedURL = externalURL
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+            urlField = ",\"url\":\"\(escapedURL)\""
+        }
+        let json = "{\"uri\":\"\(escaped)\"\(urlField)}"
         DebugLogger.shared.log("🔗 native-ui: dispatching __deeplink event: \(route)")
         NativeElementBridge.sendNativeEvent(eventName: "__deeplink", payloadJson: json)
     }

--- a/src/Concerns/RunsAndroid.php
+++ b/src/Concerns/RunsAndroid.php
@@ -293,6 +293,13 @@ trait RunsAndroid
         );
 
         // Build the filters based on what's configured
+        // A published config may hand us a bare string ('/docs/') rather than a
+        // list. Take it as a single path — failing open to the whole domain is
+        // the one outcome a scoping setting must never produce.
+        if (is_string($paths)) {
+            $paths = $paths === '' ? [] : [$paths];
+        }
+
         $filters = $this->generateDeepLinkFilters($scheme, $host, is_array($paths) ? $paths : []);
 
         if ($filters) {
@@ -348,7 +355,13 @@ trait RunsAndroid
             // host only misbehaves on Android.
             $data = $this->deepLinkPathData($host, $paths);
 
-            $filters[] = <<<XML
+            // Every configured path was unusable. Claiming the whole domain here
+            // is the exact failure this setting exists to prevent, so claim
+            // nothing instead and say why.
+            if ($data === null) {
+                $this->warn("Ignoring deeplink_host \"{$host}\": every configured deeplink_paths entry was invalid. Use comma-separated paths, e.g. NATIVEPHP_DEEPLINK_PATHS=\"/docs/,/orders/\".");
+            } else {
+                $filters[] = <<<XML
             <!-- App Links (HTTPS) -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
@@ -357,6 +370,7 @@ trait RunsAndroid
 {$data}
             </intent-filter>
 XML;
+            }
         }
 
         // Deep Links: Custom scheme (no host restriction to match iOS behavior)
@@ -383,14 +397,19 @@ XML;
     /**
      * Build the <data> path elements for the App Links filter.
      *
-     * A prefix ending in `/` claims that whole subtree; anything else is
-     * treated as an exact path so `/orders` doesn't also swallow `/orders-faq`.
-     * No prefixes configured means the whole domain, which is what apps got
-     * before this was configurable.
+     * A value ending in `/` becomes a `pathPrefix` claiming everything beneath
+     * it — note that `/docs/` claims `/docs/x` but NOT `/docs` itself, since
+     * Android matches the prefix literally. Anything else becomes an exact
+     * `path`, so `/orders` doesn't also swallow `/orders-faq`.
+     *
+     * Returns the whole-domain claim when nothing is configured (what apps got
+     * before this was configurable), or null when paths were configured but
+     * none survived validation — the caller must not fall back to the whole
+     * domain in that case.
      *
      * @param  list<string>  $paths
      */
-    private function deepLinkPathData(string $host, array $paths): string
+    private function deepLinkPathData(string $host, array $paths): ?string
     {
         $prefixes = [];
 
@@ -405,7 +424,9 @@ XML;
 
             // Reject anything that can't sit in an XML attribute unescaped, or
             // that would quietly widen the claim back out to the whole domain.
-            if ($path === '/' || preg_match('/[\s"\'<>&]/', $path)) {
+            // /u so a non-breaking space is caught as whitespace rather than
+            // sailing through into a prefix that can never match.
+            if ($path === '/' || preg_match('/[\s"\'<>&]/u', $path)) {
                 continue;
             }
 
@@ -415,7 +436,10 @@ XML;
         $prefix = '                <data android:scheme="https" android:host="'.$host.'" ';
 
         if ($prefixes === []) {
-            return $prefix.'android:pathPrefix="/" />';
+            // Nothing configured: whole domain, as before. Something configured
+            // but all of it rejected: refuse, so a typo can't hand the app the
+            // whole domain by accident.
+            return $paths === [] ? $prefix.'android:pathPrefix="/" />' : null;
         }
 
         $lines = [];

--- a/src/Concerns/RunsAndroid.php
+++ b/src/Concerns/RunsAndroid.php
@@ -267,6 +267,7 @@ trait RunsAndroid
     {
         $scheme = config('nativephp.deeplink_scheme');
         $host = config('nativephp.deeplink_host');
+        $paths = config('nativephp.deeplink_paths', []);
 
         // Both are opt-in: only add filters if configured
         if (! $scheme && ! $host) {
@@ -292,7 +293,7 @@ trait RunsAndroid
         );
 
         // Build the filters based on what's configured
-        $filters = $this->generateDeepLinkFilters($scheme, $host);
+        $filters = $this->generateDeepLinkFilters($scheme, $host, is_array($paths) ? $paths : []);
 
         if ($filters) {
             // Inject filters into MainActivity
@@ -329,19 +330,31 @@ trait RunsAndroid
         }
     }
 
-    private function generateDeepLinkFilters(?string $scheme, ?string $host): string
+    /**
+     * @param  list<string>  $paths  Path prefixes to claim on the host. Empty
+     *                               claims the whole domain (the default).
+     */
+    private function generateDeepLinkFilters(?string $scheme, ?string $host, array $paths = []): string
     {
         $filters = [];
 
         // App Links: HTTPS with configurable host (for universal links / verified links)
         if ($host) {
+            // One <data> per claimed prefix. Android's assetlinks.json grants the
+            // app the whole domain (it has no path component), so unless the app
+            // narrows it here every link to the host is pulled out of the browser
+            // and into an app that has no route for it. iOS scopes this in the
+            // apple-app-site-association file instead, which is why an unscoped
+            // host only misbehaves on Android.
+            $data = $this->deepLinkPathData($host, $paths);
+
             $filters[] = <<<XML
             <!-- App Links (HTTPS) -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" android:host="{$host}" android:pathPrefix="/" />
+{$data}
             </intent-filter>
 XML;
         }
@@ -365,6 +378,54 @@ XML;
         }
 
         return "            <!-- NATIVEPHP-DEEPLINKS-START -->\n".implode("\n", $filters)."\n            <!-- NATIVEPHP-DEEPLINKS-END -->";
+    }
+
+    /**
+     * Build the <data> path elements for the App Links filter.
+     *
+     * A prefix ending in `/` claims that whole subtree; anything else is
+     * treated as an exact path so `/orders` doesn't also swallow `/orders-faq`.
+     * No prefixes configured means the whole domain, which is what apps got
+     * before this was configurable.
+     *
+     * @param  list<string>  $paths
+     */
+    private function deepLinkPathData(string $host, array $paths): string
+    {
+        $prefixes = [];
+
+        foreach ($paths as $path) {
+            $path = trim((string) $path);
+
+            if ($path === '') {
+                continue;
+            }
+
+            $path = '/'.ltrim($path, '/');
+
+            // Reject anything that can't sit in an XML attribute unescaped, or
+            // that would quietly widen the claim back out to the whole domain.
+            if ($path === '/' || preg_match('/[\s"\'<>&]/', $path)) {
+                continue;
+            }
+
+            $prefixes[$path] = true;
+        }
+
+        $prefix = '                <data android:scheme="https" android:host="'.$host.'" ';
+
+        if ($prefixes === []) {
+            return $prefix.'android:pathPrefix="/" />';
+        }
+
+        $lines = [];
+
+        foreach (array_keys($prefixes) as $path) {
+            $attribute = str_ends_with($path, '/') ? 'pathPrefix' : 'path';
+            $lines[] = $prefix.'android:'.$attribute.'="'.$path.'" />';
+        }
+
+        return implode("\n", $lines);
     }
 
     private function updateIcuConfiguration(): void

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -1748,15 +1748,18 @@ abstract class NativeComponent
             return true;
         }
 
-        try {
-            app('router')->getRoutes()->match(Request::create($uri, 'GET'));
+        // Deliberately not RouteCollection::match() — that binds the request to
+        // the matched Route object the collection holds, mutating shared state
+        // from what is only meant to be a question.
+        $request = Request::create($uri, 'GET');
 
-            return true;
-        } catch (\Throwable) {
-            // No matching route (or the router couldn't tell us) — treat the
-            // link as unhandled rather than risk stranding the user on a 404.
-            return false;
+        foreach (app('router')->getRoutes()->getRoutes() as $route) {
+            if (in_array('GET', $route->methods(), true) && $route->matches($request)) {
+                return true;
+            }
         }
+
+        return false;
     }
 
     /**
@@ -1783,11 +1786,17 @@ abstract class NativeComponent
                 // serves a local 404 — a dead end the user can't back out of. The
                 // link belongs to the site we took it from, so give it back to the
                 // browser and leave the current screen alone.
+                // open() is a no-op when the app doesn't ship a browser handler,
+                // so only swallow the link if it was actually handed off —
+                // otherwise fall through and behave exactly as before.
                 if (is_string($url) && $url !== '' && ! static::routableDeepLink($uri)) {
                     NativeRouter::debugLog("DEEPLINK: no route for $uri — opening $url in the browser");
-                    (new Browser)->open($url);
 
-                    return;
+                    if ((new Browser)->open($url)) {
+                        return;
+                    }
+
+                    NativeRouter::debugLog('DEEPLINK: browser handoff unavailable, navigating anyway');
                 }
 
                 NativeRouter::debugLog("DEEPLINK: navigating to $uri");

--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -2,6 +2,7 @@
 
 namespace Native\Mobile\Edge;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Str;
 use Illuminate\View\Engines\CompilerEngine;
@@ -13,6 +14,7 @@ use Native\Mobile\Attributes\Locked;
 use Native\Mobile\Attributes\On;
 use Native\Mobile\Attributes\OnNative;
 use Native\Mobile\Attributes\Poll;
+use Native\Mobile\Browser;
 use Native\Mobile\Edge\Elements\ActivityIndicator;
 use Native\Mobile\Edge\Elements\BottomBar;
 use Native\Mobile\Edge\Elements\Column;
@@ -1733,6 +1735,31 @@ abstract class NativeComponent
     }
 
     /**
+     * Can this app render the target of a deep link?
+     *
+     * True for a Route::native screen, and also for a plain Laravel route —
+     * those legitimately exit to the WebView and render there, which is how
+     * WebView and hybrid apps have always handled deep links. Only a URI that
+     * matches neither is a guaranteed 404.
+     */
+    protected static function routableDeepLink(string $uri): bool
+    {
+        if (NativeRouter::isNativeRoute($uri)) {
+            return true;
+        }
+
+        try {
+            app('router')->getRoutes()->match(Request::create($uri, 'GET'));
+
+            return true;
+        } catch (\Throwable) {
+            // No matching route (or the router couldn't tell us) — treat the
+            // link as unhandled rather than risk stranding the user on a 404.
+            return false;
+        }
+    }
+
+    /**
      * Handle a native event (type 20) by looking up #[OnNative] listeners.
      */
     protected function dispatchNativeEvent(array $event): void
@@ -1748,7 +1775,21 @@ abstract class NativeComponent
         // an in-app @tap navigate.
         if ($eventName === '__deeplink') {
             $uri = is_array($payload) ? ($payload['uri'] ?? null) : null;
+            $url = is_array($payload) ? ($payload['url'] ?? null) : null;
+
             if (is_string($uri) && $uri !== '') {
+                // A verified app link the app has no route for. Navigating would
+                // tear the native UI down and hand the path to the WebView, which
+                // serves a local 404 — a dead end the user can't back out of. The
+                // link belongs to the site we took it from, so give it back to the
+                // browser and leave the current screen alone.
+                if (is_string($url) && $url !== '' && ! static::routableDeepLink($uri)) {
+                    NativeRouter::debugLog("DEEPLINK: no route for $uri — opening $url in the browser");
+                    (new Browser)->open($url);
+
+                    return;
+                }
+
                 NativeRouter::debugLog("DEEPLINK: navigating to $uri");
                 $this->nativeNavigationIntent = new NavigationIntent(NavigationIntent::NAVIGATE, $uri);
                 $this->stop();

--- a/src/Edge/NativeRouter.php
+++ b/src/Edge/NativeRouter.php
@@ -178,6 +178,13 @@ class NativeRouter
     {
         $uri = '/'.ltrim($uri, '/');
 
+        // Match on the path alone. A query string would otherwise be swallowed
+        // by the last route parameter — "/docs/{page}?utm_source=x" matched with
+        // page = "installation?utm_source=x", so a tagged link resolved to a
+        // screen that then found nothing. Tagged links are the common case for
+        // anything shared publicly.
+        $uri = explode('?', $uri, 2)[0];
+
         // Exact match first
         if (isset(static::$routes[$uri])) {
             $entry = static::$routes[$uri];

--- a/tests/Feature/DeepLinkFallbackTest.php
+++ b/tests/Feature/DeepLinkFallbackTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Native\Mobile\Edge\NativeRouter;
+use Tests\Fixtures\Edge\CounterScreen;
+
+beforeEach(fn () => NativeRouter::clearRoutes());
+afterEach(fn () => NativeRouter::clearRoutes());
+
+/** Reach the protected helper the __deeplink handler gates on. */
+function routable(string $uri): bool
+{
+    return (fn () => static::routableDeepLink($uri))->call(new CounterScreen);
+}
+
+it('treats a native route as routable', function () {
+    Route::native('/docs/{section}/{page}', CounterScreen::class);
+
+    expect(routable('/docs/getting-started/installation'))->toBeTrue();
+});
+
+it('treats a plain Laravel route as routable', function () {
+    // WebView and hybrid apps deep link to these; they render in the WebView.
+    Route::get('/receipts/{id}', fn () => 'ok');
+
+    expect(routable('/receipts/42'))->toBeTrue();
+});
+
+it('does not treat an unrouted path as routable', function () {
+    Route::native('/docs/{section}/{page}', CounterScreen::class);
+
+    // The reported bug: a marketing page on the claimed domain, and a real docs
+    // URL one segment deeper than the route that claims it. Both used to exit to
+    // the WebView and serve a local 404.
+    expect(routable('/blog'))->toBeFalse()
+        ->and(routable('/docs/plugins/core/camera'))->toBeFalse();
+});
+
+it('respects an app-registered fallback route', function () {
+    Route::fallback(fn () => 'caught');
+
+    expect(routable('/anything-at-all'))->toBeTrue();
+});

--- a/tests/Feature/DeepLinkFallbackTest.php
+++ b/tests/Feature/DeepLinkFallbackTest.php
@@ -41,3 +41,27 @@ it('respects an app-registered fallback route', function () {
 
     expect(routable('/anything-at-all'))->toBeTrue();
 });
+
+it('ignores a query string when deciding routability', function () {
+    Route::native('/docs/{section}/{page}', CounterScreen::class);
+
+    // Shared links carry utm tags. The query used to be swallowed by {page},
+    // so the link "resolved" to a screen that then found nothing.
+    expect(routable('/docs/getting-started/installation?utm_source=twitter'))->toBeTrue();
+});
+
+it('does not leak a query string into route params', function () {
+    Route::native('/docs/{section}/{page}', CounterScreen::class);
+
+    expect(NativeRouter::resolve('/docs/getting-started/installation?utm_source=twitter')['params'])
+        ->toBe(['section' => 'getting-started', 'page' => 'installation']);
+});
+
+it('does not bind the shared route object while probing', function () {
+    Route::get('/docs/{page}', fn () => 'ok')->name('probe.docs');
+
+    routable('/docs/probe');
+
+    // A read-only question must not leave the collection's Route mutated.
+    expect(app('router')->getRoutes()->getByName('probe.docs')->parameters ?? null)->toBeNull();
+});

--- a/tests/Unit/Concerns/RunsAndroidTest.php
+++ b/tests/Unit/Concerns/RunsAndroidTest.php
@@ -300,6 +300,50 @@ class RunsAndroidTest extends TestCase
         );
     }
 
+    public function test_deep_link_configuration_claims_nothing_when_every_path_is_invalid()
+    {
+        config(['nativephp.deeplink_host' => 'app.example.com']);
+        // Space-separated instead of comma-separated: a plausible typo that used
+        // to hand the app the whole domain — the exact failure scoping prevents.
+        config(['nativephp.deeplink_paths' => ['/docs/ /orders/']]);
+
+        $manifestPath = $this->writeBareManifest();
+
+        $this->updateDeepLinkConfiguration();
+
+        $manifestContents = File::get($manifestPath);
+
+        $this->assertStringNotContainsString('android:pathPrefix="/" />', $manifestContents);
+        $this->assertStringNotContainsString('android:scheme="https"', $manifestContents);
+    }
+
+    public function test_deep_link_paths_accept_a_bare_string()
+    {
+        config(['nativephp.deeplink_host' => 'app.example.com']);
+        config(['nativephp.deeplink_paths' => '/docs/']);
+
+        $manifestPath = $this->writeBareManifest();
+
+        $this->updateDeepLinkConfiguration();
+
+        $manifestContents = File::get($manifestPath);
+
+        $this->assertStringContainsString('android:pathPrefix="/docs/" />', $manifestContents);
+        $this->assertStringNotContainsString('android:pathPrefix="/" />', $manifestContents);
+    }
+
+    public function test_deep_link_path_data_refuses_rather_than_widening()
+    {
+        // Nothing configured — whole domain, exactly as before.
+        $this->assertSame(
+            '                <data android:scheme="https" android:host="app.example.com" android:pathPrefix="/" />',
+            $this->deepLinkPathData('app.example.com', [])
+        );
+
+        // Configured but unusable (a non-breaking space is still whitespace).
+        $this->assertNull($this->deepLinkPathData('app.example.com', ["/docs\u{00a0}x/", '/']));
+    }
+
     private function writeBareManifest(): string
     {
         $manifestPath = $this->testProjectPath.'/nativephp/android/app/src/main/AndroidManifest.xml';

--- a/tests/Unit/Concerns/RunsAndroidTest.php
+++ b/tests/Unit/Concerns/RunsAndroidTest.php
@@ -242,6 +242,82 @@ class RunsAndroidTest extends TestCase
         $this->assertStringContainsString('android:host="app.example.com"', $manifestContents);
     }
 
+    public function test_deep_link_configuration_claims_whole_host_when_no_paths_configured()
+    {
+        config(['nativephp.deeplink_host' => 'app.example.com']);
+        config(['nativephp.deeplink_paths' => []]);
+
+        $manifestPath = $this->writeBareManifest();
+
+        $this->updateDeepLinkConfiguration();
+
+        $this->assertStringContainsString(
+            '<data android:scheme="https" android:host="app.example.com" android:pathPrefix="/" />',
+            File::get($manifestPath)
+        );
+    }
+
+    public function test_deep_link_configuration_claims_only_configured_paths()
+    {
+        config(['nativephp.deeplink_host' => 'app.example.com']);
+        config(['nativephp.deeplink_paths' => ['/docs/', 'orders/']]);
+
+        $manifestPath = $this->writeBareManifest();
+
+        $this->updateDeepLinkConfiguration();
+
+        $manifestContents = File::get($manifestPath);
+
+        $this->assertStringContainsString(
+            '<data android:scheme="https" android:host="app.example.com" android:pathPrefix="/docs/" />',
+            $manifestContents
+        );
+        // Leading slash is optional in config.
+        $this->assertStringContainsString(
+            '<data android:scheme="https" android:host="app.example.com" android:pathPrefix="/orders/" />',
+            $manifestContents
+        );
+        // The whole-domain claim is what pulled unrouted links out of the browser.
+        $this->assertStringNotContainsString('android:pathPrefix="/" />', $manifestContents);
+    }
+
+    public function test_deep_link_path_without_trailing_slash_is_an_exact_match()
+    {
+        // `/orders` must not also swallow `/orders-faq`.
+        $this->assertSame(
+            '                <data android:scheme="https" android:host="app.example.com" android:path="/orders" />',
+            $this->deepLinkPathData('app.example.com', ['/orders'])
+        );
+    }
+
+    public function test_deep_link_paths_ignore_unusable_values()
+    {
+        // A bare "/" or an unescapable character would silently widen the claim
+        // back out to the whole domain, or break the manifest XML.
+        $this->assertSame(
+            '                <data android:scheme="https" android:host="app.example.com" android:pathPrefix="/docs/" />',
+            $this->deepLinkPathData('app.example.com', ['', '  ', '/', '/bad path/', '/qu"ote/', '/docs/', 'docs/'])
+        );
+    }
+
+    private function writeBareManifest(): string
+    {
+        $manifestPath = $this->testProjectPath.'/nativephp/android/app/src/main/AndroidManifest.xml';
+
+        if (! File::isDirectory(dirname($manifestPath))) {
+            File::makeDirectory(dirname($manifestPath), 0755, true);
+        }
+
+        File::put($manifestPath, '<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity android:name=".ui.MainActivity">
+        </activity>
+    </application>
+</manifest>');
+
+        return $manifestPath;
+    }
+
     /**
      * Helper methods
      */


### PR DESCRIPTION
Android users on Jump reported that any link to nativephp.com opened the app and dead-ended on a 404 instead of going to the site. Setting `deeplink_host` generates an intent filter with `pathPrefix="/"`, so once assetlinks.json verifies the app it owns every URL on that domain — including all the pages the app never routed. iOS does not have this problem because the AASA file scopes paths server-side, and Android has no equivalent since assetlinks.json has no path component.

This adds a `deeplink_paths` config so an app can list the prefixes it actually handles and claim only those. Leaving it empty keeps the current whole-domain behaviour, so nothing changes for existing apps until they opt in. I also made an unroutable deep link open the original URL in the browser rather than tearing down the native UI and serving a local 404 — that only kicks in when the path matches neither a `Route::native` screen nor a plain Laravel route, so WebView and hybrid apps keep working the way they do now.

One gap worth knowing about: this covers links that arrive while the app is running. A cold start still goes through BootPlanner, which only knows about native routes, so an unroutable link that launches the app from scratch can still land on the 404. Wanted to keep this PR small.