### PR TITLE
fix(android): allow root hosts to reserve the navigation bar slot

### DIFF
--- a/resources/androidstudio/app/build.gradle.kts
+++ b/resources/androidstudio/app/build.gradle.kts
@@ -216,6 +216,7 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation(libs.androidx.ui.test.junit4)
 
     // AndroidX Security for encrypted storage
     implementation(libs.androidx.security.crypto)

--- a/resources/androidstudio/app/src/androidTest/java/com/nativephp/mobile/ui/nativerender/NativeRootNavigationBarSlotTest.kt
+++ b/resources/androidstudio/app/src/androidTest/java/com/nativephp/mobile/ui/nativerender/NativeRootNavigationBarSlotTest.kt
@@ -1,0 +1,163 @@
+package com.nativephp.mobile.ui.nativerender
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NativeRootNavigationBarSlotTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        NavigationCoordinator.reset()
+    }
+
+    @Test
+    fun stackMovesTitleForActiveHostWithoutAddingSpaceToBackButton() {
+        val title = "Stack navigation title"
+        val root = mutableStateOf(stackNode(title = title))
+
+        composeRule.setContent {
+            MaterialTheme {
+                CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                    NativeRootStackRenderer(root.value)
+                }
+            }
+        }
+
+        assertNavigationSlotBehavior(
+            title = title,
+            showReservedSlot = { root.value = stackNode(title = title, hasDrawer = true) },
+            showBackButton = { root.value = stackNode(title = title, hasDrawer = true, hasBackButton = true) },
+        )
+    }
+
+    @Test
+    fun tabsMoveTitleForActiveHostWithoutAddingSpaceToBackButton() {
+        val title = "Tabs navigation title"
+        val root = mutableStateOf(tabsNode(title = title))
+
+        composeRule.setContent {
+            MaterialTheme {
+                CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                    NativeRootTabsRenderer(root.value)
+                }
+            }
+        }
+
+        assertNavigationSlotBehavior(
+            title = title,
+            showReservedSlot = { root.value = tabsNode(title = title, hasDrawer = true) },
+            showBackButton = { root.value = tabsNode(title = title, hasDrawer = true, hasBackButton = true) },
+        )
+    }
+
+    private fun assertNavigationSlotBehavior(
+        title: String,
+        showReservedSlot: () -> Unit,
+        showBackButton: () -> Unit,
+    ) {
+        val titleWithoutSlot = titleLeft(title)
+
+        composeRule.runOnIdle(showReservedSlot)
+        val titleWithReservedSlot = titleLeft(title)
+
+        assertTrue(titleWithReservedSlot > titleWithoutSlot)
+        assertTrue(titleWithReservedSlot >= NAVIGATION_SLOT_WIDTH_DP)
+
+        composeRule.runOnIdle(showBackButton)
+        val titleWithBackButton = titleLeft(title)
+
+        assertEquals(titleWithReservedSlot, titleWithBackButton, POSITION_TOLERANCE_DP)
+    }
+
+    private fun titleLeft(title: String): Float = composeRule
+        .onNodeWithText(title)
+        .getUnclippedBoundsInRoot()
+        .left
+        .value
+
+    private fun stackNode(
+        title: String,
+        hasDrawer: Boolean = false,
+        hasBackButton: Boolean = false,
+    ) = rootNode(
+        type = "native_root_stack",
+        props = mapOf(
+            "title" to title,
+            "current_uri" to "/navigation-slot-test",
+            "back" to hasBackButton,
+        ),
+        hasDrawer = hasDrawer,
+    )
+
+    private fun tabsNode(
+        title: String,
+        hasDrawer: Boolean = false,
+        hasBackButton: Boolean = false,
+    ) = rootNode(
+        type = "native_root_tabs",
+        props = mapOf(
+            "nav_title" to title,
+            "current_uri" to "/navigation-slot-test",
+            "nav_back" to hasBackButton,
+        ),
+        hasDrawer = hasDrawer,
+    )
+
+    private fun rootNode(
+        type: String,
+        props: Map<String, Any>,
+        hasDrawer: Boolean,
+    ) = node(
+        type = type,
+        props = props,
+        children = if (hasDrawer) listOf(node(type = DRAWER_SENTINEL)) else emptyList(),
+    )
+
+    private fun node(
+        type: String,
+        props: Map<String, Any> = emptyMap(),
+        children: List<NativeUINode> = emptyList(),
+    ) = NativeUINode(
+        id = 1,
+        type = type,
+        layout = null,
+        style = null,
+        props = GenericProps(props),
+        onPress = 0,
+        onLongPress = 0,
+        children = children,
+    )
+
+    private companion object {
+        const val DRAWER_SENTINEL = "navigation_slot_layout_test_sentinel"
+        const val NAVIGATION_SLOT_WIDTH_DP = 48f
+        const val POSITION_TOLERANCE_DP = 0.5f
+
+        @BeforeClass
+        @JvmStatic
+        fun registerNavigationBarSlotHost() {
+            NativeRootHostRegistry.register(
+                name = "navigation-bar-slot-layout-test-host",
+                consumes = DRAWER_SENTINEL,
+                reservesNavigationBarSlot = true,
+            ) { _, content -> content() }
+        }
+    }
+}

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootHostRegistry.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootHostRegistry.kt
@@ -21,7 +21,11 @@ import androidx.compose.runtime.Composable
  *
  * Example (in a plugin's init function):
  * ```
- * NativeRootHostRegistry.register("native-ui.drawer", consumes = "native_drawer") { root, content ->
+ * NativeRootHostRegistry.register(
+ *     "native-ui.drawer",
+ *     consumes = "native_drawer",
+ *     reservesNavigationBarSlot = true,
+ * ) { root, content ->
  *     val node = root.children.firstOrNull { it.type == "native_drawer" }
  *     NativeLayoutDrawerHost(drawerNode = node, content = content)
  * }
@@ -38,25 +42,40 @@ object NativeRootHostRegistry {
 
     private val entries = mutableListOf<Entry>()
     private val consumedTypes = mutableSetOf<String>()
+    private val navigationBarSlotTypes = mutableSetOf<String?>()
 
     /**
      * Register a root host. [consumes] is the sentinel element type this host
      * pulls out of the tree (if any), so the root renderers exclude it from
-     * screen content. Hosts apply in registration order — the first registered
-     * ends up innermost (closest to the content).
+     * screen content. [reservesNavigationBarSlot] tells the root renderers to
+     * leave room for navigation chrome drawn by the host. For hosts that
+     * consume a sentinel, the slot is reserved only while that sentinel is
+     * present in the current root. Hosts apply in registration order — the
+     * first registered ends up innermost (closest to the content).
      */
     fun register(
         name: String,
         consumes: String? = null,
+        reservesNavigationBarSlot: Boolean = false,
         host: @Composable (root: NativeUINode, content: @Composable () -> Unit) -> Unit,
     ) {
         if (consumes != null) consumedTypes.add(consumes)
+        if (reservesNavigationBarSlot) navigationBarSlotTypes.add(consumes)
         entries.add(Entry(name, host))
     }
 
     /** Whether some registered host consumes this element type (so the root
      *  renderers should keep it out of the visible screen content). */
     fun consumes(type: String): Boolean = consumedTypes.contains(type)
+
+    /**
+     * Whether an active host draws chrome over the navigation-bar slot.
+     * Sentinel-backed hosts are active only when their sentinel is present in
+     * [root]; hosts without a sentinel are considered active globally.
+     */
+    fun reservesNavigationBarSlot(root: NativeUINode): Boolean = navigationBarSlotTypes.any { type ->
+        type == null || root.children.any { it.type == type }
+    }
 
     /**
      * Fold every registered host around [content]. A transparent pass-through

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootStackRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootStackRenderer.kt
@@ -11,11 +11,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -92,6 +94,7 @@ fun NativeRootStackRenderer(node: NativeUINode, modifier: Modifier = Modifier) {
     val title = activeNode.props.getString("title", "")
     val subtitle = activeNode.props.getString("subtitle", "")
     val showBack = activeNode.props.getBool("back")
+    val reservesNavigationBarSlot = NativeRootHostRegistry.reservesNavigationBarSlot(activeNode)
     val bgArgb = activeNode.props.getColor("background_color", 0)
     val textArgb = activeNode.props.getColor("text_color", 0)
     val hasExplicitBg = bgArgb != 0
@@ -231,6 +234,8 @@ fun NativeRootStackRenderer(node: NativeUINode, modifier: Modifier = Modifier) {
                     modifier = if (rtl) Modifier.scale(scaleX = -1f, scaleY = 1f) else Modifier
                 )
             }
+        } else if (reservesNavigationBarSlot) {
+            Spacer(modifier = Modifier.width(48.dp))
         }
     }
     val barColors = if (hasExplicitBg) {

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootTabsRenderer.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NativeRootTabsRenderer.kt
@@ -185,6 +185,7 @@ fun NativeRootTabsRenderer(node: NativeUINode, modifier: Modifier = Modifier) {
     val navBgArgb = node.props.getColor("nav_background_color", 0)
     val navTextArgb = node.props.getColor("nav_text_color", 0)
     val hasNavBar = navBack || navTitle.isNotEmpty() || titleNode != null
+    val reservesNavigationBarSlot = NativeRootHostRegistry.reservesNavigationBarSlot(node)
     // Per-layout / per-bar chrome fonts, resolved through the plugin seam.
     // `font_name` = the tab bar's font; `nav_font_name` = the folded nav
     // bar's font (falls back to the tab bar's). Null → inherit the ambient
@@ -276,6 +277,8 @@ fun NativeRootTabsRenderer(node: NativeUINode, modifier: Modifier = Modifier) {
                                     modifier = if (rtl) Modifier.scale(scaleX = -1f, scaleY = 1f) else Modifier
                                 )
                             }
+                        } else if (reservesNavigationBarSlot) {
+                            Spacer(modifier = Modifier.width(48.dp))
                         }
                     },
                     actions = {

--- a/resources/androidstudio/app/src/test/java/com/nativephp/mobile/ui/nativerender/NativeRootHostRegistryTest.kt
+++ b/resources/androidstudio/app/src/test/java/com/nativephp/mobile/ui/nativerender/NativeRootHostRegistryTest.kt
@@ -1,0 +1,53 @@
+package com.nativephp.mobile.ui.nativerender
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeRootHostRegistryTest {
+    @Test
+    fun reservesNavigationBarSlotOnlyWhileTheConsumedSentinelIsPresent() {
+        val sentinelType = "navigation_slot_test_sentinel"
+        NativeRootHostRegistry.register(
+            name = "navigation-slot-test-host",
+            consumes = sentinelType,
+            reservesNavigationBarSlot = true,
+        ) { _, content -> content() }
+
+        assertFalse(NativeRootHostRegistry.reservesNavigationBarSlot(node()))
+        assertTrue(
+            NativeRootHostRegistry.reservesNavigationBarSlot(
+                node(children = listOf(node(type = sentinelType))),
+            ),
+        )
+    }
+
+    @Test
+    fun doesNotReserveNavigationBarSlotWithoutTheHostDeclaration() {
+        val sentinelType = "non_reserving_navigation_slot_test_sentinel"
+        NativeRootHostRegistry.register(
+            name = "non-reserving-navigation-slot-test-host",
+            consumes = sentinelType,
+        ) { _, content -> content() }
+
+        assertFalse(
+            NativeRootHostRegistry.reservesNavigationBarSlot(
+                node(children = listOf(node(type = sentinelType))),
+            ),
+        )
+    }
+
+    private fun node(
+        type: String = "native_root_stack",
+        children: List<NativeUINode> = emptyList(),
+    ) = NativeUINode(
+        id = 1,
+        type = type,
+        layout = null,
+        style = null,
+        props = GenericProps(),
+        onPress = 0,
+        onLongPress = 0,
+        children = children,
+    )
+}


### PR DESCRIPTION
## Description

### Summary

Adds the core opt-in API needed for Android root hosts to reserve the `TopAppBar` navigation slot. Once a host adopts it, chrome rendered as an overlay can reserve space instead of overlapping the navigation title.

### Problem

On Android, the `mobile-ui` drawer button is rendered as an overlay, while the `mobile-air` `TopAppBar` only reserves its navigation slot for a back button. As a result, the drawer icon overlaps the navigation title.

Android
<img width="325" height="132" alt="Captura de Tela 2026-08-29 às 15 26 27" src="https://github.com/user-attachments/assets/e2be3cdb-1245-43bc-9189-d94c4a1bb60d" />

iOS
<img width="330" height="111" alt="Captura de Tela 2026-08-29 às 15 28 55" src="https://github.com/user-attachments/assets/8ac1622b-b379-4cb6-8da5-866840656f37" />


### Changes

- Adds `reservesNavigationBarSlot` to `NativeRootHostRegistry.register()`.
- Reserves a `48.dp` navigation slot in stack and tab root renderers when an active host requests it and no back button is present.
- Reserves the slot only while a host's consumed sentinel exists in the current root; hosts without a sentinel remain globally active.
- Adds registry unit coverage and Compose layout tests for both root renderers.

### Dependency and rollout

This PR does not fix the `mobile-ui` drawer overlap by itself. It provides the core API and renderer behavior; the companion `mobile-ui` change enables `reservesNavigationBarSlot` when registering the `native_drawer` host.

The changes should be merged and released in this order:

1. This `mobile-air` PR.
2. The companion `mobile-ui` change.

The updated `mobile-ui` source requires this new `register()` parameter, while existing hosts that do not opt in keep their current behavior.
