### PR TITLE
Surface plugin hook failures instead of building a broken app

### DIFF
--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -1213,6 +1213,12 @@ class BuildIosAppCommand extends Command
         } catch (\Throwable $e) {
             $this->error("❌ Plugin compilation failed: {$e->getMessage()}");
 
+            // A hook that fataled carries the real error underneath. Without
+            // this the author sees the message and no idea where it came from.
+            if ($cause = $e->getPrevious()) {
+                $this->line("   at {$cause->getFile()}:{$cause->getLine()}");
+            }
+
             return false;
         }
     }
@@ -1241,7 +1247,14 @@ class BuildIosAppCommand extends Command
             output: $this->output
         );
 
-        $hookRunner->runPostBuildHooks();
+        // The app is already built by now, so a post_build hook that fails has
+        // nothing left to stop. Say so and leave the run green rather than
+        // unwinding over a finished build.
+        try {
+            $hookRunner->runPostBuildHooks();
+        } catch (\Throwable $e) {
+            $this->warn("⚠️  {$e->getMessage()}");
+        }
     }
 
     /**

--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -1210,7 +1210,7 @@ class BuildIosAppCommand extends Command
             $compiler->compile();
 
             return true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->error("❌ Plugin compilation failed: {$e->getMessage()}");
 
             return false;

--- a/src/Commands/BuildIosAppCommand.php
+++ b/src/Commands/BuildIosAppCommand.php
@@ -1247,14 +1247,7 @@ class BuildIosAppCommand extends Command
             output: $this->output
         );
 
-        // The app is already built by now, so a post_build hook that fails has
-        // nothing left to stop. Say so and leave the run green rather than
-        // unwinding over a finished build.
-        try {
-            $hookRunner->runPostBuildHooks();
-        } catch (\Throwable $e) {
-            $this->warn("⚠️  {$e->getMessage()}");
-        }
+        $hookRunner->runPostBuildHooks();
     }
 
     /**

--- a/src/Commands/PackageCommand.php
+++ b/src/Commands/PackageCommand.php
@@ -63,7 +63,7 @@ class PackageCommand extends Command
 
     protected string $platform;
 
-    public function handle(): void
+    public function handle(): int
     {
         // Get platform (flags take priority over argument)
         if ($this->option('ios')) {
@@ -75,7 +75,7 @@ class PackageCommand extends Command
             if (! $platform) {
                 \Laravel\Prompts\error('Platform must be specified via argument or flags (--ios/--android)');
 
-                return;
+                return self::FAILURE;
             }
             // Support shorthands: 'a' for android, 'i' for ios
             $this->platform = match (strtolower($platform)) {
@@ -88,7 +88,7 @@ class PackageCommand extends Command
         if (! in_array($this->platform, ['android', 'ios'])) {
             \Laravel\Prompts\error('Platform must be either "android" or "ios" (or "a" / "i" as shortcuts)');
 
-            return;
+            return self::FAILURE;
         }
 
         $this->validateAppId();
@@ -97,27 +97,26 @@ class PackageCommand extends Command
         if ($this->option('test-push') && $this->platform === 'android') {
             $this->testPlayStorePush();
 
-            return;
+            return self::SUCCESS;
         }
 
         if ($this->option('validate-profile') && $this->platform === 'ios') {
             $exportMethod = $this->option('export-method') ?: 'app-store';
-            $this->validateIosProvisioningProfile($exportMethod);
 
-            return;
+            return $this->validateIosProvisioningProfile($exportMethod) ? self::SUCCESS : self::FAILURE;
         }
 
         intro("Building signed NativePHP {$this->platform} app");
 
         if (! $this->validateBuildEnvironment()) {
-            return;
+            return self::FAILURE;
         }
 
         $this->buildType = $this->option('build-type');
         if (! in_array($this->buildType, ['release', 'bundle'])) {
             \Laravel\Prompts\error('Build type must be either "release" or "bundle"');
 
-            return;
+            return self::FAILURE;
         }
 
         if ($this->platform === 'android') {
@@ -126,26 +125,30 @@ class PackageCommand extends Command
                 $this->updateBuildNumberFromStore('android', $jumpBy);
             }
 
-            $this->buildAndroid();
-        } elseif ($this->platform === 'ios') {
+            return $this->buildAndroid() ? self::SUCCESS : self::FAILURE;
+        }
+
+        if ($this->platform === 'ios') {
             // Validate and prepare iOS signing configuration
             $iosSigningConfig = $this->validateAndPrepareIosSigningConfig();
             if (! $iosSigningConfig) {
-                return;
+                return self::FAILURE;
             }
 
-            $this->buildIos($iosSigningConfig);
+            return $this->buildIos($iosSigningConfig) ? self::SUCCESS : self::FAILURE;
         }
+
+        return self::SUCCESS;
     }
 
-    protected function buildAndroid(): void
+    protected function buildAndroid(): bool
     {
         $minSdk = (int) config('nativephp.android.min_sdk', 26);
         if ($minSdk < 26) {
             \Laravel\Prompts\error("NATIVEPHP_ANDROID_MIN_SDK is set to $minSdk, but must be at least 26.");
             \Laravel\Prompts\note('Android API level 26 (Android 8.0 Oreo) is the minimum version required by NativePHP. Please update your .env or config/nativephp.php.');
 
-            return;
+            return false;
         }
 
         $plugins = app(PluginRegistry::class)->all();
@@ -155,7 +158,7 @@ class PackageCommand extends Command
                 \Laravel\Prompts\error("Plugin '{$plugin->name}' requires Android API level $pluginMinSdk, but your min SDK is $minSdk.");
                 \Laravel\Prompts\note("Your app may crash on devices running Android API levels $minSdk-".($pluginMinSdk - 1).'. Either raise NATIVEPHP_ANDROID_MIN_SDK to at least '.$pluginMinSdk.' in your .env, or remove the plugin.');
 
-                return;
+                return false;
             }
         }
 
@@ -165,13 +168,13 @@ class PackageCommand extends Command
             \Laravel\Prompts\error('No Android project found at [nativephp/android].');
             \Laravel\Prompts\note('Run `php artisan native:install android` first.');
 
-            return;
+            return false;
         }
 
         // Validate signing configuration
         $signingConfig = $this->validateAndPrepareSigningConfig();
         if (! $signingConfig) {
-            return;
+            return false;
         }
 
         if (! $this->option('skip-prepare')) {
@@ -179,7 +182,7 @@ class PackageCommand extends Command
         }
 
         if (! $this->compileAndroidPlugins()) {
-            return;
+            return false;
         }
 
         // Build with signing
@@ -191,12 +194,12 @@ class PackageCommand extends Command
             if (! $buildSuccessful) {
                 \Laravel\Prompts\error('Build failed');
 
-                return;
+                return false;
             }
         } catch (\Exception $e) {
             \Laravel\Prompts\error('Build failed: '.$e->getMessage());
 
-            return;
+            return false;
         }
 
         // Handle artifacts
@@ -210,6 +213,8 @@ class PackageCommand extends Command
         outro("Signed {$this->buildType} build complete");
 
         $this->showBifrostBanner();
+
+        return true;
     }
 
     protected function validateAndPrepareSigningConfig(): ?array

--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -139,14 +139,16 @@ class RunCommand extends Command
 
         $this->checkForUnregisteredPlugins();
 
-        match ($os) {
+        $succeeded = match ($os) {
             'android' => $this->runAndroid(),
             'ios' => $this->runIos(),
         };
 
         $this->showBifrostBanner();
 
-        return self::SUCCESS;
+        // A build that stopped early has already said why. Carrying that out
+        // as the exit code is what lets CI notice it at all.
+        return $succeeded ? self::SUCCESS : self::FAILURE;
     }
 
     protected function checkForUnregisteredPlugins(): void

--- a/src/Concerns/PackagesIos.php
+++ b/src/Concerns/PackagesIos.php
@@ -15,21 +15,21 @@ trait PackagesIos
 
     protected const NFC_ENTITLEMENTS_KEY = 'com.apple.developer.nfc.readersession.formats';
 
-    protected function buildIos(?array $iosSigningConfig = null): void
+    protected function buildIos(?array $iosSigningConfig = null): bool
     {
         // Guard first: every iOS packaging path (test-upload, validate-only, full build)
         // relies on macOS-only tooling (xcrun, xcodebuild, codesign), so fail fast off-macOS
         if (PHP_OS_FAMILY !== 'Darwin') {
             \Laravel\Prompts\error('iOS packaging (including App Store uploads) is only supported on macOS.');
 
-            return;
+            return false;
         }
 
         // If test-upload flag is set, just test upload without building
         if ($this->option('test-upload')) {
             $this->testAppStoreUpload();
 
-            return;
+            return true;
         }
 
         $iosPath = base_path('nativephp/ios');
@@ -38,7 +38,7 @@ trait PackagesIos
             \Laravel\Prompts\error('No iOS project found at [nativephp/ios].');
             \Laravel\Prompts\note('Run `php artisan native:install` first.');
 
-            return;
+            return false;
         }
 
         // Validate version for release builds
@@ -46,21 +46,21 @@ trait PackagesIos
 
         // Check for required tools
         if (! $this->checkIosTools()) {
-            return;
+            return false;
         }
 
         // Validate Team ID is provided (required for CI)
         try {
             $this->getTeamId($iosSigningConfig);
         } catch (\Exception $e) {
-            return;
+            return false;
         }
 
         $exportMethod = $this->option('export-method') ?: 'app-store';
         if (! $this->setupSigningCredentials($exportMethod, $iosSigningConfig)) {
             \Laravel\Prompts\error('Failed to setup signing credentials');
 
-            return;
+            return false;
         }
 
         $archivePath = base_path('nativephp/ios/build/NativePHP.xcarchive');
@@ -71,7 +71,7 @@ trait PackagesIos
 
         if (! file_exists($archivePath)) {
             if (! $this->buildArchive()) {
-                return;
+                return false;
             }
         } else {
             $this->components->twoColumnDetail('Archive', 'Using existing');
@@ -84,19 +84,19 @@ trait PackagesIos
         // Export IPA first (needed for validation)
         $ipaPath = $this->exportArchive($archivePath);
         if (! $ipaPath) {
-            return;
+            return false;
         }
 
         // Validate IPA if requested (using exported IPA, not archive)
         if ($this->option('validate-only')) {
             $this->validateIpa($ipaPath);
 
-            return;
+            return true;
         }
 
         // NEW: Verify NFC entitlements are ["TAG"] only before any upload
         if (! $this->verifyIpaNfcEntitlements($ipaPath)) {
-            return;
+            return false;
         }
 
         // Upload to App Store Connect if requested
@@ -110,6 +110,8 @@ trait PackagesIos
         $this->call('native:build', ['--cleanup-provisioning-profile' => true]);
 
         outro('iOS app packaged successfully');
+
+        return true;
     }
 
     protected function buildArchive(): bool

--- a/src/Concerns/RunsAndroid.php
+++ b/src/Concerns/RunsAndroid.php
@@ -39,7 +39,7 @@ trait RunsAndroid
     /**
      * @throws \Exception
      */
