### PR TITLE
Drop phpstan-deprecation-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
         "pestphp/pest-plugin-arch": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "spatie/laravel-ray": "^1.26"
     },


### PR DESCRIPTION
This package flags every call to anything marked `@deprecated`, which means tagging an internal helper fails the build on the call sites that are supposed to exist. It came up on #410: a back-compat shim carried a `@deprecated` note aimed at whoever deletes it later, and PHPStan reported all five uses from the two compilers that legitimately construct it. The choice was a red build or dropping the note, and neither is right for code with no consumers outside core.

Nothing else depends on it. The analysis runs at level 0 and these rules arrived through `phpstan/extension-installer` rather than anything in `phpstan.neon`, so removing the requirement is the whole change.