### PR TITLE
fix(ios): prevent silent corruption/truncation of binary PHP response bodies

### DIFF
--- a/resources/xcode/Include/Bridge/PHP.c
+++ b/resources/xcode/Include/Bridge/PHP.c
@@ -456,8 +456,24 @@ static void do_dispatch(const dispatch_params_t *params) {
         SG(request_info).content_length = 0;
     }
 
-    // Build dispatch eval code — same pattern as Android
-    static char eval_code[8192];
+    // Build dispatch eval code — same pattern as Android.
+    //
+    // The body is captured with ob_start()/ob_get_clean() around sendContent()
+    // rather than echoed straight through, so it can be inspected before it
+    // crosses the C -> Swift boundary. sendContent() (not getContent()) is still
+    // what generates it, so StreamedResponse / BinaryFileResponse keep working.
+    //
+    // The whole HTTP response (headers + body) travels back to Swift as one
+    // NUL-terminated C string (strdup'd below, then String(cString:) on the
+    // Swift side). A binary body (image, PDF, etc.) breaks that two ways: an
+    // embedded NUL byte truncates the response outright via strdup/strlen, and
+    // non-UTF-8 bytes get mangled by String(cString:). So the body is base64-
+    // encoded whenever it isn't valid UTF-8 or contains a NUL, flagged with an
+    // X-Native-Body-Encoding header that PHPSchemeHandler strips and decodes.
+    //
+    // Keep the PHP below comment-free: it is re-parsed by zend_eval_string on
+    // every request and has to fit eval_code alongside the substituted URI.
+    static char eval_code[16384];
     snprintf(eval_code, sizeof(eval_code),
         "try {\n"
         "    while (ob_get_level() > 0) { ob_end_clean(); }\n"
@@ -534,14 +550,21 @@ static void do_dispatch(const dispatch_params_t *params) {
         "    );\n"
         "    $__code = $__response->getStatusCode();\n"
         "    $__status = \\Symfony\\Component\\HttpFoundation\\Response::$statusTexts[$__code] ?? 'OK';\n"
+        "    ob_start();\n"
+        "    $__response->sendContent();\n"
+        "    $__body = ob_get_clean();\n"
+        "    $__isBinary = @preg_match('//u', $__body) !== 1 || strpos($__body, \"\\0\") !== false;\n"
         "    echo \"HTTP/1.1 {$__code} {$__status}\\r\\n\";\n"
         "    foreach ($__response->headers->all() as $__name => $__values) {\n"
         "        foreach ($__values as $__value) {\n"
         "            echo \"{$__name}: {$__value}\\r\\n\";\n"
         "        }\n"
         "    }\n"
+        "    if ($__isBinary) {\n"
+        "        echo \"X-Native-Body-Encoding: base64\\r\\n\";\n"
+        "    }\n"
         "    echo \"\\r\\n\";\n"
-        "    $__response->sendContent();\n"
+        "    echo $__isBinary ? base64_encode($__body) : $__body;\n"
         "} catch (\\Throwable $e) {\n"
         "    echo \"HTTP/1.1 500 Internal Server Error\\r\\n\";\n"
         "    echo \"Content-Type: text/plain\\r\\n\\r\\n\";\n"
@@ -1341,6 +1364,10 @@ static void do_webview_dispatch(webview_php_slot_t *slot) {
     // Same dispatch shape as the persistent lane, but every request value is
     // inlined — no getenv() merge, so the persistent lane's transient
     // request env vars can never bleed into (or race) this context.
+    // Body capture / base64 handling mirrors do_dispatch above — see the
+    // comment there for why a non-UTF-8 or NUL-bearing body cannot cross the
+    // C -> Swift boundary raw. Keep the PHP below comment-free: it is
+    // re-parsed by zend_eval_string on every request.
     char *eval_code = NULL;
     asprintf(&eval_code,
         "try {\n"
@@ -1407,14 +1434,21 @@ static void do_webview_dispatch(webview_php_slot_t *slot) {
         "    );\n"
         "    $__code = $__response->getStatusCode();\n"
         "    $__status = \\Symfony\\Component\\HttpFoundation\\Response::$statusTexts[$__code] ?? 'OK';\n"
+        "    ob_start();\n"
+        "    $__response->sendContent();\n"
+        "    $__body = ob_get_clean();\n"
+        "    $__isBinary = @preg_match('//u', $__body) !== 1 || strpos($__body, \"\\0\") !== false;\n"
         "    echo \"HTTP/1.1 {$__code} {$__status}\\r\\n\";\n"
         "    foreach ($__response->headers->all() as $__name => $__values) {\n"
         "        foreach ($__values as $__value) {\n"
         "            echo \"{$__name}: {$__value}\\r\\n\";\n"
         "        }\n"
         "    }\n"
+        "    if ($__isBinary) {\n"
+        "        echo \"X-Native-Body-Encoding: base64\\r\\n\";\n"
+        "    }\n"
         "    echo \"\\r\\n\";\n"
-        "    $__response->sendContent();\n"
+        "    echo $__isBinary ? base64_encode($__body) : $__body;\n"
         "} catch (\\Throwable $e) {\n"
         "    echo \"HTTP/1.1 500 Internal Server Error\\r\\n\";\n"
         "    echo \"Content-Type: text/plain\\r\\n\\r\\n\";\n"

--- a/resources/xcode/NativePHP/PHPSchemeHandler.swift
+++ b/resources/xcode/NativePHP/PHPSchemeHandler.swift
@@ -579,6 +579,19 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
                     }
                 }
 
+                // The native bridge returns the whole HTTP response (headers + body)
+                // as one NUL-terminated C string, since that's what crosses the
+                // C -> Swift boundary (String(cString:) in PersistentPHPRuntime /
+                // WebviewPHPRuntime). A body that isn't valid UTF-8 on its own (an
+                // image, a PDF, any binary content) is base64-encoded on the PHP/
+                // native side and flagged with this internal marker header --
+                // decode it back to real bytes below rather than treating it as
+                // text, or binary responses come out corrupted or truncated at the
+                // first embedded NUL byte. Strip the marker so it never reaches the
+                // WebView/network.
+                let isBase64Body = headers.removeValue(forKey: "x-native-body-encoding")?
+                    .lowercased() == "base64"
+
                 var request = requestData
                 if let location = headers["location"] {
                     request.uri = location.trimmingCharacters(in: .whitespaces)
@@ -653,10 +666,18 @@ class PHPSchemeHandler: NSObject, WKURLSchemeHandler {
                     schemeTask.didReceive(httpResponse)
 
                     // Send the body data
-                    if let bodyData = bodyString.data(using: .utf8) {
+                    let decodedBodyData: Data? = isBase64Body
+                        ? Data(base64Encoded: bodyString.trimmingCharacters(in: .whitespacesAndNewlines),
+                               options: .ignoreUnknownCharacters)
+                        : bodyString.data(using: .utf8)
+
+                    if let bodyData = decodedBodyData {
                         schemeTask.didReceive(bodyData)
                     } else {
-                        let error = self.error(code: 500, description: "Failed to encode body data")
+                        let description = isBase64Body
+                            ? "Failed to base64-decode response body"
+                            : "Failed to encode body data"
+                        let error = self.error(code: 500, description: description)
                         schemeTask.didFailWithError(error)
                         return
                     }


### PR DESCRIPTION
## Problem

The native bridge returns the whole HTTP response (headers + body) from C to Swift as a single NUL-terminated C string. Binary bodies do not survive that trip:

- `do_dispatch()` and `do_webview_dispatch()` in `PHP.c` hand the response to Swift via `strdup()`, which relies on `strlen()` — any embedded NUL byte (common in JPEG/PNG/PDF) truncates the response silently.
- `PersistentPHPRuntime.dispatch()` / `WebviewPHPRuntime.dispatch()` read it back with `String(cString:)`, mangling non-UTF-8 bytes.

In practice the response usually dies even earlier: `PHPSchemeHandler.forwardToPHP()` does `String(data:encoding:.utf8)` over the entire response, which returns `nil` for a binary body. The user sees a broken image with no error anywhere.

This is the iOS manifestation of the same bridge bug as the Android crash in #10 (there it is `JNI NewStringUTF` on non-UTF-8 bytes; here it fails silently instead).

## Fix

Capture the body with output buffering around `sendContent()` in both dispatch paths, and base64-encode it when it is not valid UTF-8 **or contains a NUL byte**, flagged with an internal `X-Native-Body-Encoding: base64` header. Base64 is pure ASCII with no NULs, so it survives `strdup`/`strlen` and `String(cString:)` intact.

`PHPSchemeHandler.forwardToPHP()` detects the header, strips it before it reaches the WebView, and base64-decodes the body back to raw `Data` (with `.ignoreUnknownCharacters`, so stray whitespace cannot turn a valid response into a 500).

Notes:
- `sendContent()` (not `getContent()`) still generates the body, so `StreamedResponse` / `BinaryFileResponse` keep working. This is not true streaming either way — `capture_php_output()` already accumulates the whole response in a thread-local buffer before handoff — so `ob_start()` adds one in-memory copy plus base64's 33% overhead, on binary bodies only.
- Text/JSON/HTML responses are byte-for-byte unchanged: no marker header, no encoding.
- The eval'd PHP is kept comment-free and `eval_code` grown 8K → 16K. That string is re-parsed by `zend_eval_string` on every request and shares a fixed buffer with the substituted request URI, where an overflow would be silently truncated by `snprintf` into malformed PHP.
- The legacy "classic mode" fallback (`NativePHPApp.laravel(request:)`) is intentionally untouched — it needs `bootstrap/ios/native.php`, outside this change.

## Verification

Tested on iPhone 17 Pro simulator (iOS 26) with a route returning `response()->file()` on a 26,015-byte JPEG.

| Build | Result |
|---|---|
| Unpatched bridge | broken-image placeholder |
| Patched bridge | image renders correctly |

Bridge-level instrumentation on the patched build:

```
status=200 isBase64=true bodyStringCount=34688
headers=["content-type": "image/jpeg", "content-length": "26015", ...]
```

`34688` is exactly base64 of 26,015 bytes, confirming the full body crossed the boundary; the marker header is absent from the dict handed to the WebView, confirming it is stripped.

Also verified: both generated PHP blocks pass `php -l`; encode/decode round-trips byte-identically for binary, UTF-8 text, HTML, and valid-UTF-8-containing-NUL bodies; normal HTML/JSON pages and Laravel's error page render unchanged through the patched bridge.