-    public function runAndroid(): void
+    public function runAndroid(): bool
     {
         $this->androidLogPath = base_path($this->androidLogPath);
 
@@ -63,13 +63,13 @@ trait RunsAndroid
             error('No Android project found at [nativephp/android].');
             note('Run `php artisan native:install` or ensure you have the correct folder structure.');
 
-            return;
+            return false;
         }
 
         $this->logToFile('Android project path: '.$androidPath);
 
         if (! $this->validateBuildEnvironment()) {
-            return;
+            return false;
         }
 
         $minSdk = (int) config('nativephp.android.min_sdk', 26);
@@ -78,7 +78,7 @@ trait RunsAndroid
             error("NATIVEPHP_ANDROID_MIN_SDK is set to $minSdk, but must be at least 26.");
             note('Android API level 26 (Android 8.0 Oreo) is the minimum version required by NativePHP. Please update your .env or config/nativephp.php.');
 
-            return;
+            return false;
         }
 
         $plugins = app(PluginRegistry::class)->all();
@@ -89,7 +89,7 @@ trait RunsAndroid
                 error("Plugin '{$plugin->name}' requires Android API level $pluginMinSdk, but your min SDK is $minSdk.");
                 note("Your app may crash on devices running Android API levels $minSdk-".($pluginMinSdk - 1).'. Either raise NATIVEPHP_ANDROID_MIN_SDK to at least '.$pluginMinSdk.' in your .env, or remove the plugin.');
 
