### PR TITLE
fix: make native:check-build-number work for iOS

### DIFF
--- a/src/Commands/CheckBuildNumberCommand.php
+++ b/src/Commands/CheckBuildNumberCommand.php
@@ -78,7 +78,9 @@ class CheckBuildNumberCommand extends Command
                 $this->line('🔧 To update: add --update flag');
             }
         } else {
-            $baseSuggested = 1;
+            // Same reasoning as the iOS branch: this is also reached when the
+            // Play Store lookup fails, not only for a genuinely new app.
+            $baseSuggested = $currentLocal ? ((int) $currentLocal + 1) : 1;
             $suggested = $baseSuggested + $jumpBy;
             $this->line('📱 Play Store: No releases found (new app)');
             $this->line('💻 Local current: '.($currentLocal ?: 'not set'));
@@ -113,9 +115,14 @@ class CheckBuildNumberCommand extends Command
                 $this->line('🔧 To update: add --update flag');
             }
         } else {
+            // Suggest one past whatever is configured locally. A flat "1" is
+            // wrong for any app that has already shipped, and this branch is
+            // reached when the lookup FAILS as well as when the app is genuinely
+            // new. App Store Connect rejects a build number it has already seen,
+            // so following that suggestion costs a whole build and upload.
             $this->line('📱 App Store: No releases found or check not implemented');
             $this->line('💻 Local current: '.($currentLocal ?: 'not set'));
-            $this->line('💡 Suggested next: 1');
+            $this->line('💡 Suggested next: '.($currentLocal ? ((int) $currentLocal + 1) : 1));
         }
 
         $this->newLine();

--- a/src/Concerns/ChecksLatestBuildNumber.php
+++ b/src/Concerns/ChecksLatestBuildNumber.php
@@ -26,7 +26,7 @@ trait ChecksLatestBuildNumber
     private function getLatestAndroidBuildNumber(): ?int
     {
         try {
-            $googleServiceKey = $this->option('google-service-key') ?? env('GOOGLE_SERVICE_ACCOUNT_KEY');
+            $googleServiceKey = $this->consoleOption('google-service-key') ?? env('GOOGLE_SERVICE_ACCOUNT_KEY');
 
             if (! $googleServiceKey) {
                 note('No Google Service Account Key found, skipping Play Store check');
@@ -105,14 +105,37 @@ trait ChecksLatestBuildNumber
 
     private function getApiKeyPath(): ?string
     {
-        // Check for API key file path - try flags first, then environment variables
-        $apiKeyPath = $this->option('api-key-path') ?? $this->option('api-key') ?? env('APP_STORE_API_KEY_PATH');
+        // Check for API key file path - try flags first, then environment variables.
+        //
+        // Both flags are read defensively: this trait is shared by commands that
+        // declare different subsets of them, and Illuminate's option() throws
+        // InvalidArgumentException for an option the command did not define
+        // rather than returning null. That threw before the ?? chain could fall
+        // through, so native:check-build-number - which declares --api-key but
+        // not --api-key-path - could never reach App Store Connect at all.
+        $apiKeyPath = $this->consoleOption('api-key-path')
+            ?? $this->consoleOption('api-key')
+            ?? env('APP_STORE_API_KEY_PATH');
 
         if ($apiKeyPath && file_exists($apiKeyPath)) {
             return $apiKeyPath;
         }
 
         return null;
+    }
+
+    /**
+     * Read a console option that the calling command may not have declared.
+     */
+    private function consoleOption(string $name): ?string
+    {
+        if (! $this->getDefinition()->hasOption($name)) {
+            return null;
+        }
+
+        $value = $this->option($name);
+
+        return $value === null ? null : (string) $value;
     }
 
     public function updateBuildNumberFromStore(string $platform, int $jumpBy = 0): bool
@@ -153,8 +176,8 @@ trait ChecksLatestBuildNumber
     {
         try {
             $apiKeyPath = $this->getApiKeyPath();
-            $apiKeyId = $this->option('api-key-id') ?? env('APP_STORE_API_KEY_ID');
-            $apiIssuerId = $this->option('api-issuer-id') ?? env('APP_STORE_API_ISSUER_ID');
+            $apiKeyId = $this->consoleOption('api-key-id') ?? env('APP_STORE_API_KEY_ID');
+            $apiIssuerId = $this->consoleOption('api-issuer-id') ?? env('APP_STORE_API_ISSUER_ID');
             $appId = config('nativephp.app_id');
 
             if (! $apiKeyPath || ! $apiKeyId || ! $apiIssuerId || ! $appId) {


### PR DESCRIPTION
The iOS check could never succeed. It always reported `Could not check App Store Connect` and then suggested build number `1`.

```
$ php artisan native:check-build-number ios --api-key=/path/to/AuthKey.p8

 Could not check App Store Connect: The "api-key-path" option does not exist.
📱 App Store: No releases found or check not implemented
💻 Local current: 2
💡 Suggested next: 1
```

## Cause

`ChecksLatestBuildNumber` is shared by three commands that declare different subsets of the same flags, and it read four of them unconditionally — `api-key-path`, `api-key-id`, `api-issuer-id` and `google-service-key`:

```php
$apiKeyPath = $this->option('api-key-path') ?? $this->option('api-key') ?? env('APP_STORE_API_KEY_PATH');
```

Illuminate's `option()` **throws** `InvalidArgumentException` for an option the command has not defined, rather than returning null — so the throw happens before `??` can fall through to the env fallback. `BuildIosAppCommand` and `PackageCommand` declare `--api-key-path` and `--api-key-id`, so they are unaffected. `CheckBuildNumberCommand` declares only `--api-key`, so every lookup threw and was swallowed by the surrounding `catch`, surfacing as the generic warning above.

Fixing only `api-key-path` is not enough — with that alone the next call throws on `api-key-id` instead. (Found the hard way.)

These reads now go through a small `consoleOption()` helper that checks the command's own definition first, so each command contributes whichever flags it declares and the env fallback still applies to the rest. No command's CLI surface changes.

## Also: the fallback suggestion

That branch is reached when the lookup **fails**, not only when an app is genuinely new, and it suggested `1` unconditionally. For any app that has already shipped, `1` is a build number App Store Connect has long since seen and will reject on upload — so following the suggestion costs a full build and upload cycle to discover.

It now suggests one past the local value when there is one. The Android branch had the same flat `1` and is fixed alongside it.

## Verified against a live App Store Connect account

After:

```
  Builds found ............................. 5 for version 1.0
  Latest build ............................... 7 (version 1.0)
📱 App Store latest: 7
💻 Local current: 2
💡 Suggested next: 8
```

Two files, no behaviour change for the commands that already worked.