### PR TITLE
fix(edge): deliver nested child #[On] listeners and #[Poll] timers

### DIFF
--- a/src/Edge/NativeComponent.php
+++ b/src/Edge/NativeComponent.php
@@ -1599,11 +1599,19 @@ abstract class NativeComponent
             $deadlines[] = $next;
         }
 
+        $now = microtime(true) * 1000;
+        foreach ($this->nativeChildComponents as $child) {
+            $timeout = $child->nextEventTimeout();
+            if ($timeout >= 0) {
+                $deadlines[] = $now + $timeout;
+            }
+        }
+
         if (empty($deadlines)) {
             return -1;
         }
 
-        return max(1, (int) ceil(min($deadlines) - microtime(true) * 1000));
+        return max(1, (int) ceil(min($deadlines) - $now));
     }
 
     /**
@@ -1635,6 +1643,10 @@ abstract class NativeComponent
             if ($now >= $next) {
                 $this->bladePollDeadlines[$ms] = $now + $ms;
             }
+        }
+
+        foreach ($this->nativeChildComponents as $child) {
+            $child->runDuePolls();
         }
     }
 
@@ -1816,43 +1828,58 @@ abstract class NativeComponent
         // #[On] lookup below so it fires even when this component declares no
         // listener for the event.
         $this->dispatchGloballyIfMarked($eventName, is_array($payload) ? $payload : []);
+        $this->dispatchNativeEventListeners($eventName, $payload);
+    }
+
+    private function dispatchNativeEventListeners(string $eventName, mixed $payload): void
+    {
 
         $method = $this->nativeEventListeners[$eventName]
             ?? $this->nativeEventListeners['native:'.$eventName]
             ?? null;
 
-        if ($method === null || ! method_exists($this, $method)) {
-            return;
+        if ($method !== null && method_exists($this, $method) && is_array($payload)) {
+            $reflect = new \ReflectionMethod($this, $method);
+            $parameters = $reflect->getParameters();
+            $type = $parameters[0]->getType() ?? null;
+
+            if (count($parameters) === 1
+                && $type instanceof \ReflectionNamedType
+                && $type->getName() === 'array'
+                && ! array_key_exists($parameters[0]->getName(), $payload)) {
+                $this->$method($payload);
+            } else {
+                $args = [];
+                foreach ($parameters as $param) {
+                    $name = $param->getName();
+                    if (array_key_exists($name, $payload)) {
+                        $value = $payload[$name];
+
+                        // Coerce the value to match the parameter's type hint
+                        $type = $param->getType();
+                        if ($type instanceof \ReflectionNamedType && $type->isBuiltin()) {
+                            $value = match ($type->getName()) {
+                                'int' => (int) $value,
+                                'float' => (float) $value,
+                                'string' => (string) $value,
+                                'bool' => (bool) $value,
+                                default => $value,
+                            };
+                        }
+
+                        $args[] = $value;
+                    } elseif ($param->isDefaultValueAvailable()) {
+                        $args[] = $param->getDefaultValue();
+                    }
+                }
+                $this->$method(...$args);
+            }
+        } elseif ($method !== null && method_exists($this, $method)) {
+            $this->$method($payload);
         }
 
-        if (is_array($payload)) {
-            $reflect = new \ReflectionMethod($this, $method);
-            $args = [];
-            foreach ($reflect->getParameters() as $param) {
-                $name = $param->getName();
-                if (array_key_exists($name, $payload)) {
-                    $value = $payload[$name];
-
-                    // Coerce the value to match the parameter's type hint
-                    $type = $param->getType();
-                    if ($type instanceof \ReflectionNamedType && $type->isBuiltin()) {
-                        $value = match ($type->getName()) {
-                            'int' => (int) $value,
-                            'float' => (float) $value,
-                            'string' => (string) $value,
-                            'bool' => (bool) $value,
-                            default => $value,
-                        };
-                    }
-
-                    $args[] = $value;
-                } elseif ($param->isDefaultValueAvailable()) {
-                    $args[] = $param->getDefaultValue();
-                }
-            }
-            $this->$method(...$args);
-        } else {
-            $this->$method($payload);
+        foreach ($this->nativeChildComponents as $child) {
+            $child->dispatchNativeEventListeners($eventName, $payload);
         }
     }
 

--- a/tests/Feature/Edge/NestedPollAndOnTest.php
+++ b/tests/Feature/Edge/NestedPollAndOnTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Native\Mobile\Edge\ComponentRegistry;
+use Native\Mobile\Edge\NativeComponent;
+use Native\Mobile\Testing\Native;
+use Tests\Fixtures\Edge\NestedPollAndOnChild;
+use Tests\Fixtures\Edge\NestedPollAndOnScreen;
+
+beforeEach(function () {
+    app('view')->addLocation(__DIR__.'/../../Fixtures/views');
+
+    ComponentRegistry::reset();
+    ComponentRegistry::components([
+        'nested-poll-and-on-child' => NestedPollAndOnChild::class,
+    ]);
+});
+
+afterEach(function () {
+    ComponentRegistry::reset();
+});
+
+function callPrivate(NativeComponent $component, string $method): mixed
+{
+    return Closure::bind(fn () => $this->{$method}(), $component, NativeComponent::class)();
+}
+
+/** Live child instances of a component, keyed by identity. */
+function childrenOf(NativeComponent $component): array
+{
+    return (fn () => $this->nativeChildComponents)->call($component);
+}
+
+it('recurses a child #[Poll] method when the host runs due polls', function () {
+    $screen = Native::test(NestedPollAndOnScreen::class);
+    $host = $screen->instance();
+    $children = childrenOf($host);
+    $child = $children[array_key_first($children)];
+
+    Closure::bind(function () use ($child) {
+        $this->pollDefinitions = null;
+        foreach ($child->pollDefinitions() as $i => $def) {
+            $child->pollDefinitions[$i]['next'] = 0;
+        }
+    }, $host, NativeComponent::class)();
+
+    callPrivate($host, 'runDuePolls');
+
+    expect($child->ticks)->toBe(1);
+});
+
+it('aggregates child #[Poll] deadlines into the host timeout', function () {
+    $screen = Native::test(NestedPollAndOnScreen::class);
+
+    $timeout = callPrivate($screen->instance(), 'nextEventTimeout');
+
+    expect($timeout)->toBeGreaterThan(0);
+});
+
+it('delivers a native event to a child #[On] listener', function () {
+    $screen = Native::test(NestedPollAndOnScreen::class)
+        ->emitNative('PingReceived', ['message' => 'hello-from-test']);
+
+    $children = childrenOf($screen->instance());
+
+    expect($children[array_key_first($children)]->pings)->toBe(['hello-from-test']);
+});