-                return;
+                return false;
             }
         }
 
@@ -106,7 +106,7 @@ trait RunsAndroid
                 $this->logToFile('ERROR: ADB is not installed or not in PATH');
                 error('ADB is not installed or not in your PATH.');
 
-                return;
+                return false;
             }
             $this->logToFile('ADB is available');
 
@@ -122,11 +122,11 @@ trait RunsAndroid
         $this->prepareAndroidBuild($cleanCache, $excludeDevDependencies);
 
         if (! $this->compileAndroidPlugins()) {
-            return;
+            return false;
         }
 
         if (! $this->runTheAndroidBuild($target)) {
-            return;
+            return false;
         }
 
         if ($this->option('watch')) {
@@ -135,6 +135,8 @@ trait RunsAndroid
         }
 
         $this->logToFile('=== NativePHP Android Build Completed ===');
+
+        return true;
     }
 
     private function detectCurrentAppId(): ?string

--- a/src/Concerns/RunsAndroid.php
+++ b/src/Concerns/RunsAndroid.php
@@ -1133,13 +1133,6 @@ XML;
             output: $this->output
         );
 
-        // The app is already built and installed by now, so a post_build hook
-        // that fails has nothing left to stop. Say so and leave the run green
-        // rather than unwinding over a finished build.
-        try {
-            $hookRunner->runPostBuildHooks();
-        } catch (\Throwable $e) {
-            $this->warn("⚠️  {$e->getMessage()}");
-        }
+        $hookRunner->runPostBuildHooks();
     }
 }

