### PR TITLE
Support Guzzle 8 alongside Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-dom": "*",
         "ext-simplexml": "*",
         "workerman/workerman": "^4.1",
-        "guzzlehttp/guzzle": "^7.9",
+        "guzzlehttp/guzzle": "^7.9 || ^8.0",
         "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "laravel/prompts": "^0.1.1|^0.2|^0.3",

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -3,7 +3,7 @@
 namespace Native\Mobile\Commands;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use Illuminate\Console\Command;
 use Native\Mobile\Concerns\DisplaysMarketingBanners;
 use Native\Mobile\Concerns\InstallsAndroid;
@@ -273,12 +273,17 @@ class InstallCommand extends Command
                 (new Client)->get($versionsUrl)->getBody()->getContents(),
                 true
             );
-        } catch (RequestException $e) {
+        } catch (TransferException $e) {
             // A 404 here is specific: the manifest is named for the binary
             // release this package pins, so a missing one means that release
             // was withdrawn — not that the CDN is down. Say which, because the
             // fixes are completely different.
-            if ($e->getResponse()?->getStatusCode() === 404) {
+            // method_exists() keeps this working on both Guzzle 7 (where the
+            // response lives on RequestException) and Guzzle 8 (where only
+            // the ResponseException branch exposes getResponse()).
+            $statusCode = method_exists($e, 'getResponse') ? $e->getResponse()?->getStatusCode() : null;
+
+            if ($statusCode === 404) {
                 error(sprintf(
                     'PHP binaries release %s is no longer published.'
                     ."\n".'Update nativephp/mobile to a version that pins a current release:'

--- a/src/Concerns/InstallsAndroid.php
+++ b/src/Concerns/InstallsAndroid.php
@@ -3,7 +3,7 @@
 namespace Native\Mobile\Concerns;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use Illuminate\Support\Facades\File;
 use Native\Mobile\Support\PhpBinaries;
 use ZipArchive;
@@ -191,7 +191,7 @@ trait InstallsAndroid
                     ]);
 
                     return true;
-                } catch (RequestException) {
+                } catch (TransferException) {
                     // Remove any partial/error response written to disk
                     if (file_exists($zipFile)) {
                         unlink($zipFile);

--- a/src/Concerns/InstallsIos.php
+++ b/src/Concerns/InstallsIos.php
@@ -3,7 +3,7 @@
 namespace Native\Mobile\Concerns;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use Native\Mobile\Support\PhpBinaries;
@@ -122,7 +122,7 @@ trait InstallsIos
                     ]);
 
                     return true;
-                } catch (RequestException) {
+                } catch (TransferException) {
                     // Remove any partial/error response written to disk
                     if (file_exists($zipFile)) {
                         unlink($zipFile);


### PR DESCRIPTION
## Problem

Installing this package in a Laravel app locked to Guzzle 8 fails dependency resolution:

- This package requires `guzzlehttp/guzzle: ^7.9`
- Laravel allows `guzzlehttp/guzzle: ^7.8.2 || ^8.0`, so apps locked to 8.x (e.g. 8.1.0) cannot install `nativephp/mobile` without forcing a downgrade.

## Fix

- `composer.json`: widen to `^7.9 || ^8.0` (keeps the existing 7.x floor, adds the 8.x line).
- `src/Commands/InstallCommand.php`, `src/Concerns/InstallsAndroid.php`, `src/Concerns/InstallsIos.php`: catch `TransferException` instead of only `RequestException`.
  - `ConnectException` has not been a `RequestException` since Guzzle 7.0, so connect/DNS/TLS failures previously escaped the download error handling even on Guzzle 7.
  - Guzzle 8 removed `getResponse()`/`hasResponse()` from `RequestException` and added `Network*`/`Response*` branches, so the old catch + unconditional `getResponse()` call would fatal. The manifest 404 check now guards response access with `method_exists()`, which works on both majors (and stays PHPStan-clean on either).

## Compatibility

- Guzzle 7 happy paths are unchanged: same requests, options, and messages. The only behavior delta is that network-level failures now hit the existing graceful error + partial-file cleanup paths instead of bubbling uncaught.
- Guzzle usage in this repo is confined to these three files (plain `GET` + string `sink` + int timeouts), all of which remain valid under Guzzle 8 request-option validation.
- Verified: `php -l` on all touched files, `composer validate`, and a dual-major exception-semantics probe (404 detected on both hierarchies; old pattern confirmed fatal on Guzzle 8). Live `composer update` matrix (7.x leg + 8.x leg) and full Pest run still need CI/network.