### PR TITLE
fix: Android crashes when a positional node ID changes type

### DIFF
--- a/resources/androidstudio/app/build.gradle.kts
+++ b/resources/androidstudio/app/build.gradle.kts
@@ -211,6 +211,7 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 
     // AndroidX Security for encrypted storage
     implementation(libs.androidx.security.crypto)

--- a/resources/androidstudio/app/src/androidTest/java/com/nativephp/mobile/ui/nativerender/NodeViewIdentityTest.kt
+++ b/resources/androidstudio/app/src/androidTest/java/com/nativephp/mobile/ui/nativerender/NodeViewIdentityTest.kt
@@ -1,0 +1,56 @@
+package com.nativephp.mobile.ui.nativerender
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.test.junit4.createComposeRule
+import org.junit.Rule
+import org.junit.Test
+
+class NodeViewIdentityTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun positionalIdReusedByDifferentNodeTypeDoesNotReuseComposeState() {
+        lateinit var showsConditionalChildren: MutableState<Boolean>
+
+        composeRule.setContent {
+            showsConditionalChildren = remember { mutableStateOf(true) }
+
+            FlexContainer(
+                childNodes = if (showsConditionalChildren.value) initialChildren() else reducedChildren(),
+                content = {},
+            )
+        }
+
+        composeRule.runOnIdle {
+            showsConditionalChildren.value = false
+        }
+        composeRule.waitForIdle()
+    }
+
+    private fun initialChildren(): List<NativeUINode> = listOf(
+        node(id = 1, type = "text"),
+        node(id = 2, type = "text"),
+        node(id = 3, type = "pressable", pressScale = 0.98f),
+        node(id = 4, type = "pressable", pressScale = 0.98f),
+        node(id = 5, type = "pressable", pressScale = 0.98f),
+    )
+
+    private fun reducedChildren(): List<NativeUINode> = listOf(
+        node(id = 1, type = "text"),
+        node(id = 2, type = "pressable", pressScale = 0.98f),
+    )
+
+    private fun node(id: Int, type: String, pressScale: Float? = null): NativeUINode = NativeUINode(
+        id = id,
+        type = type,
+        layout = null,
+        style = null,
+        props = GenericProps(pressScale?.let { mapOf("press-scale" to it) } ?: emptyMap()),
+        onPress = if (pressScale == null) 0 else 1,
+        onLongPress = 0,
+        children = emptyList(),
+    )
+}

--- a/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeView.kt
+++ b/resources/androidstudio/app/src/main/java/com/nativephp/mobile/ui/nativerender/NodeView.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.unit.dp
  */
 @Composable
 fun NodeView(node: NativeUINode, overrideModifier: Modifier? = null) {
-    key(node.id) {
+    key(node.id, node.type) {
         val renderer = NativeRendererRegistry.get(node.type)
         val isDarkMode = isSystemInDarkTheme()
         val safeAreaTop = LocalSafeAreaTop.current


### PR DESCRIPTION
## What's wrong
On Android, removing conditional siblings can crash the app when an unkeyed element's positional node ID is reused by a different element type.

`NodeView` keys its Compose subtree with `node.id`, but the native tree differ treats an ID **and type** change as a structural replacement. When a re-render removes elements above a pressable, the pressable can inherit the positional ID previously occupied by a text node. Compose then reuses incompatible remembered slots and crashes while collecting the pressed state:

```text
java.lang.ClassCastException:
androidx.compose.runtime.internal.ComposableLambdaImpl
cannot be cast to androidx.compose.runtime.MutableState
    at androidx.compose.foundation.interaction.PressInteractionKt.collectIsPressedAsState
    at com.nativephp.mobile.ui.nativerender.NodeViewKt.NodeView
```

Minimum repro:

```blade
<native:column>
    @if ($showOptions)
        <native:text>How?</native:text>
        <native:pressable :press-scale="0.98"><native:text>Option A</native:text></native:pressable>
        <native:pressable :press-scale="0.98"><native:text>Option B</native:text></native:pressable>
    @endif

    <native:pressable :press-scale="0.98"><native:text>Save</native:text></native:pressable>
</native:column>
```

Re-render with `$showOptions = false`. The trailing pressable takes the positional ID formerly used by the text node and Android crashes.

## What this does
- Keys each Android `NodeView` by both `node.id` and `node.type`, matching the existing structural identity check in the native tree differ.
- Recreates the Compose subtree when a positional ID is reused by another element type, instead of recycling incompatible remembered state.
- Preserves state normally when both the ID and type remain stable; explicit `native:key` behavior is unchanged.
- Adds an Android instrumentation regression that deterministically reproduced the original `ClassCastException` before the one-line fix.
- No iOS or PHP changes.

## Verification
- Before the fix: `NodeViewIdentityTest` fails with the `ComposableLambdaImpl cannot be cast to MutableState` crash above.
- After the fix: `NodeViewIdentityTest` passes on an Android API 33 emulator.
- `./gradlew assembleDebug assembleDebugAndroidTest` passes.
- `./gradlew testDebugUnitTest` passes.

No screenshot — this is a deterministic runtime crash rather than a visual rendering bug; the instrumentation regression captures the failure directly.