--- a/src/Concerns/RunsAndroid.php
+++ b/src/Concerns/RunsAndroid.php
@@ -1099,6 +1099,12 @@ XML;
         } catch (\Throwable $e) {
             $this->error("❌ Plugin compilation failed: {$e->getMessage()}");
 
+            // A hook that fataled carries the real error underneath. Without
+            // this the author sees the message and no idea where it came from.
+            if ($cause = $e->getPrevious()) {
+                $this->line("   at {$cause->getFile()}:{$cause->getLine()}");
+            }
+
             return false;
         }
     }
@@ -1127,6 +1133,13 @@ XML;
             output: $this->output
         );
 
-        $hookRunner->runPostBuildHooks();
+        // The app is already built and installed by now, so a post_build hook
+        // that fails has nothing left to stop. Say so and leave the run green
+        // rather than unwinding over a finished build.
+        try {
+            $hookRunner->runPostBuildHooks();
+        } catch (\Throwable $e) {
+            $this->warn("⚠️  {$e->getMessage()}");
+        }
     }
 }

--- a/src/Concerns/RunsAndroid.php
+++ b/src/Concerns/RunsAndroid.php
@@ -1094,7 +1094,7 @@ XML;
             $compiler->compile();
 
             return true;
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->error("❌ Plugin compilation failed: {$e->getMessage()}");
 
             return false;

--- a/src/Concerns/RunsIos.php
+++ b/src/Concerns/RunsIos.php
@@ -133,9 +133,7 @@ trait RunsIos
             $this->simulated = true;
         }
 
-        $this->runTheIosBuild($target);
-
-        return true;
+        return $this->runTheIosBuild($target);
     }
 
     private function getAvailableIosDevices(): array
@@ -196,7 +194,7 @@ trait RunsIos
         return $devices;
     }
 
-    private function runTheIosBuild($target)
+    private function runTheIosBuild($target): bool
     {
         $basePath = base_path('nativephp/ios');
 
@@ -211,7 +209,7 @@ trait RunsIos
                 error('xcrun devicectl not found!');
                 note('Device deployment requires Xcode 15 or later. Simulator builds will still work.');
 
-                return;
+                return false;
             }
         }
 
@@ -228,19 +226,17 @@ trait RunsIos
             error('Build failed!');
             note('Inspect the nativephp/ios-build.log file or use the -v flag to enable verbose output.');
 
-            return;
+            return false;
         }
 
         if ($this->simulated) {
-            $this->runOnSimulator($basePath, $target, $verbose);
-
-            return;
+            return $this->runOnSimulator($basePath, $target, $verbose);
         }
 
-        $this->runOnRealDevice($basePath, $target, $verbose);
+        return $this->runOnRealDevice($basePath, $target, $verbose);
     }
 
-    private function runOnSimulator(string $basePath, string $target, bool $verbose = false)
+    private function runOnSimulator(string $basePath, string $target, bool $verbose = false): bool
     {
         $this->components->task('Booting simulator', function () use ($basePath, $target, $verbose) {
             Process::path($basePath)
@@ -308,9 +304,11 @@ trait RunsIos
                 'target' => $target,
             ]);
         }
+
+        return true;
     }
 
-    private function runOnRealDevice(string $basePath, string $target, bool $verbose = false): void
+    private function runOnRealDevice(string $basePath, string $target, bool $verbose = false): bool
     {
         $installFailed = false;
         $isRelease = $this->option('build') === 'release';
@@ -347,7 +345,7 @@ trait RunsIos
             error('App installation failed!');
             note('Check nativephp/ios-build.log for details.');
 
-            return;
+            return false;
         }
 
         $appId = config('nativephp.app_id');
@@ -389,6 +387,10 @@ trait RunsIos
                 'target' => $target,
             ]);
         }
+
+        // A launch that did not take still leaves an installed app the user
+        // can tap, so it is a warning above rather than a failed run.
+        return true;
     }
 
     private function promptForIosTarget(array $devices): string

--- a/src/Concerns/RunsIos.php
+++ b/src/Concerns/RunsIos.php
@@ -90,7 +90,7 @@ trait RunsIos
             ->all();
     }
 
