### PR TITLE
Let plugins own native project setup

### DIFF
--- a/resources/androidstudio/app/build.gradle.kts
+++ b/resources/androidstudio/app/build.gradle.kts
@@ -4,11 +4,6 @@ plugins {
     id("org.jetbrains.kotlin.plugin.compose")
 }
 
-val googleServicesJson = file("google-services.json")
-if (googleServicesJson.exists()) {
-    apply(plugin = "com.google.gms.google-services")
-}
-
 android {
     namespace = "com.nativephp.mobile"
     compileSdk = REPLACE_COMPILE_SDK

--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -152,8 +152,6 @@ class BuildIosAppCommand extends Command
         $this->configureProvisioningProfile();
         $this->installIosIcon();
         $this->installIosSplashScreen();
-        $this->installGoogleServicesPlist();
-
         $this->updateIcuConfiguration();
 
         // Compile plugins AFTER core config so plugin entries (like info_plist)
@@ -816,22 +814,6 @@ class BuildIosAppCommand extends Command
 
             file_put_contents($entitlementsFile, $entitlementsContent);
         }
-    }
-
-    private function installGoogleServicesPlist(): void
-    {
-        $path = base_path('nativephp/resources/GoogleService-Info.plist');
-
-        if (! file_exists($path)) {
-            $path = base_path('GoogleService-Info.plist');
-        }
-
-        if (! file_exists($path)) {
-            return;
-        }
-
-        $destinationPath = $this->containerPath.'GoogleService-Info.plist';
-        @copy($path, $destinationPath);
     }
 
     private function determineApsEnvironment(): string

--- a/src/Commands/PackageCommand.php
+++ b/src/Commands/PackageCommand.php
@@ -168,10 +168,6 @@ class PackageCommand extends Command
             return;
         }
 
-        if (! $this->validateGoogleServicesConfiguration($plugins)) {
-            return;
-        }
-
         // Validate signing configuration
         $signingConfig = $this->validateAndPrepareSigningConfig();
         if (! $signingConfig) {

--- a/src/Commands/PackageCommand.php
+++ b/src/Commands/PackageCommand.php
@@ -168,6 +168,10 @@ class PackageCommand extends Command
             return;
         }
 
+        if (! $this->validateGoogleServicesConfiguration($plugins)) {
+            return;
+        }
+
         // Validate signing configuration
         $signingConfig = $this->validateAndPrepareSigningConfig();
         if (! $signingConfig) {

--- a/src/Concerns/PackagesIos.php
+++ b/src/Concerns/PackagesIos.php
@@ -1296,7 +1296,7 @@ trait PackagesIos
     }
 
     /**
-     * Configure app settings in the archive's Info.plist (export compliance and Firebase)
+     * Configure app settings in the archive's Info.plist.
      */
     protected function configureAppSettings(string $archivePath): bool
     {

--- a/src/Concerns/PreparesBuild.php
+++ b/src/Concerns/PreparesBuild.php
@@ -145,9 +145,6 @@ trait PreparesBuild
             }
             $this->updateDeepLinkConfiguration();
 
-            $this->logToFile('  Updating Firebase configuration...');
-            $this->updateFirebaseConfiguration();
-
             $this->logToFile('  Updating build configuration...');
             $buildConfig = config('nativephp.android.build', []);
             $this->logToFile('    Minify: '.($buildConfig['minify_enabled'] ?? false ? 'enabled' : 'disabled'));
@@ -975,8 +972,6 @@ trait PreparesBuild
     abstract protected function updatePermissions(): void;
 
     abstract protected function updateIcuConfiguration(): void;
-
-    abstract protected function updateFirebaseConfiguration(): void;
 
     abstract protected function removeDirectory(string $path): void;
 }

--- a/src/Concerns/RunsAndroid.php
+++ b/src/Concerns/RunsAndroid.php
@@ -2,7 +2,6 @@
 
 namespace Native\Mobile\Concerns;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
@@ -21,10 +20,6 @@ use function Laravel\Prompts\warning;
 trait RunsAndroid
 {
     use PreparesBuild, WatchesAndroid;
-
-    private const GOOGLE_SERVICES_PLUGIN_ID = 'com.google.gms.google-services';
-
-    private const GOOGLE_SERVICES_ARTIFACT = 'com.google.gms:google-services';
 
     protected string $androidLogPath = 'nativephp'.DIRECTORY_SEPARATOR.'android-build.log';
 
@@ -96,10 +91,6 @@ trait RunsAndroid
 
                 return;
             }
-        }
-
-        if (! $this->validateGoogleServicesConfiguration($plugins)) {
-            return;
         }
 
         // Start Vite dev server early if watching, so hot file is present during build
@@ -374,95 +365,6 @@ XML;
         }
 
         return "            <!-- NATIVEPHP-DEEPLINKS-START -->\n".implode("\n", $filters)."\n            <!-- NATIVEPHP-DEEPLINKS-END -->";
-    }
-
-    private function updateFirebaseConfiguration(): void
-    {
-        $source = base_path('nativephp/resources/google-services.json');
-
-        if (! file_exists($source)) {
-            $source = base_path('google-services.json');
-        }
-
-        $target = base_path('nativephp/android/app/google-services.json');
-
-        if (File::exists($source)) {
-            File::copy($source, $target);
-        }
-    }
-
-    /**
-     * A google-services.json only becomes meaningful when something owns the
-     * corresponding Gradle plugin. Fail before Gradle's opaque "plugin not
-     * found" error while keeping the build requirement with the plugin that
-     * needs it, rather than declaring a Firebase-specific version in core.
-     */
-    protected function validateGoogleServicesConfiguration(Collection $plugins): bool
-    {
-        if (! $this->hasGoogleServicesConfiguration()
-            || $this->registeredPluginDeclaresGoogleServices($plugins)
-            || $this->projectDeclaresGoogleServices()) {
-            return true;
-        }
-
-        $message = 'A google-services.json file was found, but no registered plugin declares '
-            .self::GOOGLE_SERVICES_PLUGIN_ID.'. Update to nativephp/mobile-firebase 1.1.1 or later and register it, '
-            .'declare the Gradle plugin from another registered plugin, or remove the unused configuration file.';
-
-        $this->logToFile('ERROR: '.$message);
-        $this->components->error($message);
-
-        return false;
-    }
-
-    private function hasGoogleServicesConfiguration(): bool
-    {
-        return collect([
-            base_path('nativephp/resources/google-services.json'),
-            base_path('google-services.json'),
-            base_path('nativephp/android/app/google-services.json'),
-        ])->contains(fn (string $path) => File::exists($path));
-    }
-
-    private function registeredPluginDeclaresGoogleServices(Collection $plugins): bool
-    {
-        return $plugins
-            ->filter(fn ($plugin) => $plugin->supportsPlatform('android'))
-            ->contains(function ($plugin) {
-                return collect($plugin->getAndroidGradlePlugins())
-                    ->contains(fn (array $gradlePlugin) => ($gradlePlugin['id'] ?? null) === self::GOOGLE_SERVICES_PLUGIN_ID);
-            });
-    }
-
-    /**
-     * Preserve projects that deliberately manage the plugin themselves. A
-     * generated plugin block is excluded because the compiler removes that
-     * block when its owning plugin is unregistered later in this same build.
-     */
-    private function projectDeclaresGoogleServices(): bool
-    {
-        $path = base_path('nativephp/android/build.gradle.kts');
-
-        if (! File::exists($path)) {
-            return false;
-        }
-
-        $content = File::get($path);
-        $content = preg_replace(
-            '/\/\/ BEGIN nativephp-plugin-gradle-plugins.*?\/\/ END nativephp-plugin-gradle-plugins/s',
-            '',
-            $content,
-        ) ?? $content;
-        $content = preg_replace([
-            '/\/\*.*?\*\//s',
-            '/^[ \t]*\/\/.*$/m',
-        ], '', $content) ?? $content;
-
-        $pluginId = preg_quote(self::GOOGLE_SERVICES_PLUGIN_ID, '/');
-        $artifact = preg_quote(self::GOOGLE_SERVICES_ARTIFACT, '/');
-
-        return preg_match('/id\s*\(\s*"'.$pluginId.'"\s*\)/', $content) === 1
-            || preg_match('/classpath\s*\(\s*"'.$artifact.':[^"]+"\s*\)/', $content) === 1;
     }
 
     private function updateIcuConfiguration(): void

--- a/src/Concerns/RunsAndroid.php
+++ b/src/Concerns/RunsAndroid.php
@@ -2,6 +2,7 @@
 
 namespace Native\Mobile\Concerns;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
@@ -20,6 +21,10 @@ use function Laravel\Prompts\warning;
 trait RunsAndroid
 {
     use PreparesBuild, WatchesAndroid;
+
+    private const GOOGLE_SERVICES_PLUGIN_ID = 'com.google.gms.google-services';
+
+    private const GOOGLE_SERVICES_ARTIFACT = 'com.google.gms:google-services';
 
     protected string $androidLogPath = 'nativephp'.DIRECTORY_SEPARATOR.'android-build.log';
 
@@ -91,6 +96,10 @@ trait RunsAndroid
 
                 return;
             }
+        }
+
+        if (! $this->validateGoogleServicesConfiguration($plugins)) {
+            return;
         }
 
         // Start Vite dev server early if watching, so hot file is present during build
@@ -380,6 +389,80 @@ XML;
         if (File::exists($source)) {
             File::copy($source, $target);
         }
