### PR TITLE
Mark non-production builds as testing builds for both stores

### DIFF
--- a/src/Concerns/DeclaresReleaseAudience.php
+++ b/src/Concerns/DeclaresReleaseAudience.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Native\Mobile\Concerns;
+
+/**
+ * A build made in any environment other than production is a testing build,
+ * and both stores are told so at package time: Google Play through the
+ * manifest's largest release audience, App Store Connect through TestFlight
+ * internal testing. That declaration travels with the artifact, so a testing
+ * build cannot later be promoted to a public release by hand.
+ */
+trait DeclaresReleaseAudience
+{
+    /**
+     * The AndroidManifest meta-data Google Play reads to learn how far a
+     * release may travel.
+     */
+    protected const LARGEST_RELEASE_AUDIENCE_KEY = 'com.google.android.play.largest_release_audience';
+
+    protected function buildsForProduction(): bool
+    {
+        return config('app.env') === 'production';
+    }
+
+    /**
+     * The largest audience this build may be released to, or null when it is
+     * a production build and no ceiling applies.
+     */
+    protected function largestReleaseAudience(): ?string
+    {
+        return $this->buildsForProduction() ? null : 'CLOSED_TESTING';
+    }
+
+    /**
+     * Whether an App Store Connect upload from this build must be confined to
+     * TestFlight's internal testers.
+     */
+    protected function restrictToInternalTestFlight(): bool
+    {
+        return ! $this->buildsForProduction();
+    }
+}

--- a/src/Concerns/PackagesIos.php
+++ b/src/Concerns/PackagesIos.php
@@ -9,7 +9,7 @@ use function Laravel\Prompts\outro;
 
 trait PackagesIos
 {
-    use ManagesIosSigning;
+    use DeclaresReleaseAudience, ManagesIosSigning;
 
     protected ?string $temporaryKeychainPath = null;
 
@@ -521,6 +521,15 @@ trait PackagesIos
             'teamID' => $teamId,
             'manageAppVersionAndBuildNumber' => false, // Prevent Xcode from making changes during export
         ];
