### PR TITLE
Honour a whitespace policy on <text> so slot content can keep its line breaks

### DIFF
--- a/src/Edge/Components/Native/Text.php
+++ b/src/Edge/Components/Native/Text.php
@@ -17,9 +17,14 @@ class Text extends NativeBladeComponent
     {
         return function (array $data) {
             $attrs = $data['attributes']->getAttributes();
-            $text = preg_replace('/\s+/', ' ', trim(html_entity_decode(strip_tags($data['slot']->toHtml()), ENT_QUOTES, 'UTF-8')));
+            $text = NativeElementCollector::normalizeLeafText(
+                $data['slot']->toHtml(),
+                NativeElementCollector::whiteSpacePolicy($attrs)
+            );
             if ($text !== '') {
                 $attrs['text'] = $text;
+            } else {
+                $attrs = NativeElementCollector::applyTextWhiteSpace($attrs);
             }
 
             if (NativeElementCollector::isStreaming()) {

--- a/src/Edge/Elements/Text.php
+++ b/src/Edge/Elements/Text.php
@@ -5,6 +5,7 @@ namespace Native\Mobile\Edge\Elements;
 use Native\Mobile\Edge\CallbackRegistry;
 use Native\Mobile\Edge\Element;
 use Native\Mobile\Edge\Enums\TextAlign;
+use Native\Mobile\Edge\Enums\WhiteSpace;
 
 class Text extends Element
 {
@@ -40,6 +41,7 @@ class Text extends Element
             'text-align' => 'textAlign',
             'max-lines' => 'maxLines',
             'content-transition' => 'contentTransition',
+            'white-space' => 'whiteSpace',
         ] as $kebab => $camel) {
             if (isset($attrs[$kebab]) && ! isset($attrs[$camel])) {
                 $attrs[$camel] = $attrs[$kebab];
@@ -100,6 +102,24 @@ class Text extends Element
         if (isset($attrs['contentTransition'])) {
             $this->contentTransition((string) $attrs['contentTransition']);
         }
+        if (($whiteSpace = WhiteSpace::fromAttributes($attrs)) !== null) {
+            $this->whiteSpace($whiteSpace);
+        }
+    }
+
+    /**
+     * Whitespace policy (CSS `white-space`). The collector applies it to the
+     * text on capture; the wire value is forwarded so renderers can honour
+     * the wrapping half (`nowrap`, `pre`) natively.
+     */
+    public function whiteSpace(WhiteSpace|string $policy): static
+    {
+        $resolved = $policy instanceof WhiteSpace ? $policy : WhiteSpace::fromToken($policy);
+        if ($resolved !== null) {
+            $this->textProps['white_space'] = $resolved->value;
+        }
+
+        return $this;
     }
 
     public function fontSize(float $size): static

--- a/src/Edge/Enums/WhiteSpace.php
+++ b/src/Edge/Enums/WhiteSpace.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Native\Mobile\Edge\Enums;
+
+/**
+ * Whitespace policy for `<text>` content, modelled on CSS `white-space`.
+ *
+ * Slot content is captured from an output buffer, where the newlines an
+ * author typed to wrap a template line are indistinguishable from the
+ * newlines inside a `{{ $message }}` value. The default (Normal) collapses
+ * every whitespace run to a single space, so multi-line markup renders as
+ * one flowing line — the same collapse a browser applies. `PreLine` keeps
+ * line breaks while still collapsing spaces, which is what user-written
+ * paragraphs need; `Pre`/`PreWrap` keep every byte.
+ *
+ * Wire values (`white_space` prop) follow the CSS keyword order:
+ * 0 normal, 1 nowrap, 2 pre, 3 pre-line, 4 pre-wrap. NoWrap only affects
+ * the collapse policy here; wrapping itself is a renderer concern.
+ */
+enum WhiteSpace: int
+{
+    case Normal = 0;
+
+    case NoWrap = 1;
+
+    case Pre = 2;
+
+    case PreLine = 3;
+
+    case PreWrap = 4;
+
+    /** Resolve a Tailwind `whitespace-<token>` suffix (or a `white-space` attribute value). */
+    public static function fromToken(string $token): ?self
+    {
+        return match (strtolower(trim($token))) {
+            'normal' => self::Normal,
+            'nowrap' => self::NoWrap,
+            'pre' => self::Pre,
+            'pre-line' => self::PreLine,
+            'pre-wrap' => self::PreWrap,
+            default => null,
+        };
+    }
+
+    /** Resolve from an attribute bag that may carry the parsed class value or a raw attribute. */
+    public static function fromAttributes(array $attrs): ?self
+    {
+        $value = $attrs['whiteSpace'] ?? $attrs['white-space'] ?? null;
+
+        if ($value instanceof self) {
+            return $value;
+        }
+        if (is_int($value)) {
+            return self::tryFrom($value);
+        }
+        if (is_string($value)) {
+            return is_numeric($value) ? self::tryFrom((int) $value) : self::fromToken($value);
+        }
+
+        return null;
+    }
+
+    /**
+     * Apply the policy to a text's INTERIOR whitespace. Never trims — whether
+     * the edges are meaningful is the caller's decision (a leaf trims, an
+     * inline run keeps its edge spaces).
+     */
+    public function apply(string $text): string
+    {
+        return match ($this) {
+            self::Normal, self::NoWrap => preg_replace('/\s+/', ' ', $text),
+            // Newlines survive; spaces/tabs around them are dropped and every
+            // other whitespace run collapses — CSS `pre-line` semantics.
+            self::PreLine => preg_replace(
+                '/[^\S\n]+/',
+                ' ',
+                preg_replace('/[^\S\n]*\n[^\S\n]*/', "\n", str_replace(["\r\n", "\r"], "\n", $text))
+            ),
+            self::Pre, self::PreWrap => $text,
+        };
+    }
+}

--- a/src/Edge/NativeElementCollector.php
+++ b/src/Edge/NativeElementCollector.php
@@ -10,6 +10,7 @@ use Native\Mobile\Edge\Elements\Stack;
 use Native\Mobile\Edge\Enums\AlignItems;
 use Native\Mobile\Edge\Enums\AlignSelf;
 use Native\Mobile\Edge\Enums\JustifyContent;
+use Native\Mobile\Edge\Enums\WhiteSpace;
 use Native\Mobile\Edge\Exceptions\ComponentSlotNotSupportedException;
 
 class NativeElementCollector
@@ -101,6 +102,9 @@ class NativeElementCollector
      * (children === null means a leaf run).
      */
     protected static array $textFrames = [];
+
+    /** True while a captured slot descriptor is being emitted as a leaf (see leaf()). */
+    protected static bool $emittingText = false;
 
     /**
      * Plugin-registered attribute capture.
@@ -246,6 +250,7 @@ class NativeElementCollector
         static::$stack = [];
         static::$roots = [];
         static::$textFrames = [];
+        static::$emittingText = false;
         static::$keyPathStack = [];
 
         try {
@@ -1066,6 +1071,13 @@ class NativeElementCollector
         static::guardAgainstComponentSlot($type);
         $attrs = static::stripEventBindings($attrs);
 
+        // A `:text` attribute honours an explicit whitespace policy. Slot text
+        // arriving via emitTextDescriptor() was already normalized on capture
+        // (runs keep their edge spaces), so it must not pass through again.
+        if ($type === 'text' && ! static::$emittingText) {
+            $attrs = static::applyTextWhiteSpace($attrs);
+        }
+
         if (static::$streaming) {
             static::leafStreaming($type, $attrs);
 
@@ -1110,10 +1122,11 @@ class NativeElementCollector
         $buffer = ob_get_clean();
         $frame = array_pop(static::$textFrames);
         $isNested = ! empty(static::$textFrames);
+        $policy = static::whiteSpacePolicy($frame['attrs']);
 
         if (! empty($frame['children'])) {
             // Container: its own trailing buffer is a run; own text stays empty.
-            $tail = static::normalizeRunText($buffer);
+            $tail = static::normalizeRunText($buffer, $policy);
             if ($tail !== '') {
                 $frame['children'][] = ['attrs' => ['text' => $tail], 'children' => null];
             }
@@ -1123,7 +1136,7 @@ class NativeElementCollector
             // spaces), but a top-level leaf keeps today's exact trimmed +
             // whitespace-collapsed string so nothing else regresses.
             $attrs = $frame['attrs'];
-            $text = $isNested ? static::normalizeRunText($buffer) : static::normalizeLeafText($buffer);
+            $text = $isNested ? static::normalizeRunText($buffer, $policy) : static::normalizeLeafText($buffer, $policy);
             if ($text !== '') {
                 $attrs['text'] = $text;
             }
@@ -1144,9 +1157,9 @@ class NativeElementCollector
     /** Flush the currently-buffered raw text as a run of the top frame. */
     protected static function captureRawRunIntoTopFrame(): void
     {
-        $text = static::normalizeRunText(ob_get_clean());
+        $top = count(static::$textFrames) - 1;
+        $text = static::normalizeRunText(ob_get_clean(), static::whiteSpacePolicy(static::$textFrames[$top]['attrs']));
         if ($text !== '') {
-            $top = count(static::$textFrames) - 1;
             static::$textFrames[$top]['children'][] = ['attrs' => ['text' => $text], 'children' => null];
         }
     }
@@ -1154,24 +1167,65 @@ class NativeElementCollector
     /**
      * Whitespace policy for a raw run: drop pure-whitespace segments (inter-tag
      * newlines/indentation are formatting, not content) so multiline markup
-     * doesn't inject spurious spaces; collapse internal runs of whitespace to a
-     * single space but PRESERVE meaningful leading/trailing spaces (a run may be
-     * `" / "`, or prose like `"Use "` before an inline chip).
+     * doesn't inject spurious spaces; normalize internal whitespace per the
+     * element's policy (collapse by default) but PRESERVE meaningful
+     * leading/trailing spaces (a run may be `" / "`, or prose like `"Use "`
+     * before an inline chip).
      */
-    protected static function normalizeRunText(string $raw): string
+    protected static function normalizeRunText(string $raw, ?WhiteSpace $policy = null): string
     {
         $s = html_entity_decode(strip_tags($raw), ENT_QUOTES, 'UTF-8');
         if (trim($s) === '') {
             return '';
         }
 
-        return preg_replace('/\s+/', ' ', $s);
+        return ($policy ?? WhiteSpace::Normal)->apply($s);
     }
 
-    /** Leaf `<text>` text: today's exact behavior (trim + collapse). */
-    protected static function normalizeLeafText(string $raw): string
+    /**
+     * Leaf `<text>` slot text. The edges are always trimmed — the newline and
+     * indentation around a slot are template formatting under every policy —
+     * and the interior follows the element's whitespace policy: collapsed to
+     * single spaces by default, line breaks kept under `whitespace-pre-line`,
+     * every byte kept under `whitespace-pre`.
+     */
+    public static function normalizeLeafText(string $raw, ?WhiteSpace $policy = null): string
     {
-        return preg_replace('/\s+/', ' ', trim(html_entity_decode(strip_tags($raw), ENT_QUOTES, 'UTF-8')));
+        return ($policy ?? WhiteSpace::Normal)->apply(trim(html_entity_decode(strip_tags($raw), ENT_QUOTES, 'UTF-8')));
+    }
+
+    /**
+     * The whitespace policy an element's attributes declare, via a
+     * `whitespace-*` class or a `white-space` attribute. Null when the element
+     * says nothing, so each capture path keeps its own default.
+     */
+    public static function whiteSpacePolicy(array $attrs): ?WhiteSpace
+    {
+        if (isset($attrs['class']) && is_string($attrs['class']) && str_contains($attrs['class'], 'whitespace-')) {
+            $attrs = array_merge(TailwindParser::parse($attrs['class']), $attrs);
+        }
+
+        return WhiteSpace::fromAttributes($attrs);
+    }
+
+    /**
+     * A `:text` attribute reaches the tree byte-for-byte by default (the value
+     * came from PHP, not from a template buffer, so nothing needs undoing). An
+     * explicit whitespace policy on the element applies to it as well, so slot
+     * and attribute agree whenever the author has said what they want.
+     */
+    public static function applyTextWhiteSpace(array $attrs): array
+    {
+        if (! isset($attrs['text']) || ! is_string($attrs['text'])) {
+            return $attrs;
+        }
+
+        $policy = static::whiteSpacePolicy($attrs);
+        if ($policy !== null) {
+            $attrs['text'] = $policy->apply(trim($attrs['text']));
+        }
+
+        return $attrs;
     }
 
     /**
@@ -1182,7 +1236,12 @@ class NativeElementCollector
     protected static function emitTextDescriptor(array $descriptor): void
     {
         if ($descriptor['children'] === null) {
-            static::leaf('text', $descriptor['attrs']);
+            static::$emittingText = true;
+            try {
+                static::leaf('text', $descriptor['attrs']);
+            } finally {
+                static::$emittingText = false;
+            }
 
             return;
         }
@@ -1231,6 +1290,7 @@ class NativeElementCollector
         static::$streaming = false;
         static::$pollIntervals = [];
         static::$textFrames = [];
+        static::$emittingText = false;
         // Phase 1 — clear any leftover key-path entries between frames
         // (e.g. an error thrown mid-render that skipped the matching
         // closeStreaming pops).

--- a/src/Edge/TailwindParser.php
+++ b/src/Edge/TailwindParser.php
@@ -7,6 +7,7 @@ use Native\Mobile\Edge\Enums\AlignItems;
 use Native\Mobile\Edge\Enums\AlignSelf;
 use Native\Mobile\Edge\Enums\JustifyContent;
 use Native\Mobile\Edge\Enums\TextAlign;
+use Native\Mobile\Edge\Enums\WhiteSpace;
 use Native\Mobile\Platform;
 
 class TailwindParser
@@ -642,6 +643,14 @@ class TailwindParser
             $class === 'lowercase' => ['textTransform' => 2],
             $class === 'capitalize' => ['textTransform' => 3],
             $class === 'normal-case' => ['textTransform' => 0],
+
+            // Whitespace policy (CSS `white-space`). Decides how the collector
+            // normalizes `<text>` content: the default collapses every run to
+            // one space, `whitespace-pre-line` keeps the line breaks inside a
+            // `{{ $message }}` while still collapsing spaces, `whitespace-pre`
+            // keeps every byte. Sent as int in CSS keyword order: 0 normal,
+            // 1 nowrap, 2 pre, 3 pre-line, 4 pre-wrap.
+            str_starts_with($class, 'whitespace-') => self::parseWhiteSpace(substr($class, 11)),
 
             // Text selection (opt-in). Mirrors CSS `user-select`: `select-text`
             // makes this node's subtree long-press-selectable (native Copy
@@ -1341,6 +1350,13 @@ class TailwindParser
             'left' => ['positionLeft' => (float) $value],
             default => null,
         };
+    }
+
+    private static function parseWhiteSpace(string $token): ?array
+    {
+        $policy = WhiteSpace::fromToken($token);
+
+        return $policy === null ? null : ['whiteSpace' => $policy->value];
     }
 
     private static function resolveColor(string $value, string $key): ?array

--- a/tests/Feature/Edge/InlineTextRunsTest.php
+++ b/tests/Feature/Edge/InlineTextRunsTest.php
@@ -110,3 +110,96 @@ it('keeps leaf text on the trimmed-string path (no regression)', function () {
     expect($text['props']['font_size'])->toBe(24.0);
     expect($text['children'] ?? [])->toBe([]); // leaf, no run children
 });
+
+// ── Whitespace policy (`whitespace-*`) ─────────────────
+
+it('collapses newlines in leaf slot text by default', function () {
+    $tree = renderInlineTree(<<<'BLADE'
+<native:column>
+    <native:text>
+        First paragraph.
+
+        Second paragraph.
+    </native:text>
+</native:column>
+BLADE);
+
+    expect($tree['children'][0]['props']['text'])->toBe('First paragraph. Second paragraph.');
+    expect($tree['children'][0]['props'])->not->toHaveKey('white_space');
+});
+
+it('keeps line breaks in slot text under whitespace-pre-line', function () {
+    $tree = renderInlineTree(<<<'BLADE'
+<native:column>
+    <native:text class="whitespace-pre-line">
+        First   paragraph.
+
+        Second paragraph.
+    </native:text>
+</native:column>
+BLADE);
+
+    $text = $tree['children'][0];
+    // Edges trimmed (template formatting), inner newlines kept, spaces collapsed.
+    expect($text['props']['text'])->toBe("First paragraph.\n\nSecond paragraph.");
+    expect($text['props']['white_space'])->toBe(3);
+});
+
+it('keeps every byte of slot text under whitespace-pre', function () {
+    $tree = renderInlineTree(
+        "<native:column><native:text class=\"whitespace-pre\">let x = 1;\n    return x;</native:text></native:column>"
+    );
+
+    expect($tree['children'][0]['props']['text'])->toBe("let x = 1;\n    return x;");
+    expect($tree['children'][0]['props']['white_space'])->toBe(2);
+});
+
+it('preserves newlines from an echoed value under whitespace-pre-line', function () {
+    // The reported case: user-written paragraphs rendered through the slot.
+    $tree = renderInlineTree(<<<'BLADE'
+@php($message = "First paragraph.\n\nSecond paragraph.")
+<native:column>
+    <native:text class="whitespace-pre-line">{{ $message }}</native:text>
+    <native:text>{{ $message }}</native:text>
+</native:column>
+BLADE);
+
+    expect($tree['children'][0]['props']['text'])->toBe("First paragraph.\n\nSecond paragraph.");
+    expect($tree['children'][1]['props']['text'])->toBe('First paragraph. Second paragraph.');
+});
+
+it('leaves a :text attribute untouched by default and normalizes it under an explicit policy', function () {
+    $tree = renderInlineTree(<<<'BLADE'
+@php($message = "  First   paragraph.\n\nSecond paragraph.  ")
+<native:column>
+    <native:text :text="$message" />
+    <native:text :text="$message" class="whitespace-pre-line" />
+    <native:text :text="$message" class="whitespace-normal" />
+</native:column>
+BLADE);
+
+    expect($tree['children'][0]['props']['text'])->toBe("  First   paragraph.\n\nSecond paragraph.  ");
+    expect($tree['children'][1]['props']['text'])->toBe("First paragraph.\n\nSecond paragraph.");
+    expect($tree['children'][2]['props']['text'])->toBe('First paragraph. Second paragraph.');
+});
+
+it('applies the parent policy to raw runs and keeps run edge spaces', function () {
+    $tree = renderInlineTree(
+        "<native:column><native:text class=\"whitespace-pre-line\">Line one\nline two <native:text class=\"font-mono\"> B </native:text>tail</native:text></native:column>"
+    );
+
+    $text = $tree['children'][0];
+    expect($text['children'])->toHaveCount(3);
+    expect($text['children'][0]['props']['text'])->toBe("Line one\nline two ");
+    // The nested run has no policy of its own: default collapse, edges kept.
+    expect($text['children'][1]['props']['text'])->toBe(' B ');
+    expect($text['children'][2]['props']['text'])->toBe('tail');
+});
+
+it('keeps edge spaces of a nested run that declares its own policy', function () {
+    $tree = renderInlineTree(
+        '<native:column><native:text>A<native:text class="whitespace-pre"> B </native:text>C</native:text></native:column>'
+    );
+
+    expect($tree['children'][0]['children'][1]['props']['text'])->toBe(' B ');
+});

--- a/tests/Unit/Edge/TailwindParserTest.php
+++ b/tests/Unit/Edge/TailwindParserTest.php
@@ -952,3 +952,14 @@ it('marks authored zero insets with the -0.0 sentinel so bottom-0 can anchor', f
     expect(TailwindParser::parse('bottom-2'))->toBe(['positionBottom' => 8]);
     expect(TailwindParser::parse('-right-8'))->toBe(['positionRight' => -32.0]);
 });
+
+// ── Whitespace ──────────────────────────────────────
+
+it('parses whitespace classes to the CSS keyword order', function () {
+    expect(TailwindParser::parse('whitespace-normal'))->toBe(['whiteSpace' => 0]);
+    expect(TailwindParser::parse('whitespace-nowrap'))->toBe(['whiteSpace' => 1]);
+    expect(TailwindParser::parse('whitespace-pre'))->toBe(['whiteSpace' => 2]);
+    expect(TailwindParser::parse('whitespace-pre-line'))->toBe(['whiteSpace' => 3]);
+    expect(TailwindParser::parse('whitespace-pre-wrap'))->toBe(['whiteSpace' => 4]);
+    expect(TailwindParser::parse('whitespace-bogus'))->toBe([]);
+});


### PR DESCRIPTION
Fixes #336.

## Problem

`<text>{{ $message }}</text>` collapses every whitespace run, including `\n\n`, to a single space on capture, so user-written paragraphs render as one run-on line. `<text :text="$message" />` skips that collapse, so the same value gives opposite results depending on how it arrives.

As the triage on the issue found, the collapse can't just be deleted: by the time the slot buffer is captured, the newlines inside `$message` look exactly like the newlines an author typed to wrap a long line in the template. Dropping the collapse would break every multi-line `<text>` in existing apps.

## Fix

Match the browser: keep a single collapse policy and let the author pick it with the `whitespace-*` classes Tailwind already has. The parser now knows the family, and the collector applies the element's policy to the final text.

| class | behaviour |
|---|---|
| `whitespace-normal` | collapse everything (the unchanged default) |
| `whitespace-nowrap` | same collapse; wrapping itself is a renderer concern |
| `whitespace-pre-line` | keep line breaks, collapse spaces (the chat-message case) |
| `whitespace-pre` / `whitespace-pre-wrap` | keep every byte |

Where the policy applies:

- A leaf `<text>` slot. Edges are always trimmed (the newline and indentation around a slot are template formatting under any policy); the interior follows the policy.
- Raw runs inside an inline-text container. Each run follows its parent `<text>`'s policy; a nested `<text>` with its own class governs its own content. Runs still keep their meaningful edge spaces.
- A `:text` attribute, but only when a policy is declared. With no class, `:text` still passes through byte-for-byte, so nobody's existing workaround changes. This is the conservative half of the direction discussed on the issue: slot and attribute agree whenever the author says what they want, and each path keeps its current default otherwise.
- `<x-native-text>` goes through the same helpers.

The resolved policy is forwarded as a `white_space` prop (CSS keyword order: 0 normal, 1 nowrap, 2 pre, 3 pre-line, 4 pre-wrap) so the native renderers can pick up the wrapping half (`nowrap`, `pre`) later. Nothing native changes here; the attribute path already proved `\n` survives the bridge and renders on both platforms.

For the reporter's view the change is one class:

```blade
<text class="whitespace-pre-line">{{ $message }}</text>
```

## Tests

- `TailwindParserTest`: the five `whitespace-*` tokens map to their wire values; unknown tokens are ignored.
- `InlineTextRunsTest`: default slot collapse is unchanged; `pre-line` keeps breaks from both template text and an echoed value; `pre` keeps bytes; `:text` is untouched by default and normalized under an explicit policy; parent policy flows into raw runs while nested runs keep their edge spaces.

Full `tests/Unit/Edge` + `tests/Feature/Edge` pass (322 tests).

## Verification on device

Demo screen `/masterclass/text-whitespace` in the kitchen-sink app, same three-line message through every path. Pixel 9 emulator on the left, iPhone 17 simulator on the right. Block 1 is the default slot (collapses, unchanged), block 2 is the slot with `whitespace-pre-line` (the fix), block 3 is the `:text` workaround (still verbatim).

<img width="1449" height="1600" alt="Text whitespace demo, Android beside iOS, blocks 1 to 4" src="https://github.com/user-attachments/assets/41a073c3-8cae-45e3-8c6d-dee91dba96b6" />

Lower half on Android: author-wrapped template text flows by default and breaks under `pre-line` (4), `whitespace-pre` keeps indentation (5), and a declared `whitespace-normal` collapses the `:text` attribute too (6). iOS renders the same.

<img width="713" height="1600" alt="Text whitespace demo on Android, blocks 3 to 6" src="https://github.com/user-attachments/assets/c93eb2f9-719d-4cd7-a54b-48a500ad625a" />

One thing visible in the side-by-side that is not this PR: the grey bubbles hug their text on Android and fill the width on iOS. That is the unset `align-items` default the two platforms still disagree on (see the #309 demo notes), not the whitespace policy.

## Docs

The `whitespace-*` family should be added to the text docs alongside `truncate` / `max-lines`. Not included here since the docs live outside this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CpErRGNkHRH7Du6WAzfqBz