+    }
+
+    /**
+     * A google-services.json only becomes meaningful when something owns the
+     * corresponding Gradle plugin. Fail before Gradle's opaque "plugin not
+     * found" error while keeping the build requirement with the plugin that
+     * needs it, rather than declaring a Firebase-specific version in core.
+     */
+    protected function validateGoogleServicesConfiguration(Collection $plugins): bool
+    {
+        if (! $this->hasGoogleServicesConfiguration()
+            || $this->registeredPluginDeclaresGoogleServices($plugins)
+            || $this->projectDeclaresGoogleServices()) {
+            return true;
+        }
+
+        $message = 'A google-services.json file was found, but no registered plugin declares '
+            .self::GOOGLE_SERVICES_PLUGIN_ID.'. Update to nativephp/mobile-firebase 1.1.1 or later and register it, '
+            .'declare the Gradle plugin from another registered plugin, or remove the unused configuration file.';
+
+        $this->logToFile('ERROR: '.$message);
+        $this->components->error($message);
+
+        return false;
+    }
+
+    private function hasGoogleServicesConfiguration(): bool
+    {
+        return collect([
+            base_path('nativephp/resources/google-services.json'),
+            base_path('google-services.json'),
+            base_path('nativephp/android/app/google-services.json'),
+        ])->contains(fn (string $path) => File::exists($path));
+    }
+
+    private function registeredPluginDeclaresGoogleServices(Collection $plugins): bool
+    {
+        return $plugins
+            ->filter(fn ($plugin) => $plugin->supportsPlatform('android'))
+            ->contains(function ($plugin) {
+                return collect($plugin->getAndroidGradlePlugins())
+                    ->contains(fn (array $gradlePlugin) => ($gradlePlugin['id'] ?? null) === self::GOOGLE_SERVICES_PLUGIN_ID);
+            });
+    }
+
+    /**
+     * Preserve projects that deliberately manage the plugin themselves. A
+     * generated plugin block is excluded because the compiler removes that
+     * block when its owning plugin is unregistered later in this same build.
+     */
+    private function projectDeclaresGoogleServices(): bool
+    {
+        $path = base_path('nativephp/android/build.gradle.kts');
+
+        if (! File::exists($path)) {
+            return false;
+        }
+
+        $content = File::get($path);
+        $content = preg_replace(
+            '/\/\/ BEGIN nativephp-plugin-gradle-plugins.*?\/\/ END nativephp-plugin-gradle-plugins/s',
+            '',
+            $content,
+        ) ?? $content;
+        $content = preg_replace([
+            '/\/\*.*?\*\//s',
+            '/^[ \t]*\/\/.*$/m',
+        ], '', $content) ?? $content;
+
+        $pluginId = preg_quote(self::GOOGLE_SERVICES_PLUGIN_ID, '/');
+        $artifact = preg_quote(self::GOOGLE_SERVICES_ARTIFACT, '/');
+
+        return preg_match('/id\s*\(\s*"'.$pluginId.'"\s*\)/', $content) === 1
+            || preg_match('/classpath\s*\(\s*"'.$artifact.':[^"]+"\s*\)/', $content) === 1;
     }
 
     private function updateIcuConfiguration(): void

--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -8,6 +8,7 @@ use Native\Mobile\Exceptions\PluginConflictException;
 use Native\Mobile\Plugins\Plugin;
 use Native\Mobile\Plugins\PluginHookRunner;
 use Native\Mobile\Plugins\PluginRegistry;
+use Native\Mobile\Plugins\ProjectFileManager;
 use Native\Mobile\Support\Stub;
 
 class AndroidPluginCompiler
@@ -183,9 +184,17 @@ class AndroidPluginCompiler
         // list is empty so a removed plugin's stale rules are cleared).
         $this->injectPluginProguardRules($allPlugins);
 
+        // Copy app-owned files declared by plugins into the Android project.
+        (new ProjectFileManager($this->files, $this->basePath, 'android'))->sync($allPlugins);
+
         // Declare plugin-required Gradle plugins in the root build file (runs
         // even when the list is empty so a removed plugin's declaration is cleared).
         $this->injectGradlePlugins($allPlugins);
+
+        // Apply plugin-required Gradle plugins to the app module when the
+        // manifest explicitly targets it. The marker is also cleared when a
+        // plugin is removed.
+        $this->injectAppGradlePlugins($allPlugins);
 
         if ($allPlugins->isEmpty()) {
             $this->generateEmptyRegistration();
@@ -294,9 +303,8 @@ class AndroidPluginCompiler
      * rebuilt on every compile (idempotent; a removed plugin's declaration
      * is dropped). Declared from `android.gradle_plugins` in nativephp.json.
      *
-     * Entries default to `apply false`: the plugin lands on the build
-     * classpath only, and the app module decides whether to apply it (e.g.
-     * google-services is applied only when a google-services.json exists).
+     * Entries default to `apply false`. Entries with `apply_to: "app"` are
+     * declared here with `apply false` and separately applied to the app.
      */
     protected function injectGradlePlugins(Collection $plugins): void
     {
@@ -383,7 +391,9 @@ class AndroidPluginCompiler
                     }
                 }
 
-                $apply = $gradlePlugin['apply'] ?? false;
+                $apply = ($gradlePlugin['apply_to'] ?? null) === 'app'
+                    ? false
+                    : ($gradlePlugin['apply'] ?? false);
                 $entries[$id] = "    id(\"{$id}\") version \"{$version}\" apply ".($apply ? 'true' : 'false');
             }
         }
@@ -396,6 +406,84 @@ class AndroidPluginCompiler
             ."    // Auto-generated on every build from installed plugins — do not edit.\n"
             .implode("\n", $entries)."\n"
             ."    // END nativephp-plugin-gradle-plugins\n";