+
+        // Anything built outside the production environment is a testing
+        // build, so the package is marked for TestFlight's internal testers
+        // only. Without this the same archive could be handed to external
+        // testers or submitted for App Store review.
+        if ($exportMethod === 'app-store' && $this->restrictToInternalTestFlight()) {
+            $exportOptions['testFlightInternalTestingOnly'] = true;
+            $this->components->twoColumnDetail('TestFlight', 'Internal testing only (APP_ENV='.config('app.env').')');
+        }
 
         // Use automatic for debugging only; manual for everything else (app-store, ad-hoc, enterprise, etc.)
         if ($exportMethod === 'debugging') {

--- a/src/Concerns/PreparesBuild.php
+++ b/src/Concerns/PreparesBuild.php
@@ -12,7 +12,7 @@ use Symfony\Component\Process\Process as SymfonyProcess;
 
 trait PreparesBuild
 {
-    use CleansEnvFile, InstallsAndroidSplashScreen, InstallsAppIcon, PlatformFileOperations;
+    use CleansEnvFile, DeclaresReleaseAudience, InstallsAndroidSplashScreen, InstallsAppIcon, PlatformFileOperations;
 
     /**
      * Validate required environment variables for building
@@ -130,6 +130,10 @@ trait PreparesBuild
 
             $this->logToFile('  Updating permissions...');
             $this->updatePermissions();
+
+            $audience = $this->largestReleaseAudience();
+            $this->logToFile('  Updating release audience: '.($audience ?? 'unrestricted (production)'));
+            $this->updateReleaseAudience();
 
             $this->logToFile('  Updating orientation configuration...');
             $this->updateOrientationConfiguration();
@@ -970,6 +974,8 @@ trait PreparesBuild
     abstract protected function updateDeepLinkConfiguration(): void;
 
     abstract protected function updatePermissions(): void;
+
+    abstract protected function updateReleaseAudience(): void;
 
     abstract protected function updateIcuConfiguration(): void;
 

--- a/src/Concerns/PublishesToPlayStore.php
+++ b/src/Concerns/PublishesToPlayStore.php
@@ -7,11 +7,23 @@ use Illuminate\Support\Facades\Http;
 
 trait PublishesToPlayStore
 {
+    use DeclaresReleaseAudience;
+
     protected function publishToPlayStore(array $config): bool
     {
         $this->info('🚀 Starting Play Store upload...');
 
         if (! $this->validatePlayStoreConfig($config)) {
+            return false;
+        }
+
+        // The manifest of a non-production build declares a closed testing
+        // audience, so Play would reject the production track anyway. Refuse it
+        // here, where the reason can still be explained.
+        if (($config['track'] ?? null) === 'production' && ! $this->buildsForProduction()) {
+            $this->error('❌ Refusing to publish to the production track: this app was built with APP_ENV='.config('app.env').'.');
+            $this->line('   Build with APP_ENV=production to make a production release.');
+
             return false;
         }
 

--- a/src/Concerns/RunsAndroid.php
+++ b/src/Concerns/RunsAndroid.php
@@ -19,7 +19,7 @@ use function Laravel\Prompts\warning;
 
 trait RunsAndroid
 {
-    use PreparesBuild, WatchesAndroid;
+    use DeclaresReleaseAudience, PreparesBuild, WatchesAndroid;
 
     protected string $androidLogPath = 'nativephp'.DIRECTORY_SEPARATOR.'android-build.log';
 
@@ -254,6 +254,52 @@ trait RunsAndroid
                     }
                 }
             }
+        }
+
+        $normalizedContents = $this->normalizeLineEndings($contents);
+
+        if ($this->validateXml($normalizedContents)) {
+            File::put($manifestPath, $normalizedContents);
+        }
+    }
+
+    /**
+     * Declare to Google Play how far this build may travel. Anything built
+     * outside the production environment carries the closed testing audience,
+     * which Play holds the artifact to: it cannot be promoted to the
+     * production track later. A production build carries no ceiling, so a
+     * declaration left behind by an earlier build is stripped.
+     */
+    private function updateReleaseAudience(): void
+    {
+        $manifestPath = base_path('nativephp/android/app/src/main/AndroidManifest.xml');
+
+        if (! File::exists($manifestPath)) {
+            return;
+        }
+
+        $contents = File::get($manifestPath);
+
+        // Always drop the previous declaration first: the native project is
+        // reused between builds, so a stale audience would otherwise survive a
+        // move back to production.
+        $contents = preg_replace(
+            '/\s*<meta-data\s+android:name="'.preg_quote(self::LARGEST_RELEASE_AUDIENCE_KEY, '/').'"[^>]*\/>/s',
+            '',
+            $contents
+        );
+
+        $audience = $this->largestReleaseAudience();
+
+        if ($audience !== null) {
+            $entry = "\n        <meta-data\n            android:name=\"".self::LARGEST_RELEASE_AUDIENCE_KEY."\"\n            android:value=\"{$audience}\" />";
+
+            $contents = preg_replace_callback(
+                '/<application[^>]*>/',
+                fn (array $matches): string => $matches[0].$entry,
+                $contents,
+                1
+            );
         }
 
         $normalizedContents = $this->normalizeLineEndings($contents);

--- a/tests/Feature/ReleaseAudienceTest.php
+++ b/tests/Feature/ReleaseAudienceTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\File;
+use Native\Mobile\Commands\PackageCommand;
+use ReflectionClass;
+use ReflectionMethod;
+use Tests\TestCase;
+
+/**
+ * A build made outside the production environment is a testing build, and both
+ * stores are told so at package time: Google Play through the manifest's
+ * largest release audience, App Store Connect through TestFlight internal
+ * testing. Without those declarations the same artifact can be promoted by
+ * hand to a public release.
+ */
+class ReleaseAudienceTest extends TestCase
+{
+    protected string $projectPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->projectPath = sys_get_temp_dir().'/nativephp_release_audience_'.uniqid();
+        File::makeDirectory($this->projectPath.'/nativephp/android/app/src/main', 0755, true);
+        app()->setBasePath($this->projectPath);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->projectPath);
+
+        parent::tearDown();
+    }
+
+    public function test_a_testing_build_declares_a_closed_testing_audience_to_play(): void
+    {
+        config(['app.env' => 'testing']);
+        $this->writeManifest();
+
+        $this->updateReleaseAudience();
+
+        $this->assertStringContainsString(
+            'android:name="com.google.android.play.largest_release_audience"',
+            $this->manifest()
+        );
+        $this->assertStringContainsString('android:value="CLOSED_TESTING"', $this->manifest());
+    }
+
+    public function test_the_declaration_sits_inside_the_application_element(): void
+    {
+        config(['app.env' => 'testing']);
+        $this->writeManifest();
+
+        $this->updateReleaseAudience();
+
+        $this->assertMatchesRegularExpression(
+            '/<application[^>]*>.*largest_release_audience.*<\/application>/s',
+            $this->manifest()
+        );
+    }
+
+    public function test_a_production_build_carries_no_ceiling(): void
+    {
+        config(['app.env' => 'production']);
+        $this->writeManifest();
+
+        $this->updateReleaseAudience();
+
+        $this->assertStringNotContainsString('largest_release_audience', $this->manifest());
+    }
+
+    public function test_moving_back_to_production_strips_a_stale_declaration(): void
+    {
+        $this->writeManifest();
+
+        config(['app.env' => 'testing']);
+        $this->updateReleaseAudience();
+        $this->assertStringContainsString('CLOSED_TESTING', $this->manifest());
+
+        config(['app.env' => 'production']);
+        $this->updateReleaseAudience();
+        $this->assertStringNotContainsString('largest_release_audience', $this->manifest());
+    }
+
+    public function test_repeated_testing_builds_declare_the_audience_once(): void
+    {
+        config(['app.env' => 'testing']);
+        $this->writeManifest();
+
+        $this->updateReleaseAudience();
+        $this->updateReleaseAudience();
+
+        $this->assertSame(1, substr_count($this->manifest(), 'largest_release_audience'));
+    }
+
+    public function test_a_manifest_that_does_not_exist_is_left_alone(): void
+    {
+        config(['app.env' => 'testing']);
+
+        $this->updateReleaseAudience();
+
+        $this->assertFileDoesNotExist($this->manifestPath());
+    }
+
+    public function test_only_production_escapes_the_ceiling(): void
+    {
+        $audience = new ReflectionMethod(PackageCommand::class, 'largestReleaseAudience');
+        $internal = new ReflectionMethod(PackageCommand::class, 'restrictToInternalTestFlight');
+
+        $command = (new ReflectionClass(PackageCommand::class))->newInstanceWithoutConstructor();
+
+        foreach (['local', 'testing', 'staging'] as $env) {
+            config(['app.env' => $env]);
+            $this->assertSame('CLOSED_TESTING', $audience->invoke($command), $env);
+            $this->assertTrue($internal->invoke($command), $env);
+        }
+
+        config(['app.env' => 'production']);
+        $this->assertNull($audience->invoke($command));
+        $this->assertFalse($internal->invoke($command));
+    }
+
+    private function manifestPath(): string
+    {
+        return $this->projectPath.'/nativephp/android/app/src/main/AndroidManifest.xml';
+    }
+
+    private function manifest(): string
+    {
+        return File::get($this->manifestPath());
+    }
+
+    private function writeManifest(): void
+    {
+        File::put($this->manifestPath(), <<<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application android:label="NativePHP">
+        <activity android:name=".MainActivity" />
+    </application>
+</manifest>
+XML);
+    }
+
+    private function updateReleaseAudience(): void
+    {
+        $command = (new ReflectionClass(PackageCommand::class))->newInstanceWithoutConstructor();
+
+        (new ReflectionMethod(PackageCommand::class, 'updateReleaseAudience'))->invoke($command);
+    }
+}

--- a/tests/Feature/ReleaseBuildBundleTest.php
+++ b/tests/Feature/ReleaseBuildBundleTest.php
@@ -252,5 +252,7 @@ class ReleaseBuildTester
 
     protected function updatePermissions(): void {}
 
+    protected function updateReleaseAudience(): void {}
+
     protected function updateIcuConfiguration(): void {}
 }