--- a/tests/Fixtures/Edge/NestedPollAndOnChild.php
+++ b/tests/Fixtures/Edge/NestedPollAndOnChild.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Illuminate\View\View;
+use Native\Mobile\Attributes\On;
+use Native\Mobile\Attributes\Poll;
+use Native\Mobile\Edge\NativeComponent;
+
+class NestedPollAndOnChild extends NativeComponent
+{
+    public int $ticks = 0;
+
+    /** @var list<string> */
+    public array $pings = [];
+
+    #[Poll(1000)]
+    public function tick(): void
+    {
+        $this->ticks++;
+    }
+
+    #[On('PingReceived')]
+    public function onPing(array $payload): void
+    {
+        $message = (string) ($payload['message'] ?? '');
+        if ($message !== '') {
+            $this->pings[] = $message;
+        }
+    }
+
+    public function render(): View
+    {
+        return view('nested-poll-and-on-child');
+    }
+}

--- a/tests/Fixtures/Edge/NestedPollAndOnScreen.php
+++ b/tests/Fixtures/Edge/NestedPollAndOnScreen.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Fixtures\Edge;
+
+use Illuminate\View\View;
+use Native\Mobile\Edge\NativeComponent;
+
+class NestedPollAndOnScreen extends NativeComponent
+{
+    public function render(): View
+    {
+        return view('nested-poll-and-on-screen');
+    }
+}

--- a/tests/Fixtures/views/nested-poll-and-on-child.blade.php
+++ b/tests/Fixtures/views/nested-poll-and-on-child.blade.php
@@ -1,0 +1,4 @@
+<native:column>
+    <native:text>Ticks: {{ $ticks }}</native:text>
+    <native:text>Pings: {{ count($pings) }}</native:text>
+</native:column>

--- a/tests/Fixtures/views/nested-poll-and-on-screen.blade.php
+++ b/tests/Fixtures/views/nested-poll-and-on-screen.blade.php
@@ -1,0 +1,3 @@
+<native:column>
+    <native:nested-poll-and-on-child key="poll-and-on-child|key:child" />
+</native:column>


### PR DESCRIPTION
## Summary
- recurse native event dispatch and poll scheduling into `nativeChildComponents`, so nested native components receive their `#[On]` handlers and have their `#[Poll]` timers driven by the host runloop
- fix `#[On]` listeners that declare a single `array` parameter being invoked with zero arguments

## Why
Dispatch and polling only ever ran on the root screen. A component mounted globally through a layout — e.g. a drawer rendering `<native:assistant-drawer />` — is a child of every screen, so its listeners and recovery poll never fired at all.

Three paths needed the same recursion:
- `runDuePolls()` — run children's due polls
- `nextEventTimeout()` — fold child deadlines into the aggregate, otherwise the runloop sleeps past them and the poll fix has no effect
- the listener path, extracted into a private `dispatchNativeEventListeners()` so the handler-resolution logic can recurse

`dispatchNativeEvent()` keeps its `protected` signature, and `dispatchGloballyIfMarked()` stays in the outer method so it still fires exactly once per event.

Separately, argument binding was strictly by parameter name. A listener written as `onStreamDelta(array $payload)` receiving `['text' => …]` finds no key named `payload`, has no default, and so gets called with no arguments — `ArgumentCountError` on the first event. The fallback passes the whole payload only when the method takes exactly one parameter, typed `array`, whose name is absent from the payload; a listener whose parameter name does match a key keeps named binding and its scalar type coercion, so existing handlers are unaffected.

## Tests
`tests/Feature/Edge/NestedPollAndOnTest.php` — child `#[Poll]` recursion, child `#[On]` delivery, and child-poll timeout aggregation, with a parent screen, child component, and two Blade fixtures.

## Notes
Split out of #367 as requested. That PR is now just the one-line `symfony/process` constraint; this branch is off `component-async-api` and touches no `composer.json`.