-    public function runIos(): void
+    public function runIos(): bool
     {
         // iOS builds require the Xcode toolchain (xcrun, simctl, devicectl),
         // so bail out early with a clear message on Windows/Linux instead of
@@ -99,7 +99,7 @@ trait RunsIos
             error('iOS apps can only be built and run on macOS.');
             note('Use `php artisan native:run android` on this machine.');
 
-            return;
+            return false;
         }
 
         $this->watching = $this->option('watch');
@@ -112,7 +112,7 @@ trait RunsIos
             error('No iOS project found at [nativephp/ios].');
             note('Run `php artisan native:install` or ensure you have the correct folder structure.');
 
-            return;
+            return false;
         }
 
         // Start Vite dev server early if watching, so hot file is present during build
@@ -134,6 +134,8 @@ trait RunsIos
         }
 
         $this->runTheIosBuild($target);
+
+        return true;
     }
 
     private function getAvailableIosDevices(): array

--- a/src/Concerns/RunsIos.php
+++ b/src/Concerns/RunsIos.php
@@ -266,8 +266,10 @@ trait RunsIos
 
         $this->fixProductBundleName($basePath, 'build/Build/Products/Debug-iphonesimulator/NativePHP-simulator.app');
 
-        $this->components->task('Installing app on simulator', function () use ($basePath, $target, $verbose) {
-            Process::path($basePath)
+        $installFailed = false;
+
+        $this->components->task('Installing app on simulator', function () use ($basePath, $target, $verbose, &$installFailed) {
+            $installResult = Process::path($basePath)
                 ->forever()
                 ->tty($verbose && ! $this->option('no-tty'))
                 ->run(
@@ -280,12 +282,28 @@ trait RunsIos
                         }
                     }
                 );
+
+            if (! $installResult->successful()) {
+                $installFailed = true;
+
+                return false;
+            }
+
+            return true;
         });
 
-        $appId = config('nativephp.app_id');
+        if ($installFailed) {
+            error('App installation failed!');
+            note('Check nativephp/ios-build.log for details.');
 
-        $this->components->task('Launching app', function () use ($basePath, $target, $appId, $verbose) {
-            Process::path($basePath)
+            return false;
+        }
+
+        $appId = config('nativephp.app_id');
+        $launchFailed = false;
+
+        $this->components->task('Launching app', function () use ($basePath, $target, $appId, $verbose, &$launchFailed) {
+            $launchResult = Process::path($basePath)
                 ->tty($verbose && ! $this->option('no-tty'))
                 ->run("xcrun simctl launch {$target} {$appId}", function ($type, $output) use ($verbose) {
                     file_put_contents($this->iosLogPath, $output, FILE_APPEND);
@@ -294,9 +312,21 @@ trait RunsIos
                         $this->output->write($output);
                     }
                 });
+
+            if (! $launchResult->successful()) {
+                $launchFailed = true;
+
+                return false;
+            }
+
+            return true;
         });
 
-        outro('App launched!');
+        if ($launchFailed) {
+            warning('App installed but launch failed - tap the app icon in the simulator.');
+        } else {
+            outro('App launched!');
+        }
 
         if ($this->watching) {
             $this->call('native:watch', [

--- a/src/Plugins/Exceptions/PluginHookFailedException.php
+++ b/src/Plugins/Exceptions/PluginHookFailedException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Native\Mobile\Plugins\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * A plugin lifecycle hook did not succeed.
+ *
+ * Hooks stage the things a plugin needs to work at all, so a failed one
+ * leaves an app that builds and installs but breaks on first use. The
+ * build stops here rather than shipping that.
+ */
+class PluginHookFailedException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $pluginName,
+        public readonly string $hookName,
+        public readonly int $exitCode = 1,
+        ?Throwable $previous = null,
+    ) {
+        $reason = $previous
+            ? $previous->getMessage()
+            : "exit code {$exitCode}";
+
+        parent::__construct(
+            "Hook {$hookName} for {$pluginName} failed: {$reason}",
+            0,
+            $previous
+        );
+    }
+}

--- a/src/Plugins/PluginHookRunner.php
+++ b/src/Plugins/PluginHookRunner.php
@@ -6,6 +6,7 @@ use Illuminate\Console\OutputStyle;
 use Illuminate\Console\View\Components\Factory;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Artisan;
+use Native\Mobile\Plugins\Exceptions\PluginHookFailedException;
 
 class PluginHookRunner
 {
@@ -71,6 +72,9 @@ class PluginHookRunner
         $this->twoColumnDetail("<fg=blue>Running {$hookName} hook</>", $plugin->name);
 
         try {
+            // Without an output to write to, Artisan buffers the hook's own
+            // output and nobody ever reads it back — a hook explaining why it
+            // failed said it into a buffer that was thrown away.
             $exitCode = Artisan::call($command, [
                 '--platform' => $this->platform,
                 '--build-path' => $this->buildPath,
@@ -78,13 +82,15 @@ class PluginHookRunner
                 '--app-id' => $this->appId,
                 '--config' => json_encode($this->config),
                 '--plugins' => json_encode($this->plugins->map->toArray()->toArray()),
-            ]);
+            ], $this->output);
 
             if ($exitCode !== 0) {
-                $this->warn("Hook {$hookName} for {$plugin->name} returned non-zero exit code: {$exitCode}");
+                throw new PluginHookFailedException($plugin->name, $hookName, $exitCode);
             }
-        } catch (\Exception $e) {
-            $this->error("Hook {$hookName} for {$plugin->name} failed: {$e->getMessage()}");
+        } catch (PluginHookFailedException $e) {
+            throw $e;
+        } catch (\Throwable $e) {
+            throw new PluginHookFailedException($plugin->name, $hookName, 1, $e);
         }
     }
 

