### PR TITLE
fix(ios): let the window background reach tab-hosted screens

### DIFF
--- a/resources/xcode/NativePHP/NativeRender/NativeRootTabsRenderer.swift
+++ b/resources/xcode/NativePHP/NativeRender/NativeRootTabsRenderer.swift
@@ -569,6 +569,12 @@ private struct PerTabContent: View {
                 // business, and wrapping the TabView risks iOS 26's search
                 // capsule (mobile-air #308).
                 .dismissesKeyboardOnTap()
+                // TabView hosts its content on its own `systemBackground`
+                // container, which covers the base layer ContentView paints —
+                // so without this the window background never reaches a tabbed
+                // screen. Attached here rather than to the TabView for the same
+                // reason as `dismissesKeyboardOnTap` above (#308).
+                .modifier(TabScreenBackgroundModifier())
         } else {
             Color.clear
         }
@@ -736,6 +742,26 @@ private struct BottomBarInsetModifier: ViewModifier {
         let darkBg = colorScheme == .dark ? node.props.getColor("dark_bg_color", default: 0) : 0
         let argb = darkBg != 0 ? darkBg : (node.style?.bgColor ?? 0)
         return argb != 0 ? Color(argb: argb) : .clear
+    }
+}
+
+/// Backgrounds a tab-hosted screen with the PHP-set window background
+/// (`UI.SetBackground`), extended through the safe areas. TabView draws its
+/// own `systemBackground` container behind tab content with no SwiftUI
+/// override hook, and that container covers the base layer `ContentView`
+/// paints — so without this a dark app renders on white in light appearance
+/// on every tabbed screen. Twin of `NativeRootStackRenderer`'s
+/// `StackScreenBackgroundModifier`. No-op when no override is set,
+/// preserving the stock appearance.
+private struct TabScreenBackgroundModifier: ViewModifier {
+    @ObservedObject private var windowBackground = WindowBackgroundState.shared
+
+    func body(content: Content) -> some View {
+        if let color = windowBackground.color {
+            content.background(color.ignoresSafeArea())
+        } else {
+            content
+        }
     }
 }
 


### PR DESCRIPTION
## The problem

`UI.SetBackground` writes `WindowBackgroundState.shared.color`. Three surfaces read it:

| | |
|---|---|
| `ContentView.swift:22` | the base layer every native screen renders over |
| `NativeRootStackRenderer.swift:275` | per stack screen, via `StackScreenBackgroundModifier` |
| `SetBackground.execute` | the UIKit windows |

`NativeRootTabsRenderer` does not — zero references. TabView hosts its content on its own
`systemBackground` container, which covers the base layer `ContentView` paints underneath.

So on an app whose routes are all under a `usesNativeChrome()` layout with a `tabBar()`,
`UI.SetBackground` has **no observable effect anywhere**. A dark-themed app renders on a
white page ground on a light-appearance device, whatever the `background` token says.

This is the same defect `StackScreenBackgroundModifier` was written for — its own doc comment
describes the symptom:

> NavigationStack draws its own `systemBackground` container behind screen content with no
> SwiftUI override hook — without this, a dark app shows a white band in the bottom safe-area
> inset on every stack screen.

The tabs twin was never written.

## The fix

`TabScreenBackgroundModifier`, mirroring the stack twin, attached to the screen content inside
`PerTabContent` rather than to the TabView — same reasoning as the neighbouring
`dismissesKeyboardOnTap`, which is deliberately kept off the TabView to avoid iOS 26's search
capsule (#308). It's a no-op when no override is set, so stock appearance is untouched.

Follows the file-local twin convention already used for
`StackBottomBarInsetModifier`/`BottomBarInsetModifier` and
`StackBarBackgroundModifier`/`ExplicitBarBackgroundModifier`.

## Reproducing

1. A layout with `usesNativeChrome() == true` and a `tabBar()`, attached via `Route::nativeGroup()`.
2. A dark `background` token in `config/native-ui.php` (e.g. `#191722`).
3. `nativephp_call('UI.SetBackground', json_encode(['color' => theme('background')]))` at boot.
4. Run on a device set to **light** appearance.

Expected the page ground to be `#191722`; it is white.

A confirming variant, before this patch: add `->dark()` to the `TabBar`. The ground becomes
**pure black** rather than `#191722` — `preferredColorScheme(.dark)` changes what
`systemBackground` resolves to, which shows it is `systemBackground` being painted and not the
window color.

Found on `nativephp/mobile` 4.3.2, iPhone 17 Pro simulator / iOS 26.5.

## Verification

Built and run on an iPhone 17 Pro simulator (iOS 26.5) against a tabs-only app with
`background` = `#191722`.

Sampling the rendered framebuffer, **before** this patch (with `->dark()` on the `TabBar`, so
`systemBackground` resolves dark): `#000000` at every background sample point — the window color
is absent. **After**: `#191722` at every point, including both the status-bar strip and the
region below the tab bar.

```
  #191722   status-bar strip (top inset)
  #191722   page ground (upper / mid / lower)
  #191722   below the tab bar (bottom inset)
```

`** BUILD SUCCEEDED **`, no new warnings.

## Two adjacent gaps, not fixed here

Mentioning these since they're the same story, but deliberately out of scope for this PR:

1. **Nothing ever paints the window from the theme.** The framework knows the `background` token
   and the docs call it "the page root behind everything", but no code path pushes it to the
   window. The only caller of `UI.SetBackground` in the framework is
   `Edge/BenchmarkComponent.php:378`, with a hardcoded `#0F172A`, and there's no facade or docs
   page — so every dark-themed app hits this and has to find an undocumented bridge call.
   Painting from `theme('background')` at boot and on `AppearanceChanged` would make it correct
   by default.

2. **The published starter layout teaches a pattern that can't work under chrome.**
   `mobile-ui`'s `stubs/views/components/layouts/app.blade.php` puts `bg-theme-background` on the
   screen root (lines 43 and 49). Under a chrome layout that fill is laid out in the inset box, so
   it stops short of the screen edge while scroll content keeps drawing past it under the Liquid
   Glass bar — the boundary reads as a hard line above the tab bar. Different repo; happy to open
   that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RRCNbc5FrcTjiD8aXUfKTA