--- a/tests/Feature/TestingBuildStoreGuardsTest.php
+++ b/tests/Feature/TestingBuildStoreGuardsTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Console\Command;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Console\View\Components\Factory;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use Native\Mobile\Concerns\PackagesIos;
+use Native\Mobile\Concerns\PublishesToPlayStore;
+use ReflectionMethod;
+use ReflectionProperty;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Tests\TestCase;
+
+/**
+ * The two store-side halves of a testing build: iOS declares TestFlight
+ * internal testing in the export options, and a Play Store upload refuses the
+ * production track outright.
+ */
+class TestingBuildStoreGuardsTest extends TestCase
+{
+    protected string $projectPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Nothing here should reach Google: the arc guard has to turn a
+        // production-track upload away before any of the API work starts.
+        Http::preventStrayRequests();
+        Http::fake();
+
+        $this->projectPath = sys_get_temp_dir().'/nativephp_store_guards_'.uniqid();
+        File::makeDirectory($this->projectPath.'/build', 0755, true);
+        config(['nativephp.app_id' => 'com.example.app']);
+        putenv('EXTRACTED_PROVISIONING_PROFILE_UUID=00000000-0000-0000-0000-000000000000');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('EXTRACTED_PROVISIONING_PROFILE_UUID');
+        File::deleteDirectory($this->projectPath);
+
+        parent::tearDown();
+    }
+
+    public function test_a_testing_build_is_exported_for_internal_testflight_only(): void
+    {
+        config(['app.env' => 'testing']);
+
+        $this->assertStringContainsString(
+            '<key>testFlightInternalTestingOnly</key>',
+            $this->exportOptions('app-store')
+        );
+    }
+
+    public function test_a_production_build_is_exported_without_the_restriction(): void
+    {
+        config(['app.env' => 'production']);
+
+        $this->assertStringNotContainsString(
+            'testFlightInternalTestingOnly',
+            $this->exportOptions('app-store')
+        );
+    }
+
+    public function test_the_restriction_is_only_meaningful_for_app_store_exports(): void
+    {
+        config(['app.env' => 'testing']);
+
+        $this->assertStringNotContainsString(
+            'testFlightInternalTestingOnly',
+            $this->exportOptions('ad-hoc')
+        );
+    }
+
+    public function test_a_testing_build_refuses_the_play_store_production_track(): void
+    {
+        config(['app.env' => 'testing']);
+
+        [$published, $output] = $this->publish('production');
+
+        $this->assertFalse($published);
+        $this->assertStringContainsString('Refusing to publish to the production track', $output);
+    }
+
+    public function test_a_testing_build_may_still_reach_a_testing_track(): void
+    {
+        config(['app.env' => 'testing']);
+
+        // The upload itself has no credentials to work with, so it fails later —
+        // what matters is that it was not turned away by the arc guard.
+        [, $output] = $this->publish('internal');
+
+        $this->assertStringNotContainsString('Refusing to publish', $output);
+    }
+
+    public function test_a_production_build_may_reach_the_production_track(): void
+    {
+        config(['app.env' => 'production']);
+
+        [, $output] = $this->publish('production');
+
+        $this->assertStringNotContainsString('Refusing to publish', $output);
+    }
+
+    private function exportOptions(string $exportMethod): string
+    {
+        $command = $this->command(['export-method' => $exportMethod]);
+
+        $path = (new ReflectionMethod($command, 'createExportOptions'))->invoke($command, $this->projectPath);
+
+        return File::get($path);
+    }
+
+    /**
+     * @return array{0: bool, 1: string}
+     */
+    private function publish(string $track): array
+    {
+        $key = $this->projectPath.'/service-account.json';
+        $bundle = $this->projectPath.'/app.aab';
+        File::put($key, json_encode(['client_email' => 'a@b.c', 'private_key' => 'nope']));
+        File::put($bundle, 'not-a-real-bundle');
+
+        $command = $this->command();
+
+        $published = (new ReflectionMethod($command, 'publishToPlayStore'))->invoke($command, [
+            'service_account_key' => $key,
+            'package_name' => 'com.example.app',
+            'bundle_path' => $bundle,
+            'track' => $track,
+        ]);
+
+        return [$published, $command->buffer->fetch()];
+    }
+
+    /**
+     * @param  array<string, string>  $options
+     */
+    private function command(array $options = []): Command
+    {
+        $command = new class($options) extends Command
+        {
+            use PackagesIos, PublishesToPlayStore;
+
+            public BufferedOutput $buffer;
+
+            /**
+             * @param  array<string, string>  $options
+             */
+            public function __construct(private array $commandOptions)
+            {
+                parent::__construct();
+
+                $this->buffer = new BufferedOutput;
+                $this->setOutput(new OutputStyle(new ArrayInput([]), $this->buffer));
+            }
+
+            public function option($key = null)
+            {
+                return $this->commandOptions[$key] ?? null;
+            }
+
+            protected function getTeamId(?array $iosSigningConfig = null): string
+            {
+                return 'ABCDE12345';
+            }
+        };
+
+        $components = new ReflectionProperty(Command::class, 'components');
+        $components->setValue($command, new Factory($command->buffer));
+
+        return $command;
+    }
+}