+    }
+
+    /**
+     * Apply manifest-declared Gradle plugins to the app module.
+     */
+    protected function injectAppGradlePlugins(Collection $plugins): void
+    {
+        $appGradlePath = $this->androidProjectPath.'/app/build.gradle.kts';
+
+        if (! $this->files->exists($appGradlePath)) {
+            return;
+        }
+
+        $content = $this->files->get($appGradlePath);
+        $begin = '// BEGIN nativephp-plugin-app-gradle-plugins';
+        $end = '// END nativephp-plugin-app-gradle-plugins';
+        $block = $this->buildAppGradlePluginsBlock($plugins, $content);
+
+        if (str_contains($content, $begin) && str_contains($content, $end)) {
+            $content = preg_replace(
+                '/[ \t]*'.preg_quote($begin, '/').'.*?'.preg_quote($end, '/').'\n?/s',
+                $block,
+                $content,
+                1
+            );
+        } elseif ($block !== '') {
+            $content = preg_replace(
+                '/(plugins\s*\{.*?)(\n\})/s',
+                '$1'."\n".rtrim($block).'$2',
+                $content,
+                1
+            );
+        } else {
+            return;
+        }
+
+        $this->files->put($appGradlePath, $content);
+    }
+
+    public function buildAppGradlePluginsBlock(Collection $plugins, string $existingContent = ''): string
+    {
+        $entries = [];
+        $withoutBlock = preg_replace(
+            '/\/\/ BEGIN nativephp-plugin-app-gradle-plugins.*?\/\/ END nativephp-plugin-app-gradle-plugins/s',
+            '',
+            $existingContent
+        ) ?? $existingContent;
+
+        foreach ($plugins as $plugin) {
+            foreach ($plugin->getAndroidGradlePlugins() as $gradlePlugin) {
+                if (($gradlePlugin['apply_to'] ?? null) !== 'app') {
+                    continue;
+                }
+
+                $id = $gradlePlugin['id'] ?? null;
+
+                if (! is_string($id) || ! preg_match('/^[A-Za-z0-9._-]+$/', $id)) {
+                    $this->warn("Plugin '{$plugin->name}' declares an invalid app gradle plugin id — skipping");
+
+                    continue;
+                }
+
+                if (isset($entries[$id]) || str_contains($withoutBlock, "id(\"{$id}\")")) {
+                    continue;
+                }
+
+                $entries[$id] = "    id(\"{$id}\")";
+            }
+        }
+
+        if ($entries === []) {
+            return '';
+        }
+
+        return "    // BEGIN nativephp-plugin-app-gradle-plugins\n"
+            ."    // Auto-generated on every build from installed plugins — do not edit.\n"
+            .implode("\n", $entries)."\n"
+            ."    // END nativephp-plugin-app-gradle-plugins\n";
     }
 
     /**

--- a/src/Plugins/Compilers/AndroidPluginCompiler.php
+++ b/src/Plugins/Compilers/AndroidPluginCompiler.php
@@ -5,6 +5,7 @@ namespace Native\Mobile\Plugins\Compilers;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use Native\Mobile\Exceptions\PluginConflictException;
+use Native\Mobile\Plugins\LegacyFirebaseConfig;
 use Native\Mobile\Plugins\Plugin;
 use Native\Mobile\Plugins\PluginHookRunner;
 use Native\Mobile\Plugins\PluginRegistry;
@@ -79,8 +80,21 @@ class AndroidPluginCompiler
      */
     protected function warn(string $message): void
     {
-        if ($this->output) {
+        if ($this->output === null) {
+            return;
+        }
+
+        // A Command has warn(); Illuminate\Console\OutputStyle — which is what
+        // the build commands actually pass — does not, so calling it blindly
+        // fataled the build and guarding on it swallowed the message entirely.
+        if (method_exists($this->output, 'warn')) {
             $this->output->warn($message);
+
+            return;
+        }
+
+        if (method_exists($this->output, 'writeln')) {
+            $this->output->writeln("<comment>{$message}</comment>");
         }
     }
 
@@ -187,14 +201,27 @@ class AndroidPluginCompiler
         // Copy app-owned files declared by plugins into the Android project.
         (new ProjectFileManager($this->files, $this->basePath, 'android'))->sync($allPlugins);
 
+        // Back-compat: install Firebase config on behalf of a plugin that
+        // predates project_files, so bumping core alone cannot silently stop
+        // push from working. Does nothing once the plugin owns its config.
+        $legacyFirebase = (new LegacyFirebaseConfig($this->files, $this->basePath))->sync($allPlugins, 'android');
+
+        if ($legacyFirebase !== null) {
+            $this->warn(LegacyFirebaseConfig::deprecationNotice($legacyFirebase, 'android'));
+        }
+
         // Declare plugin-required Gradle plugins in the root build file (runs
         // even when the list is empty so a removed plugin's declaration is cleared).
         $this->injectGradlePlugins($allPlugins);
 
         // Apply plugin-required Gradle plugins to the app module when the
         // manifest explicitly targets it. The marker is also cleared when a
-        // plugin is removed.
-        $this->injectAppGradlePlugins($allPlugins);
+        // plugin is removed. The shim applies Google Services the same way
+        // core's old build.gradle.kts conditional did.
+        $this->injectAppGradlePlugins(
+            $allPlugins,
+            $legacyFirebase !== null ? [LegacyFirebaseConfig::GRADLE_PLUGIN_ID] : []
+        );
 
         if ($allPlugins->isEmpty()) {
             $this->generateEmptyRegistration();
@@ -411,7 +438,7 @@ class AndroidPluginCompiler
     /**
      * Apply manifest-declared Gradle plugins to the app module.
      */
-    protected function injectAppGradlePlugins(Collection $plugins): void
+    protected function injectAppGradlePlugins(Collection $plugins, array $extraIds = []): void
     {
         $appGradlePath = $this->androidProjectPath.'/app/build.gradle.kts';
 
@@ -422,7 +449,7 @@ class AndroidPluginCompiler
         $content = $this->files->get($appGradlePath);
         $begin = '// BEGIN nativephp-plugin-app-gradle-plugins';
         $end = '// END nativephp-plugin-app-gradle-plugins';
-        $block = $this->buildAppGradlePluginsBlock($plugins, $content);
+        $block = $this->buildAppGradlePluginsBlock($plugins, $content, $extraIds);
 
         if (str_contains($content, $begin) && str_contains($content, $end)) {
             $content = preg_replace(
@@ -445,7 +472,7 @@ class AndroidPluginCompiler
         $this->files->put($appGradlePath, $content);
     }
 
-    public function buildAppGradlePluginsBlock(Collection $plugins, string $existingContent = ''): string
+    public function buildAppGradlePluginsBlock(Collection $plugins, string $existingContent = '', array $extraIds = []): string
     {
         $entries = [];
         $withoutBlock = preg_replace(
@@ -474,6 +501,18 @@ class AndroidPluginCompiler
 
                 $entries[$id] = "    id(\"{$id}\")";
             }
+        }
+
+        foreach ($extraIds as $id) {
+            if (! is_string($id) || ! preg_match('/^[A-Za-z0-9._-]+$/', $id)) {
+                continue;
+            }
+
+            if (isset($entries[$id]) || str_contains($withoutBlock, "id(\"{$id}\")")) {
+                continue;
+            }
+
+            $entries[$id] = "    id(\"{$id}\")";
         }
 
         if ($entries === []) {

--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -8,6 +8,7 @@ use Native\Mobile\Exceptions\PluginConflictException;
 use Native\Mobile\Plugins\Plugin;
 use Native\Mobile\Plugins\PluginHookRunner;
 use Native\Mobile\Plugins\PluginRegistry;
+use Native\Mobile\Plugins\ProjectFileManager;
 use Native\Mobile\Plugins\SwiftSourceFilter;
 use Native\Mobile\Support\Stub;
 
@@ -111,6 +112,9 @@ class IOSPluginCompiler
         // duplicate-symbol build failures in Xcode.
         $this->clean();
         $this->files->ensureDirectoryExists($this->generatedPath);
+
+        // Copy app-owned files declared by plugins into the iOS project.
+        (new ProjectFileManager($this->files, $this->basePath, 'ios'))->sync($allPlugins);
 
         // Get plugins with iOS code (for copying files)
         $pluginsWithCode = $allPlugins->filter(fn (Plugin $p) => $p->hasIosCode());

--- a/src/Plugins/Compilers/IOSPluginCompiler.php
+++ b/src/Plugins/Compilers/IOSPluginCompiler.php
@@ -5,6 +5,7 @@ namespace Native\Mobile\Plugins\Compilers;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use Native\Mobile\Exceptions\PluginConflictException;
+use Native\Mobile\Plugins\LegacyFirebaseConfig;
 use Native\Mobile\Plugins\Plugin;
 use Native\Mobile\Plugins\PluginHookRunner;
 use Native\Mobile\Plugins\PluginRegistry;
@@ -115,6 +116,14 @@ class IOSPluginCompiler
 
         // Copy app-owned files declared by plugins into the iOS project.
         (new ProjectFileManager($this->files, $this->basePath, 'ios'))->sync($allPlugins);
+
+        // Back-compat: install GoogleService-Info.plist on behalf of a plugin
+        // that predates project_files. Does nothing once the plugin owns it.
+        $legacyFirebase = (new LegacyFirebaseConfig($this->files, $this->basePath))->sync($allPlugins, 'ios');
+
+        if ($legacyFirebase !== null) {
+            $this->warn(LegacyFirebaseConfig::deprecationNotice($legacyFirebase, 'ios'));
+        }
 
         // Get plugins with iOS code (for copying files)
         $pluginsWithCode = $allPlugins->filter(fn (Plugin $p) => $p->hasIosCode());
@@ -285,8 +294,21 @@ class IOSPluginCompiler
      */
     protected function warn(string $message): void
     {
-        if ($this->output !== null && method_exists($this->output, 'warn')) {
+        if ($this->output === null) {
+            return;
+        }
+
+        // A Command has warn(); Illuminate\Console\OutputStyle — which is what
+        // the build commands actually pass — does not, so calling it blindly
+        // fataled the build and guarding on it swallowed the message entirely.
+        if (method_exists($this->output, 'warn')) {
             $this->output->warn($message);
+
+            return;
+        }
+
+        if (method_exists($this->output, 'writeln')) {
+            $this->output->writeln("<comment>{$message}</comment>");
         }
     }
 
@@ -655,8 +677,8 @@ class IOSPluginCompiler
             if (str_contains($plist, "<key>{$key}</key>")) {
                 if (is_array($value)) {
                     $plist = $this->mergeArrayEntry($plist, $key, $value);
-                } elseif (is_string($value)) {
-                    $plist = $this->updateStringEntry($plist, $key, $this->substituteEnvPlaceholders($value));
+                } else {
+                    $plist = $this->updateScalarEntry($plist, $key, $value);
                 }
 
                 continue;
@@ -666,14 +688,11 @@ class IOSPluginCompiler
             if (is_array($value)) {
                 $arrayContent = '';
                 foreach ($value as $item) {
-                    $item = $this->substituteEnvPlaceholders($item);
-                    $arrayContent .= "\n\t\t<string>{$item}</string>";
+                    $arrayContent .= "\n\t\t".$this->plistScalar($item);
                 }
                 $entry = "\n\t<key>{$key}</key>\n\t<array>{$arrayContent}\n\t</array>";
             } else {
-                // Handle string values - substitute placeholders
-                $value = $this->substituteEnvPlaceholders($value);
-                $entry = "\n\t<key>{$key}</key>\n\t<string>{$value}</string>";
+                $entry = "\n\t<key>{$key}</key>\n\t".$this->plistScalar($value);
             }
 
             // Add before closing </dict>
@@ -691,6 +710,54 @@ class IOSPluginCompiler
     /**
      * Update an existing string entry's value in the plist
      */
+    /**
+     * Render a manifest value as a plist element.
+     *
+     * Booleans and numbers have their own plist types. Writing them as
+     * <string> gives "" for false and "1" for true, which readers such as
+     * Firebase cannot interpret as a boolean — the key reads as unset and
+     * the declared setting is silently ignored.
+     */
+    protected function plistScalar(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? '<true/>' : '<false/>';
+        }
+
+        if (is_int($value)) {
+            return "<integer>{$value}</integer>";
+        }
+
+        if (is_float($value)) {
+            return "<real>{$value}</real>";
+        }
+
+        $value = $this->substituteEnvPlaceholders((string) $value);
+
+        return '<string>'.htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8').'</string>';
+    }
+
+    /**
+     * Replace an existing key's value, whatever plist type it currently has.
+     * Declaring `false` for a key that already holds a <string> must be able
+     * to change the element type, not just its contents.
+     */
+    protected function updateScalarEntry(string $plist, string $key, mixed $value): string
+    {
+        // Each type has an empty self-closing form too (<string/>), which is
+        // what a previously-mangled boolean leaves behind.
+        $pattern = '/(<key>'.preg_quote($key, '/').'<\/key>\s*)'
+            .'(<string>[^<]*<\/string>|<integer>[^<]*<\/integer>|<real>[^<]*<\/real>'
+            .'|<(?:string|integer|real|true|false)\s*\/>)/';
+
+        return preg_replace_callback(
+            $pattern,
+            fn ($matches) => $matches[1].$this->plistScalar($value),
+            $plist,
+            1
+        ) ?? $plist;
+    }
+
     protected function updateStringEntry(string $plist, string $key, string $value): string
     {
         $pattern = '/(<key>'.preg_quote($key, '/').'<\/key>\s*<string>)([^<]*)(<\/string>)/';

--- a/src/Plugins/LegacyFirebaseConfig.php
+++ b/src/Plugins/LegacyFirebaseConfig.php
@@ -22,9 +22,11 @@ use Illuminate\Support\Collection;
  * declared that it owns this destination?" — so a plugin release that has
  * not shipped yet takes over automatically, with no floor to bump here.
  *
- * @deprecated Delete once the supported floor for Firebase plugins declares
- *             its own project_files, and add the matching `conflict` entry
- *             to composer.json at the same time.
+ * Removing it: once the supported floor for Firebase plugins declares its own
+ * project_files, delete this class along with its two call sites, and add the
+ * matching `conflict` entry to composer.json in the same change. Not tagged
+ * deprecated on purpose — nothing outside core may call it, and the tag makes
+ * static analysis flag the call sites that are supposed to exist.
  */
 class LegacyFirebaseConfig
 {

--- a/src/Plugins/LegacyFirebaseConfig.php
+++ b/src/Plugins/LegacyFirebaseConfig.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Native\Mobile\Plugins;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+
+/**
+ * Back-compat shim for Firebase plugins released before `project_files`.
+ *
+ * Core used to install the Firebase config itself — copying
+ * google-services.json / GoogleService-Info.plist out of the project root
+ * and, on Android, applying the Google Services Gradle plugin. That work now
+ * belongs to the plugin that needs it, declared as `project_files` and
+ * `gradle_plugins.apply_to` in its manifest.
+ *
+ * Dropping core's copy outright would silently break every app still on an
+ * older plugin: the build still succeeds, push just stops arriving. So core
+ * keeps doing the job, but only while nobody else has claimed it.
+ *
+ * The check is on capability, not version — "has some installed plugin
+ * declared that it owns this destination?" — so a plugin release that has
+ * not shipped yet takes over automatically, with no floor to bump here.
+ *
+ * @deprecated Delete once the supported floor for Firebase plugins declares
+ *             its own project_files, and add the matching `conflict` entry
+ *             to composer.json at the same time.
+ */
+class LegacyFirebaseConfig
+{
+    public const GRADLE_PLUGIN_ID = 'com.google.gms.google-services';
+
+    /** Where core used to put each platform's config, relative to the native project. */
+    private const DESTINATIONS = [
+        'android' => 'app/google-services.json',
+        'ios' => 'NativePHP/GoogleService-Info.plist',
+    ];
+
+    /** Where core used to look for it, relative to the project root. */
+    private const SOURCES = [
+        'android' => 'google-services.json',
+        'ios' => 'GoogleService-Info.plist',
+    ];
+
+    private string $projectPath;
+
+    public function __construct(
+        private readonly Filesystem $files,
+        private readonly string $basePath,
+    ) {
+        $this->projectPath = dirname(rtrim($basePath, '/\\'));
+    }
+
+    /**
+     * Install the platform's Firebase config the way core used to.
+     *
+     * Returns the name of the plugin core covered for, so the caller can say
+     * so, or null when the shim had nothing to do — which is the case for
+     * every app whose plugin already owns its own config.
+     */
+    public function sync(Collection $plugins, string $platform): ?string
+    {
+        if (! isset(self::DESTINATIONS[$platform]) || $this->isClaimed($plugins, $platform)) {
+            return null;
+        }
+
+        $plugin = $this->firebasePlugin($plugins, $platform);
+
+        if ($plugin === null) {
+            return null;
+        }
+
+        $source = $this->projectPath.'/'.self::SOURCES[$platform];
+
+        // No config file is not an error: core's old copy was conditional
+        // too, and Firebase was never going to work without one anyway.
+        if (! $this->files->isFile($source)) {
+            return null;
+        }
+
+        $target = $this->basePath.'/'.$platform.'/'.self::DESTINATIONS[$platform];
+        $this->files->ensureDirectoryExists(dirname($target));
+        $this->files->copy($source, $target);
+
+        return $plugin->name;
+    }
+
+    /**
+     * The nudge to show when the shim ran.
+     */
+    public static function deprecationNotice(string $pluginName, string $platform): string
+    {
+        $source = self::SOURCES[$platform] ?? 'its Firebase config';
+
+        return "Plugin '{$pluginName}' relies on core to install {$source}. "
+            ."Update it to a version that declares {$platform}.project_files — "
+            .'core will stop doing this on its behalf.';
+    }
+
+    /**
+     * Has an installed plugin declared that it owns this destination?
+     */
+    private function isClaimed(Collection $plugins, string $platform): bool
+    {
+        foreach ($plugins as $plugin) {
+            foreach ($plugin->getProjectFiles($platform) as $declaration) {
+                if (! is_array($declaration)) {
+                    continue;
+                }
+
+                $destination = $declaration['destination'] ?? null;
+
+                if (is_string($destination)
+                    && $this->normalizePath($destination) === self::DESTINATIONS[$platform]) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Find an installed plugin that wants Firebase on this platform.
+     *
+     * Android has an unambiguous marker — the Google Services Gradle plugin.
+     * iOS has no equivalent, so a Firebase CocoaPod stands in for one. Both
+     * exist to keep a stray config file in a project with no Firebase plugin
+     * from being copied anywhere.
+     */
+    private function firebasePlugin(Collection $plugins, string $platform): ?Plugin
+    {
+        return $plugins->first(fn (Plugin $plugin) => $platform === 'android'
+            ? $this->declaresGoogleServicesPlugin($plugin)
+            : $this->declaresFirebasePod($plugin));
+    }
+
+    private function declaresGoogleServicesPlugin(Plugin $plugin): bool
+    {
+        foreach ($plugin->getAndroidGradlePlugins() as $gradlePlugin) {
+            if (is_array($gradlePlugin) && ($gradlePlugin['id'] ?? null) === self::GRADLE_PLUGIN_ID) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function declaresFirebasePod(Plugin $plugin): bool
+    {
+        foreach ($plugin->getIosDependencies()['pods'] ?? [] as $pod) {
+            $name = is_array($pod) ? ($pod['name'] ?? null) : $pod;
+
+            if (is_string($name) && str_starts_with($name, 'Firebase')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function normalizePath(string $path): string
+    {
+        return trim(str_replace('\\', '/', $path), '/');
+    }
+}

--- a/src/Plugins/Plugin.php
+++ b/src/Plugins/Plugin.php
@@ -166,14 +166,25 @@ class Plugin
     /**
      * Gradle plugins this plugin needs declared in the root build.gradle.kts
      * plugins {} block, as `android.gradle_plugins` in nativephp.json.
-     * Each entry: ['id' => string, 'version' => string, 'apply' => bool (default false)].
-     * `apply => false` puts the plugin on the build classpath only, so the
-     * app module can apply it conditionally (e.g. google-services when a
-     * google-services.json is present).
+     * Each entry: ['id' => string, 'version' => string, 'apply' => bool
+     * (default false), 'apply_to' => 'app' (optional)].
      */
     public function getAndroidGradlePlugins(): array
     {
         return $this->manifest->android['gradle_plugins'] ?? [];
+    }
+
+    /**
+     * Application-owned files this plugin needs copied into the generated
+     * native project for the requested platform.
+     */
+    public function getProjectFiles(string $platform): array
+    {
+        return match (strtolower($platform)) {
+            'android' => $this->manifest->android['project_files'] ?? [],
+            'ios' => $this->manifest->ios['project_files'] ?? [],
+            default => [],
+        };
     }
 
     public function getAndroidFeatures(): array

--- a/src/Plugins/ProjectFileManager.php
+++ b/src/Plugins/ProjectFileManager.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Native\Mobile\Plugins;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+use RuntimeException;
+
+class ProjectFileManager
+{
+    private string $projectPath;
+
+    private string $nativeProjectPath;
+
+    private string $statePath;
+
+    public function __construct(
+        private readonly Filesystem $files,
+        private readonly string $basePath,
+        private readonly string $platform,
+    ) {
+        $this->projectPath = dirname(rtrim($basePath, '/\\'));
+        $this->nativeProjectPath = $basePath.'/'.$platform;
+        $this->statePath = $basePath.'/.generated/project-files-'.$platform.'.json';
+    }
+
+    /**
+     * Copy application-owned files declared by plugins into the generated
+     * native project, and remove files managed by plugins that are no longer
+     * installed or no longer declare them.
+     */
+    public function sync(Collection $plugins): void
+    {
+        $files = $this->resolveFiles($plugins);
+        $previousDestinations = $this->readManagedDestinations();
+        $currentDestinations = array_keys($files);
+
+        foreach (array_diff($previousDestinations, $currentDestinations) as $destination) {
+            $this->files->delete($this->nativeProjectPath.'/'.$destination);
+        }
+
+        foreach ($files as $destination => $file) {
+            $target = $this->nativeProjectPath.'/'.$destination;
+            $this->files->ensureDirectoryExists(dirname($target));
+            $this->files->copy($file['source'], $target);
+        }
+
+        $this->writeManagedDestinations($currentDestinations);
+    }
+
+    private function resolveFiles(Collection $plugins): array
+    {
+        $resolved = [];
+
+        foreach ($plugins as $plugin) {
+            foreach ($plugin->getProjectFiles($this->platform) as $declaration) {
+                if (! is_array($declaration)) {
+                    throw new RuntimeException(
+                        "Plugin '{$plugin->name}' has an invalid {$this->platform}.project_files declaration."
+                    );
+                }
+
+                $sources = $declaration['sources'] ?? [];
+                $destination = $declaration['destination'] ?? null;
+                $required = $declaration['required'] ?? false;
+
+                if (is_string($sources)) {
+                    $sources = [$sources];
+                }
+
+                if (! is_array($sources) || $sources === [] || ! is_string($destination) || $destination === '') {
+                    throw new RuntimeException(
+                        "Plugin '{$plugin->name}' must declare sources and a destination for each {$this->platform}.project_files entry."
+                    );
+                }
+
+                foreach ($sources as $source) {
+                    $this->assertSafeRelativePath($source, "Plugin '{$plugin->name}' project file source");
+                }
+                $this->assertSafeRelativePath($destination, "Plugin '{$plugin->name}' project file destination");
+
+                $destination = $this->normalizePath($destination);
+
+                if (isset($resolved[$destination])) {
+                    throw new RuntimeException(
+                        "Plugins '{$resolved[$destination]['plugin']}' and '{$plugin->name}' both manage {$this->platform} project file '{$destination}'."
+                    );
+                }
+
+                $source = collect($sources)
+                    ->map(fn (string $path) => $this->projectPath.'/'.$this->normalizePath($path))
+                    ->first(fn (string $path) => $this->files->isFile($path));
+
+                if ($source === null) {
+                    if ($required) {
+                        throw new RuntimeException(
+                            "Plugin '{$plugin->name}' requires one of these project files for {$this->platform}: ".implode(', ', $sources).'.'
+                        );
+                    }
+
+                    continue;
+                }
+
+                $resolved[$destination] = [
+                    'plugin' => $plugin->name,
+                    'source' => $source,
+                ];
+            }
+        }
+
+        return $resolved;
+    }
+
+    private function readManagedDestinations(): array
+    {
+        if (! $this->files->isFile($this->statePath)) {
+            return [];
+        }
+
+        $destinations = json_decode($this->files->get($this->statePath), true);
+
+        if (! is_array($destinations)) {
+            return [];
+        }
+
+        return array_values(array_filter($destinations, function ($destination) {
+            if (! is_string($destination)) {
+                return false;
+            }
+
+            try {
+                $this->assertSafeRelativePath($destination, 'Managed project file destination');
+
+                return true;
+            } catch (RuntimeException) {
+                return false;
+            }
+        }));
+    }
+
+    private function writeManagedDestinations(array $destinations): void
+    {
+        if ($destinations === []) {
+            $this->files->delete($this->statePath);
+
+            return;
+        }
+
+        $this->files->ensureDirectoryExists(dirname($this->statePath));
+        $this->files->put(
+            $this->statePath,
+            json_encode(array_values($destinations), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n"
+        );
+    }
+
+    private function assertSafeRelativePath(mixed $path, string $label): void
+    {
+        if (! is_string($path) || $path === '' || str_starts_with($path, '/') || preg_match('/^[A-Za-z]:[\\\\\/]/', $path)) {
+            throw new RuntimeException("{$label} must be a relative path.");
+        }
+
+        $segments = preg_split('/[\\\\\/]+/', $path);
+
+        if (in_array('..', $segments, true)) {
+            throw new RuntimeException("{$label} may not traverse outside the project.");
+        }
+    }
+
+    private function normalizePath(string $path): string
+    {
+        return trim(str_replace('\\', '/', $path), '/');
+    }
+}

--- a/src/Plugins/ProjectFileManager.php
+++ b/src/Plugins/ProjectFileManager.php
@@ -93,8 +93,11 @@ class ProjectFileManager
 
                 if ($source === null) {
                     if ($required) {
-                        throw new RuntimeException(
-                            "Plugin '{$plugin->name}' requires one of these project files for {$this->platform}: ".implode(', ', $sources).'.'
+                        $sources = array_values($sources);
+
+                        throw new RuntimeException(count($sources) === 1
+                            ? "Plugin '{$plugin->name}' requires '{$sources[0]}' in your project root for {$this->platform}."
+                            : "Plugin '{$plugin->name}' requires one of these project files for {$this->platform}, relative to your project root: ".implode(', ', $sources).'.'
                         );
                     }
 

--- a/tests/Feature/Plugins/AndroidCompilerTest.php
+++ b/tests/Feature/Plugins/AndroidCompilerTest.php
@@ -1610,6 +1610,74 @@ object TestFunctions {
         $this->assertStringContainsString('id("com.example.application-plugin")', $app);
     }
 
+    /**
+     * @test
+     *
+     * The back-compat shim applies Google Services to the app module the way
+     * core's old build.gradle.kts conditional did, for a plugin that declares
+     * the Gradle plugin but not `apply_to`.
+     */
+    public function it_applies_extra_gradle_plugin_ids_supplied_by_the_legacy_shim(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'gradle_plugins' => [
+                    ['id' => 'com.google.gms.google-services', 'version' => '4.4.3'],
+                ],
+            ],
+        ]);
+
+        $block = $this->compiler->buildAppGradlePluginsBlock(
+            collect([$plugin]),
+            '',
+            ['com.google.gms.google-services']
+        );
+
+        $this->assertStringContainsString('id("com.google.gms.google-services")', $block);
+    }
+
+    /**
+     * @test
+     *
+     * A plugin declaring `apply_to: app` already lands the id, so the shim
+     * passing the same one must not produce a duplicate.
+     */
+    public function it_does_not_duplicate_a_shim_id_the_manifest_already_applies(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'gradle_plugins' => [
+                    ['id' => 'com.google.gms.google-services', 'version' => '4.4.3', 'apply_to' => 'app'],
+                ],
+            ],
+        ]);
+
+        $block = $this->compiler->buildAppGradlePluginsBlock(
+            collect([$plugin]),
+            '',
+            ['com.google.gms.google-services']
+        );
+
+        $this->assertSame(1, substr_count($block, 'id("com.google.gms.google-services")'));
+    }
+
+    /** @test */
+    public function it_skips_a_shim_id_already_declared_outside_the_markers(): void
+    {
+        $existing = 'plugins {'.PHP_EOL
+            .'    id("com.android.application")'.PHP_EOL
+            .'    id("com.google.gms.google-services")'.PHP_EOL
+            .'}'.PHP_EOL;
+
+        $block = $this->compiler->buildAppGradlePluginsBlock(
+            collect([]),
+            $existing,
+            ['com.google.gms.google-services']
+        );
+
+        $this->assertSame('', $block);
+    }
+
     /** @test */
     public function it_clears_app_gradle_plugins_when_the_plugin_is_removed(): void
     {

--- a/tests/Feature/Plugins/AndroidCompilerTest.php
+++ b/tests/Feature/Plugins/AndroidCompilerTest.php
@@ -1580,6 +1580,87 @@ object TestFunctions {
         );
     }
 
+    /** @test */
+    public function it_applies_declared_gradle_plugins_to_the_app_module(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'gradle_plugins' => [
+                    [
+                        'id' => 'com.example.application-plugin',
+                        'version' => '1.2.3',
+                        'apply_to' => 'app',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $root = $this->files->get($this->testBasePath.'/android/build.gradle.kts');
+        $app = $this->files->get($this->testBasePath.'/android/app/build.gradle.kts');
+
+        $this->assertStringContainsString(
+            'id("com.example.application-plugin") version "1.2.3" apply false',
+            $root
+        );
+        $this->assertStringContainsString('// BEGIN nativephp-plugin-app-gradle-plugins', $app);
+        $this->assertStringContainsString('id("com.example.application-plugin")', $app);
+    }
+
+    /** @test */
+    public function it_clears_app_gradle_plugins_when_the_plugin_is_removed(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'gradle_plugins' => [
+                    ['id' => 'com.example.application-plugin', 'version' => '1.2.3', 'apply_to' => 'app'],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+        $this->compiler->compile();
+
+        $emptyRegistry = Mockery::mock(PluginRegistry::class);
+        $emptyRegistry->shouldReceive('detectConflicts')->andReturn([]);
+        $emptyRegistry->shouldReceive('all')->andReturn(collect([]));
+
+        (new AndroidPluginCompiler($this->files, $emptyRegistry, $this->testBasePath))->compile();
+
+        $app = $this->files->get($this->testBasePath.'/android/app/build.gradle.kts');
+
+        $this->assertStringNotContainsString('com.example.application-plugin', $app);
+        $this->assertStringNotContainsString('nativephp-plugin-app-gradle-plugins', $app);
+    }
+
+    /** @test */
+    public function it_does_not_duplicate_a_manually_applied_app_gradle_plugin(): void
+    {
+        $appPath = $this->testBasePath.'/android/app/build.gradle.kts';
+        $this->files->put($appPath, 'plugins {'.PHP_EOL
+            .'    id("com.android.application")'.PHP_EOL
+            .'    id("com.example.application-plugin")'.PHP_EOL
+            .'}'.PHP_EOL);
+
+        $plugin = $this->createTestPlugin([
+            'android' => [
+                'gradle_plugins' => [
+                    ['id' => 'com.example.application-plugin', 'version' => '1.2.3', 'apply_to' => 'app'],
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+        $this->compiler->compile();
+
+        $app = $this->files->get($appPath);
+
+        $this->assertSame(1, substr_count($app, 'id("com.example.application-plugin")'));
+    }
+
     /**
      * @test
      *

--- a/tests/Feature/Plugins/IOSCompilerTest.php
+++ b/tests/Feature/Plugins/IOSCompilerTest.php
@@ -344,6 +344,125 @@ class NestedClass {}');
     /**
      * @test
      *
+     * A manifest boolean must land as <true/> / <false/>. Written as a
+     * <string> it renders as "" for false, which Firebase and friends read
+     * as unset — the declared setting is silently ignored.
+     */
+    public function it_writes_manifest_booleans_as_plist_booleans(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'ios' => [
+                'info_plist' => [
+                    'FirebaseAppDelegateProxyEnabled' => false,
+                    'UIFileSharingEnabled' => true,
+                ],
+            ],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $content = $this->files->get($this->testBasePath.'/ios/NativePHP/Info.plist');
+
+        $this->assertMatchesRegularExpression(
+            '/<key>FirebaseAppDelegateProxyEnabled<\/key>\s*<false\s*\/>/',
+            $content
+        );
+        $this->assertMatchesRegularExpression(
+            '/<key>UIFileSharingEnabled<\/key>\s*<true\s*\/>/',
+            $content
+        );
+        $this->assertStringNotContainsString(
+            '<key>FirebaseAppDelegateProxyEnabled</key>',
+            str_replace('<key>FirebaseAppDelegateProxyEnabled</key>', '', $content)
+        );
+    }
+
+    /**
+     * @test
+     *
+     * An earlier build wrote booleans as <string/>. Recompiling has to
+     * replace that self-closing element, not skip it as unmatched.
+     */
+    public function it_repairs_a_boolean_previously_written_as_an_empty_string(): void
+    {
+        $plistPath = $this->testBasePath.'/ios/NativePHP/Info.plist';
+        $this->files->put($plistPath, str_replace(
+            '</dict>',
+            "\t<key>FirebaseAppDelegateProxyEnabled</key>\n\t<string/>\n</dict>",
+            $this->files->get($plistPath)
+        ));
+
+        $plugin = $this->createTestPlugin([
+            'ios' => ['info_plist' => ['FirebaseAppDelegateProxyEnabled' => false]],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $content = $this->files->get($plistPath);
+
+        $this->assertMatchesRegularExpression(
+            '/<key>FirebaseAppDelegateProxyEnabled<\/key>\s*<false\s*\/>/',
+            $content
+        );
+        $this->assertStringNotContainsString('<string/>', $content);
+    }
+
+    /** @test */
+    public function it_writes_manifest_integers_as_plist_integers(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'ios' => ['info_plist' => ['SomeNumericSetting' => 42]],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+
+        $this->compiler->compile();
+
+        $content = $this->files->get($this->testBasePath.'/ios/NativePHP/Info.plist');
+
+        $this->assertMatchesRegularExpression(
+            '/<key>SomeNumericSetting<\/key>\s*<integer>42<\/integer>/',
+            $content
+        );
+    }
+
+    /**
+     * @test
+     *
+     * Declaring a boolean for a key that already holds a <string> has to
+     * change the element type, not just its contents.
+     */
+    public function it_replaces_an_existing_string_entry_with_a_boolean(): void
+    {
+        $plugin = $this->createTestPlugin([
+            'ios' => ['info_plist' => ['NSCameraUsageDescription' => 'Camera access']],
+        ]);
+
+        $this->mockRegistry->shouldReceive('all')->andReturn(collect([$plugin]));
+        $this->compiler->compile();
+
+        $plistPath = $this->testBasePath.'/ios/NativePHP/Info.plist';
+        $this->assertStringContainsString('<string>Camera access</string>', $this->files->get($plistPath));
+
+        config()->set('nativephp.permissions', ['NSCameraUsageDescription' => false]);
+        $this->compiler->compile();
+
+        $content = $this->files->get($plistPath);
+
+        $this->assertMatchesRegularExpression(
+            '/<key>NSCameraUsageDescription<\/key>\s*<false\s*\/>/',
+            $content
+        );
+        $this->assertStringNotContainsString('<string>Camera access</string>', $content);
+    }
+
+    /**
+     * @test
+     *
      * App-level config('nativephp.permissions.ios') wins over plugin manifests,
      * so an app developer can resolve key collisions between plugins.
      */

--- a/tests/Feature/ReleaseBuildBundleTest.php
+++ b/tests/Feature/ReleaseBuildBundleTest.php
@@ -253,6 +253,4 @@ class ReleaseBuildTester
     protected function updatePermissions(): void {}
 
     protected function updateIcuConfiguration(): void {}
-
-    protected function updateFirebaseConfiguration(): void {}
 }

--- a/tests/Unit/BuildConfigurationTest.php
+++ b/tests/Unit/BuildConfigurationTest.php
@@ -333,6 +333,4 @@ REPLACE_CUSTOM_PROGUARD_RULES',
     protected function updatePermissions(): void {}
 
     protected function updateIcuConfiguration(): void {}
-
-    protected function updateFirebaseConfiguration(): void {}
 }

--- a/tests/Unit/Concerns/RunsAndroidTest.php
+++ b/tests/Unit/Concerns/RunsAndroidTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit\Concerns;
 use Illuminate\Support\Facades\File;
 use Mockery;
 use Native\Mobile\Concerns\RunsAndroid;
+use Native\Mobile\Plugins\Plugin;
+use Native\Mobile\Plugins\PluginManifest;
 use Orchestra\Testbench\TestCase;
 
 class RunsAndroidTest extends TestCase
@@ -26,6 +28,8 @@ class RunsAndroidTest extends TestCase
         // Mock $this->components for task() calls used by PreparesBuild
         $this->components = new class
         {
+            public array $errors = [];
+
             public function task(string $title, callable $callback)
             {
                 $callback();
@@ -34,7 +38,14 @@ class RunsAndroidTest extends TestCase
             public function twoColumnDetail(...$args) {}
 
             public function warn(...$args) {}
+
+            public function error(string $message): void
+            {
+                $this->errors[] = $message;
+            }
         };
+
+        $this->androidLogPath = $this->testProjectPath.'/nativephp/android-build.log';
     }
 
     protected function tearDown(): void
@@ -201,6 +212,117 @@ class RunsAndroidTest extends TestCase
         $targetPath = $targetDir.'/google-services.json';
         $this->assertFileExists($targetPath);
         $this->assertEquals('{"project_id": "test"}', File::get($targetPath));
+    }
+
+    public function test_google_services_configuration_requires_a_declaring_plugin()
+    {
+        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
+
+        $this->assertFalse($this->validateGoogleServicesConfiguration(collect()));
+        $this->assertCount(1, $this->components->errors);
+        $this->assertStringContainsString('nativephp/mobile-firebase', $this->components->errors[0]);
+    }
+
+    public function test_registered_plugin_can_own_google_services_configuration()
+    {
+        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
+
+        $plugin = new Plugin(
+            name: 'nativephp/mobile-firebase',
+            version: '1.1.1',
+            path: $this->testProjectPath.'/vendor/nativephp/mobile-firebase',
+            manifest: new PluginManifest([
+                'namespace' => 'Firebase',
+                'android' => [
+                    'gradle_plugins' => [
+                        ['id' => 'com.google.gms.google-services', 'version' => '4.4.3'],
+                    ],
+                ],
+            ]),
+        );
+
+        $this->assertTrue($this->validateGoogleServicesConfiguration(collect([$plugin])));
+        $this->assertSame([], $this->components->errors);
+    }
+
+    public function test_plugin_name_alone_does_not_claim_google_services_configuration()
+    {
+        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
+
+        $plugin = new Plugin(
+            name: 'nativephp/mobile-firebase',
+            version: '1.1.0',
+            path: $this->testProjectPath.'/vendor/nativephp/mobile-firebase',
+            manifest: new PluginManifest([
+                'namespace' => 'Firebase',
+                'android' => [],
+            ]),
+        );
+
+        $this->assertFalse($this->validateGoogleServicesConfiguration(collect([$plugin])));
+    }
+
+    public function test_manual_gradle_declaration_can_own_google_services_configuration()
+    {
+        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
+        File::put(
+            $this->testProjectPath.'/nativephp/android/build.gradle.kts',
+            'plugins {'.PHP_EOL
+            .'    id("com.google.gms.google-services") version "4.4.3" apply false'.PHP_EOL
+            .'}'.PHP_EOL,
+        );
+
+        $this->assertTrue($this->validateGoogleServicesConfiguration(collect()));
+        $this->assertSame([], $this->components->errors);
+    }
+
+    public function test_manual_buildscript_classpath_can_own_google_services_configuration()
+    {
+        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
+        File::put(
+            $this->testProjectPath.'/nativephp/android/build.gradle.kts',
+            'buildscript {'.PHP_EOL
+            .'    dependencies {'.PHP_EOL
+            .'        classpath("com.google.gms:google-services:4.4.2")'.PHP_EOL
+            .'    }'.PHP_EOL
+            .'}'.PHP_EOL,
+        );
+
+        $this->assertTrue($this->validateGoogleServicesConfiguration(collect()));
+        $this->assertSame([], $this->components->errors);
+    }
+
+    public function test_google_services_mentioned_only_in_a_comment_is_not_a_declaration()
+    {
+        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
+        File::put(
+            $this->testProjectPath.'/nativephp/android/build.gradle.kts',
+            '// id("com.google.gms.google-services") is intentionally not configured'.PHP_EOL,
+        );
+
+        $this->assertFalse($this->validateGoogleServicesConfiguration(collect()));
+    }
+
+    public function test_stale_generated_declaration_does_not_claim_google_services_configuration()
+    {
+        File::makeDirectory($this->testProjectPath.'/nativephp/android/app', 0755, true);
+        File::put($this->testProjectPath.'/nativephp/android/app/google-services.json', '{"project_id": "test"}');
+        File::put(
+            $this->testProjectPath.'/nativephp/android/build.gradle.kts',
+            'plugins {'.PHP_EOL
+            .'    // BEGIN nativephp-plugin-gradle-plugins'.PHP_EOL
+            .'    id("com.google.gms.google-services") version "4.4.3" apply false'.PHP_EOL
+            .'    // END nativephp-plugin-gradle-plugins'.PHP_EOL
+            .'}'.PHP_EOL,
+        );
+
+        $this->assertFalse($this->validateGoogleServicesConfiguration(collect()));
+    }
+
+    public function test_project_without_google_services_configuration_needs_no_plugin()
+    {
+        $this->assertTrue($this->validateGoogleServicesConfiguration(collect()));
+        $this->assertSame([], $this->components->errors);
     }
 
     public function test_update_local_properties_windows_path()

--- a/tests/Unit/Concerns/RunsAndroidTest.php
+++ b/tests/Unit/Concerns/RunsAndroidTest.php
@@ -5,8 +5,6 @@ namespace Tests\Unit\Concerns;
 use Illuminate\Support\Facades\File;
 use Mockery;
 use Native\Mobile\Concerns\RunsAndroid;
-use Native\Mobile\Plugins\Plugin;
-use Native\Mobile\Plugins\PluginManifest;
 use Orchestra\Testbench\TestCase;
 
 class RunsAndroidTest extends TestCase
@@ -28,8 +26,6 @@ class RunsAndroidTest extends TestCase
         // Mock $this->components for task() calls used by PreparesBuild
         $this->components = new class
         {
-            public array $errors = [];
-
             public function task(string $title, callable $callback)
             {
                 $callback();
@@ -38,14 +34,7 @@ class RunsAndroidTest extends TestCase
             public function twoColumnDetail(...$args) {}
 
             public function warn(...$args) {}
-
-            public function error(string $message): void
-            {
-                $this->errors[] = $message;
-            }
         };
-
-        $this->androidLogPath = $this->testProjectPath.'/nativephp/android-build.log';
     }
 
     protected function tearDown(): void
@@ -193,136 +182,6 @@ class RunsAndroidTest extends TestCase
 
         $contents = File::get($manifestPath);
         $this->assertStringNotContainsString('android.permission.POST_NOTIFICATIONS', $contents);
-    }
-
-    public function test_update_firebase_configuration_copies_file()
-    {
-        // Create source google-services.json
-        $sourcePath = $this->testProjectPath.'/google-services.json';
-        File::put($sourcePath, '{"project_id": "test"}');
-
-        // Create target directory
-        $targetDir = $this->testProjectPath.'/nativephp/android/app';
-        File::makeDirectory($targetDir, 0755, true);
-
-        // Execute
-        $this->updateFirebaseConfiguration();
-
-        // Assert file was copied
-        $targetPath = $targetDir.'/google-services.json';
-        $this->assertFileExists($targetPath);
-        $this->assertEquals('{"project_id": "test"}', File::get($targetPath));
-    }
-
-    public function test_google_services_configuration_requires_a_declaring_plugin()
-    {
-        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
-
-        $this->assertFalse($this->validateGoogleServicesConfiguration(collect()));
-        $this->assertCount(1, $this->components->errors);
-        $this->assertStringContainsString('nativephp/mobile-firebase', $this->components->errors[0]);
-    }
-
-    public function test_registered_plugin_can_own_google_services_configuration()
-    {
-        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
-
-        $plugin = new Plugin(
-            name: 'nativephp/mobile-firebase',
-            version: '1.1.1',
-            path: $this->testProjectPath.'/vendor/nativephp/mobile-firebase',
-            manifest: new PluginManifest([
-                'namespace' => 'Firebase',
-                'android' => [
-                    'gradle_plugins' => [
-                        ['id' => 'com.google.gms.google-services', 'version' => '4.4.3'],
-                    ],
-                ],
-            ]),
-        );
-
-        $this->assertTrue($this->validateGoogleServicesConfiguration(collect([$plugin])));
-        $this->assertSame([], $this->components->errors);
-    }
-
-    public function test_plugin_name_alone_does_not_claim_google_services_configuration()
-    {
-        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
-
-        $plugin = new Plugin(
-            name: 'nativephp/mobile-firebase',
-            version: '1.1.0',
-            path: $this->testProjectPath.'/vendor/nativephp/mobile-firebase',
-            manifest: new PluginManifest([
-                'namespace' => 'Firebase',
-                'android' => [],
-            ]),
-        );
-
-        $this->assertFalse($this->validateGoogleServicesConfiguration(collect([$plugin])));
-    }
-
-    public function test_manual_gradle_declaration_can_own_google_services_configuration()
-    {
-        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
-        File::put(
-            $this->testProjectPath.'/nativephp/android/build.gradle.kts',
-            'plugins {'.PHP_EOL
-            .'    id("com.google.gms.google-services") version "4.4.3" apply false'.PHP_EOL
-            .'}'.PHP_EOL,
-        );
-
-        $this->assertTrue($this->validateGoogleServicesConfiguration(collect()));
-        $this->assertSame([], $this->components->errors);
-    }
-
-    public function test_manual_buildscript_classpath_can_own_google_services_configuration()
-    {
-        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
-        File::put(
-            $this->testProjectPath.'/nativephp/android/build.gradle.kts',
-            'buildscript {'.PHP_EOL
-            .'    dependencies {'.PHP_EOL
-            .'        classpath("com.google.gms:google-services:4.4.2")'.PHP_EOL
-            .'    }'.PHP_EOL
-            .'}'.PHP_EOL,
-        );
-
-        $this->assertTrue($this->validateGoogleServicesConfiguration(collect()));
-        $this->assertSame([], $this->components->errors);
-    }
-
-    public function test_google_services_mentioned_only_in_a_comment_is_not_a_declaration()
-    {
-        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
-        File::put(
-            $this->testProjectPath.'/nativephp/android/build.gradle.kts',
-            '// id("com.google.gms.google-services") is intentionally not configured'.PHP_EOL,
-        );
-
-        $this->assertFalse($this->validateGoogleServicesConfiguration(collect()));
-    }
-
-    public function test_stale_generated_declaration_does_not_claim_google_services_configuration()
-    {
-        File::makeDirectory($this->testProjectPath.'/nativephp/android/app', 0755, true);
-        File::put($this->testProjectPath.'/nativephp/android/app/google-services.json', '{"project_id": "test"}');
-        File::put(
-            $this->testProjectPath.'/nativephp/android/build.gradle.kts',
-            'plugins {'.PHP_EOL
-            .'    // BEGIN nativephp-plugin-gradle-plugins'.PHP_EOL
-            .'    id("com.google.gms.google-services") version "4.4.3" apply false'.PHP_EOL
-            .'    // END nativephp-plugin-gradle-plugins'.PHP_EOL
-            .'}'.PHP_EOL,
-        );
-
-        $this->assertFalse($this->validateGoogleServicesConfiguration(collect()));
-    }
-
-    public function test_project_without_google_services_configuration_needs_no_plugin()
-    {
-        $this->assertTrue($this->validateGoogleServicesConfiguration(collect()));
-        $this->assertSame([], $this->components->errors);
     }
 
     public function test_update_local_properties_windows_path()

--- a/tests/Unit/ConfigurationUpdatesTest.php
+++ b/tests/Unit/ConfigurationUpdatesTest.php
@@ -66,9 +66,6 @@ class ConfigurationUpdatesTest extends TestCase
             'nativephp.android.build.debug_symbols' => 'SYMBOL_TABLE',
         ]);
 
-        // Create google-services.json
-        File::put($this->testProjectPath.'/google-services.json', '{"project_id": "test"}');
-
         // Enable ICU via nativephp.lock
         File::put($this->testProjectPath.'/nativephp.lock', json_encode(['php' => ['version' => '8.4.7', 'icu' => true]]));
 
@@ -81,7 +78,6 @@ class ConfigurationUpdatesTest extends TestCase
         $this->assertAppNameUpdated();
         $this->assertPermissionsUpdated();
         $this->assertDeepLinksConfigured();
-        $this->assertFirebaseConfigCopied();
         $this->assertSdkPathUpdated();
         $this->assertIcuConfigured();
         $this->assertBuildConfigurationUpdated();
@@ -333,13 +329,6 @@ Java_com_nativephp_mobile_bridge_PHPBridge',
         $this->assertStringContainsString('android:host="new.example.com"', $contents);
     }
 
-    protected function assertFirebaseConfigCopied(): void
-    {
-        $targetPath = $this->testProjectPath.'/nativephp/android/app/google-services.json';
-        $this->assertFileExists($targetPath);
-        $this->assertEquals('{"project_id": "test"}', File::get($targetPath));
-    }
-
     protected function assertSdkPathUpdated(): void
     {
         $localPropertiesPath = $this->testProjectPath.'/nativephp/android/local.properties';
@@ -584,16 +573,6 @@ Java_com_nativephp_mobile_bridge_PHPBridge',
                 $contents = str_replace('System.loadLibrary("php")', 'System.loadLibrary("icudata")'.PHP_EOL.'        System.loadLibrary("php")', $contents);
             }
             File::put($bridgePath, $contents);
-        }
-    }
-
-    protected function updateFirebaseConfiguration(): void
-    {
-        $sourcePath = $this->testProjectPath.'/google-services.json';
-        $targetPath = $this->testProjectPath.'/nativephp/android/app/google-services.json';
-
-        if (File::exists($sourcePath)) {
-            File::copy($sourcePath, $targetPath);
         }
     }
 

--- a/tests/Unit/Plugins/LegacyFirebaseConfigTest.php
+++ b/tests/Unit/Plugins/LegacyFirebaseConfigTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Unit\Plugins;
+
+use Illuminate\Filesystem\Filesystem;
+use Native\Mobile\Plugins\LegacyFirebaseConfig;
+use Native\Mobile\Plugins\Plugin;
+use Native\Mobile\Plugins\PluginManifest;
+use PHPUnit\Framework\TestCase;
+
+class LegacyFirebaseConfigTest extends TestCase
+{
+    private Filesystem $files;
+
+    private string $projectPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = new Filesystem;
+        $this->projectPath = sys_get_temp_dir().'/nativephp-legacy-firebase-'.uniqid();
+        $this->files->ensureDirectoryExists($this->projectPath.'/nativephp/android/app');
+        $this->files->ensureDirectoryExists($this->projectPath.'/nativephp/ios/NativePHP');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->files->deleteDirectory($this->projectPath);
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_installs_android_config_for_a_plugin_that_predates_project_files(): void
+    {
+        $this->files->put($this->projectPath.'/google-services.json', '{"project_id":"legacy"}');
+
+        $covered = $this->shim()->sync(collect([$this->oldPlugin()]), 'android');
+
+        $this->assertSame('vendor/firebase-plugin', $covered);
+        $this->assertSame(
+            '{"project_id":"legacy"}',
+            $this->files->get($this->projectPath.'/nativephp/android/app/google-services.json')
+        );
+    }
+
+    /** @test */
+    public function it_installs_ios_config_for_a_plugin_that_predates_project_files(): void
+    {
+        $this->files->put($this->projectPath.'/GoogleService-Info.plist', '<plist/>');
+
+        $covered = $this->shim()->sync(collect([$this->oldPlugin()]), 'ios');
+
+        $this->assertSame('vendor/firebase-plugin', $covered);
+        $this->assertFileExists($this->projectPath.'/nativephp/ios/NativePHP/GoogleService-Info.plist');
+    }
+
+    /**
+     * @test
+     *
+     * The handover: once the plugin declares the destination itself,
+     * ProjectFileManager owns the copy and core must keep its hands off.
+     */
+    public function it_stands_down_once_the_plugin_owns_the_destination(): void
+    {
+        $this->files->put($this->projectPath.'/google-services.json', 'root');
+
+        $covered = $this->shim()->sync(collect([$this->newPlugin()]), 'android');
+
+        $this->assertNull($covered);
+        $this->assertFileDoesNotExist($this->projectPath.'/nativephp/android/app/google-services.json');
+    }
+
+    /**
+     * @test
+     *
+     * A stray config file with no Firebase plugin installed is not core's
+     * business — copying it in is what made the Gradle build fail.
+     */
+    public function it_ignores_a_config_file_when_no_plugin_wants_firebase(): void
+    {
+        $this->files->put($this->projectPath.'/google-services.json', 'root');
+        $this->files->put($this->projectPath.'/GoogleService-Info.plist', '<plist/>');
+
+        $unrelated = $this->plugin('vendor/unrelated', []);
+
+        $this->assertNull($this->shim()->sync(collect([$unrelated]), 'android'));
+        $this->assertNull($this->shim()->sync(collect([$unrelated]), 'ios'));
+        $this->assertFileDoesNotExist($this->projectPath.'/nativephp/android/app/google-services.json');
+        $this->assertFileDoesNotExist($this->projectPath.'/nativephp/ios/NativePHP/GoogleService-Info.plist');
+    }
+
+    /** @test */
+    public function it_does_nothing_when_there_is_no_config_file_to_install(): void
+    {
+        $this->assertNull($this->shim()->sync(collect([$this->oldPlugin()]), 'android'));
+        $this->assertFileDoesNotExist($this->projectPath.'/nativephp/android/app/google-services.json');
+    }
+
+    private function shim(): LegacyFirebaseConfig
+    {
+        return new LegacyFirebaseConfig($this->files, $this->projectPath.'/nativephp');
+    }
+
+    /** A pre-`project_files` Firebase plugin: Gradle plugin + pods, no ownership. */
+    private function oldPlugin(): Plugin
+    {
+        return $this->plugin('vendor/firebase-plugin', [
+            'android' => [
+                'gradle_plugins' => [
+                    ['id' => 'com.google.gms.google-services', 'version' => '4.4.3'],
+                ],
+            ],
+            'ios' => [
+                'dependencies' => ['pods' => [['name' => 'FirebaseMessaging', 'version' => '~> 12.6.0']]],
+            ],
+        ]);
+    }
+
+    /** The same plugin once it declares its own config files. */
+    private function newPlugin(): Plugin
+    {
+        return $this->plugin('vendor/firebase-plugin', [
+            'android' => [
+                'gradle_plugins' => [
+                    ['id' => 'com.google.gms.google-services', 'version' => '4.4.3', 'apply_to' => 'app'],
+                ],
+                'project_files' => [[
+                    'sources' => ['google-services.json'],
+                    'destination' => 'app/google-services.json',
+                    'required' => true,
+                ]],
+            ],
+        ]);
+    }
+
+    private function plugin(string $name, array $platforms): Plugin
+    {
+        return new Plugin(
+            name: $name,
+            version: '1.0.0',
+            path: $this->projectPath.'/vendor/'.$name,
+            manifest: new PluginManifest(array_merge([
+                'namespace' => 'Firebase',
+            ], $platforms)),
+        );
+    }
+}

--- a/tests/Unit/Plugins/PluginTest.php
+++ b/tests/Unit/Plugins/PluginTest.php
@@ -199,6 +199,29 @@ class PluginTest extends TestCase
         $this->assertSame([], $this->plugin->getAndroidProguardRules());
     }
 
+    /** @test */
+    public function it_returns_platform_project_files(): void
+    {
+        $manifest = new PluginManifest([
+            'namespace' => 'FilesPlugin',
+            'android' => [
+                'project_files' => [
+                    ['sources' => ['service.json'], 'destination' => 'app/service.json'],
+                ],
+            ],
+            'ios' => [
+                'project_files' => [
+                    ['sources' => ['Service.plist'], 'destination' => 'NativePHP/Service.plist'],
+                ],
+            ],
+        ]);
+        $plugin = new Plugin('vendor/files-plugin', '1.0.0', $this->validPluginPath, $manifest);
+
+        $this->assertSame($manifest->android['project_files'], $plugin->getProjectFiles('android'));
+        $this->assertSame($manifest->ios['project_files'], $plugin->getProjectFiles('ios'));
+        $this->assertSame([], $plugin->getProjectFiles('windows'));
+    }
+
     /**
      * @test
      *

--- a/tests/Unit/Plugins/ProjectFileManagerTest.php
+++ b/tests/Unit/Plugins/ProjectFileManagerTest.php
@@ -54,10 +54,25 @@ class ProjectFileManagerTest extends TestCase
     public function it_reports_a_missing_required_file_as_the_plugins_requirement(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage("Plugin 'vendor/files-plugin' requires one of these project files for android: service.json.");
+        $this->expectExceptionMessage("Plugin 'vendor/files-plugin' requires 'service.json' in your project root for android.");
 
         $this->manager()->sync(collect([$this->plugin([
             'sources' => ['service.json'],
+            'destination' => 'app/service.json',
+            'required' => true,
+        ])]));
+    }
+
+    /** @test */
+    public function it_lists_every_candidate_when_a_required_file_has_several_sources(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            "Plugin 'vendor/files-plugin' requires one of these project files for android, relative to your project root: service.json, config/service.json."
+        );
+
+        $this->manager()->sync(collect([$this->plugin([
+            'sources' => ['service.json', 'config/service.json'],
             'destination' => 'app/service.json',
             'required' => true,
         ])]));

--- a/tests/Unit/Plugins/ProjectFileManagerTest.php
+++ b/tests/Unit/Plugins/ProjectFileManagerTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Unit\Plugins;
+
+use Illuminate\Filesystem\Filesystem;
+use Native\Mobile\Plugins\Plugin;
+use Native\Mobile\Plugins\PluginManifest;
+use Native\Mobile\Plugins\ProjectFileManager;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class ProjectFileManagerTest extends TestCase
+{
+    private Filesystem $files;
+
+    private string $projectPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->files = new Filesystem;
+        $this->projectPath = sys_get_temp_dir().'/nativephp-project-files-'.uniqid();
+        $this->files->ensureDirectoryExists($this->projectPath.'/nativephp/android/app');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->files->deleteDirectory($this->projectPath);
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_copies_the_first_available_project_file_source(): void
+    {
+        $this->files->ensureDirectoryExists($this->projectPath.'/nativephp/resources');
+        $this->files->put($this->projectPath.'/service.json', 'root');
+        $this->files->put($this->projectPath.'/nativephp/resources/service.json', 'preferred');
+
+        $this->manager()->sync(collect([$this->plugin([
+            'sources' => ['nativephp/resources/service.json', 'service.json'],
+            'destination' => 'app/service.json',
+            'required' => true,
+        ])]));
+
+        $this->assertSame(
+            'preferred',
+            $this->files->get($this->projectPath.'/nativephp/android/app/service.json')
+        );
+    }
+
+    /** @test */
+    public function it_reports_a_missing_required_file_as_the_plugins_requirement(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Plugin 'vendor/files-plugin' requires one of these project files for android: service.json.");
+
+        $this->manager()->sync(collect([$this->plugin([
+            'sources' => ['service.json'],
+            'destination' => 'app/service.json',
+            'required' => true,
+        ])]));
+    }
+
+    /** @test */
+    public function it_removes_a_previously_managed_file_after_the_plugin_is_removed(): void
+    {
+        $this->files->put($this->projectPath.'/service.json', 'configured');
+        $this->manager()->sync(collect([$this->plugin([
+            'sources' => ['service.json'],
+            'destination' => 'app/service.json',
+        ])]));
+
+        $this->assertFileExists($this->projectPath.'/nativephp/android/app/service.json');
+
+        $this->manager()->sync(collect());
+
+        $this->assertFileDoesNotExist($this->projectPath.'/nativephp/android/app/service.json');
+    }
+
+    /** @test */
+    public function it_rejects_paths_that_escape_the_project(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('may not traverse outside the project');
+
+        $this->manager()->sync(collect([$this->plugin([
+            'sources' => ['../service.json'],
+            'destination' => 'app/service.json',
+        ])]));
+    }
+
+    private function manager(): ProjectFileManager
+    {
+        return new ProjectFileManager($this->files, $this->projectPath.'/nativephp', 'android');
+    }
+
+    private function plugin(array $projectFile): Plugin
+    {
+        return new Plugin(
+            'vendor/files-plugin',
+            '1.0.0',
+            $this->projectPath.'/vendor/files-plugin',
+            new PluginManifest([
+                'namespace' => 'FilesPlugin',
+                'android' => ['project_files' => [$projectFile]],
+            ])
+        );
+    }
+}


### PR DESCRIPTION
Core has been doing Firebase's setup work for it: copying `google-services.json` into place and applying the Google Services Gradle plugin. That's the plugin's job, and as it stands it breaks the build for anyone with a stray `google-services.json` and no Firebase plugin installed, since the Gradle plugin isn't on any classpath. Plugins now declare what they need through two new manifest keys, `project_files` and `gradle_plugins.apply_to`.

Unlike the first cut of this, NativePHP/mobile-firebase#6 no longer has to land and release first. Core keeps installing the config until an installed plugin claims it, so bumping core on its own is safe whether you're on an old plugin, a new one, or none at all. Two unrelated fixes fell out of testing it: manifest booleans were landing in Info.plist as empty strings, and `warn()` crashed Android builds.