### PR TITLE
Add native:screenshot command for capturing device/simulator screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ claude.md
 test-keystore.jks
 .secrets
 .phpunit.cache/test-results
+/tests/coverage
+.phpactor.json
 .github/workflows/test-package-local.yml
 
 /composer.lock

--- a/src/Commands/ScreenshotCommand.php
+++ b/src/Commands/ScreenshotCommand.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Native\Mobile\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Process;
+use Native\Mobile\Support\HostOperatingSystem;
+
+final class ScreenshotCommand extends Command
+{
+    /** `xcrun simctl`'s own alias for "whichever simulator is currently booted". */
+    private const string DEFAULT_IOS_TARGET = 'booted';
+
+    protected $signature = 'native:screenshot
+        {os : Platform (android/a or ios/i)}
+        {udid? : Specific simulator/emulator UDID (iOS defaults to the booted simulator; Android requires exactly one connected device when omitted)}
+        {--output= : File path to write the PNG to}';
+
+    protected $description = 'Capture a screenshot of the app on a running simulator, emulator, or device';
+
+    public function handle(): int
+    {
+        $rawOs = (string) $this->argument('os');
+        $platform = ScreenshotPlatform::fromInput($rawOs);
+
+        if ($platform === null) {
+            $this->error(sprintf("Invalid platform '%s'. Use 'ios'/'i' or 'android'/'a'.", $rawOs));
+
+            return self::FAILURE;
+        }
+
+        $outputPath = (string) $this->option('output');
+
+        if ($outputPath === '') {
+            $this->error('--output is required.');
+
+            return self::FAILURE;
+        }
+
+        $outputDirectory = dirname($outputPath);
+
+        if (! is_dir($outputDirectory)) {
+            $this->error(sprintf('Output directory does not exist: %s', $outputDirectory));
+
+            return self::FAILURE;
+        }
+
+        return match ($platform) {
+            ScreenshotPlatform::Ios => $this->captureIos($outputPath),
+            ScreenshotPlatform::Android => $this->captureAndroid($outputPath),
+        };
+    }
+
+    private function captureIos(string $outputPath): int
+    {
+        if (HostOperatingSystem::current() !== HostOperatingSystem::Darwin) {
+            $this->error('iOS screenshots require macOS (Xcode toolchain).');
+
+            return self::FAILURE;
+        }
+
+        $target = (string) $this->argument('udid') ?: self::DEFAULT_IOS_TARGET;
+
+        // Array-form Process::run() has Symfony escape each argument itself
+        // (no shell is invoked), so $target/$outputPath need no manual
+        // escaping here — unlike the Android string-form command below.
+        $result = Process::run(['xcrun', 'simctl', 'io', $target, 'screenshot', $outputPath]);
+
+        if (! $result->successful()) {
+            $this->reportSimctlFailure($result->errorOutput(), $target);
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function captureAndroid(string $outputPath): int
+    {
+        $adbCommand = HostOperatingSystem::current() === HostOperatingSystem::Windows ? 'adb.exe' : 'adb';
+
+        if (! Process::run(sprintf('%s version', $adbCommand))->successful()) {
+            $this->error('ADB is not installed or not in your PATH.');
+
+            return self::FAILURE;
+        }
+
+        $target = (string) $this->argument('udid');
+
+        if ($target === '') {
+            $target = $this->resolveAndroidTarget($adbCommand);
+
+            if ($target === null) {
+                return self::FAILURE;
+            }
+        }
+
+        // exec-out writes binary PNG data to stdout — needs shell redirection,
+        // so this has to run as a shell string rather than array-form argv,
+        // which means every interpolated value must be escaped by hand.
+        $command = sprintf(
+            '%s -s %s exec-out screencap -p > %s',
+            escapeshellarg($adbCommand),
+            escapeshellarg($target),
+            escapeshellarg($outputPath),
+        );
+
+        $result = Process::run($command);
+
+        if (! $result->successful()) {
+            $errorOutput = $result->errorOutput();
+            $this->error($errorOutput !== '' ? $errorOutput : sprintf('adb screencap failed for device %s.', $target));
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Resolves the only sensible implicit target: exactly one connected
+     * device. Zero and "more than one" are both genuine ambiguity, but
+     * reported distinctly rather than as one generic "not found" — a
+     * second booted emulator is a common local setup, not a missing one.
+     */
+    private function resolveAndroidTarget(string $adbCommand): ?string
+    {
+        $devices = $this->parseAdbDevices($adbCommand);
+
+        if (count($devices) === 1) {
+            return array_key_first($devices);
+        }
+
+        $this->error($devices === []
+            ? 'No connected Android device or emulator found. Connect one, or pass a udid.'
+            : sprintf('Multiple Android devices found (%s). Pass a udid to pick one.', implode(', ', array_keys($devices))));
+
+        return null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function parseAdbDevices(string $adbCommand): array
+    {
+        $result = Process::run(sprintf('%s devices', $adbCommand));
+
+        if (! $result->successful()) {
+            return [];
+        }
+
+        return collect(explode("\n", $result->output()))
+            ->filter(fn (string $line): bool => str_contains($line, "\tdevice"))
+            ->mapWithKeys(function (string $line): array {
+                $serial = explode("\t", $line)[0];
+
+                return [$serial => $serial];
+            })
+            ->all();
+    }
+
+    /**
+     * `xcrun simctl io <target> screenshot` reports two distinct failures
+     * for an unusable target — verified directly against a real `xcrun
+     * simctl` invocation, since neither matches the wording `SimCommand`
+     * checks for (that one covers a different simctl subcommand):
+     * "No devices are booted." for the bare `booted` alias, and
+     * "Invalid device: <udid>" for a udid that doesn't exist at all.
+     */
+    private function reportSimctlFailure(string $stderr, string $target): void
+    {
+        $stderr = trim($stderr);
+
+        if (str_contains($stderr, 'No devices')) {
+            $this->error('No booted simulator found.');
+
+            return;
+        }
+
+        if (str_contains($stderr, 'Invalid device')) {
+            $this->error(sprintf("No simulator found for target '%s'.", $target));
+
+            return;
+        }
+
+        $this->error($stderr !== '' ? $stderr : sprintf("simctl screenshot failed for target '%s'.", $target));
+    }
+}

--- a/src/Commands/ScreenshotCommand.php
+++ b/src/Commands/ScreenshotCommand.php
@@ -291,7 +291,11 @@ final class ScreenshotCommand extends Command
         $devices = $this->parseAdbDevices($adbCommand);
 
         if (count($devices) === 1) {
-            return array_key_first($devices);
+            // Not array_key_first(): PHP casts a purely-numeric string key
+            // (a serial like "1234567890") to int, which would violate this
+            // method's ?string return type. The values are the same serials
+            // as plain strings, unaffected by that casting.
+            return reset($devices);
         }
 
         $this->error($devices === []

--- a/src/Commands/ScreenshotCommand.php
+++ b/src/Commands/ScreenshotCommand.php
@@ -15,6 +15,8 @@ final class ScreenshotCommand extends Command
 
     private const float DEFAULT_CROP_PERCENT = 0.25;
 
+    private const float DEFAULT_CROP_OFFSET = 0.0;
+
     /** Exclusive ceiling for `--crop-percent` when trimming both edges at once (each edge takes half the budget). */
     private const float BOTH_EDGES_CROP_PERCENT_CEILING = 0.5;
 
@@ -31,9 +33,11 @@ final class ScreenshotCommand extends Command
         {udid? : Specific simulator/emulator UDID (iOS defaults to the booted simulator; Android requires exactly one connected device when omitted)}
         {--output= : File path to write the PNG to}
         {--crop= : top/bottom keep only a strip nearest that edge; both trims that fraction off each edge and keeps the middle}
-        {--crop-percent=%s : Fraction of the full image height the crop strip uses (0-1, exclusive; below %s for --crop=both), used with --crop}',
+        {--crop-percent=%s : Fraction of the full image height the crop strip uses (0-1, exclusive; below %s for --crop=both), used with --crop}
+        {--crop-offset=%s : Fraction of the full image height to skip from the --crop edge before measuring --crop-percent — e.g. to exclude the OS status bar from a --crop=top strip. top/bottom only.}',
             self::DEFAULT_CROP_PERCENT,
             self::BOTH_EDGES_CROP_PERCENT_CEILING,
+            self::DEFAULT_CROP_OFFSET,
         );
 
         parent::__construct();
@@ -94,6 +98,27 @@ final class ScreenshotCommand extends Command
             return self::FAILURE;
         }
 
+        $cropOffset = (float) $this->option('crop-offset');
+
+        if ($crop !== null && $cropOffset !== self::DEFAULT_CROP_OFFSET) {
+            if ($crop === ScreenshotCrop::Both) {
+                $this->error('--crop-offset is not supported with --crop=both.');
+
+                return self::FAILURE;
+            }
+
+            if ($cropOffset < 0 || $cropOffset + $cropPercent >= self::SINGLE_EDGE_CROP_PERCENT_CEILING) {
+                $this->error(sprintf(
+                    '--crop-offset (%s) plus --crop-percent (%s) must be less than %s.',
+                    $this->option('crop-offset'),
+                    $this->option('crop-percent'),
+                    self::SINGLE_EDGE_CROP_PERCENT_CEILING,
+                ));
+
+                return self::FAILURE;
+            }
+        }
+
         $result = match ($platform) {
             ScreenshotPlatform::Ios => $this->captureIos($outputPath),
             ScreenshotPlatform::Android => $this->captureAndroid($outputPath),
@@ -103,7 +128,7 @@ final class ScreenshotCommand extends Command
             return $result;
         }
 
-        if (! $this->cropScreenshot($outputPath, $crop, $cropPercent)) {
+        if (! $this->cropScreenshot($outputPath, $crop, $cropPercent, $cropOffset)) {
             $this->error(sprintf('Captured %s but failed to crop it.', $outputPath));
 
             return self::FAILURE;
@@ -142,9 +167,12 @@ final class ScreenshotCommand extends Command
      * bottom tab bar) without the rest of the screen. `both` trims
      * `$percent` off each edge instead and keeps the middle — useful for
      * dropping OS chrome (the status bar, the home indicator) while
-     * keeping the app's own content visible.
+     * keeping the app's own content visible. `$offset` (top/bottom only)
+     * skips that fraction of the height from the crop edge first — e.g.
+     * a `top` crop with an offset can keep a nav bar strip while still
+     * excluding the OS status bar sitting above it.
      */
-    private function cropScreenshot(string $path, ScreenshotCrop $crop, float $percent): bool
+    private function cropScreenshot(string $path, ScreenshotCrop $crop, float $percent, float $offset = 0.0): bool
     {
         $source = @imagecreatefrompng($path);
 
@@ -155,17 +183,19 @@ final class ScreenshotCommand extends Command
         $width = imagesx($source);
         $height = imagesy($source);
         $edge = max(1, (int) round($height * $percent));
+        $offsetPx = (int) round($height * $offset);
 
         [$y, $cropHeight] = match ($crop) {
-            ScreenshotCrop::Top => [0, $edge],
-            ScreenshotCrop::Bottom => [$height - $edge, $edge],
+            ScreenshotCrop::Top => [$offsetPx, $edge],
+            ScreenshotCrop::Bottom => [$height - $edge - $offsetPx, $edge],
             ScreenshotCrop::Both => [$edge, $height - (2 * $edge)],
         };
 
-        // A --crop-percent near the (0.5, exclusive) ceiling for --crop=both
-        // can round two symmetric edges into consuming the entire image —
-        // fail rather than silently write a near-empty screenshot.
-        if ($cropHeight < 1) {
+        // An --crop-offset large enough to push the window past the far
+        // edge, or a --crop-percent near the (0.5, exclusive) ceiling for
+        // --crop=both rounding two symmetric edges into consuming the
+        // entire image — fail rather than silently write a wrong crop.
+        if ($cropHeight < 1 || $y < 0 || $y + $cropHeight > $height) {
             imagedestroy($source);
 
             return false;

--- a/src/Commands/ScreenshotCommand.php
+++ b/src/Commands/ScreenshotCommand.php
@@ -13,14 +13,31 @@ final class ScreenshotCommand extends Command
     /** `xcrun simctl`'s own alias for "whichever simulator is currently booted". */
     private const string DEFAULT_IOS_TARGET = 'booted';
 
-    protected $signature = 'native:screenshot
+    private const float DEFAULT_CROP_PERCENT = 0.25;
+
+    /** Exclusive ceiling for `--crop-percent` when trimming both edges at once (each edge takes half the budget). */
+    private const float BOTH_EDGES_CROP_PERCENT_CEILING = 0.5;
+
+    /** Exclusive ceiling for `--crop-percent` when keeping a strip nearest a single edge. */
+    private const float SINGLE_EDGE_CROP_PERCENT_CEILING = 1.0;
+
+    protected $description = 'Capture a screenshot of the app on a running simulator, emulator, or device';
+
+    public function __construct()
+    {
+        $this->signature = sprintf(
+            'native:screenshot
         {os : Platform (android/a or ios/i)}
         {udid? : Specific simulator/emulator UDID (iOS defaults to the booted simulator; Android requires exactly one connected device when omitted)}
         {--output= : File path to write the PNG to}
         {--crop= : top/bottom keep only a strip nearest that edge; both trims that fraction off each edge and keeps the middle}
-        {--crop-percent=0.25 : Fraction of the full image height the crop strip uses (0-1, exclusive; below 0.5 for --crop=both), used with --crop}';
+        {--crop-percent=%s : Fraction of the full image height the crop strip uses (0-1, exclusive; below %s for --crop=both), used with --crop}',
+            self::DEFAULT_CROP_PERCENT,
+            self::BOTH_EDGES_CROP_PERCENT_CEILING,
+        );
 
-    protected $description = 'Capture a screenshot of the app on a running simulator, emulator, or device';
+        parent::__construct();
+    }
 
     public function handle(): int
     {
@@ -62,7 +79,9 @@ final class ScreenshotCommand extends Command
         }
 
         $cropPercent = (float) $this->option('crop-percent');
-        $cropPercentCeiling = $crop === ScreenshotCrop::Both ? 0.5 : 1.0;
+        $cropPercentCeiling = $crop === ScreenshotCrop::Both
+            ? self::BOTH_EDGES_CROP_PERCENT_CEILING
+            : self::SINGLE_EDGE_CROP_PERCENT_CEILING;
 
         if ($crop !== null && ($cropPercent <= 0 || $cropPercent >= $cropPercentCeiling)) {
             $this->error(sprintf(

--- a/src/Commands/ScreenshotCommand.php
+++ b/src/Commands/ScreenshotCommand.php
@@ -16,7 +16,9 @@ final class ScreenshotCommand extends Command
     protected $signature = 'native:screenshot
         {os : Platform (android/a or ios/i)}
         {udid? : Specific simulator/emulator UDID (iOS defaults to the booted simulator; Android requires exactly one connected device when omitted)}
-        {--output= : File path to write the PNG to}';
+        {--output= : File path to write the PNG to}
+        {--crop= : top/bottom keep only a strip nearest that edge; both trims that fraction off each edge and keeps the middle}
+        {--crop-percent=0.25 : Fraction of the full image height the crop strip uses (0-1, exclusive; below 0.5 for --crop=both), used with --crop}';
 
     protected $description = 'Capture a screenshot of the app on a running simulator, emulator, or device';
 
@@ -47,10 +49,120 @@ final class ScreenshotCommand extends Command
             return self::FAILURE;
         }
 
-        return match ($platform) {
+        $crop = $this->resolveCrop();
+
+        if ($crop === false) {
+            return self::FAILURE;
+        }
+
+        if ($crop !== null && ! extension_loaded('gd')) {
+            $this->error('--crop requires the PHP gd extension, which is not loaded.');
+
+            return self::FAILURE;
+        }
+
+        $cropPercent = (float) $this->option('crop-percent');
+        $cropPercentCeiling = $crop === ScreenshotCrop::Both ? 0.5 : 1.0;
+
+        if ($crop !== null && ($cropPercent <= 0 || $cropPercent >= $cropPercentCeiling)) {
+            $this->error(sprintf(
+                '--crop-percent must be between 0 and %s (exclusive) for --crop=%s, got %s.',
+                $cropPercentCeiling,
+                $crop->value,
+                $this->option('crop-percent')
+            ));
+
+            return self::FAILURE;
+        }
+
+        $result = match ($platform) {
             ScreenshotPlatform::Ios => $this->captureIos($outputPath),
             ScreenshotPlatform::Android => $this->captureAndroid($outputPath),
         };
+
+        if ($result !== self::SUCCESS || $crop === null) {
+            return $result;
+        }
+
+        if (! $this->cropScreenshot($outputPath, $crop, $cropPercent)) {
+            $this->error(sprintf('Captured %s but failed to crop it.', $outputPath));
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Parses `--crop`. Returns null when the option was omitted (a valid,
+     * common case — no cropping), the resolved crop, or false after
+     * reporting an invalid value.
+     */
+    private function resolveCrop(): ScreenshotCrop|false|null
+    {
+        $raw = (string) $this->option('crop');
+
+        if ($raw === '') {
+            return null;
+        }
+
+        $crop = ScreenshotCrop::tryFrom($raw);
+
+        if ($crop === null) {
+            $this->error(sprintf("Invalid --crop '%s'. Use 'top', 'bottom', or 'both'.", $raw));
+
+            return false;
+        }
+
+        return $crop;
+    }
+
+    /**
+     * `top`/`bottom` keep only a `$percent` strip nearest that edge —
+     * useful for a screenshot meant to show one bar (a top nav bar, a
+     * bottom tab bar) without the rest of the screen. `both` trims
+     * `$percent` off each edge instead and keeps the middle — useful for
+     * dropping OS chrome (the status bar, the home indicator) while
+     * keeping the app's own content visible.
+     */
+    private function cropScreenshot(string $path, ScreenshotCrop $crop, float $percent): bool
+    {
+        $source = @imagecreatefrompng($path);
+
+        if ($source === false) {
+            return false;
+        }
+
+        $width = imagesx($source);
+        $height = imagesy($source);
+        $edge = max(1, (int) round($height * $percent));
+
+        [$y, $cropHeight] = match ($crop) {
+            ScreenshotCrop::Top => [0, $edge],
+            ScreenshotCrop::Bottom => [$height - $edge, $edge],
+            ScreenshotCrop::Both => [$edge, $height - (2 * $edge)],
+        };
+
+        // A --crop-percent near the (0.5, exclusive) ceiling for --crop=both
+        // can round two symmetric edges into consuming the entire image —
+        // fail rather than silently write a near-empty screenshot.
+        if ($cropHeight < 1) {
+            imagedestroy($source);
+
+            return false;
+        }
+
+        $cropped = imagecrop($source, ['x' => 0, 'y' => $y, 'width' => $width, 'height' => $cropHeight]);
+        imagedestroy($source);
+
+        if ($cropped === false) {
+            return false;
+        }
+
+        $saved = imagepng($cropped, $path);
+        imagedestroy($cropped);
+
+        return $saved;
     }
 
     private function captureIos(string $outputPath): int

--- a/src/Commands/ScreenshotCrop.php
+++ b/src/Commands/ScreenshotCrop.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Native\Mobile\Commands;
+
+enum ScreenshotCrop: string
+{
+    /** Keep only a strip nearest the top edge — everything else is discarded. */
+    case Top = 'top';
+
+    /** Keep only a strip nearest the bottom edge — everything else is discarded. */
+    case Bottom = 'bottom';
+
+    /** Trim a strip off both the top and bottom edges, keeping the middle. */
+    case Both = 'both';
+}

--- a/src/Commands/ScreenshotPlatform.php
+++ b/src/Commands/ScreenshotPlatform.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Native\Mobile\Commands;
+
+use Native\Mobile\Platform;
+
+enum ScreenshotPlatform: string
+{
+    case Ios = Platform::IOS;
+    case Android = Platform::ANDROID;
+
+    /**
+     * Parse a `native:screenshot {os}` argument, accepting the short
+     * aliases (`i`/`a`) the rest of the `native:*` commands also accept.
+     */
+    public static function fromInput(string $value): ?self
+    {
+        return match (strtolower($value)) {
+            'ios', 'i' => self::Ios,
+            'android', 'a' => self::Android,
+            default => null,
+        };
+    }
+}

--- a/src/Concerns/RunsIos.php
+++ b/src/Concerns/RunsIos.php
@@ -394,10 +394,18 @@ trait RunsIos
         $lastUsedUdid = $this->getLastUsedIosDevice();
         $filteredDevices = $this->filterIosDevices($devices, $lastUsedUdid);
 
-        $target = $this->showDeviceSelector($filteredDevices, $lastUsedUdid, showAllOption: true);
+        // Mirrors RunsAndroid's single-device shortcut: with exactly one
+        // sensible candidate, there's nothing to choose between, so skip the
+        // interactive prompt — which also lets a --no-tty run (no attached
+        // terminal) succeed instead of failing on a prompt it can't answer.
+        if (count($filteredDevices) === 1) {
+            $target = $filteredDevices[0]['udid'];
+        } else {
+            $target = $this->showDeviceSelector($filteredDevices, $lastUsedUdid, showAllOption: true);
 
-        if ($target === '__show_all__') {
-            $target = $this->showDeviceSelector($devices, $lastUsedUdid, showAllOption: false);
+            if ($target === '__show_all__') {
+                $target = $this->showDeviceSelector($devices, $lastUsedUdid, showAllOption: false);
+            }
         }
 
         $this->saveLastUsedIosDevice($target);

--- a/src/Concerns/RunsIos.php
+++ b/src/Concerns/RunsIos.php
@@ -126,7 +126,7 @@ trait RunsIos
         $devices = $this->getAvailableIosDevices();
 
         if (! $target = $this->argument('udid')) {
-            $target = $this->promptForIosTarget($devices);
+            $target = $this->resolveDefaultIosTarget($devices);
         }
 
         if (array_key_exists($target, $this->simulators)) {
@@ -387,6 +387,46 @@ trait RunsIos
                 'target' => $target,
             ]);
         }
+    }
+
+    /**
+     * `xctrace list devices` (which feeds `promptForIosTarget`'s filtering)
+     * lists every installed simulator, booted or not — so on a machine with
+     * several iPhone models installed, filtering alone rarely narrows to
+     * one. Prefer a simulator that's already booted instead: that's the one
+     * the developer is actually looking at, the same "just use what's
+     * running" default `native:screenshot` already applies via simctl's own
+     * `booted` alias.
+     */
+    private function resolveDefaultIosTarget(array $devices): string
+    {
+        $bootedSimulators = $this->getBootedIosSimulatorUdids();
+
+        if (count($bootedSimulators) === 1) {
+            return $bootedSimulators[0];
+        }
+
+        return $this->promptForIosTarget($devices);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function getBootedIosSimulatorUdids(): array
+    {
+        $result = Process::run(['xcrun', 'simctl', 'list', 'devices', 'booted', '-j']);
+
+        if (! $result->successful()) {
+            return [];
+        }
+
+        $devices = json_decode($result->output(), true)['devices'] ?? null;
+
+        if (! is_array($devices)) {
+            return [];
+        }
+
+        return collect($devices)->flatten(1)->pluck('udid')->all();
     }
 
     private function promptForIosTarget(array $devices): string

--- a/src/Concerns/RunsIos.php
+++ b/src/Concerns/RunsIos.php
@@ -426,7 +426,15 @@ trait RunsIos
             return [];
         }
 
-        return collect($devices)->flatten(1)->pluck('udid')->all();
+        // Keyed by runtime identifier (e.g.
+        // "com.apple.CoreSimulator.SimRuntime.iOS-18-6"), which also covers
+        // watchOS/tvOS runtimes — filter to iOS before flattening so a lone
+        // booted Watch/TV simulator is never auto-selected as the target.
+        return collect($devices)
+            ->filter(fn (array $devicesForRuntime, string $runtime): bool => str_contains($runtime, '.SimRuntime.iOS-'))
+            ->flatten(1)
+            ->pluck('udid')
+            ->all();
     }
 
     private function promptForIosTarget(array $devices): string

--- a/src/NativeServiceProvider.php
+++ b/src/NativeServiceProvider.php
@@ -31,6 +31,7 @@ use Native\Mobile\Commands\PluginValidateCommand;
 use Native\Mobile\Commands\ReleaseCommand;
 use Native\Mobile\Commands\RemoveNativeComponentCommand;
 use Native\Mobile\Commands\RunCommand;
+use Native\Mobile\Commands\ScreenshotCommand;
 use Native\Mobile\Commands\SimCommand;
 use Native\Mobile\Commands\TailCommand;
 use Native\Mobile\Commands\ValidateCommand;
@@ -72,6 +73,7 @@ class NativeServiceProvider extends PackageServiceProvider
                 OpenProjectCommand::class,
                 LaunchEmulatorCommand::class,
                 SimCommand::class,
+                ScreenshotCommand::class,
                 ReleaseCommand::class,
                 JumpCommand::class,
                 WatchCommand::class,

--- a/src/Support/HostOperatingSystem.php
+++ b/src/Support/HostOperatingSystem.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Native\Mobile\Support;
+
+/**
+ * Wraps `PHP_OS_FAMILY` (the machine running this CLI process, not the app's
+ * target platform — see `Native\Mobile\Platform` for that) so call sites
+ * compare against a fixed enum instead of matching its raw string values.
+ */
+enum HostOperatingSystem: string
+{
+    case Darwin = 'Darwin';
+    case Windows = 'Windows';
+    case Linux = 'Linux';
+    case BSD = 'BSD';
+    case Solaris = 'Solaris';
+    case Unknown = 'Unknown';
+
+    public static function current(): self
+    {
+        return self::tryFrom(PHP_OS_FAMILY) ?? self::Unknown;
+    }
+}

--- a/tests/Feature/ScreenshotCommandTest.php
+++ b/tests/Feature/ScreenshotCommandTest.php
@@ -343,6 +343,115 @@ final class ScreenshotCommandTest extends TestCase
             ->assertFailed();
     }
 
+    public function test_ios_capture_crops_to_a_top_strip_excluding_an_offset(): void
+    {
+        $outputPath = $this->outputDir.'/shot.png';
+
+        Process::fake([
+            '*simctl*screenshot*' => function () use ($outputPath) {
+                $this->writeTestPng($outputPath, 200, 1000);
+
+                return Process::result();
+            },
+        ]);
+
+        $this->artisan('native:screenshot', [
+            'os' => 'ios',
+            '--output' => $outputPath,
+            '--crop' => 'top',
+            '--crop-percent' => '0.3',
+            '--crop-offset' => '0.1',
+        ])->assertSuccessful();
+
+        // Skips the first 10% (100px, the "status bar"), then keeps a 30%
+        // (300px) strip below it.
+        $cropped = imagecreatefrompng($outputPath);
+        $this->assertSame(200, imagesx($cropped));
+        $this->assertSame(300, imagesy($cropped));
+        imagedestroy($cropped);
+    }
+
+    public function test_android_capture_crops_to_a_bottom_strip_excluding_an_offset(): void
+    {
+        $outputPath = $this->outputDir.'/shot.png';
+
+        Process::fake([
+            'adb version' => Process::result(),
+            'adb devices' => Process::result(output: "List of devices attached\nemulator-5554\tdevice\n"),
+            '*screencap*' => function () use ($outputPath) {
+                $this->writeTestPng($outputPath, 200, 1000);
+
+                return Process::result();
+            },
+        ]);
+
+        $this->artisan('native:screenshot', [
+            'os' => 'android',
+            '--output' => $outputPath,
+            '--crop' => 'bottom',
+            '--crop-percent' => '0.2',
+            '--crop-offset' => '0.05',
+        ])->assertSuccessful();
+
+        // Skips the last 5% (50px, e.g. the home indicator), then keeps a
+        // 20% (200px) strip above it.
+        $cropped = imagecreatefrompng($outputPath);
+        $this->assertSame(200, imagesx($cropped));
+        $this->assertSame(200, imagesy($cropped));
+        imagedestroy($cropped);
+    }
+
+    public function test_it_rejects_crop_offset_with_both_edges(): void
+    {
+        Process::fake();
+
+        $this->artisan('native:screenshot', [
+            'os' => 'ios',
+            '--output' => $this->outputDir.'/shot.png',
+            '--crop' => 'both',
+            '--crop-percent' => '0.1',
+            '--crop-offset' => '0.1',
+        ])
+            ->expectsOutputToContain('--crop-offset is not supported with --crop=both')
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    }
+
+    public function test_it_rejects_a_crop_offset_that_leaves_no_room_for_crop_percent(): void
+    {
+        Process::fake();
+
+        $this->artisan('native:screenshot', [
+            'os' => 'ios',
+            '--output' => $this->outputDir.'/shot.png',
+            '--crop' => 'top',
+            '--crop-percent' => '0.3',
+            '--crop-offset' => '0.8',
+        ])
+            ->expectsOutputToContain('--crop-offset (0.8) plus --crop-percent (0.3) must be less than 1')
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    }
+
+    public function test_it_rejects_a_negative_crop_offset(): void
+    {
+        Process::fake();
+
+        $this->artisan('native:screenshot', [
+            'os' => 'ios',
+            '--output' => $this->outputDir.'/shot.png',
+            '--crop' => 'top',
+            '--crop-percent' => '0.3',
+            '--crop-offset' => '-0.1',
+        ])
+            ->expectsOutputToContain('--crop-offset (-0.1) plus --crop-percent (0.3) must be less than 1')
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    }
+
     public function test_android_capture_crops_to_a_bottom_strip(): void
     {
         $outputPath = $this->outputDir.'/shot.png';

--- a/tests/Feature/ScreenshotCommandTest.php
+++ b/tests/Feature/ScreenshotCommandTest.php
@@ -191,6 +191,25 @@ final class ScreenshotCommandTest extends TestCase
             ->assertFailed();
     }
 
+    public function test_android_capture_auto_selects_a_purely_numeric_serial(): void
+    {
+        // A serial that's all digits (some real device serials are) becomes
+        // an int array key under PHP's numeric-string casting — regression
+        // test for a TypeError this used to throw via array_key_first().
+        Process::fake([
+            'adb version' => Process::result(),
+            'adb devices' => Process::result(output: "List of devices attached\n1234567890\tdevice\n"),
+            '*screencap*' => Process::result(),
+        ]);
+
+        $outputPath = $this->outputDir.'/shot.png';
+
+        $this->artisan('native:screenshot', ['os' => 'android', '--output' => $outputPath])
+            ->assertSuccessful();
+
+        Process::assertRan(sprintf("'adb' -s '1234567890' exec-out screencap -p > '%s'", $outputPath));
+    }
+
     public function test_android_capture_fails_when_multiple_devices_are_connected_and_no_udid_given(): void
     {
         Process::fake([

--- a/tests/Feature/ScreenshotCommandTest.php
+++ b/tests/Feature/ScreenshotCommandTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
+use Tests\TestCase;
+
+final class ScreenshotCommandTest extends TestCase
+{
+    protected string $outputDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->outputDir = sys_get_temp_dir().'/nativephp_screenshot_test_'.uniqid();
+        File::makeDirectory($this->outputDir, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->outputDir);
+
+        parent::tearDown();
+    }
+
+    public function test_it_rejects_an_unknown_platform(): void
+    {
+        Process::fake();
+
+        $this->artisan('native:screenshot', ['os' => 'blackberry', '--output' => $this->outputDir.'/shot.png'])
+            ->expectsOutputToContain("Invalid platform 'blackberry'")
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    }
+
+    public function test_it_requires_an_output_path(): void
+    {
+        Process::fake();
+
+        $this->artisan('native:screenshot', ['os' => 'ios'])
+            ->expectsOutputToContain('--output is required')
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    }
+
+    public function test_it_rejects_an_output_path_whose_directory_does_not_exist(): void
+    {
+        Process::fake();
+
+        $missingDir = $this->outputDir.'/does-not-exist/shot.png';
+
+        $this->artisan('native:screenshot', ['os' => 'ios', '--output' => $missingDir])
+            ->expectsOutputToContain('Output directory does not exist')
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    }
+
+    public function test_ios_capture_defaults_to_the_booted_simulator(): void
+    {
+        Process::fake();
+
+        $outputPath = $this->outputDir.'/shot.png';
+
+        $this->artisan('native:screenshot', ['os' => 'ios', '--output' => $outputPath])
+            ->assertSuccessful();
+
+        // assertRan()'s $callback must be a Closure|string, so an array
+        // command (as this class passes to Process::run()) is compared here
+        // rather than being handed to assertRan() directly.
+        Process::assertRan(fn ($process) => $process->command === ['xcrun', 'simctl', 'io', 'booted', 'screenshot', $outputPath]);
+    }
+
+    public function test_ios_capture_uses_the_given_udid(): void
+    {
+        Process::fake();
+
+        $outputPath = $this->outputDir.'/shot.png';
+        $udid = 'ABCD-1234';
+
+        $this->artisan('native:screenshot', ['os' => 'i', 'udid' => $udid, '--output' => $outputPath])
+            ->assertSuccessful();
+
+        Process::assertRan(fn ($process) => $process->command === ['xcrun', 'simctl', 'io', $udid, 'screenshot', $outputPath]);
+    }
+
+    public function test_ios_capture_reports_no_booted_simulator(): void
+    {
+        // Verified against a real `xcrun simctl io booted screenshot` with
+        // nothing booted — this is the actual stderr text, not a guess.
+        Process::fake([
+            '*simctl*booted*screenshot*' => Process::result(errorOutput: 'No devices are booted.', exitCode: 148),
+        ]);
+
+        $this->artisan('native:screenshot', ['os' => 'ios', '--output' => $this->outputDir.'/shot.png'])
+            ->expectsOutputToContain('No booted simulator found.')
+            ->assertFailed();
+    }
+
+    public function test_ios_capture_reports_an_invalid_udid(): void
+    {
+        // Verified against a real `xcrun simctl io <bogus-udid> screenshot`.
+        Process::fake([
+            '*simctl*screenshot*' => Process::result(errorOutput: 'Invalid device: NOT-A-REAL-UDID', exitCode: 148),
+        ]);
+
+        $this->artisan('native:screenshot', ['os' => 'ios', 'udid' => 'NOT-A-REAL-UDID', '--output' => $this->outputDir.'/shot.png'])
+            ->expectsOutputToContain("No simulator found for target 'NOT-A-REAL-UDID'")
+            ->assertFailed();
+    }
+
+    public function test_android_capture_fails_when_adb_is_not_installed(): void
+    {
+        Process::fake([
+            'adb version' => Process::result(exitCode: 127),
+        ]);
+
+        $this->artisan('native:screenshot', ['os' => 'android', '--output' => $this->outputDir.'/shot.png'])
+            ->expectsOutputToContain('ADB is not installed or not in your PATH')
+            ->assertFailed();
+
+        Process::assertDidntRun('adb devices');
+    }
+
+    public function test_android_capture_uses_the_only_connected_device(): void
+    {
+        Process::fake([
+            'adb version' => Process::result(),
+            'adb devices' => Process::result(output: "List of devices attached\nemulator-5554\tdevice\n"),
+            '*screencap*' => Process::result(),
+        ]);
+
+        $outputPath = $this->outputDir.'/shot.png';
+
+        $this->artisan('native:screenshot', ['os' => 'android', '--output' => $outputPath])
+            ->assertSuccessful();
+
+        // Every interpolated value is escapeshellarg()'d before this string
+        // reaches the shell, so the recorded command carries single quotes.
+        Process::assertRan(sprintf("'adb' -s 'emulator-5554' exec-out screencap -p > '%s'", $outputPath));
+    }
+
+    public function test_android_capture_escapes_an_output_path_containing_a_space(): void
+    {
+        Process::fake([
+            'adb version' => Process::result(),
+            'adb devices' => Process::result(output: "List of devices attached\nemulator-5554\tdevice\n"),
+            '*screencap*' => Process::result(),
+        ]);
+
+        $outputPath = $this->outputDir.'/My Screenshots/shot.png';
+        File::makeDirectory(dirname($outputPath), 0755, true);
+
+        $this->artisan('native:screenshot', ['os' => 'android', '--output' => $outputPath])
+            ->assertSuccessful();
+
+        Process::assertRan(sprintf("'adb' -s 'emulator-5554' exec-out screencap -p > '%s'", $outputPath));
+    }
+
+    public function test_android_capture_uses_the_given_udid_without_querying_devices(): void
+    {
+        Process::fake([
+            'adb version' => Process::result(),
+            '*screencap*' => Process::result(),
+        ]);
+
+        $outputPath = $this->outputDir.'/shot.png';
+
+        $this->artisan('native:screenshot', ['os' => 'a', 'udid' => 'emulator-9999', '--output' => $outputPath])
+            ->assertSuccessful();
+
+        Process::assertDidntRun('adb devices');
+        Process::assertRan(sprintf("'adb' -s 'emulator-9999' exec-out screencap -p > '%s'", $outputPath));
+    }
+
+    public function test_android_capture_fails_when_no_device_is_connected(): void
+    {
+        Process::fake([
+            'adb version' => Process::result(),
+            'adb devices' => Process::result(output: "List of devices attached\n"),
+        ]);
+
+        $this->artisan('native:screenshot', ['os' => 'android', '--output' => $this->outputDir.'/shot.png'])
+            ->expectsOutputToContain('No connected Android device or emulator found')
+            ->assertFailed();
+    }
+
+    public function test_android_capture_fails_when_multiple_devices_are_connected_and_no_udid_given(): void
+    {
+        Process::fake([
+            'adb version' => Process::result(),
+            'adb devices' => Process::result(output: "List of devices attached\nemulator-5554\tdevice\nemulator-5556\tdevice\n"),
+        ]);
+
+        $this->artisan('native:screenshot', ['os' => 'android', '--output' => $this->outputDir.'/shot.png'])
+            ->expectsOutputToContain('Multiple Android devices found (emulator-5554, emulator-5556). Pass a udid to pick one.')
+            ->assertFailed();
+
+        // This is a genuine ambiguity, not "nothing found" — must not be
+        // reported as the zero-devices case.
+        Process::assertRan('adb devices');
+    }
+}

--- a/tests/Feature/ScreenshotCommandTest.php
+++ b/tests/Feature/ScreenshotCommandTest.php
@@ -206,4 +206,194 @@ final class ScreenshotCommandTest extends TestCase
         // reported as the zero-devices case.
         Process::assertRan('adb devices');
     }
+
+    public function test_it_rejects_an_invalid_crop_value(): void
+    {
+        Process::fake();
+
+        $this->artisan('native:screenshot', ['os' => 'ios', '--output' => $this->outputDir.'/shot.png', '--crop' => 'left'])
+            ->expectsOutputToContain("Invalid --crop 'left'")
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    }
+
+    public function test_it_rejects_an_out_of_range_crop_percent(): void
+    {
+        Process::fake();
+
+        $this->artisan('native:screenshot', [
+            'os' => 'ios',
+            '--output' => $this->outputDir.'/shot.png',
+            '--crop' => 'top',
+            '--crop-percent' => '1.5',
+        ])
+            ->expectsOutputToContain('--crop-percent must be between 0 and 1')
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    }
+
+    public function test_it_rejects_a_crop_percent_of_exactly_one_for_a_single_edge(): void
+    {
+        Process::fake();
+
+        $this->artisan('native:screenshot', [
+            'os' => 'ios',
+            '--output' => $this->outputDir.'/shot.png',
+            '--crop' => 'top',
+            '--crop-percent' => '1',
+        ])
+            ->expectsOutputToContain('--crop-percent must be between 0 and 1')
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    }
+
+    public function test_ios_capture_crops_to_a_top_strip(): void
+    {
+        $outputPath = $this->outputDir.'/shot.png';
+
+        Process::fake([
+            '*simctl*screenshot*' => function () use ($outputPath) {
+                $this->writeTestPng($outputPath, 200, 1000);
+
+                return Process::result();
+            },
+        ]);
+
+        $this->artisan('native:screenshot', [
+            'os' => 'ios',
+            '--output' => $outputPath,
+            '--crop' => 'top',
+            '--crop-percent' => '0.3',
+        ])->assertSuccessful();
+
+        $cropped = imagecreatefrompng($outputPath);
+        $this->assertSame(200, imagesx($cropped));
+        $this->assertSame(300, imagesy($cropped));
+        imagedestroy($cropped);
+    }
+
+    public function test_capture_crops_both_edges_and_keeps_the_middle(): void
+    {
+        $outputPath = $this->outputDir.'/shot.png';
+
+        Process::fake([
+            '*simctl*screenshot*' => function () use ($outputPath) {
+                $this->writeTestPng($outputPath, 200, 1000);
+
+                return Process::result();
+            },
+        ]);
+
+        $this->artisan('native:screenshot', [
+            'os' => 'ios',
+            '--output' => $outputPath,
+            '--crop' => 'both',
+            '--crop-percent' => '0.1',
+        ])->assertSuccessful();
+
+        // 10% trimmed off each of the 1000px edges leaves the middle 800px.
+        $cropped = imagecreatefrompng($outputPath);
+        $this->assertSame(200, imagesx($cropped));
+        $this->assertSame(800, imagesy($cropped));
+        imagedestroy($cropped);
+    }
+
+    public function test_it_rejects_a_crop_percent_of_half_or_more_for_both_edges(): void
+    {
+        Process::fake();
+
+        $this->artisan('native:screenshot', [
+            'os' => 'ios',
+            '--output' => $this->outputDir.'/shot.png',
+            '--crop' => 'both',
+            '--crop-percent' => '0.5',
+        ])
+            ->expectsOutputToContain('--crop-percent must be between 0 and 0.5')
+            ->assertFailed();
+
+        Process::assertNothingRan();
+    }
+
+    public function test_capture_fails_cleanly_when_a_near_ceiling_both_crop_percent_rounds_away_the_whole_image(): void
+    {
+        $outputPath = $this->outputDir.'/shot.png';
+
+        // 1000 * 0.4995 = 499.5, which rounds to 500 per edge — 2 * 500 is
+        // the entire image height, leaving nothing for the middle. This is
+        // a valid --crop-percent by the (0, 0.5) exclusive range check, so
+        // only the crop step itself (not upfront validation) can catch it.
+        Process::fake([
+            '*simctl*screenshot*' => function () use ($outputPath) {
+                $this->writeTestPng($outputPath, 200, 1000);
+
+                return Process::result();
+            },
+        ]);
+
+        $this->artisan('native:screenshot', [
+            'os' => 'ios',
+            '--output' => $outputPath,
+            '--crop' => 'both',
+            '--crop-percent' => '0.4995',
+        ])
+            ->expectsOutputToContain('failed to crop')
+            ->assertFailed();
+    }
+
+    public function test_android_capture_crops_to_a_bottom_strip(): void
+    {
+        $outputPath = $this->outputDir.'/shot.png';
+
+        Process::fake([
+            'adb version' => Process::result(),
+            'adb devices' => Process::result(output: "List of devices attached\nemulator-5554\tdevice\n"),
+            '*screencap*' => function () use ($outputPath) {
+                $this->writeTestPng($outputPath, 200, 1000);
+
+                return Process::result();
+            },
+        ]);
+
+        $this->artisan('native:screenshot', [
+            'os' => 'android',
+            '--output' => $outputPath,
+            '--crop' => 'bottom',
+            '--crop-percent' => '0.2',
+        ])->assertSuccessful();
+
+        $cropped = imagecreatefrompng($outputPath);
+        $this->assertSame(200, imagesx($cropped));
+        $this->assertSame(200, imagesy($cropped));
+        imagedestroy($cropped);
+    }
+
+    public function test_capture_without_crop_leaves_the_image_full_size(): void
+    {
+        $outputPath = $this->outputDir.'/shot.png';
+
+        Process::fake([
+            '*simctl*screenshot*' => function () use ($outputPath) {
+                $this->writeTestPng($outputPath, 200, 1000);
+
+                return Process::result();
+            },
+        ]);
+
+        $this->artisan('native:screenshot', ['os' => 'ios', '--output' => $outputPath])
+            ->assertSuccessful();
+
+        $full = imagecreatefrompng($outputPath);
+        $this->assertSame(1000, imagesy($full));
+        imagedestroy($full);
+    }
+
+    private function writeTestPng(string $path, int $width, int $height): void
+    {
+        $image = imagecreatetruecolor($width, $height);
+        imagepng($image, $path);
+        imagedestroy($image);
+    }
 }

--- a/tests/Unit/Concerns/RunsIosTest.php
+++ b/tests/Unit/Concerns/RunsIosTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Unit\Concerns;
+
+use Illuminate\Support\Facades\File;
+use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
+use Native\Mobile\Concerns\RunsIos;
+use Orchestra\Testbench\TestCase;
+
+class RunsIosTest extends TestCase
+{
+    use RunsIos;
+
+    protected string $testProjectPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->testProjectPath = sys_get_temp_dir().'/nativephp_ios_test_'.uniqid();
+        File::makeDirectory($this->testProjectPath, 0755, true);
+
+        app()->setBasePath($this->testProjectPath);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->testProjectPath);
+
+        parent::tearDown();
+    }
+
+    public function test_returns_the_single_filtered_device_without_prompting()
+    {
+        $devices = [
+            [
+                'name' => 'iPhone 17 Pro',
+                'version' => '18.6',
+                'udid' => 'FC4BFF3D-8B7B-4331-ACB7-ED78DCC313A6',
+                'category' => 'Simulators',
+            ],
+        ];
+
+        $target = $this->promptForIosTarget($devices);
+
+        $this->assertSame('FC4BFF3D-8B7B-4331-ACB7-ED78DCC313A6', $target);
+    }
+
+    public function test_prompts_when_multiple_devices_are_available()
+    {
+        $devices = [
+            [
+                'name' => 'iPhone 17 Pro',
+                'version' => '18.6',
+                'udid' => 'FC4BFF3D-8B7B-4331-ACB7-ED78DCC313A6',
+                'category' => 'Simulators',
+            ],
+            [
+                'name' => 'iPhone 17',
+                'version' => '18.6',
+                'udid' => '0D25A1A9-959C-404C-8E40-7863A7AF508F',
+                'category' => 'Simulators',
+            ],
+        ];
+
+        // With more than one candidate, the trait still asks — no attached
+        // terminal here, so Prompts fails the "Required" validation instead
+        // of silently guessing, proving the single-device shortcut was not
+        // (wrongly) taken.
+        $this->expectException(NonInteractiveValidationException::class);
+
+        $this->promptForIosTarget($devices);
+    }
+}

--- a/tests/Unit/Concerns/RunsIosTest.php
+++ b/tests/Unit/Concerns/RunsIosTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Concerns;
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
 use Laravel\Prompts\Exceptions\NonInteractiveValidationException;
 use Native\Mobile\Concerns\RunsIos;
 use Orchestra\Testbench\TestCase;
@@ -21,6 +22,8 @@ class RunsIosTest extends TestCase
         File::makeDirectory($this->testProjectPath, 0755, true);
 
         app()->setBasePath($this->testProjectPath);
+
+        Process::preventStrayProcesses();
     }
 
     protected function tearDown(): void
@@ -70,5 +73,69 @@ class RunsIosTest extends TestCase
         $this->expectException(NonInteractiveValidationException::class);
 
         $this->promptForIosTarget($devices);
+    }
+
+    public function test_resolve_default_target_prefers_the_one_booted_simulator_over_prompting()
+    {
+        // Two installed simulators would normally force a prompt, but only
+        // one of them is actually booted.
+        $devices = [
+            [
+                'name' => 'iPhone 17 Pro',
+                'version' => '26.5',
+                'udid' => 'FC4BFF3D-8B7B-4331-ACB7-ED78DCC313A6',
+                'category' => 'Simulators',
+            ],
+            [
+                'name' => 'iPhone 17',
+                'version' => '26.5',
+                'udid' => '0D25A1A9-959C-404C-8E40-7863A7AF508F',
+                'category' => 'Simulators',
+            ],
+        ];
+
+        Process::fake([
+            '*simctl*list*devices*booted*' => Process::result(json_encode([
+                'devices' => [
+                    'com.apple.CoreSimulator.SimRuntime.iOS-26-5' => [
+                        ['udid' => 'FC4BFF3D-8B7B-4331-ACB7-ED78DCC313A6', 'state' => 'Booted'],
+                    ],
+                ],
+            ])),
+        ]);
+
+        $target = $this->resolveDefaultIosTarget($devices);
+
+        $this->assertSame('FC4BFF3D-8B7B-4331-ACB7-ED78DCC313A6', $target);
+    }
+
+    public function test_resolve_default_target_falls_back_to_prompting_with_no_booted_simulator()
+    {
+        $devices = [
+            [
+                'name' => 'iPhone 17 Pro',
+                'version' => '18.6',
+                'udid' => 'FC4BFF3D-8B7B-4331-ACB7-ED78DCC313A6',
+                'category' => 'Simulators',
+            ],
+            [
+                'name' => 'iPhone 17',
+                'version' => '18.6',
+                'udid' => '0D25A1A9-959C-404C-8E40-7863A7AF508F',
+                'category' => 'Simulators',
+            ],
+        ];
+
+        Process::fake([
+            '*simctl*list*devices*booted*' => Process::result(json_encode([
+                'devices' => [
+                    'com.apple.CoreSimulator.SimRuntime.iOS-18-6' => [],
+                ],
+            ])),
+        ]);
+
+        $this->expectException(NonInteractiveValidationException::class);
+
+        $this->resolveDefaultIosTarget($devices);
     }
 }

--- a/tests/Unit/Concerns/RunsIosTest.php
+++ b/tests/Unit/Concerns/RunsIosTest.php
@@ -138,4 +138,34 @@ class RunsIosTest extends TestCase
 
         $this->resolveDefaultIosTarget($devices);
     }
+
+    public function test_resolve_default_target_ignores_a_lone_booted_watch_simulator()
+    {
+        // Only one simulator is booted overall, but it's a Watch — the iOS
+        // device list has neither of these UDIDs, so falling through to the
+        // (single-candidate) prompt shortcut proves the Watch was filtered
+        // out rather than wrongly auto-selected.
+        $devices = [
+            [
+                'name' => 'iPhone 17 Pro',
+                'version' => '18.6',
+                'udid' => 'FC4BFF3D-8B7B-4331-ACB7-ED78DCC313A6',
+                'category' => 'Simulators',
+            ],
+        ];
+
+        Process::fake([
+            '*simctl*list*devices*booted*' => Process::result(json_encode([
+                'devices' => [
+                    'com.apple.CoreSimulator.SimRuntime.watchOS-10-0' => [
+                        ['udid' => '11111111-2222-3333-4444-555555555555', 'state' => 'Booted'],
+                    ],
+                ],
+            ])),
+        ]);
+
+        $target = $this->resolveDefaultIosTarget($devices);
+
+        $this->assertSame('FC4BFF3D-8B7B-4331-ACB7-ED78DCC313A6', $target);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `native:screenshot {os} {udid?} --output=`, capturing a PNG from a booted iOS simulator (`xcrun simctl io`) or connected Android device/emulator (`adb exec-out screencap`)
- Adds `--crop=top|bottom|both` with `--crop-percent` and `--crop-offset` to trim OS chrome (status bar, home indicator/nav bar) or keep just a strip near one edge, so docs/marketing screenshots don't need manual cropping
- iOS target auto-selects the booted simulator when unambiguous instead of always prompting
- Android target auto-resolves when exactly one device is connected, with clear errors for zero or multiple devices

## Test plan
- [x] `vendor/bin/pest --filter=Screenshot` passes (27 tests)
- [x] Full suite passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)