### PR TITLE
Support Guzzle 8 alongside Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-dom": "*",
         "ext-simplexml": "*",
         "workerman/workerman": "^4.1",
-        "guzzlehttp/guzzle": "^7.9",
+        "guzzlehttp/guzzle": "^7.9 || ^8.0",
         "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "laravel/prompts": "^0.1.1|^0.2|^0.3",

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -3,7 +3,7 @@
 namespace Native\Mobile\Commands;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use Illuminate\Console\Command;
 use Native\Mobile\Traits\DisplaysMarketingBanners;
 use Native\Mobile\Traits\InstallsAndroid;
@@ -285,7 +285,7 @@ class InstallCommand extends Command
                 (new Client)->get($versionsUrl)->getBody()->getContents(),
                 true
             );
-        } catch (RequestException $e) {
+        } catch (TransferException) {
             error("Failed to fetch versions manifest from: {$versionsUrl}");
         }
     }

--- a/src/Traits/InstallsAndroid.php
+++ b/src/Traits/InstallsAndroid.php
@@ -3,7 +3,7 @@
 namespace Native\Mobile\Traits;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use Illuminate\Support\Facades\File;
 use ZipArchive;
 
@@ -171,7 +171,7 @@ trait InstallsAndroid
                     ]);
 
                     return true;
-                } catch (RequestException) {
+                } catch (TransferException) {
                     // Remove any partial/error response written to disk
                     if (file_exists($zipFile)) {
                         unlink($zipFile);

--- a/src/Traits/InstallsIos.php
+++ b/src/Traits/InstallsIos.php
@@ -3,7 +3,7 @@
 namespace Native\Mobile\Traits;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
 use ZipArchive;
@@ -115,7 +115,7 @@ trait InstallsIos
                     ]);
 
                     return true;
-                } catch (RequestException) {
+                } catch (TransferException) {
                     // Remove any partial/error response written to disk
                     if (file_exists($zipFile)) {
                         unlink($zipFile);


### PR DESCRIPTION
Backport of #417 to 3.x.

Laravel 13 allows `guzzlehttp/guzzle` `^7.8.2 || ^8.0`, so a fresh Laravel 13 app resolves to Guzzle 8 and then can't install nativephp/mobile 3.x at all:

```
- nativephp/mobile[3.3.0, ..., 3.3.7] require guzzlehttp/guzzle ^7.9 -> found
  guzzlehttp/guzzle[7.9.0, ..., 7.15.5] but the package is fixed to 8.2.0
```

Same two changes as #417:

- Widen the constraint to `^7.9 || ^8.0`.
- Catch `TransferException` instead of `RequestException` at the three download/manifest call sites. `ConnectException` hasn't been a `RequestException` since Guzzle 7.0, and Guzzle 8 splits failures into Network and Response branches, so `RequestException` no longer covers everything these calls can throw.

3.x doesn't have the 404-specific manifest branch that main has, so the `method_exists()` guard from #417 isn't needed here. The catch in `fetchVersionsManifest()` never used its `$e`, so I dropped the variable.

## Testing

- Package suite on the branch: 284 passed, resolving to Guzzle 8.2.0. Pint and PHPStan clean.
- Fresh `laravel/laravel:^13.0` app (Laravel 13.30.1, Guzzle 8.2.0 locked). `composer require nativephp/mobile:^3.3` fails there today with the error above; the branch installs fine.
- `php artisan native:install android` in that app: manifest fetched, binaries downloaded and extracted, install completed.
- Forced a bad manifest URL with `NATIVEPHP_BIN_BRANCH` to check the error path still gets caught rather than blowing up.


Heads up on the empty checks: every workflow on 3.x is scoped to `branches: [main]`, so nothing runs for a PR targeting 3.x. Results above are all local.

Worth a reviewer's eye on whether 3.x should get a release after this, since the whole point is unblocking Laravel 13 users who are on the 3.x line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMWF3dousE6MmnUVfBs6Kh