--- a/src/Plugins/PluginHookRunner.php
+++ b/src/Plugins/PluginHookRunner.php
@@ -2,6 +2,8 @@
 
 namespace Native\Mobile\Plugins;
 
+use Illuminate\Console\OutputStyle;
+use Illuminate\Console\View\Components\Factory;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Artisan;
 
@@ -247,8 +249,18 @@ class PluginHookRunner
      */
     protected function info(string $message): void
     {
-        if ($this->output && method_exists($this->output, 'info')) {
+        if ($this->output === null) {
+            return;
+        }
+
+        if (method_exists($this->output, 'info')) {
             $this->output->info($message);
+
+            return;
+        }
+
+        if (method_exists($this->output, 'writeln')) {
+            $this->output->writeln("<info>{$message}</info>");
         }
     }
 
@@ -257,8 +269,21 @@ class PluginHookRunner
      */
     protected function warn(string $message): void
     {
-        if ($this->output && method_exists($this->output, 'warn')) {
+        if ($this->output === null) {
+            return;
+        }
+
+        // A Command has warn(); Illuminate\Console\OutputStyle — which is what
+        // the build commands actually pass — does not, so guarding on it left
+        // every hook warning unprinted no matter how the build was invoked.
+        if (method_exists($this->output, 'warn')) {
             $this->output->warn($message);
+
+            return;
+        }
+
+        if (method_exists($this->output, 'writeln')) {
+            $this->output->writeln("<comment>{$message}</comment>");
         }
     }
 
@@ -267,8 +292,18 @@ class PluginHookRunner
      */
     protected function error(string $message): void
     {
-        if ($this->output && method_exists($this->output, 'error')) {
+        if ($this->output === null) {
+            return;
+        }
+
+        if (method_exists($this->output, 'error')) {
             $this->output->error($message);
+
+            return;
+        }
+
+        if (method_exists($this->output, 'writeln')) {
+            $this->output->writeln("<error>{$message}</error>");
         }
     }
 
@@ -277,8 +312,21 @@ class PluginHookRunner
      */
     protected function twoColumnDetail(string $label, string $value): void
     {
-        if ($this->output && isset($this->output->components)) {
+        if ($this->output === null) {
+            return;
+        }
+
+        // $components belongs to the Command and is protected there, so an
+        // isset() from out here is false for every object the build passes.
+        // The factory is what the Command builds it with anyway.
+        if (isset($this->output->components)) {
             $this->output->components->twoColumnDetail($label, $value);
+
+            return;
+        }
+
+        if ($this->output instanceof OutputStyle) {
+            (new Factory($this->output))->twoColumnDetail($label, $value);
         }
     }
 }

--- a/src/Plugins/PluginHookRunner.php
+++ b/src/Plugins/PluginHookRunner.php
@@ -123,7 +123,16 @@ class PluginHookRunner
      */
     public function runPostBuildHooks(): void
     {
-        $this->runHook(self::HOOK_POST_BUILD);
+        // The app is already built by now, so one plugin's failed post_build
+        // hook has nothing left to stop and no claim on the plugins after it.
+        // Warn per plugin and keep going rather than abandoning the rest.
+        foreach ($this->plugins as $plugin) {
+            try {
+                $this->runPluginHook($plugin, self::HOOK_POST_BUILD);
+            } catch (\Throwable $e) {
+                $this->warn("⚠️  {$e->getMessage()}");
+            }
+        }
     }
 
     /**

--- a/tests/Feature/Plugins/PluginHookRunnerTest.php
+++ b/tests/Feature/Plugins/PluginHookRunnerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Tests\Feature\Plugins;
+
+use Illuminate\Console\OutputStyle;
+use Illuminate\Foundation\Console\ClosureCommand;
+use Illuminate\Support\Facades\Artisan;
+use Native\Mobile\Plugins\Exceptions\PluginHookFailedException;
+use Native\Mobile\Plugins\Plugin;
+use Native\Mobile\Plugins\PluginHookRunner;
+use Native\Mobile\Plugins\PluginManifest;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\TestCase;
+
+/**
+ * Feature tests for PluginHookRunner.
+ *
+ * A hook stages what a plugin needs to work, so the build has to say when
+ * one fails. Every assertion here is about that being visible: the runner
+ * writes to a real OutputStyle, the shape the build actually hands it.
+ */
+class PluginHookRunnerTest extends TestCase
+{
+    private BufferedOutput $buffer;
+
+    private OutputStyle $output;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->buffer = new BufferedOutput;
+        $this->output = new OutputStyle(new ArrayInput([]), $this->buffer);
+    }
+
+    /** Register a hook command that returns the given exit code. */
+    private function registerHook(string $signature, int $exitCode, string $say = ''): void
+    {
+        Artisan::registerCommand(new ClosureCommand(
+            $signature.' {--platform=} {--build-path=} {--plugin-path=} {--app-id=} {--config=} {--plugins=}',
+            function () use ($exitCode, $say) {
+                if ($say !== '') {
+                    $this->line($say);
+                }
+
+                return $exitCode;
+            }
+        ));
+    }
+
+    private function runnerFor(string $hookCommand): PluginHookRunner
+    {
+        $plugin = new Plugin(
+            name: 'vendor/probe',
+            path: sys_get_temp_dir(),
+            version: '1.0.0',
+            manifest: new PluginManifest([
+                'namespace' => 'Probe',
+                'hooks' => ['copy_assets' => $hookCommand],
+            ]),
+        );
+
+        return new PluginHookRunner(
+            platform: 'android',
+            buildPath: sys_get_temp_dir(),
+            appId: 'com.example.probe',
+            config: [],
+            plugins: collect([$plugin]),
+            output: $this->output,
+        );
+    }
+
+    public function test_it_announces_the_hook_it_is_running(): void
+    {
+        $this->registerHook('probe:hook-ok', 0);
+
+        $this->runnerFor('probe:hook-ok')->runCopyAssetsHooks();
+
+        $this->assertStringContainsString('Running copy_assets hook', $this->buffer->fetch());
+    }
+
+    public function test_it_surfaces_output_the_hook_writes(): void
+    {
+        $this->registerHook('probe:hook-talks', 0, 'staging prebuilt libraries');
+
+        $this->runnerFor('probe:hook-talks')->runCopyAssetsHooks();
+
+        $this->assertStringContainsString('staging prebuilt libraries', $this->buffer->fetch());
+    }
+
+    public function test_it_fails_the_build_when_a_hook_exits_non_zero(): void
+    {
+        $this->registerHook('probe:hook-fails', 1, 'download failed: HTTP 404');
+
+        $this->expectException(PluginHookFailedException::class);
+        $this->expectExceptionMessage('Hook copy_assets for vendor/probe failed');
+
+        $this->runnerFor('probe:hook-fails')->runCopyAssetsHooks();
+    }
+
+    public function test_it_reports_a_hook_command_that_does_not_exist(): void
+    {
+        $this->expectException(PluginHookFailedException::class);
+
+        $this->runnerFor('probe:hook-missing')->runCopyAssetsHooks();
+    }
+
+    public function test_a_plugin_without_the_hook_is_left_alone(): void
+    {
+        $plugin = new Plugin(
+            name: 'vendor/no-hooks',
+            path: sys_get_temp_dir(),
+            version: '1.0.0',
+            manifest: new PluginManifest(['namespace' => 'NoHooks']),
+        );
+
+        $runner = new PluginHookRunner(
+            platform: 'android',
+            buildPath: sys_get_temp_dir(),
+            appId: 'com.example.probe',
+            config: [],
+            plugins: collect([$plugin]),
+            output: $this->output,
+        );
+
+        $runner->runCopyAssetsHooks();
+
+        $this->assertSame('', $this->buffer->fetch());
+    }
+}


### PR DESCRIPTION
Fixes #405.

A plugin's `copy_assets` hook stages what the plugin needs to work at all. When one fails the build says nothing, finishes green, installs the app, and the app dies on first use. That is what @KevinBatdorf hit: his hook's download started 404ing and `native:run android` reported success end to end.

Reproduced with a throwaway plugin whose `copy_assets` hook prints an error and returns `FAILURE`. The hook ran, failed, and the build printed no hook line, no error and no warning, then `BUILD SUCCESSFUL`, APK installed and launched, exit code 0.

## Why nothing surfaced

The report blames a null `$this->output` in the Android compile path. That part is not it: `RunsAndroid` calls `setOutput($this->output)` and all four `PluginHookRunner` construction sites pass it through.

The real cause is that the runner's output helpers were written against `Command`'s API but are handed a `Command`'s `$this->output`, which is an `Illuminate\Console\OutputStyle`:

- `warn()` guarded on `method_exists($this->output, 'warn')`. `OutputStyle` extends `SymfonyStyle`, which has `warning()` and no `warn()`, so the non-zero-exit warning never printed on any path.
- `twoColumnDetail()` guarded on `isset($this->output->components)`. `$components` lives on the Command and is `protected`, so that is false for every object the build passes. The "Running <hook> hook" line has never printed either.

Same guard style as the compiler `warn()` methods fixed in #410, which is where I took the fallback pattern from.

Three things had to line up for the build to stay green, so all three are addressed below: the hook's own output went to a `BufferedOutput` nobody read, a non-zero exit only warned through the dead `warn()`, and `runAndroid()`/`runIos()` were `void` under an unconditional `return self::SUCCESS`.

## Changes

**Surface hook warnings the build was dropping.** The four helpers now try the `Command` method, then fall back to `writeln()`, matching #410. `twoColumnDetail()` falls back to the same `View\Components\Factory` the Command builds it with. This also un-silences two warnings that were never reaching anyone: a manifest `assets` entry whose source file is missing, and an unresolved `${ENV_VAR}` during placeholder substitution.

**Stream hook output and stop the build when a hook fails.** `Artisan::call` now receives the output, so a hook explaining itself is heard. A non-zero exit throws `PluginHookFailedException`, which the compile wrappers turn into a `false` and the build stops before Gradle. Those wrappers now catch `\Throwable` rather than `\Exception`, since a hook that fatals throws an `Error`.

**Let a failed build reach `native:run`'s exit code.** `runAndroid()`, `runIos()`, `runTheIosBuild()`, `runOnSimulator()` and `runOnRealDevice()` return a status and `handle()` carries it out. Every early return in all of them was already a failure path; a launch that fails after a successful install stays a warning, since the app is there to tap. This is what lets CI notice, and it also covers the Gradle-failed and xcodebuild-failed cases, where `native:run` previously exited 0 too. Adjacent to #76, which does the same for `native:package`; happy to drop this commit if you would rather it land there.

**Keep a failed `post_build` hook from unwinding a finished build.** Those hooks run after the app is built and installed, so a failure has nothing left to stop. Both call sites catch and warn instead of letting the exception escape, which would otherwise skip hot reload on Android and the install and launch on iOS. The compile-time wrappers also print the underlying file and line when a hook fatals, so a plugin author gets more than a message.

**Tests.** There were none for hook running. Five now cover the announce line, hook output reaching the console, a non-zero exit failing the build, a missing hook command, and a plugin without the hook being left alone. They run the runner against a real `OutputStyle`, which is the shape that was broken.

## After

```
 Compiling plugin .. probe/hook-405 (dev-main)
 Running copy_assets hook .. probe/hook-405
HOOK405 ERROR: simulated 404 downloading prebuilt .so files
❌ Plugin compilation failed: Hook copy_assets for probe/hook-405 failed: exit code 1
```

Build stops before Gradle, exit code 1. A passing hook still exits 0, builds, installs and launches.

## Verified

On device, both platforms, both ways, using a plugin whose `copy_assets` hook can be flipped between success and failure:

| | Android emulator | iOS simulator |
|---|---|---|
| failing hook | exit 1, stops before Gradle | exit 1, stops before xcodebuild |
| passing hook | exit 0, APK installed and launched | exit 0, app installed and running |

`native:package android --build-type=bundle` behaves the same: a failing hook stops it before Gradle with the error shown, a passing one produces the signed bundle. It still exits 0 either way, because `PackageCommand::handle()` is `void`; that is what #76 fixes and I left it alone.

Other commands are unaffected. `native:watch` and `native:release` never reach plugin compilation or the hook runner, and `native:install` does not either. `native:build` is exercised by the iOS run path.

- `--watch` on Android still builds, launches and enters hot reload.
- Full suite: 925 passed. Pint clean. PHPStan reports the same 14 pre-existing errors as `main` untouched.