--- a/tests/Unit/BuildConfigurationTest.php
+++ b/tests/Unit/BuildConfigurationTest.php
@@ -332,5 +332,7 @@ REPLACE_CUSTOM_PROGUARD_RULES',
 
     protected function updatePermissions(): void {}
 
+    protected function updateReleaseAudience(): void {}
+
     protected function updateIcuConfiguration(): void {}
 }

--- a/tests/Unit/ConfigurationUpdatesTest.php
+++ b/tests/Unit/ConfigurationUpdatesTest.php
@@ -485,6 +485,8 @@ Java_com_nativephp_mobile_bridge_PHPBridge',
         }
     }
 
+    protected function updateReleaseAudience(): void {}
+
     protected function updatePermissions(): void
     {
         $manifestPath = $this->testProjectPath.'/nativephp/android/app/src/main/AndroidManifest.xml';


### PR DESCRIPTION
## What

A build made in any environment other than `production` is a testing build. Both stores are now told so **at package time**, so the declaration travels with the artifact and a testing build cannot later be promoted to a public release by hand.

Three pieces, one per store surface:

**Google Play — manifest audience.** `AndroidManifest.xml` gains a `com.google.android.play.largest_release_audience` meta-data entry set to `CLOSED_TESTING`. Play holds the artifact to that ceiling. The native project is reused between builds, so the previous declaration is always stripped first — moving back to `production` does not leave a stale ceiling behind.

**App Store Connect — TestFlight.** An `app-store` export sets `testFlightInternalTestingOnly` in the export options, confining the upload to TestFlight's internal testers. Without it, the same archive could be handed to external testers or submitted for review. Other export methods (`ad-hoc`, `enterprise`, `debugging`) are unaffected, where the key has no meaning.

**Play Store upload — refuse the production track.** A non-production build's manifest declares a closed testing audience, so Play would reject the production track anyway. The upload is now refused up front, where the reason can still be explained, instead of failing later against the API. Testing tracks (`internal`, etc.) are still reachable.

The shared predicate lives in a new `DeclaresReleaseAudience` trait, so "is this a production build?" is answered in one place across iOS packaging, Android preparation, and Play publishing.

## Why

Nothing previously distinguished a build made with `APP_ENV=staging` from a real release once the artifact existed. The environment was a property of the machine that ran the build, not of the thing it produced, so a testing build could be uploaded to a production track or promoted through App Store Connect with no signal that it was never meant to ship. Marking the artifact itself moves that check to where it cannot be skipped.

## Testing

- `composer test` — 933 passed (3099 assertions), 3 skipped, 4 risky.
- `composer format` — pass.
- New `tests/Feature/ReleaseAudienceTest.php` covers the manifest: the entry is written for testing builds, sits inside `<application>`, is absent for production, is stripped when moving back to production, is written only once across repeated builds, and a missing manifest is left alone.
- New `tests/Feature/TestingBuildStoreGuardsTest.php` covers both store-side halves: the iOS export options with and without the restriction (and that it is confined to `app-store` exports), and that the Play upload refuses `production` from a testing build while still allowing testing tracks. It uses `Http::preventStrayRequests()` so the guard is proven to turn the upload away before any API work begins.
- Existing test doubles that compose `PreparesBuild` gained the new `updateReleaseAudience()` stub.

## Note

`composer analyse` reports 3 pre-existing PHPStan errors in `src/Concerns/RunsAndroid.php` (lines 97/113/132, about `native:package` options `watch`/`udid`). Verified against an unmodified worktree at the base commit — they are unrelated to this change and are not introduced here. Also note PHPStan needs `--memory-limit=2G`; the default 128M crashes the parallel worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Non-production Android builds are labeled as non-production releases.
  - Non-production iOS App Store exports are restricted to internal TestFlight testing.
  - Production publishing to Google Play requires a production build.

- **Bug Fixes**
  - Prevents testing builds from being distributed through production release channels.
  - Preserves developer-defined Android release audience restrictions.

- **Tests**
  - Added coverage for Android release labeling and iOS and Google Play distribution safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->